### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent environment variable leakage in Ping strategy

### DIFF
--- a/.changeset/silly-ghosts-run.md
+++ b/.changeset/silly-ghosts-run.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/healthcheck-ping-backend": patch
+---
+
+Security: Prevent environment variable leakage in Ping strategy

--- a/plugins/healthcheck-ping-backend/src/strategy.test.ts
+++ b/plugins/healthcheck-ping-backend/src/strategy.test.ts
@@ -137,6 +137,30 @@ describe("PingHealthCheckStrategy", () => {
 
       connectedClient.close();
     });
+
+    it("should sanitize environment variables", async () => {
+      // Setup sensitive env var
+      process.env.SECRET_KEY = "super_secret";
+
+      const connectedClient = await strategy.createClient({ timeout: 5000 });
+      await connectedClient.client.exec({
+        host: "8.8.8.8",
+        count: 1,
+        timeout: 5000,
+      });
+
+      // Verify spawn was called with sanitized env
+      // @ts-expect-error - mock property access
+      const spawnCall = Bun.spawn.mock.calls[0];
+      const spawnOptions = spawnCall[0] as { env?: Record<string, string> };
+
+      expect(spawnOptions.env).toBeDefined();
+      expect(spawnOptions.env?.SECRET_KEY).toBeUndefined();
+
+      // Cleanup
+      delete process.env.SECRET_KEY;
+      connectedClient.close();
+    });
   });
 
   describe("mergeResult", () => {

--- a/plugins/healthcheck-ping-backend/src/strategy.ts
+++ b/plugins/healthcheck-ping-backend/src/strategy.ts
@@ -210,11 +210,32 @@ export class PingHealthCheckStrategy implements HealthCheckStrategy<
       ? ["-c", String(count), "-W", String(Math.ceil(timeout / 1000)), host]
       : ["-c", String(count), "-W", String(Math.ceil(timeout / 1000)), host];
 
+    const SAFE_ENV_VARS = [
+      "PATH",
+      "HOME",
+      "USER",
+      "LANG",
+      "LC_ALL",
+      "LC_CTYPE",
+      "TZ",
+      "TMPDIR",
+      "HOSTNAME",
+      "SHELL",
+    ];
+
+    const safeEnv: Record<string, string> = {};
+    for (const key of SAFE_ENV_VARS) {
+      if (process.env[key] !== undefined) {
+        safeEnv[key] = process.env[key]!;
+      }
+    }
+
     try {
       const proc = Bun.spawn({
         cmd: ["ping", ...args],
         stdout: "pipe",
         stderr: "pipe",
+        env: safeEnv,
       });
 
       const output = await new Response(proc.stdout).text();


### PR DESCRIPTION
Sanitized environment variables passed to the `ping` command in `PingHealthCheckStrategy`. 
Created an allowlist of safe environment variables (`PATH`, `HOME`, etc.) and explicitly passed them to `Bun.spawn` to prevent the child process from inheriting sensitive secrets from the parent process environment.
Added a regression test to verify that `Bun.spawn` is called with the sanitized environment.

---
*PR created automatically by Jules for task [15304342054592192399](https://jules.google.com/task/15304342054592192399) started by @enyineer*