### PR TITLE
🛡️ Sentinel: [HIGH] Fix BOLA in Team Management Endpoints

### DIFF
--- a/core/auth-backend/src/router.ts
+++ b/core/auth-backend/src/router.ts
@@ -8,7 +8,13 @@ import {
   type ConfigService,
   toJsonSchema,
 } from "@checkstack/backend-api";
-import { authContract, passwordSchema } from "@checkstack/auth-common";
+import {
+  authContract,
+  passwordSchema,
+  authAccess,
+  pluginMetadata,
+} from "@checkstack/auth-common";
+import { qualifyAccessRuleId } from "@checkstack/common";
 import { hashPassword } from "better-auth/crypto";
 import * as schema from "./schema";
 import { eq, inArray, and } from "drizzle-orm";
@@ -115,6 +121,55 @@ function generateSecret(): string {
   const array = new Uint8Array(32);
   crypto.getRandomValues(array);
   return Array.from(array, (byte) => chars[byte % chars.length]).join("");
+}
+
+/**
+ * Helper to enforce team manager or global admin access.
+ * Used for sensitive team operations where the contract only requires 'read' access.
+ */
+async function checkTeamManagerOrAdmin(
+  context: RpcContext,
+  internalDb: SafeDatabase<typeof schema>,
+  teamId: string,
+) {
+  const user = context.user;
+  if (!user) {
+    throw new ORPCError("UNAUTHORIZED", { message: "Not authenticated" });
+  }
+
+  // Calculate qualified global manage permission ID (e.g. "auth.teams.manage")
+  const managePermission = qualifyAccessRuleId(
+    pluginMetadata,
+    authAccess.teams.manage,
+  );
+
+  // Check if user has global manage permission (or wildcard)
+  const hasGlobalManage =
+    user.accessRules?.includes("*") ||
+    user.accessRules?.includes(managePermission);
+
+  if (hasGlobalManage) return;
+
+  // If not global admin, must be a real user who is a manager of this team
+  if (user.type === "user") {
+    const manager = await internalDb
+      .select()
+      .from(schema.teamManager)
+      .where(
+        and(
+          eq(schema.teamManager.teamId, teamId),
+          eq(schema.teamManager.userId, user.id),
+        ),
+      )
+      .limit(1);
+
+    if (manager.length > 0) return;
+  }
+
+  throw new ORPCError("FORBIDDEN", {
+    message:
+      "You must be a team manager or have global team management permissions to perform this action.",
+  });
 }
 
 export const createAuthRouter = (
@@ -1385,7 +1440,10 @@ export const createAuthRouter = (
 
   const updateTeam = os.updateTeam.handler(async ({ input, context }) => {
     const { id, name, description } = input;
-    // TODO: Check if user is manager or has teamsManage access
+
+    // Enforce manager or global admin access
+    await checkTeamManagerOrAdmin(context, internalDb, id);
+
     const updates: {
       name?: string;
       description?: string | null;
@@ -1419,7 +1477,10 @@ export const createAuthRouter = (
     context.logger.info(`[auth-backend] Deleted team: ${id}`);
   });
 
-  const addUserToTeam = os.addUserToTeam.handler(async ({ input }) => {
+  const addUserToTeam = os.addUserToTeam.handler(async ({ input, context }) => {
+    // Enforce manager or global admin access
+    await checkTeamManagerOrAdmin(context, internalDb, input.teamId);
+
     await internalDb
       .insert(schema.userTeam)
       .values({ userId: input.userId, teamId: input.teamId })
@@ -1427,7 +1488,10 @@ export const createAuthRouter = (
   });
 
   const removeUserFromTeam = os.removeUserFromTeam.handler(
-    async ({ input }) => {
+    async ({ input, context }) => {
+      // Enforce manager or global admin access
+      await checkTeamManagerOrAdmin(context, internalDb, input.teamId);
+
       await internalDb
         .delete(schema.userTeam)
         .where(

--- a/core/auth-backend/src/teams-security.test.ts
+++ b/core/auth-backend/src/teams-security.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, mock } from "bun:test";
+import { createAuthRouter, type AuthRouter } from "./router";
+import { createMockRpcContext } from "@checkstack/backend-api";
+import { call, ORPCError } from "@orpc/server";
+import { z } from "zod";
+import * as schema from "./schema";
+import type { SafeDatabase } from "@checkstack/backend-api";
+
+type AuthDatabase = SafeDatabase<typeof schema>;
+
+describe("Teams Security Vulnerability", () => {
+  // Mock regular user with ONLY read access
+  const mockRegularUser = {
+    type: "user" as const,
+    id: "regular-user",
+    accessRules: ["test-plugin.teams.read"], // Only read access
+    roles: ["users"],
+    teamIds: ["team-beta"],
+  };
+
+  function createChain<T>(data: T[] = []): Record<string, unknown> {
+    const chain: Record<string, unknown> = {
+      where: mock(() => chain),
+      innerJoin: mock(() => chain),
+      limit: mock(() => chain),
+      offset: mock(() => chain),
+      orderBy: mock(() => chain),
+      onConflictDoUpdate: mock(() => Promise.resolve()),
+      onConflictDoNothing: mock(() => Promise.resolve()),
+      then: (resolve: (value: T[]) => void) => Promise.resolve(resolve(data)),
+    };
+    return chain;
+  }
+
+  function createMockDb(): AuthDatabase {
+    const mockDb = {
+      select: mock(() => ({
+        from: mock(() => createChain([])),
+      })),
+      insert: mock(() => ({
+        values: mock(() => ({
+          onConflictDoNothing: mock(() => Promise.resolve()),
+          onConflictDoUpdate: mock(() => Promise.resolve()),
+          then: (resolve: (value: unknown) => void) =>
+            Promise.resolve(resolve(undefined)),
+        })),
+      })),
+      update: mock(() => ({
+        set: mock(() => ({
+          where: mock(() => Promise.resolve()),
+        })),
+      })),
+      delete: mock(() => ({
+        where: mock(() => Promise.resolve()),
+      })),
+      transaction: mock((cb: (tx: typeof mockDb) => Promise<void>) =>
+        cb(mockDb)
+      ),
+    };
+    return mockDb as unknown as AuthDatabase;
+  }
+
+  const mockRegistry = {
+    getStrategies: () => [],
+  };
+
+  const mockConfigService = {
+    get: mock(() => Promise.resolve(undefined)),
+    getRedacted: mock(() => Promise.resolve({})),
+    set: mock(() => Promise.resolve()),
+    delete: mock(() => Promise.resolve()),
+    list: mock(() => Promise.resolve([])),
+  };
+
+  const mockAccessRuleRegistry = {
+    getAccessRules: () => [
+      { id: "auth.teams.read", description: "View teams" },
+      { id: "auth.teams.manage", description: "Manage teams" },
+    ],
+  };
+
+  it("FIXED: updateTeam prevents user with only read access from updating team", async () => {
+    const mockDb = createMockDb();
+    let updatedData: Record<string, unknown> | undefined;
+
+    (mockDb.update as ReturnType<typeof mock>).mockImplementationOnce(() => ({
+      set: mock((data: Record<string, unknown>) => {
+        updatedData = data;
+        return {
+          where: mock(() => Promise.resolve()),
+        };
+      }),
+    }));
+
+    // Mock manager check: User is NOT a manager
+    (mockDb.select as ReturnType<typeof mock>).mockImplementation((() => ({
+        from: mock(() => createChain([])), // No results for teamManager check
+    })));
+
+
+    const router = createAuthRouter(
+      mockDb,
+      mockRegistry,
+      async () => {},
+      mockConfigService,
+      mockAccessRuleRegistry
+    );
+
+    const context = createMockRpcContext({ user: mockRegularUser });
+
+    try {
+      await call(
+        router.updateTeam,
+        { id: "team-alpha", name: "Hacked Team Name" },
+        { context }
+      );
+    } catch (e) {
+      if (e instanceof ORPCError && e.code === "FORBIDDEN") {
+        return; // Success: Access denied
+      }
+      throw e;
+    }
+
+    throw new Error("Security check failed: User with read-only access updated the team!");
+  });
+
+  it("FIXED: addUserToTeam prevents user with only read access from adding users", async () => {
+      const mockDb = createMockDb();
+
+      // Mock manager check: User is NOT a manager
+      (mockDb.select as ReturnType<typeof mock>).mockImplementation((() => ({
+          from: mock(() => createChain([])),
+      })));
+
+      const router = createAuthRouter(
+        mockDb,
+        mockRegistry,
+        async () => {},
+        mockConfigService,
+        mockAccessRuleRegistry
+      );
+
+      const context = createMockRpcContext({ user: mockRegularUser });
+
+      try {
+        await call(
+            router.addUserToTeam,
+            { teamId: "team-alpha", userId: "new-user" },
+            { context }
+        );
+      } catch (e) {
+        if (e instanceof ORPCError && e.code === "FORBIDDEN") {
+            return; // Success: Access denied
+        }
+        throw e;
+      }
+
+      throw new Error("Security check failed: User with read-only access added a user!");
+  });
+});


### PR DESCRIPTION
Sentinel detected and fixed a security vulnerability in the team management endpoints. Previously, the `updateTeam`, `addUserToTeam`, and `removeUserFromTeam` endpoints relied solely on the `auth.teams.read` permission defined in the RPC contract, which allowed any user with read access to modify any team.

I have implemented an explicit authorization check within the handlers to verify that the requesting user is either a global administrator (with `auth.teams.manage` permission) or a designated manager of the specific team being modified.

A permanent regression test suite (`core/auth-backend/src/teams-security.test.ts`) has been added to prevent this vulnerability from resurfacing.

---
*PR created automatically by Jules for task [12365171903592532245](https://jules.google.com/task/12365171903592532245) started by @enyineer*