### PR TITLE
🎨 Palette: Add ARIA labels to KeyValueEditor

### DIFF
--- a/core/ui/src/components/DynamicForm/KeyValueEditor.test.tsx
+++ b/core/ui/src/components/DynamicForm/KeyValueEditor.test.tsx
@@ -1,0 +1,55 @@
+import { render } from "@testing-library/react";
+import { KeyValueEditor } from "./KeyValueEditor";
+import { describe, it, expect, vi } from "bun:test";
+
+describe("KeyValueEditor", () => {
+  it("renders with correct accessibility attributes", () => {
+    const onChange = vi.fn();
+    const value = [{ key: "test-key", value: "test-value" }];
+
+    const { getByLabelText } = render(
+      <KeyValueEditor
+        id="test-editor"
+        value={value}
+        onChange={onChange}
+      />,
+    );
+
+    // Check for remove button with aria-label
+    const removeButton = getByLabelText("Remove item");
+    expect(removeButton).toBeInTheDocument();
+    expect(removeButton.tagName).toBe("BUTTON");
+
+    // Check for inputs with aria-label
+    const keyInput = getByLabelText("Key");
+    expect(keyInput).toBeInTheDocument();
+    expect(keyInput.tagName).toBe("INPUT");
+    expect(keyInput).toHaveValue("test-key");
+
+    const valueInput = getByLabelText("Value");
+    expect(valueInput).toBeInTheDocument();
+    expect(valueInput.tagName).toBe("INPUT");
+    expect(valueInput).toHaveValue("test-value");
+  });
+
+  it("renders custom placeholders as aria-labels", () => {
+    const onChange = vi.fn();
+    const value = [{ key: "custom-key", value: "custom-value" }];
+
+    const { getByLabelText } = render(
+      <KeyValueEditor
+        id="custom-editor"
+        value={value}
+        onChange={onChange}
+        keyPlaceholder="Custom Key Name"
+        valuePlaceholder="Custom Value Name"
+      />,
+    );
+
+    const keyInput = getByLabelText("Custom Key Name");
+    expect(keyInput).toBeInTheDocument();
+
+    const valueInput = getByLabelText("Custom Value Name");
+    expect(valueInput).toBeInTheDocument();
+  });
+});

--- a/core/ui/src/components/DynamicForm/KeyValueEditor.tsx
+++ b/core/ui/src/components/DynamicForm/KeyValueEditor.tsx
@@ -129,6 +129,7 @@ export const KeyValueEditor: React.FC<KeyValueEditorProps> = ({
             onChange={(e) => handleKeyChange(index, e.target.value)}
             placeholder={keyPlaceholder}
             className="flex-1 font-mono text-sm"
+            aria-label={keyPlaceholder}
           />
           <span className="text-muted-foreground">=</span>
           <TemplateInput
@@ -137,6 +138,7 @@ export const KeyValueEditor: React.FC<KeyValueEditorProps> = ({
             onChange={(newValue) => handleValueChange(index, newValue)}
             placeholder={valuePlaceholder}
             templateProperties={templateProperties}
+            aria-label={valuePlaceholder}
           />
           <Button
             type="button"
@@ -144,6 +146,7 @@ export const KeyValueEditor: React.FC<KeyValueEditorProps> = ({
             size="icon"
             onClick={() => handleRemove(index)}
             className="h-8 w-8 text-destructive hover:text-destructive/90 hover:bg-destructive/10 shrink-0"
+            aria-label="Remove item"
           >
             <Trash2 className="h-4 w-4" />
           </Button>
@@ -173,7 +176,15 @@ const TemplateInput: React.FC<{
   onChange: (value: string) => void;
   placeholder?: string;
   templateProperties?: TemplateProperty[];
-}> = ({ id, value, onChange, placeholder, templateProperties }) => {
+  "aria-label"?: string;
+}> = ({
+  id,
+  value,
+  onChange,
+  placeholder,
+  templateProperties,
+  "aria-label": ariaLabel,
+}) => {
   const inputRef = React.useRef<HTMLInputElement>(null);
   const [showPopup, setShowPopup] = React.useState(false);
   const [selectedIndex, setSelectedIndex] = React.useState(0);
@@ -282,6 +293,7 @@ const TemplateInput: React.FC<{
         onBlur={handleBlur}
         placeholder={placeholder}
         className="font-mono text-sm"
+        aria-label={ariaLabel}
       />
       {showPopup && filteredProperties.length > 0 && (
         <div className="absolute z-50 top-full left-0 mt-1 w-64 max-h-48 overflow-y-auto rounded-md border border-border bg-popover shadow-lg">


### PR DESCRIPTION
This PR improves the accessibility of the `KeyValueEditor` component by adding missing ARIA labels.

### Changes
- Added `aria-label="Remove item"` to the icon-only trash button.
- Added `aria-label` to key and value inputs, defaulting to "Key" and "Value" respectively, or using the provided placeholders.
- Updated `TemplateInput` component to support `aria-label` prop.
- Added `core/ui/src/components/DynamicForm/KeyValueEditor.test.tsx` to verify the changes.

### Why
The delete button was an icon-only button without an accessible name, making it difficult for screen reader users to understand its purpose. The key/value inputs also lacked labels, which is common in dynamic forms but problematic for accessibility. Adding `aria-label` ensures these controls are accessible.

### Testing
- Created a new test file `core/ui/src/components/DynamicForm/KeyValueEditor.test.tsx`.
- Ran `bun test core/ui/src/components/DynamicForm/KeyValueEditor.test.tsx` and verified it passes.
- Verified that existing tests (`bun test`) still pass.

---
*PR created automatically by Jules for task [11660299821213940868](https://jules.google.com/task/11660299821213940868) started by @enyineer*