### PR TITLE
🎨 Palette: Improve LoadingSpinner accessibility and flexibility

### DIFF
--- a/.changeset/clean-peaches-sing.md
+++ b/.changeset/clean-peaches-sing.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/ui": patch
+---
+
+Improve LoadingSpinner accessibility with role="status" and inline prop

--- a/core/ui/src/components/LoadingSpinner.test.tsx
+++ b/core/ui/src/components/LoadingSpinner.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { LoadingSpinner } from "./LoadingSpinner";
+import { describe, it, expect } from "bun:test";
+
+describe("LoadingSpinner", () => {
+  it("renders with correct accessibility attributes", () => {
+    const { getByRole } = render(<LoadingSpinner />);
+    const spinner = getByRole("status");
+    expect(spinner).toBeDefined();
+    expect(spinner.getAttribute("aria-label")).toBe("Loading");
+    expect(spinner.textContent).toContain("Loading...");
+  });
+
+  it("renders with py-12 by default (block mode)", () => {
+    const { container } = render(<LoadingSpinner />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("py-12");
+    expect(wrapper.className).toContain("flex");
+    expect(wrapper.className).not.toContain("inline-flex");
+  });
+
+  it("renders inline correctly", () => {
+    const { container } = render(<LoadingSpinner inline />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).not.toContain("py-12");
+    expect(wrapper.className).toContain("inline-flex");
+  });
+});

--- a/core/ui/src/components/LoadingSpinner.tsx
+++ b/core/ui/src/components/LoadingSpinner.tsx
@@ -3,10 +3,12 @@ import { cn } from "../utils";
 
 interface LoadingSpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: "sm" | "md" | "lg";
+  inline?: boolean;
 }
 
 export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   size = "md",
+  inline = false,
   className,
   ...props
 }) => {
@@ -17,7 +19,18 @@ export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   };
 
   return (
-    <div className={cn("flex justify-center py-12", className)} {...props}>
+    <div
+      role="status"
+      aria-label="Loading"
+      className={cn(
+        "flex justify-center",
+        !inline && "py-12",
+        inline && "inline-flex py-0",
+        className
+      )}
+      {...props}
+    >
+      <span className="sr-only">Loading...</span>
       <div
         className={cn(
           "border-indigo-200 border-t-indigo-500 rounded-full animate-spin",


### PR DESCRIPTION
💡 **What:**
- Added `role="status"` and `aria-label="Loading"` to `LoadingSpinner`.
- Added a visually hidden "Loading..." span for screen readers.
- Added an `inline` prop (default `false`) to `LoadingSpinner`.
  - When `true`, it uses `inline-flex` and removes the default `py-12` padding.
  - When `false` (default), it preserves the original `flex` and `py-12` styling.

🎯 **Why:**
- **Accessibility:** Screen readers previously ignored the spinner. Now they announce "Loading".
- **UX/DX:** The spinner was hardcoded with large vertical padding (`py-12`), making it impossible to use inside buttons or inline text without ugly hacks. The `inline` prop makes it reusable in compact contexts.

📸 **Verification:**
- **Tests:** Added `core/ui/src/components/LoadingSpinner.test.tsx` which verifies a11y attributes and class names.
- **Visual:** Verified using a temporary route and Playwright screenshot that the default block spinner remains unchanged, and the inline spinner renders correctly within a button.

♿ **Accessibility:**
- Complies with WCAG guidelines for status messages.

---
*PR created automatically by Jules for task [15024795215137946053](https://jules.google.com/task/15024795215137946053) started by @enyineer*