### PR TITLE
Implement permission check for team updates

### DIFF
--- a/.changeset/breezy-cats-sing.md
+++ b/.changeset/breezy-cats-sing.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/auth-backend": minor
+---
+
+Implement permission check for team updates and fix API key validation logic.

--- a/.changeset/swift-zebras-jump.md
+++ b/.changeset/swift-zebras-jump.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/ui": patch
+---
+
+Added `@testing-library/react` to devDependencies.

--- a/core/auth-backend/src/index.ts
+++ b/core/auth-backend/src/index.ts
@@ -420,7 +420,7 @@ export default createBackendPlugin({
                     id: app.id,
                     name: app.name,
                     roles: roleIds,
-                    accessRulesArray,
+                    accessRules: accessRulesArray,
                     teamIds,
                   };
                 }

--- a/core/auth-backend/src/router.ts
+++ b/core/auth-backend/src/router.ts
@@ -1385,7 +1385,42 @@ export const createAuthRouter = (
 
   const updateTeam = os.updateTeam.handler(async ({ input, context }) => {
     const { id, name, description } = input;
-    // TODO: Check if user is manager or has teamsManage access
+
+    const user = context.user;
+    // Services are trusted via middleware, but for users/applications we must check permissions
+    if (user?.type !== "service") {
+      const hasGlobalManage =
+        user?.accessRules?.includes("*") ||
+        user?.accessRules?.includes("auth.teams.manage");
+
+      if (!hasGlobalManage) {
+        // If not a global manager, check if the user is a manager of this specific team
+        if (isRealUser(user)) {
+          const [managerRecord] = await internalDb
+            .select()
+            .from(schema.teamManager)
+            .where(
+              and(
+                eq(schema.teamManager.teamId, id),
+                eq(schema.teamManager.userId, user.id),
+              ),
+            )
+            .limit(1);
+
+          if (!managerRecord) {
+            throw new ORPCError("FORBIDDEN", {
+              message: "You do not have permission to update this team",
+            });
+          }
+        } else {
+          // Applications and unauthenticated users (if any reached here) without global manage are forbidden
+          throw new ORPCError("FORBIDDEN", {
+            message: "You do not have permission to update this team",
+          });
+        }
+      }
+    }
+
     const updates: {
       name?: string;
       description?: string | null;


### PR DESCRIPTION
Implemented the requested permission check for team updates. The solution ensures that only authorized users (global managers or specific team managers) can modify team details. Additionally, a bug in the user context population for external applications was fixed to ensure permission checks work correctly for API keys.

---
*PR created automatically by Jules for task [8738504725888606142](https://jules.google.com/task/8738504725888606142) started by @enyineer*