### PR TITLE
fix(ldap): render CA certificate field as multi-line textarea

### DIFF
--- a/.changeset/fix-ldap-ca-certificate-input.md
+++ b/.changeset/fix-ldap-ca-certificate-input.md
@@ -1,0 +1,6 @@
+---
+"@checkstack/auth-ldap-backend": patch
+"@checkstack/ui": patch
+---
+
+Fix LDAP CA certificate input: The custom CA certificate field was rendered as a single-line password input, which stripped newlines from PEM certificates and caused TLS connection failures ("Failed to connect"). The field now renders as a multi-line secret textarea that properly preserves PEM format while still encrypting the value in storage.

--- a/core/ui/src/components/DynamicForm/FormField.tsx
+++ b/core/ui/src/components/DynamicForm/FormField.tsx
@@ -140,6 +140,20 @@ export const FormField: React.FC<FormFieldProps> = ({
       propSchema as JsonSchemaProperty & { "x-secret"?: boolean }
     )["x-secret"];
 
+    // Secret textarea fields (e.g., PEM certificates)
+    if (isTextarea && isSecret) {
+      return (
+        <SecretTextareaField
+          id={id}
+          label={label}
+          description={cleanDesc}
+          value={value as string}
+          isRequired={isRequired}
+          onChange={onChange}
+        />
+      );
+    }
+
     // Textarea fields
     if (isTextarea) {
       return (
@@ -578,6 +592,56 @@ export const FormField: React.FC<FormFieldProps> = ({
 };
 
 /**
+ * Shared visibility toggle button for secret fields.
+ */
+const VisibilityToggle: React.FC<{
+  visible: boolean;
+  onToggle: () => void;
+}> = ({ visible, onToggle }) => (
+  <button
+    type="button"
+    onClick={onToggle}
+    className="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
+  >
+    {visible ? (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+        />
+      </svg>
+    ) : (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+        />
+      </svg>
+    )}
+  </button>
+);
+
+/**
  * Secret field component with password visibility toggle.
  * Extracted to keep hooks at component top level.
  */
@@ -612,47 +676,91 @@ const SecretField: React.FC<{
           placeholder={hasExistingValue ? "••••••••" : "Enter secret value"}
           className="pr-10"
         />
-        <button
-          type="button"
-          onClick={() => setShowPassword(!showPassword)}
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-        >
-          {showPassword ? (
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-              />
-            </svg>
-          ) : (
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-              />
-            </svg>
-          )}
-        </button>
+        <VisibilityToggle
+          visible={showPassword}
+          onToggle={() => setShowPassword(!showPassword)}
+        />
+      </div>
+      {hasExistingValue && currentValue === "" && (
+        <p className="text-xs text-muted-foreground">
+          Leave empty to keep existing value
+        </p>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Secret textarea field for multi-line secrets (e.g., PEM certificates).
+ * Renders a textarea with a visibility toggle and secret-like behavior.
+ */
+const SecretTextareaField: React.FC<{
+  id: string;
+  label: string;
+  description?: string;
+  value: string;
+  isRequired?: boolean;
+  onChange: (val: unknown) => void;
+}> = ({ id, label, description, value, isRequired, onChange }) => {
+  const [showContent, setShowContent] = React.useState(false);
+  const currentValue = value || "";
+  const hasExistingValue = currentValue.length > 0;
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <Label htmlFor={id}>
+          {label} {isRequired && "*"}
+        </Label>
+        {description && (
+          <p className="text-sm text-muted-foreground mt-0.5">{description}</p>
+        )}
+      </div>
+      <div className="relative">
+        {showContent ? (
+          <Textarea
+            id={id}
+            value={currentValue}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={
+              hasExistingValue ? "Leave empty to keep existing value" : "Paste content here"
+            }
+            rows={5}
+            className="pr-10 font-mono text-xs"
+          />
+        ) : (
+          <Textarea
+            id={id}
+            value={currentValue ? "••••••••••••••••••••" : ""}
+            onChange={(e) => {
+              // If user types/pastes into masked field, switch to visible mode
+              const newVal = e.target.value.replaceAll("•", "");
+              if (newVal) {
+                setShowContent(true);
+                onChange(newVal);
+              }
+            }}
+            onPaste={(e) => {
+              // On paste, switch to visible mode and use pasted content
+              e.preventDefault();
+              const pastedText = e.clipboardData.getData("text");
+              if (pastedText) {
+                setShowContent(true);
+                onChange(pastedText);
+              }
+            }}
+            placeholder={
+              hasExistingValue ? "Leave empty to keep existing value" : "Paste content here"
+            }
+            rows={3}
+            className="pr-10"
+            readOnly={!!currentValue}
+          />
+        )}
+        <VisibilityToggle
+          visible={showContent}
+          onToggle={() => setShowContent(!showContent)}
+        />
       </div>
       {hasExistingValue && currentValue === "" && (
         <p className="text-xs text-muted-foreground">

--- a/plugins/auth-ldap-backend/src/index.ts
+++ b/plugins/auth-ldap-backend/src/index.ts
@@ -71,7 +71,7 @@ const _ldapConfigV1 = z.object({
         .default(true)
         .describe("Reject unauthorized SSL certificates"),
       ca: configString({ "x-secret": true })
-        .describe("Custom CA certificate (PEM format)")
+        .describe("[textarea] Custom CA certificate (PEM format)")
         .optional(),
     })
     .default({ rejectUnauthorized: true })
@@ -138,7 +138,7 @@ const _ldapConfigV2 = z.object({
         .default(true)
         .describe("Reject unauthorized SSL certificates"),
       ca: configString({ "x-secret": true })
-        .describe("Custom CA certificate (PEM format)")
+        .describe("[textarea] Custom CA certificate (PEM format)")
         .optional(),
     })
     .default({ rejectUnauthorized: true })
@@ -239,7 +239,7 @@ const ldapConfigV3 = z.object({
         .default(true)
         .describe("Reject unauthorized SSL certificates"),
       ca: configString({ "x-secret": true })
-        .describe("Custom CA certificate (PEM format)")
+        .describe("[textarea] Custom CA certificate (PEM format)")
         .optional(),
     })
     .default({ rejectUnauthorized: true })


### PR DESCRIPTION
## Problem

When configuring LDAP with a custom CA certificate in production, pasting a multi-line PEM certificate into the config UI caused `"Failed to connect"` errors. The CA certificate field was rendered as a single-line password `<input>` (due to `x-secret: true`), which stripped all newlines from the PEM content, producing a malformed certificate that broke `tls.connect()`.

## Root Cause

The DynamicForm's `FormField` component had no handling for fields that need to be **both** multi-line (`[textarea]`) **and** secret (`x-secret`). The `x-secret` flag always rendered a single-line password input, making it impossible to enter PEM certificates correctly.

## Changes

### `core/ui` — `FormField.tsx`
- New **`SecretTextareaField`** component: multi-line textarea with visibility toggle and "leave empty to keep existing" behavior, used when a field has both `x-secret` and `[textarea]`
- Extracted shared **`VisibilityToggle`** component from `SecretField` (DRY refactor)

### `plugins/auth-ldap-backend` — `index.ts`
- Added `[textarea]` marker to the CA certificate field description in all 3 schema versions

## Testing
- All existing DynamicForm tests pass (62/62)
- All existing LDAP plugin tests pass (44/44)
- Lint and typecheck clean