### PR TITLE
feat: Add About page with platform info, license, and version details

### DIFF
--- a/.changeset/add-about-page.md
+++ b/.changeset/add-about-page.md
@@ -1,0 +1,13 @@
+---
+"@checkstack/about-common": minor
+"@checkstack/about-frontend": minor
+"@checkstack/backend": minor
+"@checkstack/frontend": minor
+---
+
+Add About page with platform information, license, contact details, and version information
+
+- New `about-common` package with plugin metadata
+- New `about-frontend` package with the About page and user menu item
+- New `/api/about` backend endpoint exposing core version and loaded plugin versions
+- Accessible via "About Checkstack" in the user menu dropdown

--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@
 ---
 
 > [!WARNING]
-> Checkstack is currently in **alpha** and is not ready for production use.
+> Checkstack Core is currently in **beta**.
 >
-> Breaking changes are to be expected regularly in this development phase. We're still happy if you try it out and give us feedback!
+> Breaking changes might happen, but are not to be expected regularly.
+>
+> Some plugins are still in Alpha and need more testing, as we don't have all the integration systems available to thoroughly test them right now.
+>
+> Please report any issues you find via the [issue tracker](https://github.com/checkstack/checkstack/issues)!
 
 ## 📸 Screenshots
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,37 @@
         "typescript-eslint": "^8.58.2",
       },
     },
+    "core/about-common": {
+      "name": "@checkstack/about-common",
+      "version": "0.1.0",
+      "dependencies": {
+        "@checkstack/common": "workspace:*",
+      },
+      "devDependencies": {
+        "@checkstack/scripts": "workspace:*",
+        "@checkstack/tsconfig": "workspace:*",
+        "typescript": "^5.7.2",
+      },
+    },
+    "core/about-frontend": {
+      "name": "@checkstack/about-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@checkstack/about-common": "workspace:*",
+        "@checkstack/common": "workspace:*",
+        "@checkstack/frontend-api": "workspace:*",
+        "@checkstack/ui": "workspace:*",
+        "lucide-react": "^0.344.0",
+        "react": "^18.2.0",
+        "react-router-dom": "^6.22.0",
+      },
+      "devDependencies": {
+        "@checkstack/scripts": "workspace:*",
+        "@checkstack/tsconfig": "workspace:*",
+        "@types/react": "^18.2.0",
+        "typescript": "^5.0.0",
+      },
+    },
     "core/announcement-backend": {
       "name": "@checkstack/announcement-backend",
       "version": "0.1.0",
@@ -407,6 +438,7 @@
       "name": "@checkstack/frontend",
       "version": "0.2.22",
       "dependencies": {
+        "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-frontend": "workspace:*",
@@ -1727,6 +1759,10 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@checkstack/about-common": ["@checkstack/about-common@workspace:core/about-common"],
+
+    "@checkstack/about-frontend": ["@checkstack/about-frontend@workspace:core/about-frontend"],
 
     "@checkstack/announcement-backend": ["@checkstack/announcement-backend@workspace:core/announcement-backend"],
 

--- a/core/about-common/package.json
+++ b/core/about-common/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@checkstack/about-common",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "@checkstack/common": "workspace:*"
+  },
+  "devDependencies": {
+    "@checkstack/tsconfig": "workspace:*",
+    "@checkstack/scripts": "workspace:*",
+    "typescript": "^5.7.2"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "bun run lint:code",
+    "lint:code": "eslint . --max-warnings 0"
+  },
+  "checkstack": {
+    "type": "common"
+  }
+}

--- a/core/about-common/src/index.ts
+++ b/core/about-common/src/index.ts
@@ -1,0 +1,1 @@
+export { pluginMetadata } from "./plugin-metadata";

--- a/core/about-common/src/plugin-metadata.ts
+++ b/core/about-common/src/plugin-metadata.ts
@@ -1,0 +1,5 @@
+import { definePluginMetadata } from "@checkstack/common";
+
+export const pluginMetadata = definePluginMetadata({
+  pluginId: "about",
+});

--- a/core/about-common/tsconfig.json
+++ b/core/about-common/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@checkstack/tsconfig/common.json",
+  "include": [
+    "src"
+  ]
+}

