### PR TITLE
chore: add missing changeset for healthcheck-ping-backend

### DIFF
--- a/.changeset/stale-foxes-swim.md
+++ b/.changeset/stale-foxes-swim.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/healthcheck-ping-backend": patch
+---
+
+Fix environment variable leakage in ping command execution by using a strict allowlist.


### PR DESCRIPTION
Added a changeset file for @checkstack/healthcheck-ping-backend to document the fix for environment variable leakage.

---
*PR created automatically by Jules for task [9543255466231292896](https://jules.google.com/task/9543255466231292896) started by @enyineer*