### PR TITLE
🛡️ Sentinel: [HIGH] Add missing security headers

### DIFF
--- a/core/backend/src/index.ts
+++ b/core/backend/src/index.ts
@@ -29,6 +29,7 @@ import {
 } from "@checkstack/api-docs-common";
 
 import { cors } from "hono/cors";
+import { secureHeaders } from "hono/secure-headers";
 
 const app = new Hono();
 const pluginManager = new PluginManager();
@@ -58,6 +59,21 @@ app.use(
     credentials: true,
   })
 );
+
+// Add security headers to all responses
+app.use(
+  "*",
+  secureHeaders({
+    // Explicitly disable CSP to avoid conflicts with Vite's dev server (inline scripts/styles)
+    contentSecurityPolicy: false,
+    // Explicitly set Referrer-Policy to allow some referrer info for internal navigation/analytics
+    referrerPolicy: "strict-origin-when-cross-origin",
+    // Defaults:
+    // xFrameOptions: "SAMEORIGIN" - Protects against clickjacking
+    // xContentTypeOptions: "nosniff" - Protects against MIME sniffing
+  })
+);
+
 app.use("*", logger());
 
 // Runtime config endpoint - returns BASE_URL for frontend


### PR DESCRIPTION
This PR adds standard security headers to the backend application using Hono's `secureHeaders` middleware. It addresses a missing security configuration identified during a security scan.

Changes:
- Modified `core/backend/src/index.ts` to include `secureHeaders` middleware.
- Configured `Referrer-Policy` to `strict-origin-when-cross-origin`.
- Explicitly disabled CSP to prevent development issues.

Verified by creating a temporary reproduction test that confirmed headers were missing before the fix and present after the fix. ran all backend tests to ensure no regressions.

---
*PR created automatically by Jules for task [1854892075321951165](https://jules.google.com/task/1854892075321951165) started by @enyineer*