### PR TITLE
fix: LDAP group-to-role mapping, login flows, and session bridge

### DIFF
--- a/.changeset/fix-ldap-flow.md
+++ b/.changeset/fix-ldap-flow.md
@@ -1,0 +1,12 @@
+---
+"@checkstack/backend-api": minor
+"@checkstack/auth-common": minor
+"@checkstack/auth-backend": patch
+"@checkstack/auth-frontend": patch
+"@checkstack/auth-ldap-backend": patch
+"@checkstack/auth-saml-backend": patch
+"@checkstack/auth-github-backend": patch
+"@checkstack/auth-credential-backend": patch
+---
+
+Introduce generic "Login Flows" to allow authentication strategies to define their own interaction patterns (form, redirect, or oauth) during registration. This fixes an issue where LDAP login attempts were incorrectly routed through the standard social login flow by instead providing a dedicated credential collection form for LDAP.

--- a/.changeset/fix-ldap-flow.md
+++ b/.changeset/fix-ldap-flow.md
@@ -7,6 +7,7 @@
 "@checkstack/auth-saml-backend": patch
 "@checkstack/auth-github-backend": patch
 "@checkstack/auth-credential-backend": patch
+"@checkstack/backend": patch
 ---
 
 Introduce generic "Login Flows" to allow authentication strategies to define their own interaction patterns (form, redirect, or oauth) during registration. This fixes an issue where LDAP login attempts were incorrectly routed through the standard social login flow by instead providing a dedicated credential collection form for LDAP.

--- a/.changeset/fix-ldap-group-mapping.md
+++ b/.changeset/fix-ldap-group-mapping.md
@@ -1,0 +1,6 @@
+---
+"@checkstack/auth-ldap-backend": patch
+"@checkstack/ui": patch
+---
+
+Fix LDAP group-to-role mapping not assigning roles on login. The LDAP search now explicitly requests the `memberOf` operational attribute, which is not returned by default. Also fixes array flattening that discarded multi-valued group memberships, and adds case-insensitive DN comparison for group matching. The test LDAP environment now uses `groupOfUniqueNames` to enable the memberOf overlay. Additionally, the DynamicForm validation no longer blocks saving when optional array fields (like group mappings) are empty.

--- a/.changeset/secure-session-bridge.md
+++ b/.changeset/secure-session-bridge.md
@@ -1,0 +1,8 @@
+---
+"@checkstack/auth-common": patch
+"@checkstack/auth-backend": patch
+"@checkstack/auth-ldap-backend": patch
+"@checkstack/auth-saml-backend": patch
+---
+
+Refactor manual session creation to use a secure, bridged oRPC endpoint. This ensures that custom authentication strategies (LDAP, SAML) leverage Better-Auth's native session establishment utilities, including cryptographic signing and reliable cookie attribute management.

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "core/api-docs-common": {
       "name": "@checkstack/api-docs-common",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -36,7 +36,7 @@
     },
     "core/api-docs-frontend": {
       "name": "@checkstack/api-docs-frontend",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -55,7 +55,7 @@
     },
     "core/auth-backend": {
       "name": "@checkstack/auth-backend",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -79,7 +79,7 @@
     },
     "core/auth-common": {
       "name": "@checkstack/auth-common",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -93,7 +93,7 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.5.12",
+      "version": "0.5.13",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -115,7 +115,7 @@
     },
     "core/backend": {
       "name": "@checkstack/backend",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -149,7 +149,7 @@
     },
     "core/backend-api": {
       "name": "@checkstack/backend-api",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
@@ -177,7 +177,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -204,7 +204,7 @@
     },
     "core/catalog-common": {
       "name": "@checkstack/catalog-common",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -220,7 +220,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -244,7 +244,7 @@
     },
     "core/command-backend": {
       "name": "@checkstack/command-backend",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-common": "workspace:*",
@@ -262,7 +262,7 @@
     },
     "core/command-common": {
       "name": "@checkstack/command-common",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -276,7 +276,7 @@
     },
     "core/command-frontend": {
       "name": "@checkstack/command-frontend",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@checkstack/command-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -295,7 +295,7 @@
     },
     "core/common": {
       "name": "@checkstack/common",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dependencies": {
         "@orpc/contract": "^1.13.14",
         "lucide-react": "0.562.0",
@@ -309,7 +309,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -338,14 +338,14 @@
     },
     "core/drizzle-helper": {
       "name": "@checkstack/drizzle-helper",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "devDependencies": {
         "typescript": "^5.0.0",
       },
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-frontend": "workspace:*",
@@ -382,7 +382,7 @@
     },
     "core/frontend-api": {
       "name": "@checkstack/frontend-api",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/client": "^1.13.14",
@@ -403,7 +403,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -436,7 +436,7 @@
     },
     "core/healthcheck-common": {
       "name": "@checkstack/healthcheck-common",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -450,7 +450,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -479,7 +479,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -506,7 +506,7 @@
     },
     "core/incident-common": {
       "name": "@checkstack/incident-common",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -522,7 +522,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -546,7 +546,7 @@
     },
     "core/integration-backend": {
       "name": "@checkstack/integration-backend",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -569,7 +569,7 @@
     },
     "core/integration-common": {
       "name": "@checkstack/integration-common",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -584,7 +584,7 @@
     },
     "core/integration-frontend": {
       "name": "@checkstack/integration-frontend",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -604,7 +604,7 @@
     },
     "core/maintenance-backend": {
       "name": "@checkstack/maintenance-backend",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -631,7 +631,7 @@
     },
     "core/maintenance-common": {
       "name": "@checkstack/maintenance-common",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -647,7 +647,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -671,7 +671,7 @@
     },
     "core/notification-backend": {
       "name": "@checkstack/notification-backend",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -695,7 +695,7 @@
     },
     "core/notification-common": {
       "name": "@checkstack/notification-common",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -710,7 +710,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -731,7 +731,7 @@
     },
     "core/queue-api": {
       "name": "@checkstack/queue-api",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -743,7 +743,7 @@
     },
     "core/queue-backend": {
       "name": "@checkstack/queue-backend",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -762,7 +762,7 @@
     },
     "core/queue-common": {
       "name": "@checkstack/queue-common",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -777,7 +777,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -800,11 +800,11 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.34.0",
+      "version": "0.35.0",
     },
     "core/scripts": {
       "name": "@checkstack/scripts",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "checkstack-scripts": "./src/cli.ts",
       },
@@ -821,7 +821,7 @@
     },
     "core/signal-backend": {
       "name": "@checkstack/signal-backend",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -837,7 +837,7 @@
     },
     "core/signal-common": {
       "name": "@checkstack/signal-common",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
@@ -850,7 +850,7 @@
     },
     "core/signal-frontend": {
       "name": "@checkstack/signal-frontend",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "@checkstack/signal-common": "workspace:*",
       },
