### PR TITLE
fix: detect misconfigured BASE_URL and show diagnostic error screen

### DIFF
--- a/.changeset/fix-base-url-onboarding.md
+++ b/.changeset/fix-base-url-onboarding.md
@@ -1,0 +1,24 @@
+---
+"@checkstack/frontend": patch
+"@checkstack/frontend-api": patch
+---
+
+Fix onboarding flow not appearing on fresh Docker deployments (issue #79)
+
+The `.env.example` had `BASE_URL` defaulting to `http://localhost:5173`
+(the Vite dev server port). Users copying this file verbatim for a Docker
+deployment would get a frontend that silently made all API calls to the
+wrong origin, causing empty state and extreme sluggishness.
+
+**Changes:**
+
+- `.env.example`: Adds clear comments explaining the value must match the 
+  container's exposed port.
+- `frontend-api` (`RuntimeConfigProvider`): Removes the silent fallback when
+  `/api/config` returns an unreachable baseUrl — instead propagates the error 
+  so it can be surfaced.
+- `frontend` (`App.tsx`): Renders an actionable error screen when the backend
+  config cannot be loaded, showing the exact `BASE_URL` fix and the
+  `docker compose` command to recover.
+- `docs/getting-started/docker.md`: Adds a dedicated troubleshooting section
+  for this exact misconfiguration.

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 # Database configuration
 DATABASE_URL=postgres://checkstack:checkstack@localhost:5432/checkstack
 
-# App URL
+# Public URL where Checkstack is accessed.
+# IMPORTANT: This MUST match the port your container exposes (default: 3000).
+# - Docker / production:   BASE_URL=http://localhost:3000  (or your public domain)
+# - Local dev (Vite):      BASE_URL=http://localhost:5173
 BASE_URL=http://localhost:5173
 
 # Secret encryption - REQUIRED! Must be exactly 64 hex characters (32 bytes)

--- a/.github/workflows/changeset-reminder.yml
+++ b/.github/workflows/changeset-reminder.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 concurrency:
-  group: changeset-reminder-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: changeset-reminder-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/core/frontend-api/src/runtime-config.tsx
+++ b/core/frontend-api/src/runtime-config.tsx
@@ -42,8 +42,34 @@ interface RuntimeConfigProviderProps {
 }
 
 /**
- * Fetches runtime config from backend on mount.
- * All consumers should wait for config to load before rendering.
+ * Safely reads the current page origin without requiring the DOM lib
+ * to be in scope in every consuming package's tsconfig.
+ *
+ * Accesses `location` via `globalThis` cast to avoid the untyped-global
+ * error that appears when non-browser packages (e.g. catalog-common) run
+ * TypeScript against this file and their tsconfig doesn't include "DOM".
+ */
+function getCurrentOrigin(): string | undefined {
+  const g = globalThis as Record<string, unknown>;
+  const loc = g["location"] as { origin?: string } | undefined;
+  const origin = loc?.origin;
+  return typeof origin === "string" && origin.length > 0 ? origin : undefined;
+}
+
+/**
+ * Fetches runtime config from the backend on mount, then validates the returned
+ * `baseUrl` is actually reachable.
+ *
+ * Why the probe step matters: `/api/config` is always fetched from the current
+ * origin and always succeeds — but the `baseUrl` it returns could point to the
+ * wrong port (e.g. the Vite dev server) if `BASE_URL` is misconfigured.
+ * Without the probe, all subsequent API calls silently fail with CORS/network
+ * errors and the user sees an empty, unresponsive dashboard (issue #79).
+ *
+ * Probe logic:
+ * - If `baseUrl` matches the current page origin → trivially reachable, skip probe.
+ * - Otherwise → HEAD-request `${baseUrl}/api/config` with a 5 s timeout.
+ *   A connection error here means the baseUrl is wrong.
  */
 export const RuntimeConfigProvider: React.FC<RuntimeConfigProviderProps> = ({
   children,
@@ -55,28 +81,50 @@ export const RuntimeConfigProvider: React.FC<RuntimeConfigProviderProps> = ({
   useEffect(() => {
     const fetchConfig = async () => {
       try {
-        // In development, the proxy handles /api routes
-        // In production, this is the same origin
+        // Step 1: Fetch config from same-origin backend (always succeeds).
         const response = await fetch("/api/config");
         if (!response.ok) {
-          throw new Error(`Failed to fetch config: ${response.status}`);
+          throw new Error(`Failed to fetch runtime config: ${response.status}`);
         }
         const data = (await response.json()) as RuntimeConfig;
-        cachedConfig = data; // Populate module-level cache
+
+        // Step 2: Validate the returned baseUrl is actually reachable.
+        // We only need to probe when baseUrl differs from the current page
+        // origin — same-origin is trivially reachable.
+        const currentOrigin = getCurrentOrigin();
+        if (currentOrigin && data.baseUrl !== currentOrigin) {
+          try {
+            await fetch(`${data.baseUrl}/api/config`, {
+              method: "HEAD",
+              signal: AbortSignal.timeout(5000),
+            });
+          } catch {
+            // baseUrl is not reachable — misconfigured BASE_URL env var.
+            setError(
+              new Error(
+                `BASE_URL is set to "${data.baseUrl}" but it cannot be reached. ` +
+                  `Update BASE_URL in your .env to match the port your container exposes (e.g. ${currentOrigin}).`
+              )
+            );
+            // Don't set config so the error screen renders.
+            return;
+          }
+        }
+
+        cachedConfig = data;
         setConfig(data);
       } catch (error_) {
         console.error("RuntimeConfigProvider: Failed to load config", error_);
-        // Fallback to localhost for development
-        const fallback = { baseUrl: "http://localhost:3000" };
-        cachedConfig = fallback; // Populate cache even on error
-        setConfig(fallback);
-        setError(error_ instanceof Error ? error_ : new Error(String(error_)));
+        setError(
+          error_ instanceof Error ? error_ : new Error(String(error_))
+        );
+        // Do NOT set a fallback — surface the error visibly.
       } finally {
         setIsLoading(false);
       }
     };
 
-    fetchConfig();
+    void fetchConfig();
   }, []);
 
   return (
@@ -91,15 +139,15 @@ export const RuntimeConfigProvider: React.FC<RuntimeConfigProviderProps> = ({
 // =============================================================================
 
 /**
- * Access the runtime config context.
- * Returns { config, isLoading, error }.
+ * Access the runtime config. Consumers should check isLoading first.
  */
 export function useRuntimeConfig(): RuntimeConfig {
   const { config, isLoading } = useContext(RuntimeConfigContext);
 
   if (isLoading || !config) {
-    // Return fallback during loading - consumers should check isLoading
-    return { baseUrl: "http://localhost:3000" };
+    // Return a safe fallback while loading — consumers must check isLoading
+    // if they need to block on the config being available.
+    return { baseUrl: getCurrentOrigin() ?? "http://localhost:3000" };
   }
 
   return config;

--- a/core/frontend/src/App.tsx
+++ b/core/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import {
   RuntimeConfigProvider,
   useRuntimeConfigLoading,
   useRuntimeConfig,
+  useRuntimeConfigContext,
   OrpcQueryProvider,
 } from "@checkstack/frontend-api";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -185,6 +186,8 @@ function AppContent() {
  */
 function AppWithApis() {
   const isConfigLoading = useRuntimeConfigLoading();
+  const { error: configError, config: runtimeConfig } =
+    useRuntimeConfigContext();
   const { baseUrl } = useRuntimeConfig();
 
   const apiRegistry = useMemo(() => {
@@ -220,11 +223,53 @@ function AppWithApis() {
     return registryBuilder.build();
   }, [baseUrl]);
 
-  // Show loading while fetching runtime config
+  // Show spinner while fetching runtime config and probing baseUrl.
   if (isConfigLoading) {
     return (
       <div className="h-screen flex items-center justify-center bg-background">
         <LoadingSpinner />
+      </div>
+    );
+  }
+
+  // Config probe failed — baseUrl is not reachable (misconfigured BASE_URL).
+  // Surface a clear diagnostic rather than a broken empty dashboard.
+  if (!runtimeConfig || configError) {
+    return (
+      <div className="h-screen flex items-center justify-center bg-background p-8">
+        <div className="max-w-lg w-full rounded-xl border border-destructive/50 bg-destructive/10 p-8 space-y-4 text-center">
+          <div className="text-4xl">⚠️</div>
+          <h1 className="text-xl font-bold text-destructive">
+            Cannot connect to Checkstack backend
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            The app loaded but its configured{" "}
+            <code className="bg-muted rounded px-1">BASE_URL</code> is not
+            reachable. Make sure it matches the URL + port your container or
+            reverse proxy exposes.
+          </p>
+          <div className="text-left bg-muted rounded-lg p-4 space-y-1 text-sm font-mono">
+            <p className="text-muted-foreground">
+              # For a default Docker setup:
+            </p>
+            <p className="text-foreground">BASE_URL=http://localhost:3000</p>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            After updating your{" "}
+            <code className="bg-muted rounded px-1">.env</code>, recreate the
+            container:
+          </p>
+          <div className="text-left bg-muted rounded-lg p-4 text-sm font-mono">
+            <p className="text-foreground">
+              docker compose up -d --force-recreate
+            </p>
+          </div>
+          {configError && (
+            <p className="text-xs text-destructive/70 break-all">
+              {configError.message}
+            </p>
+          )}
+        </div>
       </div>
     );
   }

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -153,7 +153,35 @@ Your encryption key is not the correct length. Generate a new one using the comm
 
 Your auth secret is too short. Generate a longer one using the commands above.
 
+### Onboarding screen does not appear / app loads empty or very slowly
+
+This is almost always caused by a wrong `BASE_URL`. When `BASE_URL` points to a port that is not running (e.g. the Vite dev server on `:5173`), the frontend cannot reach the backend for session and onboarding checks, which causes it to silently show empty state.
+
+**Make sure `BASE_URL` matches the port your container exposes:**
+
+```bash
+# Docker / production (default port 3000)
+BASE_URL=http://localhost:3000
+
+# Or your public domain in production
+BASE_URL=https://status.example.com
+```
+
+You can verify the value your container is using by checking the config endpoint:
+
+```bash
+curl http://localhost:3000/api/config
+# Expected: {"baseUrl":"http://localhost:3000"}
+```
+
+If `baseUrl` in the response points to port `5173` or any other wrong address, update `BASE_URL` in your `.env` file and recreate the container:
+
+```bash
+docker compose up -d --force-recreate
+```
+
 ### Database connection errors
+
 
 - Verify your `DATABASE_URL` is correct and the database is reachable
 - Ensure PostgreSQL is running and accepting connections


### PR DESCRIPTION
## Summary

Fixes #79 — fresh Docker deployments showed an empty/unresponsive dashboard and never triggered the onboarding flow.

### Root cause

`.env.example` had `BASE_URL=http://localhost:5173` (the Vite dev server port). Since `/api/config` is fetched same-origin and always succeeds, the frontend silently received the wrong `baseUrl` and routed **all API calls** (session checks, onboarding status, data queries) to the wrong port. With no server listening there, everything failed with CORS / connection-refused errors — but the app showed a blank dashboard with no explanation.

### Changes

**`.env.example`**
Adds prominent comments explaining dev vs. production values.

**`core/frontend-api` — `RuntimeConfigProvider`**
After fetching `/api/config`, if the returned `baseUrl` differs from the current page origin, the provider now probes it with a `HEAD` request (5 s timeout). A connection error means the value is misconfigured → error state is set (no silent fallback).

**`core/frontend` — `App.tsx`**
Renders an actionable error screen when the config probe fails:
- Explains the `BASE_URL` misconfiguration
- Shows the correct value for a default Docker setup
- Includes the `docker compose up -d --force-recreate` recovery command

<img width="571" height="554" alt="image" src="https://github.com/user-attachments/assets/50a9e0fd-827d-4ca0-b73b-00a651c435ab" />

**`docs/getting-started/docker.md`**
Adds a dedicated troubleshooting section for this symptom with a `curl /api/config` verification step.

### How it was tested

Built a local Docker image from the current source and ran it with `BASE_URL=http://localhost:5173` deliberately set. The error screen appeared immediately on page load. With `BASE_URL=http://localhost:3000` the onboarding flow triggers as expected.