### PR TITLE
🛡️ Sentinel: Fix command injection in disk collector

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The application was passing `process.env` (containing sensitive secrets like `DATABASE_URL` and `BETTER_AUTH_SECRET`) to user-defined scripts executed via `Bun.spawn` in `healthcheck-script-backend` and `integration-script-backend`.
 **Learning:** `Bun.spawn` (and `child_process.spawn`) by default inherits `process.env`. Explicitly passing `{ ...process.env, ...config.env }` ensures leakage of all secrets.
 **Prevention:** Always use an allowlist of safe environment variables (e.g., `PATH`, `HOME`, `LANG`) when spawning child processes. Never pass `process.env` directly unless absolutely necessary and safe.
+
+## 2025-02-12 - [Critical] Command Injection in Disk Collector
+**Vulnerability:** The `DiskCollector` plugin was constructing shell commands using unsanitized user input (`config.mountPoint`) via string interpolation: ``client.exec(`df -BG ${config.mountPoint} | tail -1`)``. This allowed attackers to inject arbitrary shell commands (e.g., `/; rm -rf /`).
+**Learning:** Even internal plugins processing seemingly harmless configuration like "mount points" must validate input rigorously before passing it to `exec` or `spawn`. Zod schemas provide a first line of defense, but runtime checks immediately before execution are critical for defense-in-depth.
+**Prevention:** Always validate inputs destined for shell commands against a strict allowlist regex (e.g., `^[\w/.-]+$`). Prefer `spawn` with argument arrays over `exec` with shell strings whenever possible to bypass shell interpretation entirely.

--- a/plugins/collector-hardware-backend/src/collectors/disk.test.ts
+++ b/plugins/collector-hardware-backend/src/collectors/disk.test.ts
@@ -64,6 +64,20 @@ describe("DiskCollector", () => {
 
       expect(client.exec).toHaveBeenCalledWith("df -BG /var | tail -1");
     });
+
+    it("should reject unsafe mount points", async () => {
+      const collector = new DiskCollector();
+      const client = createMockClient();
+
+      const promise = collector.execute({
+        config: { mountPoint: "/; rm -rf /" },
+        client,
+        pluginId: "test",
+      });
+
+      expect(promise).rejects.toThrow("Invalid mount point format");
+      expect(client.exec).not.toHaveBeenCalled();
+    });
   });
 
   describe("mergeResult", () => {

--- a/plugins/collector-hardware-backend/src/collectors/disk.ts
+++ b/plugins/collector-hardware-backend/src/collectors/disk.ts
@@ -27,6 +27,7 @@ import {
 const diskConfigSchema = z.object({
   mountPoint: z
     .string()
+    .regex(/^[\w/.-]+$/, "Invalid mount point format")
     .default("/")
     .describe("Mount point to monitor (e.g., /, /home, /var)"),
 });
@@ -120,6 +121,11 @@ export class DiskCollector implements CollectorStrategy<
     client: SshTransportClient;
     pluginId: string;
   }): Promise<CollectorResult<DiskResult>> {
+    // Validate mountPoint to prevent command injection
+    if (!/^[\w/.-]+$/.test(config.mountPoint)) {
+      throw new Error("Invalid mount point format");
+    }
+
     // Use df with specific mount point, output in 1G blocks
     const dfResult = await client.exec(`df -BG ${config.mountPoint} | tail -1`);
     const parsed = this.parseDfOutput(dfResult.stdout, config.mountPoint);


### PR DESCRIPTION
Fixes a critical command injection vulnerability in `plugins/collector-hardware-backend/src/collectors/disk.ts`.
Validates `mountPoint` input using a strict regex allowlist (`^[\w/.-]+$`) to prevent shell metacharacters from being interpreted.
Includes regression tests to verify that malicious inputs are rejected.

---
*PR created automatically by Jules for task [12865900501626662661](https://jules.google.com/task/12865900501626662661) started by @enyineer*