### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix environment variable leak in ping health check

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The application was passing `process.env` (containing sensitive secrets like `DATABASE_URL` and `BETTER_AUTH_SECRET`) to user-defined scripts executed via `Bun.spawn` in `healthcheck-script-backend` and `integration-script-backend`.
 **Learning:** `Bun.spawn` (and `child_process.spawn`) by default inherits `process.env`. Explicitly passing `{ ...process.env, ...config.env }` ensures leakage of all secrets.
 **Prevention:** Always use an allowlist of safe environment variables (e.g., `PATH`, `HOME`, `LANG`) when spawning child processes. Never pass `process.env` directly unless absolutely necessary and safe.
+
+## 2025-02-12 - [Medium] Leaked Server Secrets to Ping Process
+**Vulnerability:** The `healthcheck-ping-backend` plugin was spawning the `ping` command using `Bun.spawn` without sanitizing the environment variables. This caused all server secrets (e.g. `DATABASE_URL`) to be passed to the child process.
+**Learning:** Even simple system utilities should not be trusted with sensitive environment variables. Defense in depth requires sanitizing the environment for all child processes.
+**Prevention:** Use the same `SAFE_ENV_VARS` allowlist pattern implemented in `healthcheck-script-backend` for all spawned processes.

--- a/plugins/healthcheck-ping-backend/src/strategy.test.ts
+++ b/plugins/healthcheck-ping-backend/src/strategy.test.ts
@@ -137,6 +137,56 @@ describe("PingHealthCheckStrategy", () => {
 
       connectedClient.close();
     });
+
+    it("should sanitize environment variables", async () => {
+      const originalEnv = process.env;
+      // Assigning to process.env directly might not work as expected in some environments,
+      // but modifying properties does.
+      process.env.SENSITIVE_SECRET = "secret";
+      process.env.PATH = "/bin"; // Ensure PATH is present
+
+      let capturedOptions: any;
+      // @ts-expect-error - mocking global
+      Bun.spawn = mock((options) => {
+        capturedOptions = options;
+        return {
+          stdout: new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                new TextEncoder().encode(
+                  `PING 8.8.8.8 (8.8.8.8): 56 data bytes
+64 bytes from 8.8.8.8: icmp_seq=0 ttl=118 time=10.123 ms
+
+--- 8.8.8.8 ping statistics ---
+1 packets transmitted, 1 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = 10.123/10.123/10.123/0.000 ms`,
+                ),
+              );
+              controller.close();
+            },
+          }),
+          stderr: new ReadableStream(),
+          exited: Promise.resolve(0),
+        };
+      });
+
+      const connectedClient = await strategy.createClient({ timeout: 5000 });
+      await connectedClient.client.exec({
+        host: "8.8.8.8",
+        count: 1,
+        timeout: 5000,
+      });
+
+      expect(capturedOptions).toBeDefined();
+      expect(capturedOptions.env).toBeDefined();
+      expect(capturedOptions.env.SENSITIVE_SECRET).toBeUndefined();
+      expect(capturedOptions.env.PATH).toBe("/bin");
+
+      // Cleanup
+      delete process.env.SENSITIVE_SECRET;
+      process.env = originalEnv;
+      connectedClient.close();
+    });
   });
 
   describe("mergeResult", () => {

--- a/plugins/healthcheck-ping-backend/src/strategy.ts
+++ b/plugins/healthcheck-ping-backend/src/strategy.ts
@@ -110,6 +110,23 @@ const pingAggregatedFields = {
 type PingAggregatedResult = InferAggregatedResult<typeof pingAggregatedFields>;
 
 // ============================================================================
+// SECURITY CONSTANTS
+// ============================================================================
+
+const SAFE_ENV_VARS = [
+  "PATH",
+  "HOME",
+  "USER",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TZ",
+  "TMPDIR",
+  "HOSTNAME",
+  "SHELL",
+];
+
+// ============================================================================
 // STRATEGY
 // ============================================================================
 
@@ -210,9 +227,17 @@ export class PingHealthCheckStrategy implements HealthCheckStrategy<
       ? ["-c", String(count), "-W", String(Math.ceil(timeout / 1000)), host]
       : ["-c", String(count), "-W", String(Math.ceil(timeout / 1000)), host];
 
+    const safeEnv: Record<string, string> = {};
+    for (const key of SAFE_ENV_VARS) {
+      if (process.env[key] !== undefined) {
+        safeEnv[key] = process.env[key]!;
+      }
+    }
+
     try {
       const proc = Bun.spawn({
         cmd: ["ping", ...args],
+        env: safeEnv,
         stdout: "pipe",
         stderr: "pipe",
       });


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix environment variable leak in ping health check

**Vulnerability:** The `healthcheck-ping-backend` plugin was spawning the `ping` command using `Bun.spawn` without sanitizing the environment variables. This caused all server secrets (e.g. `DATABASE_URL`) to be passed to the child process.

**Impact:** If the `ping` binary is compromised or dumps its environment on crash, sensitive secrets could be exposed.

**Fix:** Explicitly set `env` in `Bun.spawn` with an allowlist of safe variables (`PATH`, `HOME`, etc.), preventing secret leakage.

**Verification:** Added a unit test verifying that `Bun.spawn` receives only the allowlisted environment variables. Ran `bun test` in `plugins/healthcheck-ping-backend` and all tests passed.

---
*PR created automatically by Jules for task [13291728892893022749](https://jules.google.com/task/13291728892893022749) started by @enyineer*