--- a/core/about-frontend/package.json
+++ b/core/about-frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@checkstack/about-frontend",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.tsx",
+  "checkstack": {
+    "type": "frontend"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "bun run lint:code",
+    "lint:code": "eslint . --max-warnings 0"
+  },
+  "dependencies": {
+    "@checkstack/about-common": "workspace:*",
+    "@checkstack/frontend-api": "workspace:*",
+    "@checkstack/common": "workspace:*",
+    "@checkstack/ui": "workspace:*",
+    "react": "^18.2.0",
+    "react-router-dom": "^6.22.0",
+    "lucide-react": "^0.344.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/react": "^18.2.0",
+    "@checkstack/tsconfig": "workspace:*",
+    "@checkstack/scripts": "workspace:*"
+  }
+}

--- a/core/about-frontend/src/AboutMenuItem.tsx
+++ b/core/about-frontend/src/AboutMenuItem.tsx
@@ -1,0 +1,18 @@
+import { useNavigate } from "react-router-dom";
+import { Info } from "lucide-react";
+import { DropdownMenuItem } from "@checkstack/ui";
+import { resolveRoute } from "@checkstack/common";
+import { aboutRoutes } from "./index";
+
+export function AboutMenuItem() {
+  const navigate = useNavigate();
+
+  return (
+    <DropdownMenuItem
+      onClick={() => navigate(resolveRoute(aboutRoutes.routes.page))}
+      icon={<Info className="h-4 w-4" />}
+    >
+      About Checkstack
+    </DropdownMenuItem>
+  );
+}

