### PR TITLE
🎨 Palette: Improve SubscribeButton accessibility

### DIFF
--- a/.changeset/olive-snakes-play.md
+++ b/.changeset/olive-snakes-play.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/ui": patch
+---
+
+Improve accessibility of SubscribeButton component by adding appropriate ARIA labels and attributes.

--- a/core/ui/src/components/SubscribeButton.test.tsx
+++ b/core/ui/src/components/SubscribeButton.test.tsx
@@ -1,0 +1,64 @@
+import { render } from "@testing-library/react";
+import { SubscribeButton } from "./SubscribeButton";
+import { describe, it, expect, vi } from "bun:test";
+import React from "react";
+
+describe("SubscribeButton", () => {
+  it("renders with correct accessibility attributes (improved)", () => {
+    const onSubscribe = vi.fn();
+    const onUnsubscribe = vi.fn();
+
+    const { getByRole, rerender } = render(
+      <SubscribeButton
+        isSubscribed={false}
+        onSubscribe={onSubscribe}
+        onUnsubscribe={onUnsubscribe}
+      />
+    );
+
+    let button = getByRole("button");
+    // Should have aria-label matching title
+    expect(button).toHaveAttribute("aria-label", "Subscribe to notifications");
+    // Should have aria-pressed
+    expect(button).toHaveAttribute("aria-pressed", "false");
+
+    // Test subscribed state
+    rerender(
+      <SubscribeButton
+        isSubscribed={true}
+        onSubscribe={onSubscribe}
+        onUnsubscribe={onUnsubscribe}
+      />
+    );
+    button = getByRole("button");
+    expect(button).toHaveAttribute("aria-label", "Unsubscribe from notifications");
+    expect(button).toHaveAttribute("aria-pressed", "true");
+
+    // Test loading state when subscribing
+    rerender(
+      <SubscribeButton
+        isSubscribed={false}
+        loading={true}
+        onSubscribe={onSubscribe}
+        onUnsubscribe={onUnsubscribe}
+      />
+    );
+    button = getByRole("button");
+    expect(button).toHaveAttribute("aria-label", "Subscribing...");
+    // Check for spinner
+    const spinner = getByRole("status");
+    expect(spinner).toHaveAttribute("aria-label", "Loading");
+
+    // Test loading state when unsubscribing
+    rerender(
+      <SubscribeButton
+        isSubscribed={true}
+        loading={true}
+        onSubscribe={onSubscribe}
+        onUnsubscribe={onUnsubscribe}
+      />
+    );
+    button = getByRole("button");
+    expect(button).toHaveAttribute("aria-label", "Unsubscribing...");
+  });
+});

--- a/core/ui/src/components/SubscribeButton.tsx
+++ b/core/ui/src/components/SubscribeButton.tsx
@@ -79,11 +79,26 @@ export const SubscribeButton: React.FC<SubscribeButtonProps> = ({
           ? "Unsubscribe from notifications"
           : "Subscribe to notifications"
       }
+      aria-label={
+        loading
+          ? isSubscribed
+            ? "Unsubscribing..."
+            : "Subscribing..."
+          : isSubscribed
+          ? "Unsubscribe from notifications"
+          : "Subscribe to notifications"
+      }
+      aria-pressed={isSubscribed}
     >
       {loading ? (
-        <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+        <span
+          role="status"
+          aria-label="Loading"
+          className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+        />
       ) : (
         <Bell
+          aria-hidden="true"
           className={cn(
             "h-4 w-4 transition-all duration-300",
             isSubscribed && "fill-current",


### PR DESCRIPTION
* 💡 What: Added `aria-label`, `aria-pressed`, and loading indicators to the `SubscribeButton` component.
* 🎯 Why: To ensure screen reader users can understand the button's purpose and state (subscribed/unsubscribed/loading).
* 📸 Before/After: No visual changes, but screen reader announcements are now descriptive.
* ♿ Accessibility:
    * Added `aria-label` dynamic based on state.
    * Added `aria-pressed` for toggle state.
    * Added `role="status"` and `aria-label="Loading"` for loading spinner.
    * Added `aria-hidden="true"` to decorative icon.

---
*PR created automatically by Jules for task [7407244190223106799](https://jules.google.com/task/7407244190223106799) started by @enyineer*