### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in team management

### DIFF
--- a/.changeset/auth-security-fix.md
+++ b/.changeset/auth-security-fix.md
@@ -1,0 +1,7 @@
+---
+"@checkstack/auth-backend": patch
+"@checkstack/ui": patch
+---
+
+fix(auth): enforce management permissions for team updates
+fix(ui): fix test environment setup

--- a/bun.lock
+++ b/bun.lock
@@ -997,7 +997,6 @@
         "@checkstack/scripts": "workspace:*",
         "@checkstack/test-utils-frontend": "workspace:*",
         "@checkstack/tsconfig": "workspace:*",
-        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.2.0",
         "typescript": "^5.0.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "checkstack-monorepo",
@@ -35,7 +34,7 @@
     },
     "core/api-docs-frontend": {
       "name": "@checkstack/api-docs-frontend",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -54,7 +53,7 @@
     },
     "core/auth-backend": {
       "name": "@checkstack/auth-backend",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -93,7 +92,7 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -115,7 +114,7 @@
     },
     "core/backend": {
       "name": "@checkstack/backend",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -149,7 +148,7 @@
     },
     "core/backend-api": {
       "name": "@checkstack/backend-api",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
@@ -176,7 +175,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -220,7 +219,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -242,7 +241,7 @@
     },
     "core/command-backend": {
       "name": "@checkstack/command-backend",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-common": "workspace:*",
@@ -274,7 +273,7 @@
     },
     "core/command-frontend": {
       "name": "@checkstack/command-frontend",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@checkstack/command-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -307,7 +306,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -343,7 +342,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-frontend": "workspace:*",
@@ -401,7 +400,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -449,7 +448,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -480,7 +479,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -524,7 +523,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -548,7 +547,7 @@
     },
     "core/integration-backend": {
       "name": "@checkstack/integration-backend",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -587,7 +586,7 @@
     },
     "core/integration-frontend": {
       "name": "@checkstack/integration-frontend",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -607,7 +606,7 @@
     },
     "core/maintenance-backend": {
       "name": "@checkstack/maintenance-backend",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -651,7 +650,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -675,7 +674,7 @@
     },
     "core/notification-backend": {
       "name": "@checkstack/notification-backend",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -715,7 +714,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -736,7 +735,7 @@
     },
     "core/queue-api": {
       "name": "@checkstack/queue-api",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -748,7 +747,7 @@
     },
     "core/queue-backend": {
       "name": "@checkstack/queue-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -782,7 +781,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -806,7 +805,7 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.30.0",
+      "version": "0.31.0",
     },
     "core/scripts": {
       "name": "@checkstack/scripts",
@@ -827,7 +826,7 @@
     },
     "core/signal-backend": {
       "name": "@checkstack/signal-backend",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -872,7 +871,7 @@
     },
     "core/test-utils-backend": {
       "name": "@checkstack/test-utils-backend",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -908,7 +907,7 @@
     },
     "core/theme-backend": {
       "name": "@checkstack/theme-backend",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -944,7 +943,7 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -970,7 +969,7 @@
     },
     "core/ui": {
       "name": "@checkstack/ui",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -998,13 +997,14 @@
         "@checkstack/scripts": "workspace:*",
         "@checkstack/test-utils-frontend": "workspace:*",
         "@checkstack/tsconfig": "workspace:*",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.2.0",
         "typescript": "^5.0.0",
       },
     },
     "plugins/auth-credential-backend": {
       "name": "@checkstack/auth-credential-backend",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1018,7 +1018,7 @@
     },
     "plugins/auth-github-backend": {
       "name": "@checkstack/auth-github-backend",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1032,7 +1032,7 @@
     },
     "plugins/auth-ldap-backend": {
       "name": "@checkstack/auth-ldap-backend",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1051,7 +1051,7 @@
     },
     "plugins/auth-saml-backend": {
       "name": "@checkstack/auth-saml-backend",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1069,7 +1069,7 @@
     },
     "plugins/collector-hardware-backend": {
       "name": "@checkstack/collector-hardware-backend",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1085,7 +1085,7 @@
     },
     "plugins/healthcheck-dns-backend": {
       "name": "@checkstack/healthcheck-dns-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1100,7 +1100,7 @@
     },
     "plugins/healthcheck-grpc-backend": {
       "name": "@checkstack/healthcheck-grpc-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1116,7 +1116,7 @@
     },
     "plugins/healthcheck-http-backend": {
       "name": "@checkstack/healthcheck-http-backend",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1133,7 +1133,7 @@
     },
     "plugins/healthcheck-jenkins-backend": {
       "name": "@checkstack/healthcheck-jenkins-backend",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1148,7 +1148,7 @@
     },
     "plugins/healthcheck-mysql-backend": {
       "name": "@checkstack/healthcheck-mysql-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1164,7 +1164,7 @@
     },
     "plugins/healthcheck-ping-backend": {
       "name": "@checkstack/healthcheck-ping-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1179,7 +1179,7 @@
     },
     "plugins/healthcheck-postgres-backend": {
       "name": "@checkstack/healthcheck-postgres-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1196,7 +1196,7 @@
     },
     "plugins/healthcheck-rcon-backend": {
       "name": "@checkstack/healthcheck-rcon-backend",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1226,7 +1226,7 @@
     },
     "plugins/healthcheck-redis-backend": {
       "name": "@checkstack/healthcheck-redis-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1242,7 +1242,7 @@
     },
     "plugins/healthcheck-script-backend": {
       "name": "@checkstack/healthcheck-script-backend",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1257,7 +1257,7 @@
     },
     "plugins/healthcheck-ssh-backend": {
       "name": "@checkstack/healthcheck-ssh-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1288,7 +1288,7 @@
     },
     "plugins/healthcheck-tcp-backend": {
       "name": "@checkstack/healthcheck-tcp-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1303,7 +1303,7 @@
     },
     "plugins/healthcheck-tls-backend": {
       "name": "@checkstack/healthcheck-tls-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1318,7 +1318,7 @@
     },
     "plugins/integration-jira-backend": {
       "name": "@checkstack/integration-jira-backend",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1353,7 +1353,7 @@
     },
     "plugins/integration-script-backend": {
       "name": "@checkstack/integration-script-backend",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1370,7 +1370,7 @@
     },
     "plugins/integration-teams-backend": {
       "name": "@checkstack/integration-teams-backend",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1385,7 +1385,7 @@
     },
     "plugins/integration-webex-backend": {
       "name": "@checkstack/integration-webex-backend",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1400,7 +1400,7 @@
     },
     "plugins/integration-webhook-backend": {
       "name": "@checkstack/integration-webhook-backend",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1417,7 +1417,7 @@
     },
     "plugins/notification-backstage-backend": {
       "name": "@checkstack/notification-backstage-backend",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1431,7 +1431,7 @@
     },
     "plugins/notification-discord-backend": {
       "name": "@checkstack/notification-discord-backend",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1445,7 +1445,7 @@
     },
     "plugins/notification-gotify-backend": {
       "name": "@checkstack/notification-gotify-backend",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1459,7 +1459,7 @@
     },
     "plugins/notification-pushover-backend": {
       "name": "@checkstack/notification-pushover-backend",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1473,7 +1473,7 @@
     },
     "plugins/notification-slack-backend": {
       "name": "@checkstack/notification-slack-backend",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1487,7 +1487,7 @@
     },
     "plugins/notification-smtp-backend": {
       "name": "@checkstack/notification-smtp-backend",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1503,7 +1503,7 @@
     },
     "plugins/notification-teams-backend": {
       "name": "@checkstack/notification-teams-backend",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1517,7 +1517,7 @@
     },
     "plugins/notification-telegram-backend": {
       "name": "@checkstack/notification-telegram-backend",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1533,7 +1533,7 @@
     },
     "plugins/notification-webex-backend": {
       "name": "@checkstack/notification-webex-backend",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1547,7 +1547,7 @@
     },
     "plugins/queue-bullmq-backend": {
       "name": "@checkstack/queue-bullmq-backend",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1577,7 +1577,7 @@
     },
     "plugins/queue-memory-backend": {
       "name": "@checkstack/queue-memory-backend",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2361,7 +2361,7 @@
 
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
 
-    "@testing-library/react": ["@testing-library/react@16.3.1", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-gr4KtAWqIOQoucWYD/f6ki+j5chXfcPc74Col/6poTyqTmn7zRmodWahWRCp8tYd+GMqBonw6hstNzqjbs6gjw=="],
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
     "@tinyhttp/content-disposition": ["@tinyhttp/content-disposition@2.2.2", "", {}, "sha512-crXw1txzrS36huQOyQGYFvhTeLeG0Si1xu+/l6kXUVYpE0TjFjEZRqTbuadQLfKGZ0jaI+jJoRyqaWwxOSHW2g=="],
 

--- a/core/auth-backend/src/router.ts
+++ b/core/auth-backend/src/router.ts
@@ -8,7 +8,13 @@ import {
   type ConfigService,
   toJsonSchema,
 } from "@checkstack/backend-api";
-import { authContract, passwordSchema } from "@checkstack/auth-common";
+import {
+  authContract,
+  passwordSchema,
+  pluginMetadata,
+  authAccess,
+} from "@checkstack/auth-common";
+import { qualifyAccessRuleId } from "@checkstack/common";
 import { hashPassword } from "better-auth/crypto";
 import * as schema from "./schema";
 import { eq, inArray, and } from "drizzle-orm";
@@ -131,6 +137,48 @@ export const createAuthRouter = (
     }[];
   },
 ) => {
+  /**
+   * Helper to check if the current user has permission to manage a specific team.
+   * Access is granted if:
+   * 1. User has global "teams.manage" permission
+   * 2. User is an assigned manager of the specific team
+   */
+  async function checkTeamManageAccess(context: RpcContext, teamId: string) {
+    const user = context.user;
+    if (!isRealUser(user)) {
+      throw new ORPCError("UNAUTHORIZED", { message: "Not authenticated" });
+    }
+
+    // 1. Check global manage permission
+    const globalManageRule = qualifyAccessRuleId(
+      pluginMetadata,
+      authAccess.teams.manage,
+    );
+    const hasGlobalAccess =
+      (user.accessRules || []).includes("*") ||
+      (user.accessRules || []).includes(globalManageRule);
+
+    if (hasGlobalAccess) return;
+
+    // 2. Check if user is a manager of this team
+    const managers = await internalDb
+      .select()
+      .from(schema.teamManager)
+      .where(
+        and(
+          eq(schema.teamManager.teamId, teamId),
+          eq(schema.teamManager.userId, user.id),
+        ),
+      )
+      .limit(1);
+
+    if (managers.length > 0) return;
+
+    throw new ORPCError("FORBIDDEN", {
+      message: "You do not have permission to manage this team.",
+    });
+  }
+
   // Public endpoint for enabled strategies (no authentication required)
   const getEnabledStrategies = os.getEnabledStrategies.handler(async () => {
     const registeredStrategies = strategyRegistry.getStrategies();
@@ -1385,7 +1433,9 @@ export const createAuthRouter = (
 
   const updateTeam = os.updateTeam.handler(async ({ input, context }) => {
     const { id, name, description } = input;
-    // TODO: Check if user is manager or has teamsManage access
+
+    await checkTeamManageAccess(context, id);
+
     const updates: {
       name?: string;
       description?: string | null;
@@ -1419,7 +1469,9 @@ export const createAuthRouter = (
     context.logger.info(`[auth-backend] Deleted team: ${id}`);
   });
 
-  const addUserToTeam = os.addUserToTeam.handler(async ({ input }) => {
+  const addUserToTeam = os.addUserToTeam.handler(async ({ input, context }) => {
+    await checkTeamManageAccess(context, input.teamId);
+
     await internalDb
       .insert(schema.userTeam)
       .values({ userId: input.userId, teamId: input.teamId })
@@ -1427,7 +1479,9 @@ export const createAuthRouter = (
   });
 
   const removeUserFromTeam = os.removeUserFromTeam.handler(
-    async ({ input }) => {
+    async ({ input, context }) => {
+      await checkTeamManageAccess(context, input.teamId);
+
       await internalDb
         .delete(schema.userTeam)
         .where(

--- a/core/auth-backend/src/teams.test.ts
+++ b/core/auth-backend/src/teams.test.ts
@@ -39,6 +39,15 @@ describe("Teams and Resource Access Control", () => {
     teamIds: ["team-beta"],
   };
 
+  // Mock regular user for tests where pluginId is "auth"
+  const mockAuthRegularUser = {
+    type: "user" as const,
+    id: "regular-user",
+    accessRules: ["auth.teams.read"],
+    roles: ["users"],
+    teamIds: ["team-beta"],
+  };
+
   // Mock service user for S2S calls
   const mockServiceUser = {
     type: "service" as const,
@@ -559,7 +568,7 @@ describe("Teams and Resource Access Control", () => {
       );
 
       const context = createMockRpcContext({
-        user: { ...mockRegularUser, accessRules: ["auth.teams.read"] },
+        user: mockAuthRegularUser,
         pluginMetadata: { pluginId: "auth" },
       });
 
@@ -753,7 +762,7 @@ describe("Teams and Resource Access Control", () => {
       );
 
       const context = createMockRpcContext({
-        user: mockRegularUser,
+        user: mockAuthRegularUser,
         pluginMetadata: { pluginId: "auth" },
       });
 

--- a/core/auth-backend/src/teams.test.ts
+++ b/core/auth-backend/src/teams.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { createAuthRouter } from "./router";
 import { createMockRpcContext } from "@checkstack/backend-api";
-import { call } from "@orpc/server";
+import { call, ORPCError } from "@orpc/server";
 import { z } from "zod";
 import * as schema from "./schema";
 import type { SafeDatabase } from "@checkstack/backend-api";
@@ -43,6 +43,15 @@ describe("Teams and Resource Access Control", () => {
   const mockServiceUser = {
     type: "service" as const,
     pluginId: "backend-api",
+  };
+
+  // Mock team manager who manages team-1
+  const mockTeamManager = {
+    type: "user" as const,
+    id: "manager-user",
+    accessRules: ["auth.teams.read"],
+    roles: ["users"],
+    teamIds: ["team-1"],
   };
 
   /**
@@ -532,6 +541,123 @@ describe("Teams and Resource Access Control", () => {
 
       expect(updatedData?.description).toBe("New description");
     });
+
+    it("prevents regular user with read access from updating a team", async () => {
+      const mockDb = createMockDb();
+
+      // Mock team manager check (returns empty list, so user is NOT a manager)
+      (mockDb.select as ReturnType<typeof mock>).mockImplementationOnce(() => ({
+        from: mock(() => createChain([])),
+      }));
+
+      const router = createAuthRouter(
+        mockDb,
+        mockRegistry,
+        async () => {},
+        mockConfigService,
+        mockAccessRuleRegistry
+      );
+
+      const context = createMockRpcContext({
+        user: { ...mockRegularUser, accessRules: ["auth.teams.read"] },
+        user: { ...mockRegularUser, accessRules: ["auth.teams.read"] },
+        pluginMetadata: { pluginId: "auth" },
+      });
+
+      // Expect the call to fail with FORBIDDEN
+      try {
+        await call(
+          router.updateTeam,
+          { id: "team-1", name: "Hacked Team Name" },
+          { context }
+        );
+        throw new Error("Should have failed with FORBIDDEN");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ORPCError);
+        expect((e as ORPCError).code).toBe("FORBIDDEN");
+        expect((e as ORPCError).message).toContain(
+          "permission to manage this team"
+        );
+      }
+    });
+
+    it("allows team manager to update their own team", async () => {
+      const mockDb = createMockDb();
+
+      // Mock team manager check (returns match)
+      (mockDb.select as ReturnType<typeof mock>).mockImplementationOnce(() => ({
+        from: mock(() =>
+          createChain([{ teamId: "team-1", userId: "manager-user" }])
+        ),
+      }));
+
+      // Mock update operation
+      let updateCalled = false;
+      (mockDb.update as ReturnType<typeof mock>).mockImplementationOnce(() => ({
+        set: mock(() => {
+          updateCalled = true;
+          return {
+            where: mock(() => Promise.resolve()),
+          };
+        }),
+      }));
+
+      const router = createAuthRouter(
+        mockDb,
+        mockRegistry,
+        async () => {},
+        mockConfigService,
+        mockAccessRuleRegistry
+      );
+
+      const context = createMockRpcContext({
+        user: mockTeamManager,
+        pluginMetadata: { pluginId: "auth" },
+      });
+
+      await call(
+        router.updateTeam,
+        { id: "team-1", name: "Updated by Manager" },
+        { context }
+      );
+
+      expect(updateCalled).toBe(true);
+    });
+
+    it("prevents team manager from updating ANOTHER team", async () => {
+      const mockDb = createMockDb();
+
+      // Mock team manager check (returns empty because they don't manage team-2)
+      (mockDb.select as ReturnType<typeof mock>).mockImplementationOnce(() => ({
+        from: mock(() => createChain([])),
+      }));
+
+      const router = createAuthRouter(
+        mockDb,
+        mockRegistry,
+        async () => {},
+        mockConfigService,
+        mockAccessRuleRegistry
+      );
+
+      const context = createMockRpcContext({
+        user: mockTeamManager,
+        pluginMetadata: { pluginId: "auth" },
+      });
+
+      // Expect failure
+      try {
+        await call(
+          router.updateTeam,
+          { id: "team-2", name: "Hacked Other Team" },
+          { context }
+        );
+        throw new Error("Should have failed with FORBIDDEN");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ORPCError);
+        expect((e as ORPCError).code).toBe("FORBIDDEN");
+      }
+    });
   });
 
   describe("deleteTeam", () => {
@@ -609,6 +735,83 @@ describe("Teams and Resource Access Control", () => {
       expect(mockDb.insert).toHaveBeenCalled();
       expect(insertedData?.teamId).toBe("team-1");
       expect(insertedData?.userId).toBe("user-1");
+    });
+
+    it("prevents regular user from adding users to a team", async () => {
+      const mockDb = createMockDb();
+
+      // Mock team manager check (returns empty list)
+      (mockDb.select as ReturnType<typeof mock>).mockImplementationOnce(() => ({
+        from: mock(() => createChain([])),
+      }));
+
+      const router = createAuthRouter(
+        mockDb,
+        mockRegistry,
+        async () => {},
+        mockConfigService,
+        mockAccessRuleRegistry
+      );
+
+      const context = createMockRpcContext({
+        user: mockRegularUser,
+        pluginMetadata: { pluginId: "auth" },
+      });
+
+      try {
+        await call(
+          router.addUserToTeam,
+          { teamId: "team-1", userId: "new-user" },
+          { context }
+        );
+        throw new Error("Should have failed with FORBIDDEN");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ORPCError);
+        expect((e as ORPCError).code).toBe("FORBIDDEN");
+      }
+    });
+
+    it("allows team manager to add users to their team", async () => {
+      const mockDb = createMockDb();
+
+      // Mock team manager check (returns match)
+      (mockDb.select as ReturnType<typeof mock>).mockImplementationOnce(() => ({
+        from: mock(() =>
+          createChain([{ teamId: "team-1", userId: "manager-user" }])
+        ),
+      }));
+
+      // Mock insert
+      let insertCalled = false;
+      (mockDb.insert as ReturnType<typeof mock>).mockImplementationOnce(() => ({
+        values: mock(() => {
+          insertCalled = true;
+          return {
+            onConflictDoNothing: mock(() => Promise.resolve()),
+          };
+        }),
+      }));
+
+      const router = createAuthRouter(
+        mockDb,
+        mockRegistry,
+        async () => {},
+        mockConfigService,
+        mockAccessRuleRegistry
+      );
+
+      const context = createMockRpcContext({
+        user: mockTeamManager,
+        pluginMetadata: { pluginId: "auth" },
+      });
+
+      await call(
+        router.addUserToTeam,
+        { teamId: "team-1", userId: "new-user" },
+        { context }
+      );
+
+      expect(insertCalled).toBe(true);
     });
   });
 

--- a/core/auth-backend/src/teams.test.ts
+++ b/core/auth-backend/src/teams.test.ts
@@ -560,7 +560,6 @@ describe("Teams and Resource Access Control", () => {
 
       const context = createMockRpcContext({
         user: { ...mockRegularUser, accessRules: ["auth.teams.read"] },
-        user: { ...mockRegularUser, accessRules: ["auth.teams.read"] },
         pluginMetadata: { pluginId: "auth" },
       });
 
@@ -574,8 +573,8 @@ describe("Teams and Resource Access Control", () => {
         throw new Error("Should have failed with FORBIDDEN");
       } catch (e) {
         expect(e).toBeInstanceOf(ORPCError);
-        expect((e as ORPCError).code).toBe("FORBIDDEN");
-        expect((e as ORPCError).message).toContain(
+        expect((e as ORPCError<any, any>).code).toBe("FORBIDDEN");
+        expect((e as ORPCError<any, any>).message).toContain(
           "permission to manage this team"
         );
       }
@@ -655,7 +654,7 @@ describe("Teams and Resource Access Control", () => {
         throw new Error("Should have failed with FORBIDDEN");
       } catch (e) {
         expect(e).toBeInstanceOf(ORPCError);
-        expect((e as ORPCError).code).toBe("FORBIDDEN");
+        expect((e as ORPCError<any, any>).code).toBe("FORBIDDEN");
       }
     });
   });
@@ -767,7 +766,7 @@ describe("Teams and Resource Access Control", () => {
         throw new Error("Should have failed with FORBIDDEN");
       } catch (e) {
         expect(e).toBeInstanceOf(ORPCError);
-        expect((e as ORPCError).code).toBe("FORBIDDEN");
+        expect((e as ORPCError<any, any>).code).toBe("FORBIDDEN");
       }
     });
 

--- a/core/test-utils-frontend/src/setup.ts
+++ b/core/test-utils-frontend/src/setup.ts
@@ -9,6 +9,8 @@
  * preload = ["@checkstack/test-utils-frontend/setup"]
  */
 
+console.log("🛠️ Frontend Test Setup Running...");
+
 // Register Happy DOM globals first (document, window, etc.)
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 GlobalRegistrator.register();

--- a/core/test-utils-frontend/src/setup.ts
+++ b/core/test-utils-frontend/src/setup.ts
@@ -9,8 +9,6 @@
  * preload = ["@checkstack/test-utils-frontend/setup"]
  */
 
-console.log("🛠️ Frontend Test Setup Running...");
-
 // Register Happy DOM globals first (document, window, etc.)
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 GlobalRegistrator.register();

--- a/core/ui/bunfig.toml
+++ b/core/ui/bunfig.toml
@@ -1,2 +1,2 @@
 [test]
-preload = ["@checkstack/test-utils-frontend/setup"]
+preload = ["../test-utils-frontend/src/setup.ts"]

--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -30,7 +30,6 @@
     "@checkstack/scripts": "workspace:*",
     "@checkstack/test-utils-frontend": "workspace:*",
     "@checkstack/tsconfig": "workspace:*",
-    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.0",
     "typescript": "^5.0.0"
   },

--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -27,11 +27,12 @@
     "tailwind-merge": "^2.2.0"
   },
   "devDependencies": {
-    "typescript": "^5.0.0",
-    "@types/react": "^18.2.0",
+    "@checkstack/scripts": "workspace:*",
     "@checkstack/test-utils-frontend": "workspace:*",
     "@checkstack/tsconfig": "workspace:*",
-    "@checkstack/scripts": "workspace:*"
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^18.2.0",
+    "typescript": "^5.0.0"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/core/ui/src/components/SubscribeButton.test.tsx
+++ b/core/ui/src/components/SubscribeButton.test.tsx
@@ -1,4 +1,5 @@
-import { render } from "@testing-library/react";
+import "@checkstack/test-utils-frontend/setup";
+import { render } from "@checkstack/test-utils-frontend";
 import { SubscribeButton } from "./SubscribeButton";
 import { describe, it, expect, vi } from "bun:test";
 import React from "react";


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Team modification endpoints (`updateTeam`, `addUserToTeam`, `removeUserFromTeam`) were only protected by `teams.read` access rule in the contract. This meant any user with read access to teams could modify any team or change its membership.
🎯 Impact: Regular users could take over teams, add themselves as members, or deface team details.
🔧 Fix: Implemented manual authorization checks within the handlers to ensure the user either has global `teams.manage` permission OR is an explicit manager of the target team.
✅ Verification:
- Added regression tests in `core/auth-backend/src/teams.test.ts`.
- Verified that regular users get `FORBIDDEN`.
- Verified that team managers can update their own teams.
- Verified that team managers cannot update other teams.
- Verified that global admins (via existing tests) can still manage teams.

---
*PR created automatically by Jules for task [7800436986894211058](https://jules.google.com/task/7800436986894211058) started by @enyineer*