--- a/core/about-frontend/src/AboutPage.tsx
+++ b/core/about-frontend/src/AboutPage.tsx
@@ -1,0 +1,289 @@
+import { useState, useEffect } from "react";
+import { Info, Github, Mail, Scale, ExternalLink, Package } from "lucide-react";
+import {
+  PageLayout,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  Badge,
+  LoadingSpinner,
+} from "@checkstack/ui";
+
+interface PluginInfo {
+  name: string;
+  version: string;
+  type: "backend" | "frontend" | "common";
+}
+
+interface AboutInfo {
+  coreVersion: string;
+  plugins: PluginInfo[];
+}
+
+/**
+ * Formats a raw package name for display.
+ * Strips `@checkstack/` prefix and converts to title case.
+ * e.g., "@checkstack/healthcheck-http-backend" → "Healthcheck HTTP"
+ */
+function formatPluginName(name: string): string {
+  const stripped = name.replace("@checkstack/", "");
+  // Remove type suffixes (-backend, -frontend, -common)
+  const withoutSuffix = stripped
+    .replace(/-backend$/, "")
+    .replace(/-frontend$/, "")
+    .replace(/-common$/, "");
+  // Title case with dashes as spaces
+  return withoutSuffix
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/**
+ * Returns a badge variant for a plugin type.
+ */
+function typeBadgeVariant(type: string): "default" | "secondary" | "info" {
+  switch (type) {
+    case "backend": {
+      return "default";
+    }
+    case "frontend": {
+      return "info";
+    }
+    default: {
+      return "secondary";
+    }
+  }
+}
+
+export function AboutPage() {
+  const [aboutInfo, setAboutInfo] = useState<AboutInfo | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    const fetchAboutInfo = async () => {
+      try {
+        const response = await fetch("/api/about");
+        if (!response.ok) {
+          throw new Error(`Failed to fetch about info: ${response.status}`);
+        }
+        const data = (await response.json()) as AboutInfo;
+        setAboutInfo(data);
+      } catch (error) {
+        setError(
+          error instanceof Error ? error.message : "Failed to load about info",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void fetchAboutInfo();
+  }, []);
+
+  return (
+    <PageLayout
+      title="About Checkstack"
+      icon={Info}
+      subtitle="Platform information, license, and version details"
+    >
+      {/* Hero Section */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-start gap-4">
+            <div className="rounded-xl bg-primary/10 p-3">
+              <Package className="h-8 w-8 text-primary" />
+            </div>
+            <div className="space-y-1">
+              <CardTitle className="text-xl">Checkstack</CardTitle>
+              <CardDescription className="text-base">
+                The Modern Status Page &amp; Monitoring Platform
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Monitor your systems, keep users informed, and maintain trust.
+            Checkstack combines the power of a status page, uptime monitoring,
+            and incident management into a single, extensible platform.
+          </p>
+          <div className="flex flex-wrap gap-3 mt-4">
+            <a
+              href="https://github.com/enyineer/checkstack"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-border bg-secondary/50 px-4 py-2 text-sm font-medium text-foreground hover:bg-secondary transition-colors"
+            >
+              <Github className="h-4 w-4" />
+              GitHub Repository
+              <ExternalLink className="h-3 w-3 text-muted-foreground" />
+            </a>
+            <a
+              href="mailto:hi@enking.dev"
+              className="inline-flex items-center gap-2 rounded-lg border border-border bg-secondary/50 px-4 py-2 text-sm font-medium text-foreground hover:bg-secondary transition-colors"
+            >
+              <Mail className="h-4 w-4" />
+              hi@enking.dev
+            </a>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* License Section */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <Scale className="h-5 w-5 text-muted-foreground" />
+            <CardTitle className="text-lg">License</CardTitle>
+          </div>
+          <CardDescription>
+            Checkstack is licensed under the{" "}
+            <strong className="text-foreground">
+              Elastic License 2.0 (ELv2)
+            </strong>
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="rounded-lg bg-success/5 border border-success/20 p-4">
+              <h4 className="text-sm font-semibold text-success mb-2">
+                ✅ Allowed
+              </h4>
+              <ul className="space-y-1 text-sm text-muted-foreground">
+                <li>Internal company use</li>
+                <li>Personal projects</li>
+                <li>Research &amp; education</li>
+                <li>Modification &amp; redistribution</li>
+                <li>Building applications on top</li>
+              </ul>
+            </div>
+            <div className="rounded-lg bg-destructive/5 border border-destructive/20 p-4">
+              <h4 className="text-sm font-semibold text-destructive mb-2">
+                ❌ Not Allowed
+              </h4>
+              <ul className="space-y-1 text-sm text-muted-foreground">
+                <li>Selling as a managed SaaS</li>
+                <li>Removing license protections</li>
+              </ul>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground mt-4">
+            Need a commercial license to provide Checkstack as a managed / SaaS
+            service?{" "}
+            <a
+              href="mailto:hi@enking.dev"
+              className="text-primary hover:underline"
+            >
+              Contact us
+            </a>
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Version Information Section */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <Info className="h-5 w-5 text-muted-foreground" />
+            <CardTitle className="text-lg">Version Information</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading && (
+            <div className="flex justify-center py-6">
+              <LoadingSpinner />
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-lg bg-destructive/10 border border-destructive/20 p-4 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          {aboutInfo && (
+            <div className="space-y-6">
+              {/* Core Version */}
+              <div className="flex items-center justify-between rounded-lg bg-secondary/50 border border-border p-4">
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    Checkstack Core
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Backend platform engine
+                  </p>
+                </div>
+                <Badge variant="default" className="font-mono text-xs">
+                  v{aboutInfo.coreVersion}
+                </Badge>
+              </div>
+
+              {/* Plugin Versions Table */}
+              {aboutInfo.plugins.length > 0 && (
+                <div>
+                  <h4 className="text-sm font-medium text-foreground mb-3">
+                    Loaded Plugins ({aboutInfo.plugins.length})
+                  </h4>
+                  <div className="rounded-lg border border-border overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-border bg-muted/50">
+                          <th className="text-left py-2.5 px-4 font-medium text-muted-foreground">
+                            Plugin
+                          </th>
+                          <th className="text-left py-2.5 px-4 font-medium text-muted-foreground">
+                            Type
+                          </th>
+                          <th className="text-right py-2.5 px-4 font-medium text-muted-foreground">
+                            Version
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {aboutInfo.plugins.map((plugin) => (
+                          <tr
+                            key={plugin.name}
+                            className="border-b border-border last:border-0 hover:bg-muted/30 transition-colors"
+                          >
+                            <td className="py-2.5 px-4">
+                              <span className="font-medium text-foreground">
+                                {formatPluginName(plugin.name)}
+                              </span>
+                              <span className="block text-xs text-muted-foreground font-mono">
+                                {plugin.name}
+                              </span>
+                            </td>
+                            <td className="py-2.5 px-4">
+                              <Badge
+                                variant={typeBadgeVariant(plugin.type)}
+                                className="text-[10px]"
+                              >
+                                {plugin.type}
+                              </Badge>
+                            </td>
+                            <td className="py-2.5 px-4 text-right font-mono text-muted-foreground">
+                              {plugin.version}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Footer Attribution */}
+      <p className="text-center text-xs text-muted-foreground py-4">
+        Built with ❤️ for reliability engineers everywhere
+      </p>
+    </PageLayout>
+  );
+}

--- a/core/about-frontend/src/index.tsx
+++ b/core/about-frontend/src/index.tsx
@@ -1,0 +1,31 @@
+import {
+  createFrontendPlugin,
+  UserMenuItemsBottomSlot,
+} from "@checkstack/frontend-api";
+import { createRoutes } from "@checkstack/common";
+import { pluginMetadata } from "@checkstack/about-common";
+import { AboutPage } from "./AboutPage";
+import { AboutMenuItem } from "./AboutMenuItem";
+
+export const aboutRoutes = createRoutes(pluginMetadata.pluginId, {
+  page: "/",
+});
+
+export const aboutPlugin = createFrontendPlugin({
+  metadata: pluginMetadata,
+  routes: [
+    {
+      route: aboutRoutes.routes.page,
+      element: <AboutPage />,
+    },
+  ],
+  extensions: [
+    {
+      id: "about.user-menu.link",
+      slot: UserMenuItemsBottomSlot,
+      component: AboutMenuItem,
+    },
+  ],
+});
+
+export default aboutPlugin;

--- a/core/about-frontend/tsconfig.json
+++ b/core/about-frontend/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@checkstack/tsconfig/frontend.json",
+  "include": [
+    "src"
+  ]
+}

--- a/core/backend/src/index.ts
+++ b/core/backend/src/index.ts
@@ -95,6 +95,54 @@ app.get("/api/plugins", async (c) => {
   return c.json(enabledPlugins);
 });
 
+// About endpoint - returns core version and loaded plugin versions
+app.get("/api/about", async (c) => {
+  // Read core backend version from package.json
+  let coreVersion = "unknown";
+  try {
+    const corePkgPath = path.join(import.meta.dir, "..", "package.json");
+    if (fs.existsSync(corePkgPath)) {
+      const corePkg = JSON.parse(fs.readFileSync(corePkgPath, "utf8"));
+      coreVersion = corePkg.version ?? "unknown";
+    }
+  } catch {
+    rootLogger.debug("Failed to read core backend package.json for version");
+  }
+
+  // Read all enabled plugins with their versions from their package.json files
+  const enabledPlugins = await db
+    .select({
+      name: plugins.name,
+      path: plugins.path,
+      type: plugins.type,
+    })
+    .from(plugins)
+    .where(eq(plugins.enabled, true));
+
+  const pluginInfos = enabledPlugins.map((plugin) => {
+    let version = "unknown";
+    try {
+      const pkgJsonPath = path.join(plugin.path, "package.json");
+      if (fs.existsSync(pkgJsonPath)) {
+        const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+        version = pkgJson.version ?? "unknown";
+      }
+    } catch {
+      // Plugin path may not have a readable package.json (e.g., remote plugins)
+    }
+    return {
+      name: plugin.name,
+      version,
+      type: plugin.type,
+    };
+  });
+
+  return c.json({
+    coreVersion,
+    plugins: pluginInfos,
+  });
+});
+
 app.get("/.well-known/jwks.json", async (c) => {
   const { keyStore } = await import("./services/keystore");
   const jwks = await keyStore.getPublicJWKS();

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -15,6 +15,7 @@
     "lint:code": "eslint . --max-warnings 0"
   },
   "dependencies": {
+    "@checkstack/about-frontend": "workspace:*",
     "@checkstack/announcement-frontend": "workspace:*",
     "@checkstack/auth-frontend": "workspace:*",
     "@checkstack/catalog-frontend": "workspace:*",


### PR DESCRIPTION
## Summary

Adds a new **About Checkstack** page accessible from the user menu dropdown. The page displays:

- 🏁 **Platform info** — Description and GitHub repository link
- ⚖️ **License** — ELv2 allowed/not-allowed summary
- 📧 **Contact** — hi@enking.dev email link
- 📦 **Version info** — Core backend version and all loaded plugin versions with types

## Changes

### New packages
- `@checkstack/about-common` — Plugin metadata (`pluginId: "about"`)
- `@checkstack/about-frontend` — Frontend plugin with route `/about` and user menu item

### Modified packages
- `@checkstack/backend` — New public `GET /api/about` endpoint returning core + plugin versions
- `@checkstack/frontend` — Added `about-frontend` as workspace dependency

### Other
- Updated README with beta status and announcement mention

## Verification
- ✅ `bun run typecheck` — All 89 packages pass
- ✅ `bun run lint` — Clean
- ✅ `bun dev` — `/api/about` returns 200, page renders correctly