### PR TITLE
feat(ui): automatic FPS detection and anonymous performance toggle

### DIFF
--- a/.changeset/chilly-pandas-jump.md
+++ b/.changeset/chilly-pandas-jump.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/ui": patch
+---
+
+Added automatic FPS detection that enables "Low Power Mode" once for devices running below 50 FPS, ensuring smooth performance even for users unaware of the manual toggle.

--- a/.changeset/chilly-pandas-jump.md
+++ b/.changeset/chilly-pandas-jump.md
@@ -1,5 +1,6 @@
 ---
 "@checkstack/ui": patch
+"@checkstack/theme-frontend": patch
 ---
 
 Added automatic FPS detection that enables "Low Power Mode" once for devices running below 50 FPS, ensuring smooth performance even for users unaware of the manual toggle.

--- a/core/theme-frontend/src/components/NavbarPerformanceToggle.tsx
+++ b/core/theme-frontend/src/components/NavbarPerformanceToggle.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Zap, ZapOff } from "lucide-react";
+import { useApi } from "@checkstack/frontend-api";
+import { authApiRef } from "@checkstack/auth-frontend/api";
+import { Button, usePerformance } from "@checkstack/ui";
+
+/**
+ * Navbar performance toggle button for non-logged-in users.
+ *
+ * Shows a Zap icon button that toggles between high and low performance modes.
+ * Only renders when user is NOT logged in (logged-in users use the toggle in UserMenu).
+ */
+export const NavbarPerformanceToggle = () => {
+  const { manualLowPower, toggleManualLowPower } = usePerformance();
+  const authApi = useApi(authApiRef);
+  const { data: session, isPending } = authApi.useSession();
+
+  // Don't render while loading session
+  if (isPending) {
+    return <React.Fragment />;
+  }
+
+  // Don't render for logged-in users (they use UserMenu toggle)
+  if (session?.user) {
+    return <React.Fragment />;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleManualLowPower}
+      aria-label={manualLowPower ? "Switch to high performance" : "Switch to low power mode"}
+      className="rounded-full"
+    >
+      {manualLowPower ? <ZapOff className="h-5 w-5 text-muted-foreground" /> : <Zap className="h-5 w-5 text-primary" />}
+    </Button>
+  );
+};

--- a/core/theme-frontend/src/index.tsx
+++ b/core/theme-frontend/src/index.tsx
@@ -8,6 +8,7 @@ import { ThemeToggleMenuItem } from "./components/ThemeToggleMenuItem";
 import { PerformanceToggleMenuItem } from "./components/PerformanceToggleMenuItem";
 import { ThemeSynchronizer } from "./components/ThemeSynchronizer";
 import { NavbarThemeToggle } from "./components/NavbarThemeToggle";
+import { NavbarPerformanceToggle } from "./components/NavbarPerformanceToggle";
 
 export const themePlugin = createFrontendPlugin({
   metadata: pluginMetadata,
@@ -36,6 +37,12 @@ export const themePlugin = createFrontendPlugin({
       id: "theme.navbar.toggle",
       slot: NavbarRightSlot,
       component: NavbarThemeToggle,
+    },
+    // Performance toggle button in navbar (for non-logged-in users)
+    {
+      id: "theme.navbar.performance.toggle",
+      slot: NavbarRightSlot,
+      component: NavbarPerformanceToggle,
     },
   ],
 });