@@ -866,7 +866,7 @@
     },
     "core/test-utils-backend": {
       "name": "@checkstack/test-utils-backend",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -882,7 +882,7 @@
     },
     "core/test-utils-frontend": {
       "name": "@checkstack/test-utils-frontend",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.0.0",
         "@testing-library/dom": "^10.0.0",
@@ -902,7 +902,7 @@
     },
     "core/theme-backend": {
       "name": "@checkstack/theme-backend",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -923,7 +923,7 @@
     },
     "core/theme-common": {
       "name": "@checkstack/theme-common",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -937,7 +937,7 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -956,14 +956,14 @@
     },
     "core/tsconfig": {
       "name": "@checkstack/tsconfig",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "devDependencies": {
         "@checkstack/scripts": "workspace:*",
       },
     },
     "core/ui": {
       "name": "@checkstack/ui",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -998,7 +998,7 @@
     },
     "plugins/auth-credential-backend": {
       "name": "@checkstack/auth-credential-backend",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1012,7 +1012,7 @@
     },
     "plugins/auth-github-backend": {
       "name": "@checkstack/auth-github-backend",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1026,7 +1026,7 @@
     },
     "plugins/auth-ldap-backend": {
       "name": "@checkstack/auth-ldap-backend",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1045,7 +1045,7 @@
     },
     "plugins/auth-saml-backend": {
       "name": "@checkstack/auth-saml-backend",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1063,7 +1063,7 @@
     },
     "plugins/collector-hardware-backend": {
       "name": "@checkstack/collector-hardware-backend",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1079,7 +1079,7 @@
     },
     "plugins/healthcheck-dns-backend": {
       "name": "@checkstack/healthcheck-dns-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1094,7 +1094,7 @@
     },
     "plugins/healthcheck-grpc-backend": {
       "name": "@checkstack/healthcheck-grpc-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1110,7 +1110,7 @@
     },
     "plugins/healthcheck-http-backend": {
       "name": "@checkstack/healthcheck-http-backend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1126,7 +1126,7 @@
     },
     "plugins/healthcheck-jenkins-backend": {
       "name": "@checkstack/healthcheck-jenkins-backend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1141,7 +1141,7 @@
     },
     "plugins/healthcheck-mysql-backend": {
       "name": "@checkstack/healthcheck-mysql-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1157,7 +1157,7 @@
     },
     "plugins/healthcheck-ping-backend": {
       "name": "@checkstack/healthcheck-ping-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1172,7 +1172,7 @@
     },
     "plugins/healthcheck-postgres-backend": {
       "name": "@checkstack/healthcheck-postgres-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1189,7 +1189,7 @@
     },
     "plugins/healthcheck-rcon-backend": {
       "name": "@checkstack/healthcheck-rcon-backend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1206,7 +1206,7 @@
     },
     "plugins/healthcheck-rcon-common": {
       "name": "@checkstack/healthcheck-rcon-common",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -1219,7 +1219,7 @@
     },
     "plugins/healthcheck-redis-backend": {
       "name": "@checkstack/healthcheck-redis-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1235,7 +1235,7 @@
     },
     "plugins/healthcheck-script-backend": {
       "name": "@checkstack/healthcheck-script-backend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1250,7 +1250,7 @@
     },
     "plugins/healthcheck-ssh-backend": {
       "name": "@checkstack/healthcheck-ssh-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1268,7 +1268,7 @@
     },
     "plugins/healthcheck-ssh-common": {
       "name": "@checkstack/healthcheck-ssh-common",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -1281,7 +1281,7 @@
     },
     "plugins/healthcheck-tcp-backend": {
       "name": "@checkstack/healthcheck-tcp-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1296,7 +1296,7 @@
     },
     "plugins/healthcheck-tls-backend": {
       "name": "@checkstack/healthcheck-tls-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1311,7 +1311,7 @@
     },
     "plugins/integration-jira-backend": {
       "name": "@checkstack/integration-jira-backend",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1330,7 +1330,7 @@
     },
     "plugins/integration-jira-common": {
       "name": "@checkstack/integration-jira-common",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/integration-common": "workspace:*",
@@ -1346,7 +1346,7 @@
     },
     "plugins/integration-script-backend": {
       "name": "@checkstack/integration-script-backend",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1363,7 +1363,7 @@
     },
     "plugins/integration-teams-backend": {
       "name": "@checkstack/integration-teams-backend",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1378,7 +1378,7 @@
     },
     "plugins/integration-webex-backend": {
       "name": "@checkstack/integration-webex-backend",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1393,7 +1393,7 @@
     },
     "plugins/integration-webhook-backend": {
       "name": "@checkstack/integration-webhook-backend",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1410,7 +1410,7 @@
     },
     "plugins/notification-backstage-backend": {
       "name": "@checkstack/notification-backstage-backend",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1424,7 +1424,7 @@
     },
     "plugins/notification-discord-backend": {
       "name": "@checkstack/notification-discord-backend",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1438,7 +1438,7 @@
     },
     "plugins/notification-gotify-backend": {
       "name": "@checkstack/notification-gotify-backend",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1452,7 +1452,7 @@
     },
     "plugins/notification-pushover-backend": {
       "name": "@checkstack/notification-pushover-backend",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1466,7 +1466,7 @@
     },
     "plugins/notification-slack-backend": {
       "name": "@checkstack/notification-slack-backend",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1480,7 +1480,7 @@
     },
     "plugins/notification-smtp-backend": {
       "name": "@checkstack/notification-smtp-backend",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1496,7 +1496,7 @@
     },
     "plugins/notification-teams-backend": {
       "name": "@checkstack/notification-teams-backend",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1510,7 +1510,7 @@
     },
     "plugins/notification-telegram-backend": {
       "name": "@checkstack/notification-telegram-backend",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1526,7 +1526,7 @@
     },
     "plugins/notification-webex-backend": {
       "name": "@checkstack/notification-webex-backend",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1540,7 +1540,7 @@
     },
     "plugins/queue-bullmq-backend": {
       "name": "@checkstack/queue-bullmq-backend",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1558,7 +1558,7 @@
     },
     "plugins/queue-bullmq-common": {
       "name": "@checkstack/queue-bullmq-common",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -1570,7 +1570,7 @@
     },
     "plugins/queue-memory-backend": {
       "name": "@checkstack/queue-memory-backend",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1587,7 +1587,7 @@
     },
     "plugins/queue-memory-common": {
       "name": "@checkstack/queue-memory-common",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },

--- a/core/auth-backend/src/index.ts
+++ b/core/auth-backend/src/index.ts
@@ -1,7 +1,9 @@
 import { betterAuth } from "better-auth";
 import * as socialProviderFactories from "better-auth/social-providers";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { APIError } from "better-auth/api";
