### PR TITLE
🎨 Palette: Add loading state to Button and improve LoadingSpinner a11y

### DIFF
--- a/core/ui/src/components/Button.test.tsx
+++ b/core/ui/src/components/Button.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+import { Button } from "./Button";
+import React from "react";
+
+describe("Button", () => {
+  it("renders correctly", () => {
+    const { getByRole } = render(<Button>Click me</Button>);
+    const button = getByRole("button", { name: "Click me" });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+  });
+
+  it("shows loading spinner and disables when loading is true", () => {
+    const { getByRole, container } = render(<Button loading>Submit</Button>);
+    const button = getByRole("button", { name: "Submit" });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-disabled", "true");
+
+    // Check for spinner via class or SVG
+    // We can use container.querySelector to find the spinner
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("respects disabled prop regardless of loading", () => {
+    const { getByRole } = render(<Button disabled>Disabled</Button>);
+    const button = getByRole("button", { name: "Disabled" });
+    expect(button).toBeDisabled();
+  });
+});

--- a/core/ui/src/components/Button.tsx
+++ b/core/ui/src/components/Button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
 import { cn } from "../utils";
 
 const buttonVariants = cva(
@@ -36,11 +37,22 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  loading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
-    { className, variant, size, asChild = false, type = "button", ...props },
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      type = "button",
+      loading = false,
+      disabled,
+      children,
+      ...props
+    },
     ref
   ) => {
     const Comp = asChild ? Slot : "button";
@@ -49,8 +61,15 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         type={asChild ? undefined : type}
+        disabled={loading || disabled}
+        aria-disabled={loading || disabled}
         {...props}
-      />
+      >
+        {!asChild && loading && (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        )}
+        {children}
+      </Comp>
     );
   }
 );

--- a/core/ui/src/components/LoadingSpinner.test.tsx
+++ b/core/ui/src/components/LoadingSpinner.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+import { LoadingSpinner } from "./LoadingSpinner";
+import React from "react";
+
+describe("LoadingSpinner", () => {
+  it("renders with default accessibility attributes", () => {
+    const { getByRole } = render(<LoadingSpinner />);
+    const spinner = getByRole("status");
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveAttribute("aria-label", "Loading...");
+  });
+
+  it("allows overriding aria-label", () => {
+    const { getByRole } = render(<LoadingSpinner aria-label="Please wait" />);
+    const spinner = getByRole("status");
+    expect(spinner).toHaveAttribute("aria-label", "Please wait");
+  });
+
+  it("applies custom className", () => {
+    const { getByTestId } = render(<LoadingSpinner className="custom-class" data-testid="spinner" />);
+    const spinner = getByTestId("spinner");
+    expect(spinner).toHaveClass("custom-class");
+  });
+});

--- a/core/ui/src/components/LoadingSpinner.tsx
+++ b/core/ui/src/components/LoadingSpinner.tsx
@@ -8,6 +8,8 @@ interface LoadingSpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
 export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   size = "md",
   className,
+  "aria-label": ariaLabel = "Loading...",
+  role = "status",
   ...props
 }) => {
   const sizeClasses = {
@@ -17,7 +19,12 @@ export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   };
 
   return (
-    <div className={cn("flex justify-center py-12", className)} {...props}>
+    <div
+      className={cn("flex justify-center py-12", className)}
+      role={role}
+      aria-label={ariaLabel}
+      {...props}
+    >
       <div
         className={cn(
           "border-indigo-200 border-t-indigo-500 rounded-full animate-spin",

--- a/frontend_output.log
+++ b/frontend_output.log
@@ -1,0 +1,19 @@
+@checkstack/frontend dev:
+@checkstack/frontend dev:   VITE v5.4.21  ready in 358 ms
+@checkstack/frontend dev:
+@checkstack/frontend dev:   ➜  Local:   http://localhost:5173/
+@checkstack/frontend dev:   ➜  Network: use --host to expose
+@checkstack/frontend dev: 9:09:07 AM [vite] http proxy error: /api/plugins
+@checkstack/frontend dev: AggregateError [ECONNREFUSED]:
+@checkstack/frontend dev:     at internalConnectMultiple (node:net:1134:18)
+@checkstack/frontend dev:     at afterConnectMultiple (node:net:1715:7)
+@checkstack/frontend dev: 9:09:08 AM [vite] http proxy error: /api/config
+@checkstack/frontend dev: AggregateError [ECONNREFUSED]:
+@checkstack/frontend dev:     at internalConnectMultiple (node:net:1134:18)
+@checkstack/frontend dev:     at afterConnectMultiple (node:net:1715:7)
+@checkstack/frontend dev: 9:09:08 AM [vite] http proxy error: /api/config
+@checkstack/frontend dev: AggregateError [ECONNREFUSED]:
+@checkstack/frontend dev:     at internalConnectMultiple (node:net:1134:18)
+@checkstack/frontend dev:     at afterConnectMultiple (node:net:1715:7)
+@checkstack/frontend dev: 9:09:21 AM [vite] hmr update /src/App.tsx, /src/index.css
+@checkstack/frontend dev: Exited with code 0


### PR DESCRIPTION
💡 What:
- Added `loading` prop to `Button` component in `core/ui`.
- Added accessibility attributes (`role="status"`, `aria-label`) to `LoadingSpinner`.
- Added unit tests for `Button` loading state and `LoadingSpinner` a11y.

🎯 Why:
- Buttons often trigger async actions. A built-in loading state improves UX by providing immediate feedback and preventing double-submission.
- `LoadingSpinner` was missing accessibility attributes, making it invisible to screen readers.

📸 Before/After:
- Before: Buttons required manual spinner injection and state management.
- After: `<Button loading={isLoading}>Submit</Button>` automatically shows a spinner and disables the button.

♿ Accessibility:
- `LoadingSpinner` now has `role="status"` and a default label "Loading...".
- `Button` in loading state is marked as `disabled` and `aria-disabled`.

---
*PR created automatically by Jules for task [5820241311918412344](https://jules.google.com/task/5820241311918412344) started by @enyineer*