### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-05-18 - Missing ARIA Labels on Icon Buttons
+**Learning:** The `Button` component with `size="icon"` is frequently used without an `aria-label`, making interactive elements invisible to screen readers. This pattern is common in dynamic form controls (add/remove items) and pickers.
+**Action:** When creating or reviewing icon-only buttons, always enforce `aria-label` or `aria-labelledby`. Add a lint rule or component prop requirement if possible in the future.

--- a/core/test-utils-frontend/src/setup.ts
+++ b/core/test-utils-frontend/src/setup.ts
@@ -9,17 +9,19 @@
  * preload = ["@checkstack/test-utils-frontend/setup"]
  */
 
-// Register Happy DOM globals first (document, window, etc.)
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { afterEach, expect } from "bun:test";
+
+// Register Happy DOM globals first (document, window, etc.)
 GlobalRegistrator.register();
 
-// Then set up Testing Library
-import { afterEach, expect } from "bun:test";
-import { cleanup } from "@testing-library/react";
-import * as matchers from "@testing-library/jest-dom/matchers";
+// Use dynamic imports to ensure DOM is registered before Testing Library loads
+const { cleanup } = await import("@testing-library/react");
+const matchers = await import("@testing-library/jest-dom/matchers");
 
 // Extend expect with Testing Library matchers (toBeInTheDocument, etc.)
-expect.extend(matchers);
+// @ts-ignore
+expect.extend(matchers.default || matchers);
 
 // Clean up render after each test to prevent memory leaks
 afterEach(() => {

--- a/core/ui/src/components/DateTimePicker.test.tsx
+++ b/core/ui/src/components/DateTimePicker.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { DateTimePicker } from "./DateTimePicker";
+import { describe, it, expect, vi } from "bun:test";
+
+describe("DateTimePicker", () => {
+  it("calendar trigger button should have aria-label", () => {
+    const onChange = vi.fn();
+    const value = new Date();
+
+    render(
+      <DateTimePicker
+        value={value}
+        onChange={onChange}
+      />
+    );
+
+    // Should find the button by label
+    const button = screen.getByLabelText("Open calendar");
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/core/ui/src/components/DateTimePicker.tsx
+++ b/core/ui/src/components/DateTimePicker.tsx
@@ -262,6 +262,7 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
               className="h-9 w-9 rounded-none border-r"
               type="button"
               disabled={disabled}
+              aria-label="Open calendar"
             >
               <Calendar className="h-4 w-4" />
             </Button>

--- a/core/ui/src/components/DynamicForm/FormField.test.tsx
+++ b/core/ui/src/components/DynamicForm/FormField.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { FormField } from "./FormField";
+import { describe, it, expect, vi } from "bun:test";
+
+describe("FormField", () => {
+  it("array items remove button should have aria-label", () => {
+    const onChange = vi.fn();
+    const propSchema = {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    };
+
+    render(
+      <FormField
+        id="test-array"
+        label="Tags"
+        propSchema={propSchema}
+        value={["tag1"]}
+        onChange={onChange}
+      />
+    );
+
+    // Should find the remove button by label
+    const removeButton = screen.getByLabelText("Remove Tags #1");
+    expect(removeButton).toBeInTheDocument();
+  });
+});

--- a/core/ui/src/components/DynamicForm/FormField.tsx
+++ b/core/ui/src/components/DynamicForm/FormField.tsx
@@ -428,6 +428,7 @@ export const FormField: React.FC<FormFieldProps> = ({
                     onChange(next);
                   }}
                   className="absolute -top-2 -right-2 h-7 w-7 rounded-full bg-background border shadow-sm text-destructive hover:text-destructive/90 hover:bg-destructive/10"
+                  aria-label={`Remove ${label} #${index + 1}`}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                 </Button>

--- a/core/ui/src/components/DynamicForm/KeyValueEditor.test.tsx
+++ b/core/ui/src/components/DynamicForm/KeyValueEditor.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { KeyValueEditor } from "./KeyValueEditor";
+import { describe, it, expect, vi } from "bun:test";
+
+describe("KeyValueEditor", () => {
+  it("remove button should have aria-label", () => {
+    const onChange = vi.fn();
+    const value = [{ key: "foo", value: "bar" }];
+
+    render(
+      <KeyValueEditor
+        id="test-kv"
+        value={value}
+        onChange={onChange}
+      />
+    );
+
+    // Should find the remove button by label
+    const removeButton = screen.getByLabelText("Remove item");
+    expect(removeButton).toBeInTheDocument();
+  });
+});

--- a/core/ui/src/components/DynamicForm/KeyValueEditor.tsx
+++ b/core/ui/src/components/DynamicForm/KeyValueEditor.tsx
@@ -144,6 +144,7 @@ export const KeyValueEditor: React.FC<KeyValueEditorProps> = ({
             size="icon"
             onClick={() => handleRemove(index)}
             className="h-8 w-8 text-destructive hover:text-destructive/90 hover:bg-destructive/10 shrink-0"
+            aria-label="Remove item"
           >
             <Trash2 className="h-4 w-4" />
           </Button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons in `FormField`, `KeyValueEditor`, and `DateTimePicker` components. Also improved test setup to support DOM testing.
🎯 Why: These buttons were inaccessible to screen readers as they lacked descriptive labels.
♿ Accessibility: Added labels "Remove [Label] #[Index]", "Remove item", and "Open calendar".

---
*PR created automatically by Jules for task [14904411284646726147](https://jules.google.com/task/14904411284646726147) started by @enyineer*