### PR TITLE
feat(ui): improve LoadingSpinner accessibility

### DIFF
--- a/core/ui/src/components/LoadingSpinner.test.tsx
+++ b/core/ui/src/components/LoadingSpinner.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import { LoadingSpinner } from "./LoadingSpinner";
+import { describe, it, expect } from "bun:test";
+
+describe("LoadingSpinner", () => {
+  it("renders with correct accessibility attributes", () => {
+    const { getByRole } = render(<LoadingSpinner />);
+
+    // Should have role="status"
+    const status = getByRole("status");
+    expect(status).toBeDefined();
+
+    // Should have "Loading..." text for screen readers
+    expect(status.textContent).toContain("Loading...");
+  });
+
+  it("allows customizing the accessible label", () => {
+    const { getByRole } = render(<LoadingSpinner label="Processing..." />);
+
+    const status = getByRole("status");
+    expect(status.textContent).toContain("Processing...");
+  });
+});

--- a/core/ui/src/components/LoadingSpinner.tsx
+++ b/core/ui/src/components/LoadingSpinner.tsx
@@ -3,10 +3,12 @@ import { cn } from "../utils";
 
 interface LoadingSpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: "sm" | "md" | "lg";
+  label?: string;
 }
 
 export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   size = "md",
+  label = "Loading...",
   className,
   ...props
 }) => {
@@ -17,12 +19,18 @@ export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   };
 
   return (
-    <div className={cn("flex justify-center py-12", className)} {...props}>
+    <div
+      role="status"
+      className={cn("flex justify-center py-12", className)}
+      {...props}
+    >
+      <span className="sr-only">{label}</span>
       <div
         className={cn(
           "border-indigo-200 border-t-indigo-500 rounded-full animate-spin",
           sizeClasses[size]
         )}
+        aria-hidden="true"
       />
     </div>
   );


### PR DESCRIPTION
🎨 Palette: Improved LoadingSpinner accessibility

💡 What:
- Added `role="status"` to the `LoadingSpinner` component.
- Added a visually hidden label ("Loading..." by default, configurable via `label` prop) for screen readers.
- Hid the visual spinner element from assistive technology using `aria-hidden="true"`.
- Added `core/ui/bunfig.toml` to correctly configure the test environment for `core/ui` (fixing a monorepo configuration issue where frontend tests were using backend preload).

🎯 Why:
- Loading states were not announced to screen reader users, leaving them unaware that content was loading.
- The spinner was just a visual element without semantic meaning.

♿ Accessibility:
- Screen readers will now announce "Loading..." (or custom text) when the spinner appears.
- The decorative spinner graphic is properly ignored by screen readers.

📸 Before/After:
No visual changes for sighted users. The changes are strictly semantic and for screen readers.

---
*PR created automatically by Jules for task [1852037431336097085](https://jules.google.com/task/1852037431336097085) started by @enyineer*