+import { APIError, createAuthEndpoint } from "better-auth/api";
+import { setSessionCookie } from "better-auth/cookies";
+import { z } from "zod";
 import {
   createBackendPlugin,
   coreServices,
@@ -549,6 +551,74 @@ export default createBackendPlugin({
           // Default to true on fresh installs (no meta config)
           const credentialEnabled = credentialMetaConfig?.enabled ?? true;
 
+          const baseUrl = process.env.BASE_URL;
+          if (!baseUrl) {
+            throw new Error(
+              "[auth-backend] BASE_URL environment variable is not defined.",
+            );
+          }
+
+          const betterAuthSecret = process.env.BETTER_AUTH_SECRET;
+          if (!betterAuthSecret) {
+            throw new Error(
+              "[auth-backend] BETTER_AUTH_SECRET environment variable is not defined.",
+            );
+          }
+
+          const checkstackBridge = {
+            id: "checkstack-bridge",
+            endpoints: {
+              trustedLogin: createAuthEndpoint(
+                "/internal/trusted-login",
+                {
+                  method: "POST",
+                  body: z.object({ userId: z.string() }),
+                },
+                async (ctx) => {
+                  const secretHeader = ctx.request?.headers.get(
+                    "x-checkstack-internal",
+                  );
+                  if (
+                    !secretHeader ||
+                    secretHeader !== betterAuthSecret
+                  ) {
+                    throw new APIError("UNAUTHORIZED");
+                  }
+
+                  const { userId } = ctx.body;
+                  const ipAddress =
+                    ctx.request?.headers
+                      .get("x-forwarded-for")
+                      ?.split(",")[0]
+                      .trim() || undefined;
+                  const userAgent =
+                    ctx.request?.headers.get("user-agent") || undefined;
+
+                  const session =
+                    await ctx.context.internalAdapter.createSession(
+                      userId,
+                      false,
+                      {
+                        ipAddress,
+                        userAgent,
+                      },
+                    );
+                  const user =
+                    await ctx.context.internalAdapter.findUserById(userId);
+
+                  if (!user) {
+                    throw new APIError("NOT_FOUND", {
+                      message: "User not found",
+                    });
+                  }
+
+                  await setSessionCookie(ctx, { session, user });
+                  return ctx.json({ success: true, sessionId: session.id });
+                },
+              ),
+            },
+          };
+
           // Check platform registration setting
           const platformRegistrationConfig = await config.get(
             PLATFORM_REGISTRATION_CONFIG_ID,
@@ -579,8 +649,7 @@ export default createBackendPlugin({
                 // Send password reset notification via all enabled strategies
                 // Using void to prevent timing attacks revealing email existence
                 const notificationClient = rpcClient.forPlugin(NotificationApi);
-                const frontendUrl =
-                  process.env.BASE_URL || "http://localhost:5173";
+                const frontendUrl = baseUrl;
                 // SECURITY: Use URL parsing instead of brittle string splitting
                 const parsedUrl = new URL(url);
                 const resetToken = parsedUrl.searchParams.get("token");
@@ -614,8 +683,8 @@ export default createBackendPlugin({
             },
             socialProviders,
             basePath: "/api/auth",
-            baseURL: process.env.BASE_URL || "http://localhost:5173",
-            trustedOrigins: [process.env.BASE_URL || "http://localhost:5173"],
+            baseURL: baseUrl,
+            trustedOrigins: [baseUrl],
             databaseHooks: {
               user: {
                 create: {
@@ -651,6 +720,7 @@ export default createBackendPlugin({
                 },
               },
             },
+            plugins: [checkstackBridge],
           };
 
           return betterAuth(authOptions);
@@ -737,6 +807,8 @@ export default createBackendPlugin({
           reloadAuth,
           config,
           accessRuleRegistry,
+          () => auth,
+          logger,
         );
         rpc.registerRouter(authRouter, authContract);
 

--- a/core/auth-backend/src/router.test.ts
+++ b/core/auth-backend/src/router.test.ts
@@ -89,6 +89,7 @@ describe("Auth Router", () => {
     async () => {},
     mockConfigService,
     mockAccessRuleRegistry,
+    () => undefined,
   );
 
   it("getAccessRules returns current user access rules", async () => {
@@ -349,23 +350,53 @@ describe("Auth Router", () => {
     expect(mockDb.update).toHaveBeenCalled();
   });
 
-  it("createSession creates session record", async () => {
+  it("createSession calls the internal auth bridge", async () => {
     const context = createMockRpcContext({ user: mockServiceUser });
 
-    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    // Setup environment variables for the bridge call
+    process.env.BASE_URL = "http://localhost:3000";
+    process.env.BETTER_AUTH_SECRET = "test-secret";
+
+    const mockResponse = { sessionId: "session-123" };
+    const mockHandler = mock(async (_req: Request) => {
+      return new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: {
+          "Set-Cookie": "better-auth.session_token=test-token; Path=/; HttpOnly",
+        },
+      });
+    });
+
+    // We need to use a router instance that has access to our mock handler
+    const testRouter = createAuthRouter(
+      mockDb,
+      mockRegistry,
+      async () => {},
+      mockConfigService,
+      mockAccessRuleRegistry,
+      () => ({ handler: mockHandler }),
+    );
 
     const result = await call(
-      router.createSession,
+      testRouter.createSession,
       {
         userId: "user-123",
-        token: "session-token",
-        expiresAt,
       },
       { context },
     );
 
-    expect(result.sessionId).toBeDefined();
-    expect(mockDb.insert).toHaveBeenCalled();
+    expect(result.sessionId).toBe("session-123");
+    expect(result.setCookie).toContain("better-auth.session_token=test-token");
+    expect(mockHandler).toHaveBeenCalled();
+
+    // Verify the virtual request headers
+    const lastCall = mockHandler.mock.calls[0][0] as unknown as Request;
+    expect(lastCall.headers.get("Host")).toBe("localhost:3000");
+    expect(lastCall.url).toBe("http://localhost/api/auth/internal/trusted-login");
+
+    // Cleanup environment variables
+    delete process.env.BASE_URL;
+    delete process.env.BETTER_AUTH_SECRET;
   });
 
   it("upsertExternalUser syncs roles when syncRoles provided for new user", async () => {

--- a/core/auth-backend/src/router.test.ts
+++ b/core/auth-backend/src/router.test.ts
@@ -392,7 +392,7 @@ describe("Auth Router", () => {
     // Verify the virtual request headers
     const lastCall = mockHandler.mock.calls[0][0] as unknown as Request;
     expect(lastCall.headers.get("Host")).toBe("localhost:3000");
-    expect(lastCall.url).toBe("http://localhost/api/auth/internal/trusted-login");
+    expect(lastCall.url).toBe("http://localhost:3000/api/auth/internal/trusted-login");
 
     // Cleanup environment variables
     delete process.env.BASE_URL;

--- a/core/auth-backend/src/router.ts
+++ b/core/auth-backend/src/router.ts
@@ -8,7 +8,12 @@ import {
   type ConfigService,
   toJsonSchema,
 } from "@checkstack/backend-api";
-import { authContract, passwordSchema, authAccess, pluginMetadata } from "@checkstack/auth-common";
+import {
+  authContract,
+  passwordSchema,
+  authAccess,
+  pluginMetadata,
+} from "@checkstack/auth-common";
 import { qualifyAccessRuleId } from "@checkstack/common";
 import { hashPassword } from "better-auth/crypto";
 import * as schema from "./schema";
@@ -132,7 +137,9 @@ async function assertTeamManagementAccess({
 
   const hasGlobalManage =
     user?.accessRules?.includes("*") ||
-    user?.accessRules?.includes(qualifyAccessRuleId(pluginMetadata, authAccess.teams.manage));
+    user?.accessRules?.includes(
+      qualifyAccessRuleId(pluginMetadata, authAccess.teams.manage),
+    );
 
   if (hasGlobalManage) return; // Global manage allows all teams
 
@@ -157,6 +164,12 @@ async function assertTeamManagementAccess({
   });
 }
 
+const DEFAULT_LOGGER = {
+  info: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
 export const createAuthRouter = (
   internalDb: SafeDatabase<typeof schema>,
   strategyRegistry: { getStrategies: () => AuthStrategy<unknown>[] },
@@ -170,6 +183,14 @@ export const createAuthRouter = (
       isPublic?: boolean;
     }[];
   },
+  getBetterAuth: () =>
+    | { handler: (request: Request) => Promise<Response> }
+    | undefined,
+  logger: {
+    info: (msg: string, metadata?: Record<string, unknown>) => void;
+    error: (msg: string, metadata?: Record<string, unknown>) => void;
+    debug: (msg: string, metadata?: Record<string, unknown>) => void;
+  } = DEFAULT_LOGGER,
 ) => {
   // Public endpoint for enabled strategies (no authentication required)
   const getEnabledStrategies = os.getEnabledStrategies.handler(async () => {
@@ -180,9 +201,15 @@ export const createAuthRouter = (
         // Get enabled state from meta config
         const enabled = await getStrategyEnabled(strategy.id, configService);
 
-        // Determine strategy type
-        const type: "credential" | "social" =
-          strategy.id === "credential" ? "credential" : "social";
+        // Determine strategy type (backward compatibility)
+        let type: "credential" | "social" | "ldap" | "saml" = "social";
+        if (strategy.id === "credential") {
+          type = "credential";
+        } else if (strategy.clientFlow?.type === "form") {
+          type = "ldap"; // Map generic 'form' to 'ldap' for frontend compat
+        } else if (strategy.clientFlow?.type === "redirect") {
+          type = "saml"; // Map generic 'redirect' to 'saml' for frontend compat
+        }
 
         return {
           id: strategy.id,
@@ -192,6 +219,7 @@ export const createAuthRouter = (
           enabled,
           icon: strategy.icon,
           requiresManualRegistration: strategy.requiresManualRegistration,
+          clientFlow: strategy.clientFlow,
         };
       }),
     );
@@ -1031,20 +1059,82 @@ export const createAuthRouter = (
   );
 
   const createSession = os.createSession.handler(async ({ input }) => {
-    const { userId, token, expiresAt } = input;
-    const sessionId = crypto.randomUUID();
-    const now = new Date();
+    const { userId, ipAddress, userAgent } = input;
+    const auth = getBetterAuth();
 
-    await internalDb.insert(schema.session).values({
-      id: sessionId,
-      userId,
-      token,
-      expiresAt,
-      createdAt: now,
-      updatedAt: now,
+    if (!auth) {
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: "Authentication service not fully initialized.",
+      });
+    }
+
+    // Construct virtual request to the internal trusted login endpoint
+    // This allows better-auth to handle cookie signing and database persistence
+    const baseUrl = process.env.BASE_URL;
+    if (!baseUrl) {
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: "BASE_URL environment variable is not defined.",
+      });
+    }
+
+    const secret = process.env.BETTER_AUTH_SECRET;
+    if (!secret) {
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: "BETTER_AUTH_SECRET environment variable is not defined.",
+      });
+    }
+
+    const url = new URL(baseUrl);
+    const req = new Request(`${url.origin}/api/auth/internal/trusted-login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-checkstack-internal": secret,
+        "x-forwarded-for": ipAddress || "",
+        "user-agent": userAgent || "",
+        Host: url.host,
+      },
+      body: JSON.stringify({ userId }),
     });
 
-    return { sessionId };
+    const res = await auth.handler(req);
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: `Failed to create session via bridge: ${res.status} ${errorText}`,
+      });
+    }
+
+    // Extract Set-Cookie. Use getSetCookie() if available (Bun/Node 20+), otherwise fallback to get()
+    // get() usually joins multiple cookies with a comma, which is often correct but sometimes brittle
+    const setCookie =
+      typeof res.headers.getSetCookie === "function"
+        ? res.headers.getSetCookie().join(", ")
+        : res.headers.get("set-cookie");
+
+    if (!setCookie) {
+      const headers: Record<string, string> = {};
+      // eslint-disable-next-line unicorn/no-array-for-each
+      res.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+
+      logger.error("Authentication bridge did not return session cookies", {
+        status: res.status,
+        headers,
+      });
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: "Authentication service did not return session cookies.",
+      });
+    }
+
+    const body = (await res.json()) as { sessionId: string };
+
+    return {
+      sessionId: body.sessionId,
+      setCookie,
+    };
   });
 
   // ==========================================================================
@@ -1500,33 +1590,37 @@ export const createAuthRouter = (
     },
   );
 
-  const addTeamManager = os.addTeamManager.handler(async ({ input, context }) => {
-    await assertTeamManagementAccess({
-      user: context.user,
-      teamId: input.teamId,
-      internalDb,
-    });
-    await internalDb
-      .insert(schema.teamManager)
-      .values({ userId: input.userId, teamId: input.teamId })
-      .onConflictDoNothing();
-  });
+  const addTeamManager = os.addTeamManager.handler(
+    async ({ input, context }) => {
+      await assertTeamManagementAccess({
+        user: context.user,
+        teamId: input.teamId,
+        internalDb,
+      });
+      await internalDb
+        .insert(schema.teamManager)
+        .values({ userId: input.userId, teamId: input.teamId })
+        .onConflictDoNothing();
+    },
+  );
 
-  const removeTeamManager = os.removeTeamManager.handler(async ({ input, context }) => {
-    await assertTeamManagementAccess({
-      user: context.user,
-      teamId: input.teamId,
-      internalDb,
-    });
-    await internalDb
-      .delete(schema.teamManager)
-      .where(
-        and(
-          eq(schema.teamManager.userId, input.userId),
-          eq(schema.teamManager.teamId, input.teamId),
-        ),
-      );
-  });
+  const removeTeamManager = os.removeTeamManager.handler(
+    async ({ input, context }) => {
+      await assertTeamManagementAccess({
+        user: context.user,
+        teamId: input.teamId,
+        internalDb,
+      });
+      await internalDb
+        .delete(schema.teamManager)
+        .where(
+          and(
+            eq(schema.teamManager.userId, input.userId),
+            eq(schema.teamManager.teamId, input.teamId),
+          ),
+        );
+    },
+  );
 
   const getResourceTeamAccess = os.getResourceTeamAccess.handler(
     async ({ input }) => {
@@ -1787,6 +1881,50 @@ export const createAuthRouter = (
     },
   );
 
+  const getOwnStrategyConfig = os.getOwnStrategyConfig.handler(
+    async ({ context }) => {
+      if (context.user?.type !== "service") {
+        throw new ORPCError("UNAUTHORIZED", {
+          message: "This endpoint is only callable by services.",
+        });
+      }
+
+      const callerPluginId = context.user?.pluginId;
+
+      // Infer strategyId from pluginId (e.g. auth-ldap-backend -> ldap)
+      const strategyId = callerPluginId
+        .replace(/^auth-/, "")
+        .replace(/-backend$/, "");
+
+      const strategy = strategyRegistry
+        .getStrategies()
+        .find((s) => s.id === strategyId);
+
+      if (!strategy) {
+        throw new ORPCError("NOT_FOUND", {
+          message: `No strategy found for plugin ${callerPluginId} (inferred strategy ID: ${strategyId})`,
+        });
+      }
+
+      // Load full (non-redacted) config from ConfigService
+      // These configurations are stored in the auth-backend's scope
+      const config = await configService.get(
+        strategy.id,
+        strategy.configSchema,
+        strategy.configVersion,
+        strategy.migrations,
+      );
+
+      if (!config) {
+        throw new ORPCError("NOT_FOUND", {
+          message: `Configuration not found for strategy ${strategyId}`,
+        });
+      }
+
+      return { config: config as Record<string, unknown> };
+    },
+  );
+
   return os.router({
     getEnabledStrategies,
     accessRules: accessRulesHandler,
@@ -1820,6 +1958,7 @@ export const createAuthRouter = (
     updateApplication,
     deleteApplication,
     regenerateApplicationSecret,
+    getOwnStrategyConfig,
     // Teams
     getTeams,
     getTeam,

--- a/core/auth-backend/src/teams.test.ts
+++ b/core/auth-backend/src/teams.test.ts
@@ -137,7 +137,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -187,7 +188,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -252,7 +254,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       // Use mockRegularUser who has only auth.teams.read access
@@ -309,7 +312,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockRegularUser });
@@ -333,7 +337,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -389,7 +394,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -423,7 +429,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -453,7 +460,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -487,7 +495,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -520,7 +529,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -557,7 +567,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -596,7 +607,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -621,7 +633,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -658,7 +671,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -683,7 +697,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -716,7 +731,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -763,7 +779,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -808,7 +825,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -848,7 +866,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -878,7 +897,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockAdminUser });
@@ -914,7 +934,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -947,7 +968,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -998,7 +1020,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1049,7 +1072,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1102,7 +1126,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1155,7 +1180,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1206,7 +1232,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1252,7 +1279,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1303,7 +1331,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1356,7 +1385,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1414,7 +1444,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1465,7 +1496,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1518,7 +1550,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1571,7 +1604,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1601,7 +1635,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1639,7 +1674,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1702,7 +1738,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1750,7 +1787,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1813,7 +1851,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1870,7 +1909,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1933,7 +1973,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });
@@ -1966,7 +2007,8 @@ describe("Teams and Resource Access Control", () => {
         mockRegistry,
         async () => {},
         mockConfigService,
-        mockAccessRuleRegistry
+        mockAccessRuleRegistry,
+        () => undefined
       );
 
       const context = createMockRpcContext({ user: mockServiceUser });

--- a/core/auth-common/src/rpc-contract.ts
+++ b/core/auth-common/src/rpc-contract.ts
@@ -45,9 +45,28 @@ const EnabledStrategyDtoSchema = z.object({
   id: z.string(),
   displayName: z.string(),
   description: z.string().optional(),
-  type: z.enum(["credential", "social"]),
+  type: z.enum(["credential", "social", "ldap", "saml"]), // Kept for backward compatibility, but we should use clientFlow
   icon: lucideIconSchema.optional(),
   requiresManualRegistration: z.boolean(),
+  clientFlow: z
+    .discriminatedUnion("type", [
+      z.object({ type: z.literal("oauth") }),
+      z.object({ type: z.literal("redirect"), target: z.string() }),
+      z.object({
+        type: z.literal("form"),
+        target: z.string(),
+        fields: z.array(
+          z.object({
+            name: z.string(),
+            label: z.string(),
+            type: z.enum(["text", "password"]),
+            placeholder: z.string().optional(),
+          }),
+        ),
+      }),
+      z.object({ type: z.literal("credential") }),
+    ])
+    .optional(),
 });
 
 const RegistrationStatusSchema = z.object({
@@ -81,8 +100,8 @@ const UpsertExternalUserOutputSchema = z.object({
 
 const CreateSessionInputSchema = z.object({
   userId: z.string(),
-  token: z.string(),
-  expiresAt: z.coerce.date(),
+  ipAddress: z.string().optional().nullable(),
+  userAgent: z.string().optional().nullable(),
 });
 
 const CreateCredentialUserInputSchema = z.object({
@@ -337,7 +356,7 @@ export const authContract = {
     access: [],
   })
     .input(CreateSessionInputSchema)
-    .output(z.object({ sessionId: z.string() })),
+    .output(z.object({ sessionId: z.string(), setCookie: z.string() })),
 
   getUserById: proc({
     operationType: "query",
@@ -669,6 +688,12 @@ export const authContract = {
   })
     .input(z.object({ resourceType: z.string(), resourceId: z.string() }))
     .output(z.void()),
+
+  getOwnStrategyConfig: proc({
+    operationType: "query",
+    userType: "service",
+    access: [],
+  }).output(z.object({ config: z.record(z.string(), z.unknown()) })),
 };
 
 // Export contract type

--- a/core/auth-frontend/src/api.ts
+++ b/core/auth-frontend/src/api.ts
@@ -49,10 +49,26 @@ export interface EnabledAuthStrategy {
   id: string;
   displayName: string;
   description?: string;
-  type: "credential" | "social";
+  type: "credential" | "social" | "ldap" | "saml";
   icon?: LucideIconName;
   requiresManualRegistration: boolean;
+  clientFlow?: AuthClientFlow;
 }
+
+export type AuthClientFlow =
+  | { type: "oauth" }
+  | { type: "redirect"; target: string }
+  | {
+      type: "form";
+      target: string;
+      fields: Array<{
+        name: string;
+        label: string;
+        type: "text" | "password";
+        placeholder?: string;
+      }>;
+    }
+  | { type: "credential" };
 
 /**
  * AuthApi provides better-auth client methods for authentication.

--- a/core/auth-frontend/src/components/LoginPage.tsx
+++ b/core/auth-frontend/src/components/LoginPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
-import { LogIn, LogOut, AlertCircle } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
+import { LogIn, LogOut, AlertCircle, ArrowLeft } from "lucide-react";
 import {
   useApi,
   ExtensionSlot,
@@ -36,7 +36,7 @@ import {
   InfoBannerTitle,
   InfoBannerDescription,
 } from "@checkstack/ui";
-import { authApiRef } from "../api";
+import { authApiRef, EnabledAuthStrategy } from "../api";
 import { useEnabledStrategies } from "../hooks/useEnabledStrategies";
 import { useAccessRules } from "../hooks/useAccessRules";
 import { useAuthClient } from "../lib/auth-client";
@@ -44,10 +44,16 @@ import { SocialProviderButton } from "./SocialProviderButton";
 import { useEffect } from "react";
 
 export const LoginPage = () => {
+  const [activeStrategy, setActiveStrategy] = useState<
+    EnabledAuthStrategy | undefined
+  >();
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [loading, setLoading] = useState(false);
 
+  const navigate = useNavigate();
   const authApi = useApi(authApiRef);
   const authClient = usePluginClient(AuthApi);
   const { strategies, loading: strategiesLoading } = useEnabledStrategies();
@@ -61,12 +67,12 @@ export const LoginPage = () => {
   const handleCredentialLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
+    setError(undefined);
     try {
       const { error } = await authApi.signIn(email, password);
       if (error) {
-        console.error("Login failed:", error);
+        setError(error.message);
       } else {
-        // Use full page navigation to ensure session/permissions state refreshes
         globalThis.location.href = "/";
       }
     } finally {
@@ -74,24 +80,78 @@ export const LoginPage = () => {
     }
   };
 
-  const handleSocialLogin = async (provider: string) => {
+  const handleProviderClick = async (strategy: EnabledAuthStrategy) => {
+    setError(undefined);
+    const flow = strategy.clientFlow;
+
+    // Use default OAuth flow if no clientFlow provided (backward compat)
+    if (!flow || flow.type === "oauth") {
+      try {
+        await authApi.signInWithSocial(strategy.id);
+      } catch (error) {
+        setError("Failed to initialize social login");
+        console.error("Social login failed:", error);
+      }
+      return;
+    }
+
+    if (flow.type === "redirect") {
+      navigate(flow.target);
+      return;
+    }
+
+    if (flow.type === "form") {
+      setActiveStrategy(strategy);
+      setFormValues({});
+      return;
+    }
+  };
+
+  const handleCustomFormSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const flow = activeStrategy?.clientFlow;
+    if (flow?.type !== "form") return;
+
+    setLoading(true);
+    setError(undefined);
     try {
-      // SAML uses a custom endpoint, not the better-auth OAuth flow
-      if (provider === "saml") {
-        globalThis.location.href = "/api/auth-saml/saml/login";
+      const response = await fetch(flow.target, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formValues),
+      });
+
+      if (response.redirected) {
+        globalThis.location.href = response.url;
         return;
       }
-      await authApi.signInWithSocial(provider);
-      // Navigation will happen automatically after OAuth redirect
+
+      if (response.ok) {
+        const data = await response.json().catch(() => ({ success: true }));
+        if (data.success) {
+          globalThis.location.href = "/";
+          return;
+        }
+        setError(data.error?.message || "Authentication failed");
+      } else {
+        const data = await response.json().catch(() => ({}));
+        setError(data.error?.message || "Authentication failed");
+      }
     } catch (error) {
       console.error("Social login failed:", error);
     }
   };
 
-  const credentialStrategy = strategies.find((s) => s.type === "credential");
-  const socialStrategies = strategies.filter((s) => s.type === "social");
+  const credentialStrategy = strategies.find(
+    (s) => s.id === "credential" || s.clientFlow?.type === "credential",
+  );
+  const providerStrategies = strategies.filter(
+    (s) =>
+      s.id !== "credential" &&
+      (!s.clientFlow || s.clientFlow.type !== "credential"),
+  );
   const hasCredential = !!credentialStrategy;
-  const hasSocial = socialStrategies.length > 0;
+  const hasProviders = providerStrategies.length > 0;
 
   // Loading state
   if (strategiesLoading) {
@@ -144,7 +204,7 @@ export const LoginPage = () => {
         <CardHeader className="flex flex-col space-y-1 items-center">
           <CardTitle>Sign in to your account</CardTitle>
           <CardDescription>
-            {hasCredential && hasSocial
+            {hasCredential && hasProviders
               ? "Choose your preferred sign-in method"
               : hasCredential
                 ? "Enter your credentials to access the dashboard"
@@ -169,70 +229,155 @@ export const LoginPage = () => {
               </InfoBanner>
             )}
 
-            {/* Credential Form */}
-            {hasCredential && (
-              <form className="space-y-4" onSubmit={handleCredentialLogin}>
-                <div className="space-y-2">
-                  <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    placeholder="name@example.com"
-                    type="email"
-                    required
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="password">Password</Label>
-                  <Input
-                    id="password"
-                    required
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                  />
-                  <div className="text-right">
-                    <Link
-                      to={resolveRoute(authRoutes.routes.forgotPassword)}
-                      className="text-sm text-primary hover:underline"
-                    >
-                      Forgot password?
-                    </Link>
+            {/* Generic Error Alert */}
+            {error && (
+              <Alert variant="warning">
+                <AlertIcon>
+                  <AlertCircle className="h-4 w-4" />
+                </AlertIcon>
+                <AlertContent>
+                  <AlertDescription>{error}</AlertDescription>
+                </AlertContent>
+              </Alert>
+            )}
+
+            {/* Main Login Options */}
+            {!activeStrategy && (
+              <>
+                {/* Internal Credential Form */}
+                {hasCredential && (
+                  <form className="space-y-4" onSubmit={handleCredentialLogin}>
+                    <div className="space-y-2">
+                      <Label htmlFor="email">Email</Label>
+                      <Input
+                        id="email"
+                        placeholder="name@example.com"
+                        type="email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="password">Password</Label>
+                      <Input
+                        id="password"
+                        required
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                      />
+                      <div className="text-right">
+                        <Link
+                          to={resolveRoute(authRoutes.routes.forgotPassword)}
+                          className="text-sm text-primary hover:underline"
+                        >
+                          Forgot password?
+                        </Link>
+                      </div>
+                    </div>
+                    <Button type="submit" className="w-full" disabled={loading}>
+                      {loading ? "Signing In..." : "Sign In"}
+                    </Button>
+                  </form>
+                )}
+
+                {/* Separator */}
+                {hasCredential && hasProviders && (
+                  <div className="relative">
+                    <div className="absolute inset-0 flex items-center">
+                      <span className="w-full border-t border-border" />
+                    </div>
+                    <div className="relative flex justify-center text-xs uppercase">
+                      <span className="bg-card px-2 text-muted-foreground">
+                        Or continue with
+                      </span>
+                    </div>
                   </div>
-                </div>
-                <Button type="submit" className="w-full" disabled={loading}>
-                  {loading ? "Signing In..." : "Sign In"}
-                </Button>
+                )}
+
+                {/* Provider Buttons (OAuth, Redirect, or trigger Form view) */}
+                {hasProviders && (
+                  <div className="space-y-2">
+                    {providerStrategies.map((strategy) => (
+                      <SocialProviderButton
+                        key={strategy.id}
+                        displayName={strategy.displayName}
+                        icon={strategy.icon}
+                        onClick={() => handleProviderClick(strategy)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* Custom Form View (e.g. LDAP) */}
+            {activeStrategy && activeStrategy.clientFlow?.type === "form" && (
+              <form className="space-y-4" onSubmit={handleCustomFormSubmit}>
+                {(() => {
+                  const flow = activeStrategy.clientFlow;
+                  if (flow?.type !== "form") return;
+
+                  return (
+                    <>
+                      <div className="flex items-center mb-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="p-0 h-auto hover:bg-transparent -ml-1 text-muted-foreground hover:text-foreground"
+                          onClick={() => {
+                            setActiveStrategy(undefined);
+                            setError(undefined);
+                          }}
+                        >
+                          <ArrowLeft className="h-4 w-4 mr-1" />
+                          Back
+                        </Button>
+                      </div>
+
+                      <div className="space-y-2">
+                        <h4 className="font-medium text-sm">
+                          Log in with {activeStrategy.displayName}
+                        </h4>
+                        {activeStrategy.description && (
+                          <p className="text-xs text-muted-foreground">
+                            {activeStrategy.description}
+                          </p>
+                        )}
+                      </div>
+
+                      {flow.fields.map((field) => (
+                        <div key={field.name} className="space-y-2">
+                          <Label htmlFor={field.name}>{field.label}</Label>
+                          <Input
+                            id={field.name}
+                            name={field.name}
+                            type={field.type}
+                            placeholder={field.placeholder}
+                            required
+                            value={formValues[field.name] || ""}
+                            onChange={(e) =>
+                              setFormValues((prev) => ({
+                                ...prev,
+                                [field.name]: e.target.value,
+                              }))
+                            }
+                          />
+                        </div>
+                      ))}
+
+                      <Button
+                        type="submit"
+                        className="w-full"
+                        disabled={loading}
+                      >
+                        {loading ? "Processing..." : "Continue"}
+                      </Button>
+                    </>
+                  );
+                })()}
               </form>
-            )}
-
-            {/* Separator */}
-            {hasCredential && hasSocial && (
-              <div className="relative">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t border-border" />
-                </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-card px-2 text-muted-foreground">
-                    Or continue with
-                  </span>
-                </div>
-              </div>
-            )}
-
-            {/* Social Provider Buttons */}
-            {hasSocial && (
-              <div className="space-y-2">
-                {socialStrategies.map((strategy) => (
-                  <SocialProviderButton
-                    key={strategy.id}
-                    displayName={strategy.displayName}
-                    icon={strategy.icon}
-                    onClick={() => handleSocialLogin(strategy.id)}
-                  />
-                ))}
-              </div>
             )}
           </div>
         </CardContent>

--- a/core/backend-api/src/auth-strategy.ts
+++ b/core/backend-api/src/auth-strategy.ts
@@ -45,7 +45,31 @@ export interface AuthStrategy<Config = unknown> {
    * Displayed in the StrategyConfigCard before the configuration form.
    */
   adminInstructions?: string;
+
+  /**
+   * Defines how the frontend should interact with this strategy during login.
+   * If not provided, it defaults to 'oauth' for non-credential strategies.
+   */
+  clientFlow?: AuthClientFlow;
 }
+
+/**
+ * Defines the interaction pattern for the frontend during login.
+ */
+export type AuthClientFlow =
+  | { type: "oauth" } // Standard Better-Auth social flow
+  | { type: "redirect"; target: string } // Redirects user to a custom URL
+  | {
+      type: "form";
+      target: string;
+      fields: Array<{
+        name: string;
+        label: string;
+        type: "text" | "password";
+        placeholder?: string;
+      }>;
+    } // Custom credential collection form
+  | { type: "credential" }; // Native internal credential flow (internal only)
 
 /**
  * Registry for authentication strategies.

--- a/core/backend/src/services/config-service.ts
+++ b/core/backend/src/services/config-service.ts
@@ -257,6 +257,11 @@ export class ConfigServiceImpl implements ConfigService {
     // Decrypt secrets
     const decryptedData = this.decryptSecrets(schema, migratedData);
 
+    // Auto-save if migrated
+    if (versioned.needsMigration(storedRecord)) {
+      await this.set(configId, schema, version, decryptedData as T, migrations);
+    }
+
     // Validate with schema
     return schema.parse(decryptedData);
   }
@@ -294,8 +299,22 @@ export class ConfigServiceImpl implements ConfigService {
     // Parse and migrate the stored record
     const migratedData = await versioned.parse(storedRecord);
 
-    // Redact secrets (don't decrypt)
-    const redactedData = this.redactSecrets(schema, migratedData);
+    // Decrypt for auto-save (ConfigService can decrypt locally for migration persistence)
+    const decryptedData = this.decryptSecrets(schema, migratedData);
+
+    // Auto-save if migrated
+    if (versioned.needsMigration(storedRecord)) {
+      await this.set(
+        configId,
+        schema,
+        version,
+        decryptedData as T,
+        migrations
+      );
+    }
+
+    // Redact secrets for return
+    const redactedData = this.redactSecrets(schema, decryptedData);
 
     return redactedData as Partial<T>;
   }

--- a/core/ui/src/components/DynamicForm/utils.test.ts
+++ b/core/ui/src/components/DynamicForm/utils.test.ts
@@ -155,12 +155,22 @@ describe("isValueEmpty", () => {
   });
 
   describe("arrays", () => {
-    it("treats empty array as empty", () => {
-      expect(isValueEmpty([], arraySchema)).toBe(true);
+    it("treats empty array as valid when no minItems specified", () => {
+      expect(isValueEmpty([], arraySchema)).toBe(false);
+    });
+
+    it("treats empty array as empty when minItems > 0", () => {
+      const requiredArraySchema: JsonSchemaProperty = { type: "array", minItems: 1 } as JsonSchemaProperty;
+      expect(isValueEmpty([], requiredArraySchema)).toBe(true);
     });
 
     it("treats non-empty array as not empty", () => {
       expect(isValueEmpty([1, 2, 3], arraySchema)).toBe(false);
+    });
+
+    it("treats non-empty array as not empty even with minItems", () => {
+      const requiredArraySchema: JsonSchemaProperty = { type: "array", minItems: 1 } as JsonSchemaProperty;
+      expect(isValueEmpty([1], requiredArraySchema)).toBe(false);
     });
   });
 

--- a/core/ui/src/components/DynamicForm/utils.ts
+++ b/core/ui/src/components/DynamicForm/utils.ts
@@ -48,8 +48,13 @@ export function isValueEmpty(
 ): boolean {
   if (val === undefined || val === null) return true;
   if (typeof val === "string" && val.trim() === "") return true;
-  // For arrays, check if empty
-  if (Array.isArray(val) && val.length === 0) return true;
+  // For arrays, only consider empty if schema requires minimum items
+  if (Array.isArray(val) && val.length === 0) {
+    const minItems = (propSchema as JsonSchemaProperty & { minItems?: number }).minItems;
+    if (minItems !== undefined && minItems > 0) return true;
+    // Empty arrays are valid by default (e.g., optional mappings lists)
+    return false;
+  }
   // For objects (nested schemas), recursively check required fields
   if (propSchema.type === "object" && propSchema.properties) {
     const objVal = val as Record<string, unknown>;

--- a/plugins/auth-credential-backend/src/index.ts
+++ b/plugins/auth-credential-backend/src/index.ts
@@ -17,6 +17,7 @@ const credentialStrategy: AuthStrategy<z.infer<typeof credentialConfigV1>> = {
   configVersion: 1,
   configSchema: credentialConfigV1,
   requiresManualRegistration: true,
+  clientFlow: { type: "credential" },
 };
 
 export default createBackendPlugin({

--- a/plugins/auth-github-backend/src/index.ts
+++ b/plugins/auth-github-backend/src/index.ts
@@ -38,6 +38,7 @@ const githubStrategy: AuthStrategy<z.infer<typeof githubConfigV2>> = {
   configVersion: 2,
   configSchema: githubConfigV2,
   requiresManualRegistration: false,
+  clientFlow: { type: "oauth" },
   adminInstructions: `
 ## GitHub OAuth App Setup
 

--- a/plugins/auth-ldap-backend/README.md
+++ b/plugins/auth-ldap-backend/README.md
@@ -1,0 +1,41 @@
+# LDAP Auth Plugin for Checkstack
+
+This plugin provides LDAP authentication support for the Checkstack platform.
+
+## Local Test Environment
+
+To test LDAP authentication locally, we provide a pre-configured OpenLDAP server with demo data.
+
+### 1. Start the LDAP Server
+
+```bash
+cd docker
+docker-compose up -d
+```
+
+This will start:
+- **OpenLDAP**: Port `389`
+- **phpLDAPadmin**: Port `8080` (Web UI)
+
+### 2. Test Credentials
+
+- **LDAP URL**: `ldap://localhost:389`
+- **Bind DN**: `cn=admin,dc=example,dc=org`
+- **Bind Password**: `adminpassword`
+- **User Search Base**: `ou=People,dc=example,dc=org`
+- **Group Search Base**: `ou=Groups,dc=example,dc=org`
+
+#### Test User
+- **Username**: `john`
+- **Password**: `password`
+- **Groups**: `admins`
+
+### 3. Web UI
+
+You can manage the LDAP server by visiting [http://localhost:8080](http://localhost:8080).
+
+**Login Credentials for Web UI:**
+- **Login DN**: `cn=admin,dc=example,dc=org`
+- **Password**: `adminpassword`
+
+> **Note**: If you get a "connection is unencrypted" warning, you can ignore it as this is a local development container.

--- a/plugins/auth-ldap-backend/docker/bootstrap.ldif
+++ b/plugins/auth-ldap-backend/docker/bootstrap.ldif
@@ -1,0 +1,46 @@
+# LDIF Bootstrap for OpenLDAP
+# Base DN: dc=example,dc=org
+
+# Organizational Unit for People
+dn: ou=People,dc=example,dc=org
+changetype: add
+objectClass: organizationalUnit
+ou: People
+
+# Organizational Unit for Groups
+dn: ou=Groups,dc=example,dc=org
+changetype: add
+objectClass: organizationalUnit
+ou: Groups
+
+# Test User: John Doe
+dn: uid=john,ou=People,dc=example,dc=org
+changetype: add
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+cn: John Doe
+sn: Doe
+uid: john
+userPassword: password
+uidNumber: 1000
+gidNumber: 1000
+homeDirectory: /home/john
+loginShell: /bin/bash
+mail: john@example.org
+
+# Group: admins
+dn: cn=admins,ou=Groups,dc=example,dc=org
+changetype: add
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: admins
+uniqueMember: uid=john,ou=People,dc=example,dc=org
+
+# Group: developers
+dn: cn=developers,ou=Groups,dc=example,dc=org
+changetype: add
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: developers
+uniqueMember: cn=placeholder,ou=People,dc=example,dc=org

--- a/plugins/auth-ldap-backend/docker/docker-compose.yml
+++ b/plugins/auth-ldap-backend/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+name: checkstack-ldap-test
+
+services:
+  openldap:
+    image: osixia/openldap:1.5.0
+    restart: unless-stopped
+    ports:
+      - "389:389"
+      - "636:636"
+    environment:
+      LDAP_ORGANISATION: "Example Org"
+      LDAP_DOMAIN: "example.org"
+      LDAP_ADMIN_PASSWORD: "adminpassword"
+      LDAP_CONFIG_PASSWORD: "configpassword"
+    volumes:
+      - ./bootstrap.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/50-bootstrap.ldif
+    command: --copy-service --loglevel debug
+
+  phpldapadmin:
+    image: osixia/phpldapadmin:0.9.0
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    environment:
+      PHPLDAPADMIN_LDAP_HOSTS: "openldap"
+      PHPLDAPADMIN_HTTPS: "false"
+    depends_on:
+      - openldap

--- a/plugins/auth-ldap-backend/src/index.ts
+++ b/plugins/auth-ldap-backend/src/index.ts
@@ -266,6 +266,24 @@ const ldapStrategy: AuthStrategy<LdapConfig> = {
   configVersion: 3,
   configSchema: ldapConfigV3,
   requiresManualRegistration: false,
+  clientFlow: {
+    type: "form",
+    target: "/api/auth-ldap/ldap/login",
+    fields: [
+      {
+        name: "username",
+        label: "Username",
+        type: "text",
+        placeholder: "Username",
+      },
+      {
+        name: "password",
+        label: "Password",
+        type: "password",
+        placeholder: "Password",
+      },
+    ],
+  },
   adminInstructions: `
 ## LDAP Configuration
 
@@ -325,10 +343,9 @@ export default createBackendPlugin({
       deps: {
         rpc: coreServices.rpc,
         logger: coreServices.logger,
-        config: coreServices.config,
         rpcClient: coreServices.rpcClient,
       },
-      init: async ({ rpc, logger, config, rpcClient }) => {
+      init: async ({ rpc, logger, rpcClient }) => {
         logger.debug("[auth-ldap-backend] Initializing LDAP authentication...");
 
         // Create auth client once for reuse
@@ -344,8 +361,10 @@ export default createBackendPlugin({
           error?: string;
         }> => {
           try {
-            // Load LDAP configuration
-            const ldapConfig = await config.get("ldap", ldapConfigV3, 3);
+            // Load LDAP configuration from central auth-backend
+            const { config: rawConfig } =
+              await authClient.getOwnStrategyConfig();
+            const ldapConfig = ldapConfigV3.parse(rawConfig);
 
             if (!ldapConfig) {
               return {
@@ -355,19 +374,22 @@ export default createBackendPlugin({
             }
 
             // Create LDAP client
+            const isSecure = ldapConfig.url.startsWith("ldaps://");
             const client = new LdapClient({
-              url: ldapConfig.url,
+              url: ldapConfig.url.trim(),
               timeout: ldapConfig.timeout,
-              tlsOptions: ldapConfig.tlsOptions.ca
-                ? {
-                    rejectUnauthorized:
-                      ldapConfig.tlsOptions.rejectUnauthorized,
-                    ca: ldapConfig.tlsOptions.ca,
-                  }
-                : {
-                    rejectUnauthorized:
-                      ldapConfig.tlsOptions.rejectUnauthorized,
-                  },
+              tlsOptions: isSecure
+                ? ldapConfig.tlsOptions.ca
+                  ? {
+                      rejectUnauthorized:
+                        ldapConfig.tlsOptions.rejectUnauthorized,
+                      ca: ldapConfig.tlsOptions.ca,
+                    }
+                  : {
+                      rejectUnauthorized:
+                        ldapConfig.tlsOptions.rejectUnauthorized,
+                    }
+                : undefined,
             });
 
             try {
@@ -381,9 +403,17 @@ export default createBackendPlugin({
                 "{0}",
                 username,
               );
+              // Request all user attributes (*) plus the memberOf operational attribute
+              // memberOf is not returned by default in most LDAP servers
+              const searchAttributes = ["*"];
+              if (ldapConfig.groupMapping?.enabled && ldapConfig.groupMapping.memberOfAttribute) {
+                searchAttributes.push(ldapConfig.groupMapping.memberOfAttribute);
+              }
+
               const searchResult = await client.search(ldapConfig.baseDN, {
                 filter: searchFilter,
                 scope: "sub",
+                attributes: searchAttributes,
               });
 
               if (
@@ -407,18 +437,20 @@ export default createBackendPlugin({
 
               // Step 3: Try to bind as the user to verify password
               const userClient = new LdapClient({
-                url: ldapConfig.url,
+                url: ldapConfig.url.trim(),
                 timeout: ldapConfig.timeout,
-                tlsOptions: ldapConfig.tlsOptions.ca
-                  ? {
-                      rejectUnauthorized:
-                        ldapConfig.tlsOptions.rejectUnauthorized,
-                      ca: ldapConfig.tlsOptions.ca,
-                    }
-                  : {
-                      rejectUnauthorized:
-                        ldapConfig.tlsOptions.rejectUnauthorized,
-                    },
+                tlsOptions: isSecure
+                  ? ldapConfig.tlsOptions.ca
+                    ? {
+                        rejectUnauthorized:
+                          ldapConfig.tlsOptions.rejectUnauthorized,
+                        ca: ldapConfig.tlsOptions.ca,
+                      }
+                    : {
+                        rejectUnauthorized:
+                          ldapConfig.tlsOptions.rejectUnauthorized,
+                      }
+                  : undefined,
               });
 
               try {
@@ -436,8 +468,17 @@ export default createBackendPlugin({
                 if (typeof value === "string" || typeof value === "number") {
                   attributes[key] = value;
                 } else if (Array.isArray(value) && value.length > 0) {
-                  // Take first value for arrays
-                  attributes[key] = value[0];
+                  // Normalize memberOf attribute case and preserve arrays for group mapping
+                  if (
+                    ldapConfig.groupMapping?.enabled &&
+                    ldapConfig.groupMapping.memberOfAttribute &&
+                    key.toLowerCase() === ldapConfig.groupMapping.memberOfAttribute.toLowerCase()
+                  ) {
+                    attributes[ldapConfig.groupMapping.memberOfAttribute] = value;
+                  } else {
+                    // Take first value for standard attributes like name/email
+                    attributes[key] = value[0];
+                  }
                 }
               }
 
@@ -459,7 +500,9 @@ export default createBackendPlugin({
           username: string,
           ldapAttributes: Record<string, unknown>,
         ): Promise<{ userId: string; email: string; name: string }> => {
-          const ldapConfig = await config.get("ldap", ldapConfigV3, 3);
+          const { config: rawConfig } = await authClient.getOwnStrategyConfig();
+          const ldapConfig = ldapConfigV3.parse(rawConfig);
+
           if (!ldapConfig) {
             throw new Error("LDAP configuration not found");
           }
@@ -506,9 +549,11 @@ export default createBackendPlugin({
               memberOfAttribute: ldapConfig.groupMapping.memberOfAttribute,
             });
 
-            // Map groups to roles
+            // Map groups to roles (case-insensitive comparison for DN matching)
             const mappedRoles = ldapConfig.groupMapping.mappings
-              .filter((m) => groups.includes(m.directoryGroup))
+              .filter((m) =>
+                groups.some(g => g.toLowerCase() === m.directoryGroup.toLowerCase()),
+              )
               .map((m) => m.checkstackRole);
 
             // Add default role if configured
@@ -531,7 +576,7 @@ export default createBackendPlugin({
 
             if (syncRoles.length > 0) {
               logger.debug(
-                `LDAP user ${email} will be assigned roles: ${syncRoles.join(", ")}`,
+                `LDAP user ${email} matched ${groups.length} groups, assigning roles: ${syncRoles.join(", ")}`,
               );
             }
           }
@@ -586,18 +631,19 @@ export default createBackendPlugin({
             );
 
             // Create session via RPC
-            const sessionToken = crypto.randomUUID();
-            const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
+            // This delegates cookie signing to the auth-backend (Better-Auth)
+            const ipAddress = req.headers.get("x-forwarded-for")?.split(",")[0].trim() || undefined;
+            const userAgent = req.headers.get("user-agent") || undefined;
 
-            await authClient.createSession({
+            const { setCookie } = await authClient.createSession({
               userId,
-              token: sessionToken,
-              expiresAt,
+              ipAddress,
+              userAgent,
             });
 
-            logger.info(`Created session for LDAP user: ${email}`);
+            logger.info(`Created bridged session for LDAP user: ${email} (IP: ${ipAddress ?? "unknown"})`);
 
-            // Return session token in cookie format
+            // Return user info and include the signed session cookie from better-auth
             return Response.json(
               {
                 success: true,
@@ -608,12 +654,8 @@ export default createBackendPlugin({
                 },
               },
               {
-                status: 200,
                 headers: {
-                  "Content-Type": "application/json",
-                  "Set-Cookie": `better-auth.session_token=${sessionToken}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${
-                    7 * 24 * 60 * 60
-                  }`,
+                  "Set-Cookie": setCookie,
                 },
               },
             );
@@ -625,7 +667,7 @@ export default createBackendPlugin({
                 : "Authentication failed. Please try again.";
             return redirectToAuthError(message);
           }
-        });
+        }, "/ldap/login");
 
         logger.debug("✅ LDAP authentication initialized");
       },

--- a/plugins/auth-saml-backend/src/index.ts
+++ b/plugins/auth-saml-backend/src/index.ts
@@ -225,6 +225,10 @@ const samlStrategy: AuthStrategy<SamlConfig> = {
     },
   ],
   requiresManualRegistration: false,
+  clientFlow: {
+    type: "redirect",
+    target: "/api/auth-saml/saml/login",
+  },
   adminInstructions: `
 ## SAML SSO Configuration
 
@@ -274,10 +278,9 @@ export default createBackendPlugin({
       deps: {
         rpc: coreServices.rpc,
         logger: coreServices.logger,
-        config: coreServices.config,
         rpcClient: coreServices.rpcClient,
       },
-      init: async ({ rpc, logger, config, rpcClient }) => {
+      init: async ({ rpc, logger, rpcClient }) => {
         logger.debug("[auth-saml-backend] Initializing SAML authentication...");
 
         // Create auth client once for reuse
@@ -290,7 +293,8 @@ export default createBackendPlugin({
           sp: samlify.ServiceProviderInstance;
           idp: samlify.IdentityProviderInstance;
         }> => {
-          const samlConfig = await config.get("saml", samlConfigV2, 2);
+          const { config: rawConfig } = await authClient.getOwnStrategyConfig();
+          const samlConfig = samlConfigV2.parse(rawConfig);
 
           if (!samlConfig) {
             throw new Error("SAML configuration not found");
@@ -381,7 +385,9 @@ export default createBackendPlugin({
           nameId: string;
           attributes: Record<string, unknown>;
         }): Promise<{ userId: string; email: string; name: string }> => {
-          const samlConfig = await config.get("saml", samlConfigV2, 2);
+          const { config: rawConfig } = await authClient.getOwnStrategyConfig();
+          const samlConfig = samlConfigV2.parse(rawConfig);
+
           if (!samlConfig) {
             throw new Error("SAML configuration not found");
           }
@@ -539,25 +545,24 @@ export default createBackendPlugin({
             });
 
             // Create session via RPC
-            const sessionToken = crypto.randomUUID();
-            const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
+            // This delegates cookie signing to the auth-backend (Better-Auth)
+            const ipAddress = req.headers.get("x-forwarded-for")?.split(",")[0].trim() || undefined;
+            const userAgent = req.headers.get("user-agent") || undefined;
 
-            await authClient.createSession({
+            const { setCookie } = await authClient.createSession({
               userId,
-              token: sessionToken,
-              expiresAt,
+              ipAddress,
+              userAgent,
             });
 
-            logger.info(`Created session for SAML user: ${email}`);
+            logger.info(`Created bridged session for SAML user: ${email} (IP: ${ipAddress ?? "unknown"})`);
 
-            // Redirect to home with session cookie
+            // Redirect to home with the signed session cookie from better-auth
             return new Response(undefined, {
               status: 302,
               headers: {
                 Location: "/",
-                "Set-Cookie": `better-auth.session_token=${sessionToken}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${
-                  7 * 24 * 60 * 60
-                }`,
+                "Set-Cookie": setCookie,
               },
             });
           } catch (error) {


### PR DESCRIPTION
## Summary
### LDAP Group Mapping Fixes
- Request `memberOf` operational attribute explicitly in LDAP search
- Preserve multi-valued group arrays (fix attribute flattening)
- Case-insensitive DN matching for group comparison
- Test LDAP environment uses `groupOfUniqueNames` for memberOf overlay
### DynamicForm Validation Fix
- Empty arrays no longer block saves — respects `minItems` schema property
### Other
- Generic Login Flows for auth strategies (form, redirect, oauth)
- Secure bridged oRPC session creation for LDAP/SAML
- Fix stale `@ts-expect-error` in auth-backend router