### PR TITLE
ci: skip checks for automated Version Packages PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   typecheck:
     name: Typecheck
-    if: github.head_ref != 'changeset-release/main'
+    if: github.head_ref != 'changeset-release/main' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -53,7 +53,7 @@ jobs:
 
   lint:
     name: Lint
-    if: github.head_ref != 'changeset-release/main'
+    if: github.head_ref != 'changeset-release/main' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -90,7 +90,7 @@ jobs:
 
   test:
     name: Test
-    if: github.head_ref != 'changeset-release/main'
+    if: github.head_ref != 'changeset-release/main' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -127,7 +127,7 @@ jobs:
 
   security:
     name: Security
-    if: github.head_ref != 'changeset-release/main'
+    if: github.head_ref != 'changeset-release/main' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   typecheck:
     name: Typecheck
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -52,6 +53,7 @@ jobs:
 
   lint:
     name: Lint
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -88,6 +90,7 @@ jobs:
 
   test:
     name: Test
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -124,6 +127,7 @@ jobs:
 
   security:
     name: Security
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary

Skips all heavy CI jobs (Typecheck, Lint, Test, Security) for automated Version Packages PRs created by the changeset bot.

These PRs only bump version numbers and update changelogs — no code changes to validate.

## How it works

The changeset bot creates PRs from branch `changeset-release/main` with actor `github-actions[bot]`. Each heavy job checks both conditions:

```yaml
if: github.head_ref != 'changeset-release/main' || github.actor != 'github-actions[bot]'
```

| Scenario | Branch match | Actor match | Jobs run? |
|----------|-------------|-------------|-----------|
| Regular PR | ❌ | ❌ | ✅ Yes |
| Changeset bot PR | ✅ | ✅ | ⏭️ Skipped |
| Malicious user spoofing branch name | ✅ | ❌ | ✅ Yes |

The `Report` job still runs unconditionally (has `if: !cancelled()`). It already treats `skipped` results as passed, so it succeeds immediately for bot PRs.

## Branch protection

Only **`Report`** should be set as the required status check. This way:
- **Real PRs** → all jobs run, Report gates on their results
- **Version Packages PRs** → jobs skip, Report passes instantly
- **Spoofed branches** → actor mismatch, all jobs still run