### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The application was passing `process.env` (containing sensitive secrets like `DATABASE_URL` and `BETTER_AUTH_SECRET`) to user-defined scripts executed via `Bun.spawn` in `healthcheck-script-backend` and `integration-script-backend`.
 **Learning:** `Bun.spawn` (and `child_process.spawn`) by default inherits `process.env`. Explicitly passing `{ ...process.env, ...config.env }` ensures leakage of all secrets.
 **Prevention:** Always use an allowlist of safe environment variables (e.g., `PATH`, `HOME`, `LANG`) when spawning child processes. Never pass `process.env` directly unless absolutely necessary and safe.
+
+## 2025-02-13 - [Medium] Missing Security Headers in Hono Middleware
+**Vulnerability:** Core backend responses were missing basic security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), increasing risk of clickjacking and MIME sniffing.
+**Learning:** In Hono (and many async middleware frameworks), response headers must be set **before** `await next()` to ensure they are applied even if downstream handlers fail or short-circuit. Setting them after `await next()` can result in headers being missed on error responses.
+**Prevention:** Use a custom middleware that sets headers on the context (`c.header(...)`) immediately upon entry, before delegating to the next handler.

--- a/core/backend/src/index.ts
+++ b/core/backend/src/index.ts
@@ -29,6 +29,7 @@ import {
 } from "@checkstack/api-docs-common";
 
 import { cors } from "hono/cors";
+import { securityHeaders } from "./middleware/security-headers";
 
 const app = new Hono();
 const pluginManager = new PluginManager();
@@ -47,6 +48,7 @@ if (!process.env.BASE_URL || corsOrigin.includes("localhost")) {
   corsOrigins.push("http://localhost:5173");
 }
 
+app.use("*", securityHeaders());
 app.use(
   "*",
   cors({

--- a/core/backend/src/middleware/security-headers.test.ts
+++ b/core/backend/src/middleware/security-headers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { securityHeaders } from "./security-headers";
+
+describe("securityHeaders middleware", () => {
+  it("should set security headers on response", async () => {
+    const app = new Hono();
+    app.use("*", securityHeaders());
+    app.get("/", (c) => c.text("ok"));
+
+    const res = await app.request("/");
+
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    expect(await res.text()).toBe("ok");
+  });
+});

--- a/core/backend/src/middleware/security-headers.ts
+++ b/core/backend/src/middleware/security-headers.ts
@@ -1,0 +1,10 @@
+import type { MiddlewareHandler } from "hono";
+
+const handler: MiddlewareHandler = async (c, next) => {
+  c.header("X-Frame-Options", "SAMEORIGIN");
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+  await next();
+};
+
+export const securityHeaders = (): MiddlewareHandler => handler;


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add security headers middleware

**Vulnerability:** Core backend responses were missing basic security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), increasing risk of clickjacking and MIME sniffing.

**Fix:**
- Added a custom Hono middleware `securityHeaders` in `core/backend/src/middleware/security-headers.ts`.
- Configured the middleware to set:
    - `X-Frame-Options: SAMEORIGIN`
    - `X-Content-Type-Options: nosniff`
    - `Referrer-Policy: strict-origin-when-cross-origin`
- Applied the middleware globally in `core/backend/src/index.ts` before other routes.
- Added unit tests in `core/backend/src/middleware/security-headers.test.ts` to verify headers are set correctly.

**Verification:**
- Ran `bun test core/backend/src/middleware/security-headers.test.ts` to confirm headers are present.
- Ran full backend test suite `bun test core/backend` to ensure no regressions.
- Verified linting passes with `bun run lint:code`.

---
*PR created automatically by Jules for task [15696966623165557961](https://jules.google.com/task/15696966623165557961) started by @enyineer*