--- a/core/ui/src/components/PerformanceProvider.tsx
+++ b/core/ui/src/components/PerformanceProvider.tsx
@@ -1,9 +1,10 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
+import { useToast } from "./ToastProvider";
 
 const STORAGE_KEY = "checkstack-low-power";
 
 interface PerformanceContextValue {
-  /** 
+  /**
    * Whether the application should run in low-power mode.
    * Derived from (manualLowPower || prefersReducedMotion).
    */
@@ -38,9 +39,13 @@ interface PerformanceProviderProps {
  * Supports manual override (persisted to localStorage) and respects OS-level
  * Reduced Motion preferences.
  */
-export const PerformanceProvider: React.FC<PerformanceProviderProps> = ({ children }) => {
+export const PerformanceProvider: React.FC<PerformanceProviderProps> = ({
+  children,
+}) => {
+  const toast = useToast();
   const [manualLowPower, setManualLowPower] = useState<boolean>(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] =
+    useState<boolean>(false);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
 
   useEffect(() => {
@@ -51,17 +56,75 @@ export const PerformanceProvider: React.FC<PerformanceProviderProps> = ({ childr
     }
 
     // 2. Initialize Reduced Motion Detection
-    const mediaQuery = globalThis.matchMedia("(prefers-reduced-motion: reduce)");
+    const mediaQuery = globalThis.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    );
     setPrefersReducedMotion(mediaQuery.matches);
 
     // 3. Listen for changes in OS-level settings
-    const listener = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches);
+    const listener = (e: MediaQueryListEvent) =>
+      setPrefersReducedMotion(e.matches);
     mediaQuery.addEventListener("change", listener);
 
     setIsLoaded(true);
 
     return () => mediaQuery.removeEventListener("change", listener);
   }, []);
+
+  useEffect(() => {
+    // 4. Automatic FPS Detection (Runs once per device)
+    const stored = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (stored !== null) return; // User already has a saved preference, don't auto-detect
+
+    let rAFId: number;
+    let isCancelled = false;
+
+    // Wait 1 second for initial render and hydration to settle
+    const warmupTimer = setTimeout(() => {
+      if (isCancelled) return;
+
+      let frameCount = 0;
+      let startTime = performance.now();
+
+      const measure = (time: DOMHighResTimeStamp) => {
+        if (isCancelled) return;
+        if (frameCount === 0) startTime = time;
+        frameCount++;
+        const elapsed = time - startTime;
+
+        if (elapsed >= 1000) {
+          const fps = (frameCount * 1000) / elapsed;
+          if (fps < 50) {
+            setManualLowPower(true);
+            globalThis.localStorage?.setItem(STORAGE_KEY, "true");
+            toast.info(
+              "Low power mode was automatically activated to improve performance. Hardware acceleration appears to be disabled.",
+              8000
+            );
+            console.warn(
+              `[PerformanceProvider] Auto-enabled Low Power Mode. Detected FPS: ${fps.toFixed(1)}`,
+            );
+          } else {
+            // Save 'false' to prevent future auto-detection checks
+            globalThis.localStorage?.setItem(STORAGE_KEY, "false");
+            console.log(
+              `[PerformanceProvider] Performance OK. Detected FPS: ${fps.toFixed(1)}`,
+            );
+          }
+        } else {
+          rAFId = globalThis.requestAnimationFrame(measure);
+        }
+      };
+
+      rAFId = globalThis.requestAnimationFrame(measure);
+    }, 1000);
+
+    return () => {
+      isCancelled = true;
+      clearTimeout(warmupTimer);
+      if (rAFId) globalThis.cancelAnimationFrame(rAFId);
+    };
+  }, [toast]);
 
   const toggleManualLowPower = () => {
     setManualLowPower((prev) => {


### PR DESCRIPTION
## Summary
Implemented an automatic, one-time FPS detection that turns on Low Power Mode for users running at < 50 FPS. Also added a top-level navbar toggle for anonymous users.

## Key Changes
- **FPS Detection**: A 1-second `requestAnimationFrame` test ensures smooth auto-discovery of devices struggling to render visually expensive elements. This runs seamlessly in the background and respects already-defined manual preferences.
- **Informative Notification**: Automatically alerts the user when the fallback occurs via a dedicated `Info` toast.
- **Anonymous User Toggle**: Exposes a 'Zap' button inside the right-hand navbar slot for unauthenticated users, mirroring the functionality of the existing dark-mode toggle.

## Context
Refined after discovering that non-logged-in users had no way to exit "Low Power Mode" if they actively wanted high graphics quality, or alternatively, missing hardware acceleration led to a sluggish login experience.