### PR TITLE
fix(auth-backend): fix LDAP initialization TypeError

### DIFF
--- a/.changeset/fix-ldap-typeerror.md
+++ b/.changeset/fix-ldap-typeerror.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/auth-backend": patch
+---
+
+Fix TypeError in better-auth initialization when LDAP or SAML strategies are enabled. Non-social strategies are now correctly filtered out from the socialProviders configuration, and standard social providers (GitHub) are correctly initialized using their respective factory functions.

--- a/core/auth-backend/src/index.ts
+++ b/core/auth-backend/src/index.ts
@@ -1,4 +1,5 @@
 import { betterAuth } from "better-auth";
+import * as socialProviderFactories from "better-auth/social-providers";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError } from "better-auth/api";
 import {
@@ -515,10 +516,23 @@ export default createBackendPlugin({
                 strategy.id
               }: ${Object.keys(strategyConfig || {}).join(", ")}`,
             );
-            socialProviders[strategy.id] = strategyConfig;
-            logger.debug(
-              `[auth-backend]    -> ✅ Added ${strategy.id} to socialProviders`,
-            );
+
+            const providerFactory = (
+              socialProviderFactories as Record<string, unknown>
+            )[strategy.id];
+
+            if (typeof providerFactory === "function") {
+              socialProviders[strategy.id] = (
+                providerFactory as (options: unknown) => unknown
+              )(strategyConfig);
+              logger.debug(
+                `[auth-backend]    -> ✅ Added ${strategy.id} to socialProviders`,
+              );
+            } else {
+              logger.debug(
+                `[auth-backend]    -> Strategy ${strategy.id} is not a standard social provider, skipping better-auth registration`,
+              );
+            }
           }
 
           // Check if credential strategy is enabled from meta config


### PR DESCRIPTION
This PR fixes a TypeError during better-auth initialization by filtering out non-social strategies (like LDAP and SAML) from the socialProviders configuration and correctly initializing social providers using their factory functions.