### PR TITLE
feat: GitOps Entity System — declarative infrastructure-as-code for Checkstack

### DIFF
--- a/.changeset/gitops-catalog-entity-kinds.md
+++ b/.changeset/gitops-catalog-entity-kinds.md
@@ -1,0 +1,9 @@
+---
+"@checkstack/catalog-backend": minor
+"@checkstack/gitops-backend": patch
+---
+
+Register catalog System and Group as GitOps entity kinds
+
+- **catalog-backend**: Registers `kind: System` and `kind: Group` with the GitOps Entity Kind Registry. The catalog now supports declarative management via YAML descriptors in Git repositories. Systems and groups are reconciled using the `metadata.gitops_entity_name` marker for cross-sync identity lookup.
+- **gitops-backend**: Wires up the delete reconciler for orphan cleanup — both automatic deletion (via `deletionPolicy: "auto"`) and manual orphan confirmation now invoke the owning plugin's `delete()` handler before removing provenance entries.

--- a/.changeset/gitops-foundation.md
+++ b/.changeset/gitops-foundation.md
@@ -1,0 +1,6 @@
+---
+"@checkstack/gitops-common": minor
+"@checkstack/gitops-backend": minor
+---
+
+feat: add GitOps Entity System foundation — entity envelope schema, Entity Kind Registry extension point, secret field utility, secret resolution engine, provenance tracking, and RPC contract

--- a/.changeset/gitops-phase4-frontend.md
+++ b/.changeset/gitops-phase4-frontend.md
@@ -1,0 +1,20 @@
+---
+"@checkstack/gitops-common": minor
+"@checkstack/gitops-backend": minor
+"@checkstack/gitops-frontend": minor
+"@checkstack/catalog-backend": minor
+"@checkstack/catalog-frontend": minor
+---
+
+Generalized provenance system and GitOps frontend plugin
+
+**Breaking**: `EntityKindDefinition.reconcile()` now returns `{ entityId: string }` instead of `void`. Plugins must return the plugin-specific entity ID (e.g., catalog system UUID) so the engine can store it in provenance.
+
+- Added `entityId` column to the provenance table (non-nullable)
+- Reconciler engine passes `existingEntityId` to plugins for updates
+- `getProvenance` now supports lookup by `entityId` in addition to `entityName`
+- Added provider CRUD endpoints: `createProvider`, `updateProvider`, `deleteProvider`
+- Created `gitops-frontend` plugin with provider management, secret management, and sync status dashboard
+- Removed `gitops_entity_name` metadata markers from catalog entities
+- Removed `findSystemByGitOpsName`, `deleteSystemByGitOpsName` (and Group equivalents) from EntityService
+- Added provenance-based UI locking in catalog-frontend: edit/delete/drag disabled for GitOps-managed systems and groups

--- a/.changeset/gitops-phase5-healthcheck-kinds.md
+++ b/.changeset/gitops-phase5-healthcheck-kinds.md
@@ -1,0 +1,22 @@
+---
+"@checkstack/gitops-common": minor
+"@checkstack/gitops-backend": minor
+"@checkstack/healthcheck-backend": minor
+"@checkstack/healthcheck-frontend": minor
+"@checkstack/catalog-backend": patch
+---
+
+### GitOps Ecosystem: Healthcheck Kind Registration (Phase 5)
+
+**gitops-common**: Added required `resolveEntityRef` to `ReconcileContext`, enabling extension reconcilers to resolve cross-kind entity references (e.g., healthcheck refs in System extensions).
+
+**gitops-backend**: Updated reconciler to populate `resolveEntityRef` by querying local provenance — no RPC round-trip needed.
+
+**healthcheck-backend**: Registered `kind: Healthcheck` and `System → healthchecks` extension with the EntityKindRegistry:
+- Validates strategy configs against registered strategy schemas at reconcile time
+- Validates collector configs against registered collector schemas at reconcile time
+- Manages system ↔ healthcheck associations with automatic stale removal
+
+**healthcheck-frontend**: Added GitOps provenance locking to the HealthCheck IDE editor — GitOps-managed health checks show a lock banner and disable editing.
+
+**catalog-backend**: Updated test fixtures for new required `resolveEntityRef` context field.

--- a/.changeset/gitops-sync-engine.md
+++ b/.changeset/gitops-sync-engine.md
@@ -1,0 +1,13 @@
+---
+"@checkstack/gitops-backend": minor
+---
+
+Add GitOps discovery and sync engine (Phase 2)
+
+- YAML document parser with multi-document support and SHA-256 content hashing for diff detection
+- GitHub scraper: org/user repo enumeration, single-repo mode, default branch resolution, recursive Git Trees API, minimatch path filtering, Link header pagination
+- GitLab scraper: group project enumeration (including subgroups), single-project mode, recursive tree walking, minimatch filtering, x-next-page pagination
+- Configurable `baseUrl` per provider for GitHub Enterprise and self-managed GitLab instances
+- Reconciliation orchestrator: scrape → parse → validate → resolve secrets → reconcile (base + extensions) → provenance tracking → orphan detection
+- Sync worker: recurring queue jobs per provider, one-off manual trigger via triggerSync RPC
+- Per-entity error isolation ensures individual failures don't halt the sync

--- a/.changeset/kind-registry-browser.md
+++ b/.changeset/kind-registry-browser.md
@@ -1,0 +1,14 @@
+---
+"@checkstack/gitops-common": minor
+"@checkstack/gitops-backend": minor
+"@checkstack/gitops-frontend": minor
+---
+
+Add Kind Registry browser and developer documentation
+
+- Added `gitopsAccess.kinds.read` access rule for standalone Kind Registry access
+- Added `describeKinds()` method to the internal entity kind registry, serializing Zod schemas to JSON Schema
+- Added `listKinds` RPC endpoint gated by the new access rule
+- Created standalone Kind Registry page with schema visualization, extension listing, and auto-generated YAML examples
+- Added Kind Registry link to the user menu
+- Created developer documentation for entity kind and extension registration in `docs/backend/gitops-entity-kinds.md`

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "core/about-frontend": {
       "name": "@checkstack/about-frontend",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/about-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -56,7 +56,7 @@
     },
     "core/announcement-backend": {
       "name": "@checkstack/announcement-backend",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-backend": "workspace:*",
@@ -94,7 +94,7 @@
     },
     "core/announcement-frontend": {
       "name": "@checkstack/announcement-frontend",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -128,7 +128,7 @@
     },
     "core/api-docs-frontend": {
       "name": "@checkstack/api-docs-frontend",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -147,7 +147,7 @@
     },
     "core/auth-backend": {
       "name": "@checkstack/auth-backend",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.5.18",
+      "version": "0.5.19",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -207,7 +207,7 @@
     },
     "core/backend": {
       "name": "@checkstack/backend",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -241,7 +241,7 @@
     },
     "core/backend-api": {
       "name": "@checkstack/backend-api",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
@@ -269,7 +269,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -312,7 +312,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -336,7 +336,7 @@
     },
     "core/command-backend": {
       "name": "@checkstack/command-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-common": "workspace:*",
@@ -368,7 +368,7 @@
     },
     "core/command-frontend": {
       "name": "@checkstack/command-frontend",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "dependencies": {
         "@checkstack/command-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -401,7 +401,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -430,7 +430,7 @@
     },
     "core/dependency-backend": {
       "name": "@checkstack/dependency-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -473,7 +473,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -504,7 +504,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -563,9 +563,49 @@
         "react": "^18.0.0",
       },
     },
+    "core/gitops-backend": {
+      "name": "@checkstack/gitops-backend",
+      "version": "0.0.1",
+      "dependencies": {
+        "@checkstack/backend-api": "workspace:*",
+        "@checkstack/command-backend": "workspace:*",
+        "@checkstack/common": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
+        "@checkstack/queue-api": "workspace:*",
+        "@orpc/server": "^1.13.2",
+        "drizzle-orm": "^0.45.0",
+        "minimatch": "^10.0.0",
+        "uuid": "^13.0.0",
+        "yaml": "^2.7.0",
+        "zod": "^4.2.1",
+      },
+      "devDependencies": {
+        "@checkstack/drizzle-helper": "workspace:*",
+        "@checkstack/scripts": "workspace:*",
+        "@checkstack/tsconfig": "workspace:*",
+        "@types/bun": "^1.3.5",
+        "@types/node": "^20.0.0",
+        "@types/uuid": "^11.0.0",
+        "typescript": "^5.0.0",
+      },
+    },
+    "core/gitops-common": {
+      "name": "@checkstack/gitops-common",
+      "version": "0.0.1",
+      "dependencies": {
+        "@checkstack/common": "workspace:*",
+        "@orpc/contract": "^1.13.14",
+        "zod": "^4.2.1",
+      },
+      "devDependencies": {
+        "@checkstack/scripts": "workspace:*",
+        "@checkstack/tsconfig": "workspace:*",
+        "typescript": "^5.7.2",
+      },
+    },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -599,7 +639,7 @@
     },
     "core/healthcheck-common": {
       "name": "@checkstack/healthcheck-common",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -613,7 +653,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -643,7 +683,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -686,7 +726,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -710,7 +750,7 @@
     },
     "core/integration-backend": {
       "name": "@checkstack/integration-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -748,7 +788,7 @@
     },
     "core/integration-frontend": {
       "name": "@checkstack/integration-frontend",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -768,7 +808,7 @@
     },
     "core/maintenance-backend": {
       "name": "@checkstack/maintenance-backend",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -811,7 +851,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.4.20",
+      "version": "0.4.21",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -835,7 +875,7 @@
     },
     "core/notification-backend": {
       "name": "@checkstack/notification-backend",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -874,7 +914,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -895,7 +935,7 @@
     },
     "core/queue-api": {
       "name": "@checkstack/queue-api",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -907,7 +947,7 @@
     },
     "core/queue-backend": {
       "name": "@checkstack/queue-backend",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -941,7 +981,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -964,11 +1004,11 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.44.0",
+      "version": "0.45.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -983,7 +1023,7 @@
     },
     "core/satellite-backend": {
       "name": "@checkstack/satellite-backend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1007,7 +1047,7 @@
     },
     "core/satellite-common": {
       "name": "@checkstack/satellite-common",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
@@ -1023,7 +1063,7 @@
     },
     "core/satellite-frontend": {
       "name": "@checkstack/satellite-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1060,7 +1100,7 @@
     },
     "core/signal-backend": {
       "name": "@checkstack/signal-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1105,7 +1145,7 @@
     },
     "core/slo-backend": {
       "name": "@checkstack/slo-backend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -1151,7 +1191,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1176,7 +1216,7 @@
     },
     "core/test-utils-backend": {
       "name": "@checkstack/test-utils-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1212,7 +1252,7 @@
     },
     "core/theme-backend": {
       "name": "@checkstack/theme-backend",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1247,7 +1287,7 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1273,7 +1313,7 @@
     },
     "core/ui": {
       "name": "@checkstack/ui",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1308,7 +1348,7 @@
     },
     "plugins/auth-credential-backend": {
       "name": "@checkstack/auth-credential-backend",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1322,7 +1362,7 @@
     },
     "plugins/auth-github-backend": {
       "name": "@checkstack/auth-github-backend",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1336,7 +1376,7 @@
     },
     "plugins/auth-ldap-backend": {
       "name": "@checkstack/auth-ldap-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1355,7 +1395,7 @@
     },
     "plugins/auth-saml-backend": {
       "name": "@checkstack/auth-saml-backend",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1373,7 +1413,7 @@
     },
     "plugins/collector-hardware-backend": {
       "name": "@checkstack/collector-hardware-backend",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1389,7 +1429,7 @@
     },
     "plugins/healthcheck-dns-backend": {
       "name": "@checkstack/healthcheck-dns-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1404,7 +1444,7 @@
     },
     "plugins/healthcheck-grpc-backend": {
       "name": "@checkstack/healthcheck-grpc-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1420,7 +1460,7 @@
     },
     "plugins/healthcheck-http-backend": {
       "name": "@checkstack/healthcheck-http-backend",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1436,7 +1476,7 @@
     },
     "plugins/healthcheck-jenkins-backend": {
       "name": "@checkstack/healthcheck-jenkins-backend",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1451,7 +1491,7 @@
     },
     "plugins/healthcheck-mysql-backend": {
       "name": "@checkstack/healthcheck-mysql-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1467,7 +1507,7 @@
     },
     "plugins/healthcheck-ping-backend": {
       "name": "@checkstack/healthcheck-ping-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1482,7 +1522,7 @@
     },
     "plugins/healthcheck-postgres-backend": {
       "name": "@checkstack/healthcheck-postgres-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1499,7 +1539,7 @@
     },
     "plugins/healthcheck-rcon-backend": {
       "name": "@checkstack/healthcheck-rcon-backend",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1529,7 +1569,7 @@
     },
     "plugins/healthcheck-redis-backend": {
       "name": "@checkstack/healthcheck-redis-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1545,7 +1585,7 @@
     },
     "plugins/healthcheck-script-backend": {
       "name": "@checkstack/healthcheck-script-backend",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1560,7 +1600,7 @@
     },
     "plugins/healthcheck-ssh-backend": {
       "name": "@checkstack/healthcheck-ssh-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1591,7 +1631,7 @@
     },
     "plugins/healthcheck-tcp-backend": {
       "name": "@checkstack/healthcheck-tcp-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1606,7 +1646,7 @@
     },
     "plugins/healthcheck-tls-backend": {
       "name": "@checkstack/healthcheck-tls-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1621,7 +1661,7 @@
     },
     "plugins/integration-jira-backend": {
       "name": "@checkstack/integration-jira-backend",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1656,7 +1696,7 @@
     },
     "plugins/integration-script-backend": {
       "name": "@checkstack/integration-script-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1673,7 +1713,7 @@
     },
     "plugins/integration-teams-backend": {
       "name": "@checkstack/integration-teams-backend",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1688,7 +1728,7 @@
     },
     "plugins/integration-webex-backend": {
       "name": "@checkstack/integration-webex-backend",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1703,7 +1743,7 @@
     },
     "plugins/integration-webhook-backend": {
       "name": "@checkstack/integration-webhook-backend",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1720,7 +1760,7 @@
     },
     "plugins/notification-backstage-backend": {
       "name": "@checkstack/notification-backstage-backend",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1734,7 +1774,7 @@
     },
     "plugins/notification-discord-backend": {
       "name": "@checkstack/notification-discord-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1748,7 +1788,7 @@
     },
     "plugins/notification-gotify-backend": {
       "name": "@checkstack/notification-gotify-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1762,7 +1802,7 @@
     },
     "plugins/notification-pushover-backend": {
       "name": "@checkstack/notification-pushover-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1776,7 +1816,7 @@
     },
     "plugins/notification-slack-backend": {
       "name": "@checkstack/notification-slack-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1790,7 +1830,7 @@
     },
     "plugins/notification-smtp-backend": {
       "name": "@checkstack/notification-smtp-backend",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1806,7 +1846,7 @@
     },
     "plugins/notification-teams-backend": {
       "name": "@checkstack/notification-teams-backend",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1820,7 +1860,7 @@
     },
     "plugins/notification-telegram-backend": {
       "name": "@checkstack/notification-telegram-backend",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1836,7 +1876,7 @@
     },
     "plugins/notification-webex-backend": {
       "name": "@checkstack/notification-webex-backend",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1850,7 +1890,7 @@
     },
     "plugins/queue-bullmq-backend": {
       "name": "@checkstack/queue-bullmq-backend",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1880,7 +1920,7 @@
     },
     "plugins/queue-memory-backend": {
       "name": "@checkstack/queue-memory-backend",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2066,6 +2106,10 @@
     "@checkstack/frontend": ["@checkstack/frontend@workspace:core/frontend"],
 
     "@checkstack/frontend-api": ["@checkstack/frontend-api@workspace:core/frontend-api"],
+
+    "@checkstack/gitops-backend": ["@checkstack/gitops-backend@workspace:core/gitops-backend"],
+
+    "@checkstack/gitops-common": ["@checkstack/gitops-common@workspace:core/gitops-common"],
 
     "@checkstack/healthcheck-backend": ["@checkstack/healthcheck-backend@workspace:core/healthcheck-backend"],
 
@@ -2755,7 +2799,7 @@
 
     "bail": ["bail@1.0.5", "", {}, "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
 
@@ -2771,7 +2815,7 @@
 
     "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
 
-    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -3323,7 +3367,7 @@
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
-    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -3765,6 +3809,8 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
@@ -3801,11 +3847,15 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@eslint/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
     "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@inquirer/editor/@inquirer/external-editor": ["@inquirer/external-editor@3.0.0", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg=="],
 
@@ -3845,8 +3895,6 @@
 
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
-
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -3866,6 +3914,8 @@
     "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -3949,17 +3999,21 @@
 
     "@checkstack/queue-frontend/react-router-dom/react-router": ["react-router@7.14.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="],
 
+    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
     "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
-
     "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "eslint/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "mdast-util-mdx-expression/mdast-util-from-markdown/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -4061,9 +4115,13 @@
 
     "@checkstack/queue-frontend/react-router-dom/react-router/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
+    "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+    "eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "mdast-util-mdx-expression/mdast-util-to-markdown/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -277,6 +277,8 @@
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
         "@checkstack/common": "workspace:*",
+        "@checkstack/gitops-backend": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
         "@checkstack/notification-common": "workspace:*",
         "@orpc/server": "^1.13.2",
         "drizzle-orm": "^0.45.0",

--- a/bun.lock
+++ b/bun.lock
@@ -207,7 +207,7 @@
     },
     "core/backend": {
       "name": "@checkstack/backend",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -321,6 +321,7 @@
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
+        "@checkstack/gitops-frontend": "workspace:*",
         "@checkstack/notification-common": "workspace:*",
         "@checkstack/ui": "workspace:*",
         "@dnd-kit/core": "^6.3.1",
@@ -603,6 +604,25 @@
         "@checkstack/scripts": "workspace:*",
         "@checkstack/tsconfig": "workspace:*",
         "typescript": "^5.7.2",
+      },
+    },
+    "core/gitops-frontend": {
+      "name": "@checkstack/gitops-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@checkstack/common": "workspace:*",
+        "@checkstack/frontend-api": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
+        "@checkstack/ui": "workspace:*",
+        "lucide-react": "^0.344.0",
+        "react": "^18.2.0",
+        "react-router-dom": "^6.22.0",
+      },
+      "devDependencies": {
+        "@checkstack/scripts": "workspace:*",
+        "@checkstack/tsconfig": "workspace:*",
+        "@types/react": "^18.2.0",
+        "typescript": "^5.0.0",
       },
     },
     "core/healthcheck-backend": {
@@ -1006,7 +1026,7 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.45.0",
+      "version": "0.47.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
@@ -2112,6 +2132,8 @@
     "@checkstack/gitops-backend": ["@checkstack/gitops-backend@workspace:core/gitops-backend"],
 
     "@checkstack/gitops-common": ["@checkstack/gitops-common@workspace:core/gitops-common"],
+
+    "@checkstack/gitops-frontend": ["@checkstack/gitops-frontend@workspace:core/gitops-frontend"],
 
     "@checkstack/healthcheck-backend": ["@checkstack/healthcheck-backend@workspace:core/healthcheck-backend"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "core/about-frontend": {
       "name": "@checkstack/about-frontend",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "dependencies": {
         "@checkstack/about-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -94,7 +94,7 @@
     },
     "core/announcement-frontend": {
       "name": "@checkstack/announcement-frontend",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -128,7 +128,7 @@
     },
     "core/api-docs-frontend": {
       "name": "@checkstack/api-docs-frontend",
-      "version": "0.1.22",
+      "version": "0.1.26",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.5.19",
+      "version": "0.5.23",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -314,7 +314,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.5.9",
+      "version": "0.5.13",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -371,7 +371,7 @@
     },
     "core/command-frontend": {
       "name": "@checkstack/command-frontend",
-      "version": "0.2.21",
+      "version": "0.2.25",
       "dependencies": {
         "@checkstack/command-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -404,7 +404,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.3.27",
+      "version": "0.3.31",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -476,7 +476,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.2.4",
+      "version": "0.2.8",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -507,7 +507,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.3.5",
+      "version": "0.3.9",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -634,6 +634,8 @@
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
         "@checkstack/common": "workspace:*",
+        "@checkstack/gitops-backend": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
         "@checkstack/incident-common": "workspace:*",
         "@checkstack/integration-backend": "workspace:*",
@@ -675,13 +677,14 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.13.0",
+      "version": "0.13.4",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/dashboard-frontend": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
+        "@checkstack/gitops-frontend": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
         "@checkstack/satellite-common": "workspace:*",
         "@checkstack/signal-frontend": "workspace:*",
@@ -748,7 +751,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.4.17",
+      "version": "0.4.21",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -810,7 +813,7 @@
     },
     "core/integration-frontend": {
       "name": "@checkstack/integration-frontend",
-      "version": "0.2.21",
+      "version": "0.2.25",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -873,7 +876,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.4.21",
+      "version": "0.4.25",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -936,7 +939,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.2.24",
+      "version": "0.2.28",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1003,7 +1006,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.2.21",
+      "version": "0.2.25",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1026,7 +1029,7 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.47.0",
+      "version": "0.51.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
@@ -1085,7 +1088,7 @@
     },
     "core/satellite-frontend": {
       "name": "@checkstack/satellite-frontend",
-      "version": "0.2.0",
+      "version": "0.2.4",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1213,7 +1216,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.2.1",
+      "version": "0.2.5",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1309,7 +1312,7 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.23",
+      "version": "0.1.27",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1335,7 +1338,7 @@
     },
     "core/ui": {
       "name": "@checkstack/ui",
-      "version": "1.3.0",
+      "version": "1.3.4",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -1980,10658 +1980,2208 @@
     "esbuild": "^0.27.7",
   },
   "packages": {
-    "@adobe/css-tools": [
-      "@adobe/css-tools@4.4.4",
-      "",
-      {},
-      "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="
-    ],
-    "@alloc/quick-lru": [
-      "@alloc/quick-lru@5.2.0",
-      "",
-      {},
-      "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="
-    ],
-    "@authenio/xml-encryption": [
-      "@authenio/xml-encryption@2.0.2",
-      "",
-      {
-        "dependencies": {
-          "@xmldom/xmldom": "^0.8.6",
-          "escape-html": "^1.0.3",
-          "xpath": "0.0.32"
-        }
-      },
-      "sha512-cTlrKttbrRHEw3W+0/I609A2Matj5JQaRvfLtEIGZvlN0RaPi+3ANsMeqAyCAVlH/lUIW2tmtBlSMni74lcXeg=="
-    ],
-    "@babel/code-frame": [
-      "@babel/code-frame@7.29.0",
-      "",
-      {
-        "dependencies": {
-          "@babel/helper-validator-identifier": "^7.28.5",
-          "js-tokens": "^4.0.0",
-          "picocolors": "^1.1.1"
-        }
-      },
-      "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="
-    ],
-    "@babel/compat-data": [
-      "@babel/compat-data@7.29.0",
-      "",
-      {},
-      "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="
-    ],
-    "@babel/core": [
-      "@babel/core@7.29.0",
-      "",
-      {
-        "dependencies": {
-          "@babel/code-frame": "^7.29.0",
-          "@babel/generator": "^7.29.0",
-          "@babel/helper-compilation-targets": "^7.28.6",
-          "@babel/helper-module-transforms": "^7.28.6",
-          "@babel/helpers": "^7.28.6",
-          "@babel/parser": "^7.29.0",
-          "@babel/template": "^7.28.6",
-          "@babel/traverse": "^7.29.0",
-          "@babel/types": "^7.29.0",
-          "@jridgewell/remapping": "^2.3.5",
-          "convert-source-map": "^2.0.0",
-          "debug": "^4.1.0",
-          "gensync": "^1.0.0-beta.2",
-          "json5": "^2.2.3",
-          "semver": "^6.3.1"
-        }
-      },
-      "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="
-    ],
-    "@babel/generator": [
-      "@babel/generator@7.29.1",
-      "",
-      {
-        "dependencies": {
-          "@babel/parser": "^7.29.0",
-          "@babel/types": "^7.29.0",
-          "@jridgewell/gen-mapping": "^0.3.12",
-          "@jridgewell/trace-mapping": "^0.3.28",
-          "jsesc": "^3.0.2"
-        }
-      },
-      "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="
-    ],
-    "@babel/helper-compilation-targets": [
-      "@babel/helper-compilation-targets@7.28.6",
-      "",
-      {
-        "dependencies": {
-          "@babel/compat-data": "^7.28.6",
-          "@babel/helper-validator-option": "^7.27.1",
-          "browserslist": "^4.24.0",
-          "lru-cache": "^5.1.1",
-          "semver": "^6.3.1"
-        }
-      },
-      "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="
-    ],
-    "@babel/helper-globals": [
-      "@babel/helper-globals@7.28.0",
-      "",
-      {},
-      "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="
-    ],
-    "@babel/helper-module-imports": [
-      "@babel/helper-module-imports@7.28.6",
-      "",
-      {
-        "dependencies": {
-          "@babel/traverse": "^7.28.6",
-          "@babel/types": "^7.28.6"
-        }
-      },
-      "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="
-    ],
-    "@babel/helper-module-transforms": [
-      "@babel/helper-module-transforms@7.28.6",
-      "",
-      {
-        "dependencies": {
-          "@babel/helper-module-imports": "^7.28.6",
-          "@babel/helper-validator-identifier": "^7.28.5",
-          "@babel/traverse": "^7.28.6"
-        },
-        "peerDependencies": {
-          "@babel/core": "^7.0.0"
-        }
-      },
-      "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="
-    ],
-    "@babel/helper-string-parser": [
-      "@babel/helper-string-parser@7.27.1",
-      "",
-      {},
-      "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
-    ],
-    "@babel/helper-validator-identifier": [
-      "@babel/helper-validator-identifier@7.28.5",
-      "",
-      {},
-      "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
-    ],
-    "@babel/helper-validator-option": [
-      "@babel/helper-validator-option@7.27.1",
-      "",
-      {},
-      "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="
-    ],
-    "@babel/helpers": [
-      "@babel/helpers@7.29.2",
-      "",
-      {
-        "dependencies": {
-          "@babel/template": "^7.28.6",
-          "@babel/types": "^7.29.0"
-        }
-      },
-      "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="
-    ],
-    "@babel/parser": [
-      "@babel/parser@7.29.2",
-      "",
-      {
-        "dependencies": {
-          "@babel/types": "^7.29.0"
-        },
-        "bin": "./bin/babel-parser.js"
-      },
-      "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="
-    ],
-    "@babel/runtime": [
-      "@babel/runtime@7.29.2",
-      "",
-      {},
-      "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
-    ],
-    "@babel/template": [
-      "@babel/template@7.28.6",
-      "",
-      {
-        "dependencies": {
-          "@babel/code-frame": "^7.28.6",
-          "@babel/parser": "^7.28.6",
-          "@babel/types": "^7.28.6"
-        }
-      },
-      "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="
-    ],
-    "@babel/traverse": [
-      "@babel/traverse@7.29.0",
-      "",
-      {
-        "dependencies": {
-          "@babel/code-frame": "^7.29.0",
-          "@babel/generator": "^7.29.0",
-          "@babel/helper-globals": "^7.28.0",
-          "@babel/parser": "^7.29.0",
-          "@babel/template": "^7.28.6",
-          "@babel/types": "^7.29.0",
-          "debug": "^4.3.1"
-        }
-      },
-      "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="
-    ],
-    "@babel/types": [
-      "@babel/types@7.29.0",
-      "",
-      {
-        "dependencies": {
-          "@babel/helper-string-parser": "^7.27.1",
-          "@babel/helper-validator-identifier": "^7.28.5"
-        }
-      },
-      "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="
-    ],
-    "@better-auth/core": [
-      "@better-auth/core@1.6.4",
-      "",
-      {
-        "dependencies": {
-          "@opentelemetry/semantic-conventions": "^1.39.0",
-          "@standard-schema/spec": "^1.1.0",
-          "zod": "^4.3.6"
-        },
-        "peerDependencies": {
-          "@better-auth/utils": "0.4.0",
-          "@better-fetch/fetch": "1.1.21",
-          "@cloudflare/workers-types": ">=4",
-          "@opentelemetry/api": "^1.9.0",
-          "better-call": "1.3.5",
-          "jose": "^6.1.0",
-          "kysely": "^0.28.5",
-          "nanostores": "^1.0.1"
-        },
-        "optionalPeers": [
-          "@cloudflare/workers-types"
-        ]
-      },
-      "sha512-G52PXrx+qQcwkmP5Kmjjl8kWl15DFaZF5H1n9jY7kuCJiVIJMnr4WTSGMIOt07OwD+CSy9b4IA5DpuADZC5znA=="
-    ],
-    "@better-auth/drizzle-adapter": [
-      "@better-auth/drizzle-adapter@1.6.4",
-      "",
-      {
-        "peerDependencies": {
-          "@better-auth/core": "^1.6.4",
-          "@better-auth/utils": "0.4.0",
-          "drizzle-orm": "^0.45.2"
-        },
-        "optionalPeers": [
-          "drizzle-orm"
-        ]
-      },
-      "sha512-LYyFTTZD/VcSh59taYZ2V5clHP4+udQYYZlW0KTiLTzljZcmuETuflGB7++WKSdCJg7KtLQzoM0rMo9PgT/Prw=="
-    ],
-    "@better-auth/kysely-adapter": [
-      "@better-auth/kysely-adapter@1.6.4",
-      "",
-      {
-        "peerDependencies": {
-          "@better-auth/core": "^1.6.4",
-          "@better-auth/utils": "0.4.0",
-          "kysely": "^0.28.14"
-        },
-        "optionalPeers": [
-          "kysely"
-        ]
-      },
-      "sha512-CVuvhy81gs66oHjjMTVKV1bfVCPivJzf9za8xghGB9wrkeMaZnPVKVqDobHf8juDfT5XRMQJmrcGLxubI2le/A=="
-    ],
-    "@better-auth/memory-adapter": [
-      "@better-auth/memory-adapter@1.6.4",
-      "",
-      {
-        "peerDependencies": {
-          "@better-auth/core": "^1.6.4",
-          "@better-auth/utils": "0.4.0"
-        }
-      },
-      "sha512-eV6jw1roUohNHRo4qdUXJdaRpNmyWqtC1ADC2AMSRF3f6d4XPW+FqtAYhE87ZBq7nWDVgjrtawoUSVHREc8PrQ=="
-    ],
-    "@better-auth/mongo-adapter": [
-      "@better-auth/mongo-adapter@1.6.4",
-      "",
-      {
-        "peerDependencies": {
-          "@better-auth/core": "^1.6.4",
-          "@better-auth/utils": "0.4.0",
-          "mongodb": "^6.0.0 || ^7.0.0"
-        },
-        "optionalPeers": [
-          "mongodb"
-        ]
-      },
-      "sha512-N2pjOSuZHeNeRuqCXuEzSN2WFqexzb7KbtuxHislkXMIQtUiMNhM8NJMxCqnVj4t22qryim4hv0K59QfqqGXWQ=="
-    ],
-    "@better-auth/prisma-adapter": [
-      "@better-auth/prisma-adapter@1.6.4",
-      "",
-      {
-        "peerDependencies": {
-          "@better-auth/core": "^1.6.4",
-          "@better-auth/utils": "0.4.0",
-          "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-          "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
-        },
-        "optionalPeers": [
-          "@prisma/client",
-          "prisma"
-        ]
-      },
-      "sha512-h6zuYYI+p5yK1TLci0V9JKfIitThBDmRK88ipoZzmZH3EyWUQfXcgC05WwOMCuM3mH+A9Auu/hLiiM7/VRfJgw=="
-    ],
-    "@better-auth/telemetry": [
-      "@better-auth/telemetry@1.6.4",
-      "",
-      {
-        "peerDependencies": {
-          "@better-auth/core": "^1.6.4",
-          "@better-auth/utils": "0.4.0",
-          "@better-fetch/fetch": "1.1.21"
-        }
-      },
-      "sha512-x6ctfiHcdUshXvrAgGaAprxJI6obZP09BUmQn0LcQX4KYbx0B5M8+DToyVmv30iEL8rEmGyL187XamXbY4FwYw=="
-    ],
-    "@better-auth/utils": [
-      "@better-auth/utils@0.4.0",
-      "",
-      {
-        "dependencies": {
-          "@noble/hashes": "^2.0.1"
-        }
-      },
-      "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="
-    ],
-    "@better-fetch/fetch": [
-      "@better-fetch/fetch@1.1.21",
-      "",
-      {},
-      "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
-    ],
-    "@changesets/apply-release-plan": [
-      "@changesets/apply-release-plan@7.1.0",
-      "",
-      {
-        "dependencies": {
-          "@changesets/config": "^3.1.3",
-          "@changesets/get-version-range-type": "^0.4.0",
-          "@changesets/git": "^3.0.4",
-          "@changesets/should-skip-package": "^0.1.2",
-          "@changesets/types": "^6.1.0",
-          "@manypkg/get-packages": "^1.1.3",
-          "detect-indent": "^6.0.0",
-          "fs-extra": "^7.0.1",
-          "lodash.startcase": "^4.4.0",
-          "outdent": "^0.5.0",
-          "prettier": "^2.7.1",
-          "resolve-from": "^5.0.0",
-          "semver": "^7.5.3"
-        }
-      },
-      "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ=="
-    ],
-    "@changesets/assemble-release-plan": [
-      "@changesets/assemble-release-plan@6.0.9",
-      "",
-      {
-        "dependencies": {
-          "@changesets/errors": "^0.2.0",
-          "@changesets/get-dependents-graph": "^2.1.3",
-          "@changesets/should-skip-package": "^0.1.2",
-          "@changesets/types": "^6.1.0",
-          "@manypkg/get-packages": "^1.1.3",
-          "semver": "^7.5.3"
-        }
-      },
-      "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ=="
-    ],
-    "@changesets/changelog-git": [
-      "@changesets/changelog-git@0.2.1",
-      "",
-      {
-        "dependencies": {
-          "@changesets/types": "^6.1.0"
-        }
-      },
-      "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q=="
-    ],
-    "@changesets/cli": [
-      "@changesets/cli@2.30.0",
-      "",
-      {
-        "dependencies": {
-          "@changesets/apply-release-plan": "^7.1.0",
-          "@changesets/assemble-release-plan": "^6.0.9",
-          "@changesets/changelog-git": "^0.2.1",
-          "@changesets/config": "^3.1.3",
-          "@changesets/errors": "^0.2.0",
-          "@changesets/get-dependents-graph": "^2.1.3",
-          "@changesets/get-release-plan": "^4.0.15",
-          "@changesets/git": "^3.0.4",
-          "@changesets/logger": "^0.1.1",
-          "@changesets/pre": "^2.0.2",
-          "@changesets/read": "^0.6.7",
-          "@changesets/should-skip-package": "^0.1.2",
-          "@changesets/types": "^6.1.0",
-          "@changesets/write": "^0.4.0",
-          "@inquirer/external-editor": "^1.0.2",
-          "@manypkg/get-packages": "^1.1.3",
-          "ansi-colors": "^4.1.3",
-          "enquirer": "^2.4.1",
-          "fs-extra": "^7.0.1",
-          "mri": "^1.2.0",
-          "package-manager-detector": "^0.2.0",
-          "picocolors": "^1.1.0",
-          "resolve-from": "^5.0.0",
-          "semver": "^7.5.3",
-          "spawndamnit": "^3.0.1",
-          "term-size": "^2.1.0"
-        },
-        "bin": {
-          "changeset": "bin.js"
-        }
-      },
-      "sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA=="
-    ],
-    "@changesets/config": [
-      "@changesets/config@3.1.3",
-      "",
-      {
-        "dependencies": {
-          "@changesets/errors": "^0.2.0",
-          "@changesets/get-dependents-graph": "^2.1.3",
-          "@changesets/logger": "^0.1.1",
-          "@changesets/should-skip-package": "^0.1.2",
-          "@changesets/types": "^6.1.0",
-          "@manypkg/get-packages": "^1.1.3",
-          "fs-extra": "^7.0.1",
-          "micromatch": "^4.0.8"
-        }
-      },
-      "sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw=="
-    ],
-    "@changesets/errors": [
-      "@changesets/errors@0.2.0",
-      "",
-      {
-        "dependencies": {
-          "extendable-error": "^0.1.5"
-        }
-      },
-      "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow=="
-    ],
-    "@changesets/get-dependents-graph": [
-      "@changesets/get-dependents-graph@2.1.3",
-      "",
-      {
-        "dependencies": {
-          "@changesets/types": "^6.1.0",
-          "@manypkg/get-packages": "^1.1.3",
-          "picocolors": "^1.1.0",
-          "semver": "^7.5.3"
-        }
-      },
-      "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ=="
-    ],
-    "@changesets/get-release-plan": [
-      "@changesets/get-release-plan@4.0.15",
-      "",
-      {
-        "dependencies": {
-          "@changesets/assemble-release-plan": "^6.0.9",
-          "@changesets/config": "^3.1.3",
-          "@changesets/pre": "^2.0.2",
-          "@changesets/read": "^0.6.7",
-          "@changesets/types": "^6.1.0",
-          "@manypkg/get-packages": "^1.1.3"
-        }
-      },
-      "sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g=="
-    ],
-    "@changesets/get-version-range-type": [
-      "@changesets/get-version-range-type@0.4.0",
-      "",
-      {},
-      "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ=="
-    ],
-    "@changesets/git": [
-      "@changesets/git@3.0.4",
-      "",
-      {
-        "dependencies": {
-          "@changesets/errors": "^0.2.0",
-          "@manypkg/get-packages": "^1.1.3",
-          "is-subdir": "^1.1.1",
-          "micromatch": "^4.0.8",
-          "spawndamnit": "^3.0.1"
-        }
-      },
-      "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw=="
-    ],
-    "@changesets/logger": [
-      "@changesets/logger@0.1.1",
-      "",
-      {
-        "dependencies": {
-          "picocolors": "^1.1.0"
-        }
-      },
-      "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg=="
-    ],
-    "@changesets/parse": [
-      "@changesets/parse@0.4.3",
-      "",
-      {
-        "dependencies": {
-          "@changesets/types": "^6.1.0",
-          "js-yaml": "^4.1.1"
-        }
-      },
-      "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A=="
-    ],
-    "@changesets/pre": [
-      "@changesets/pre@2.0.2",
-      "",
-      {
-        "dependencies": {
-          "@changesets/errors": "^0.2.0",
-          "@changesets/types": "^6.1.0",
-          "@manypkg/get-packages": "^1.1.3",
-          "fs-extra": "^7.0.1"
-        }
-      },
-      "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug=="
-    ],
-    "@changesets/read": [
-      "@changesets/read@0.6.7",
-      "",
-      {
-        "dependencies": {
-          "@changesets/git": "^3.0.4",
-          "@changesets/logger": "^0.1.1",
-          "@changesets/parse": "^0.4.3",
-          "@changesets/types": "^6.1.0",
-          "fs-extra": "^7.0.1",
-          "p-filter": "^2.1.0",
-          "picocolors": "^1.1.0"
-        }
-      },
-      "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA=="
-    ],
-    "@changesets/should-skip-package": [
-      "@changesets/should-skip-package@0.1.2",
-      "",
-      {
-        "dependencies": {
-          "@changesets/types": "^6.1.0",
-          "@manypkg/get-packages": "^1.1.3"
-        }
-      },
-      "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw=="
-    ],
-    "@changesets/types": [
-      "@changesets/types@6.1.0",
-      "",
-      {},
-      "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="
-    ],
-    "@changesets/write": [
-      "@changesets/write@0.4.0",
-      "",
-      {
-        "dependencies": {
-          "@changesets/types": "^6.1.0",
-          "fs-extra": "^7.0.1",
-          "human-id": "^4.1.1",
-          "prettier": "^2.7.1"
-        }
-      },
-      "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="
-    ],
-    "@checkstack/about-common": [
-      "@checkstack/about-common@workspace:core/about-common"
-    ],
-    "@checkstack/about-frontend": [
-      "@checkstack/about-frontend@workspace:core/about-frontend"
-    ],
-    "@checkstack/announcement-backend": [
-      "@checkstack/announcement-backend@workspace:core/announcement-backend"
-    ],
-    "@checkstack/announcement-common": [
-      "@checkstack/announcement-common@workspace:core/announcement-common"
-    ],
-    "@checkstack/announcement-frontend": [
-      "@checkstack/announcement-frontend@workspace:core/announcement-frontend"
-    ],
-    "@checkstack/api-docs-common": [
-      "@checkstack/api-docs-common@workspace:core/api-docs-common"
-    ],
-    "@checkstack/api-docs-frontend": [
-      "@checkstack/api-docs-frontend@workspace:core/api-docs-frontend"
-    ],
-    "@checkstack/auth-backend": [
-      "@checkstack/auth-backend@workspace:core/auth-backend"
-    ],
-    "@checkstack/auth-common": [
-      "@checkstack/auth-common@workspace:core/auth-common"
-    ],
-    "@checkstack/auth-credential-backend": [
-      "@checkstack/auth-credential-backend@workspace:plugins/auth-credential-backend"
-    ],
-    "@checkstack/auth-frontend": [
-      "@checkstack/auth-frontend@workspace:core/auth-frontend"
-    ],
-    "@checkstack/auth-github-backend": [
-      "@checkstack/auth-github-backend@workspace:plugins/auth-github-backend"
-    ],
-    "@checkstack/auth-ldap-backend": [
-      "@checkstack/auth-ldap-backend@workspace:plugins/auth-ldap-backend"
-    ],
-    "@checkstack/auth-saml-backend": [
-      "@checkstack/auth-saml-backend@workspace:plugins/auth-saml-backend"
-    ],
-    "@checkstack/backend": [
-      "@checkstack/backend@workspace:core/backend"
-    ],
-    "@checkstack/backend-api": [
-      "@checkstack/backend-api@workspace:core/backend-api"
-    ],
-    "@checkstack/catalog-backend": [
-      "@checkstack/catalog-backend@workspace:core/catalog-backend"
-    ],
-    "@checkstack/catalog-common": [
-      "@checkstack/catalog-common@workspace:core/catalog-common"
-    ],
-    "@checkstack/catalog-frontend": [
-      "@checkstack/catalog-frontend@workspace:core/catalog-frontend"
-    ],
-    "@checkstack/collector-hardware-backend": [
-      "@checkstack/collector-hardware-backend@workspace:plugins/collector-hardware-backend"
-    ],
-    "@checkstack/command-backend": [
-      "@checkstack/command-backend@workspace:core/command-backend"
-    ],
-    "@checkstack/command-common": [
-      "@checkstack/command-common@workspace:core/command-common"
-    ],
-    "@checkstack/command-frontend": [
-      "@checkstack/command-frontend@workspace:core/command-frontend"
-    ],
-    "@checkstack/common": [
-      "@checkstack/common@workspace:core/common"
-    ],
-    "@checkstack/dashboard-frontend": [
-      "@checkstack/dashboard-frontend@workspace:core/dashboard-frontend"
-    ],
-    "@checkstack/dependency-backend": [
-      "@checkstack/dependency-backend@workspace:core/dependency-backend"
-    ],
-    "@checkstack/dependency-common": [
-      "@checkstack/dependency-common@workspace:core/dependency-common"
-    ],
-    "@checkstack/dependency-frontend": [
-      "@checkstack/dependency-frontend@workspace:core/dependency-frontend"
-    ],
-    "@checkstack/drizzle-helper": [
-      "@checkstack/drizzle-helper@workspace:core/drizzle-helper"
-    ],
-    "@checkstack/frontend": [
-      "@checkstack/frontend@workspace:core/frontend"
-    ],
-    "@checkstack/frontend-api": [
-      "@checkstack/frontend-api@workspace:core/frontend-api"
-    ],
-    "@checkstack/gitops-backend": [
-      "@checkstack/gitops-backend@workspace:core/gitops-backend"
-    ],
-    "@checkstack/gitops-common": [
-      "@checkstack/gitops-common@workspace:core/gitops-common"
-    ],
-    "@checkstack/gitops-frontend": [
-      "@checkstack/gitops-frontend@workspace:core/gitops-frontend"
-    ],
-    "@checkstack/healthcheck-backend": [
-      "@checkstack/healthcheck-backend@workspace:core/healthcheck-backend"
-    ],
-    "@checkstack/healthcheck-common": [
-      "@checkstack/healthcheck-common@workspace:core/healthcheck-common"
-    ],
-    "@checkstack/healthcheck-dns-backend": [
-      "@checkstack/healthcheck-dns-backend@workspace:plugins/healthcheck-dns-backend"
-    ],
-    "@checkstack/healthcheck-frontend": [
-      "@checkstack/healthcheck-frontend@workspace:core/healthcheck-frontend"
-    ],
-    "@checkstack/healthcheck-grpc-backend": [
-      "@checkstack/healthcheck-grpc-backend@workspace:plugins/healthcheck-grpc-backend"
-    ],
-    "@checkstack/healthcheck-http-backend": [
-      "@checkstack/healthcheck-http-backend@workspace:plugins/healthcheck-http-backend"
-    ],
-    "@checkstack/healthcheck-jenkins-backend": [
-      "@checkstack/healthcheck-jenkins-backend@workspace:plugins/healthcheck-jenkins-backend"
-    ],
-    "@checkstack/healthcheck-mysql-backend": [
-      "@checkstack/healthcheck-mysql-backend@workspace:plugins/healthcheck-mysql-backend"
-    ],
-    "@checkstack/healthcheck-ping-backend": [
-      "@checkstack/healthcheck-ping-backend@workspace:plugins/healthcheck-ping-backend"
-    ],
-    "@checkstack/healthcheck-postgres-backend": [
-      "@checkstack/healthcheck-postgres-backend@workspace:plugins/healthcheck-postgres-backend"
-    ],
-    "@checkstack/healthcheck-rcon-backend": [
-      "@checkstack/healthcheck-rcon-backend@workspace:plugins/healthcheck-rcon-backend"
-    ],
-    "@checkstack/healthcheck-rcon-common": [
-      "@checkstack/healthcheck-rcon-common@workspace:plugins/healthcheck-rcon-common"
-    ],
-    "@checkstack/healthcheck-redis-backend": [
-      "@checkstack/healthcheck-redis-backend@workspace:plugins/healthcheck-redis-backend"
-    ],
-    "@checkstack/healthcheck-script-backend": [
-      "@checkstack/healthcheck-script-backend@workspace:plugins/healthcheck-script-backend"
-    ],
-    "@checkstack/healthcheck-ssh-backend": [
-      "@checkstack/healthcheck-ssh-backend@workspace:plugins/healthcheck-ssh-backend"
-    ],
-    "@checkstack/healthcheck-ssh-common": [
-      "@checkstack/healthcheck-ssh-common@workspace:plugins/healthcheck-ssh-common"
-    ],
-    "@checkstack/healthcheck-tcp-backend": [
-      "@checkstack/healthcheck-tcp-backend@workspace:plugins/healthcheck-tcp-backend"
-    ],
-    "@checkstack/healthcheck-tls-backend": [
-      "@checkstack/healthcheck-tls-backend@workspace:plugins/healthcheck-tls-backend"
-    ],
-    "@checkstack/incident-backend": [
-      "@checkstack/incident-backend@workspace:core/incident-backend"
-    ],
-    "@checkstack/incident-common": [
-      "@checkstack/incident-common@workspace:core/incident-common"
-    ],
-    "@checkstack/incident-frontend": [
-      "@checkstack/incident-frontend@workspace:core/incident-frontend"
-    ],
-    "@checkstack/integration-backend": [
-      "@checkstack/integration-backend@workspace:core/integration-backend"
-    ],
-    "@checkstack/integration-common": [
-      "@checkstack/integration-common@workspace:core/integration-common"
-    ],
-    "@checkstack/integration-frontend": [
-      "@checkstack/integration-frontend@workspace:core/integration-frontend"
-    ],
-    "@checkstack/integration-jira-backend": [
-      "@checkstack/integration-jira-backend@workspace:plugins/integration-jira-backend"
-    ],
-    "@checkstack/integration-jira-common": [
-      "@checkstack/integration-jira-common@workspace:plugins/integration-jira-common"
-    ],
-    "@checkstack/integration-script-backend": [
-      "@checkstack/integration-script-backend@workspace:plugins/integration-script-backend"
-    ],
-    "@checkstack/integration-teams-backend": [
-      "@checkstack/integration-teams-backend@workspace:plugins/integration-teams-backend"
-    ],
-    "@checkstack/integration-webex-backend": [
-      "@checkstack/integration-webex-backend@workspace:plugins/integration-webex-backend"
-    ],
-    "@checkstack/integration-webhook-backend": [
-      "@checkstack/integration-webhook-backend@workspace:plugins/integration-webhook-backend"
-    ],
-    "@checkstack/maintenance-backend": [
-      "@checkstack/maintenance-backend@workspace:core/maintenance-backend"
-    ],
-    "@checkstack/maintenance-common": [
-      "@checkstack/maintenance-common@workspace:core/maintenance-common"
-    ],
-    "@checkstack/maintenance-frontend": [
-      "@checkstack/maintenance-frontend@workspace:core/maintenance-frontend"
-    ],
-    "@checkstack/notification-backend": [
-      "@checkstack/notification-backend@workspace:core/notification-backend"
-    ],
-    "@checkstack/notification-backstage-backend": [
-      "@checkstack/notification-backstage-backend@workspace:plugins/notification-backstage-backend"
-    ],
-    "@checkstack/notification-common": [
-      "@checkstack/notification-common@workspace:core/notification-common"
-    ],
-    "@checkstack/notification-discord-backend": [
-      "@checkstack/notification-discord-backend@workspace:plugins/notification-discord-backend"
-    ],
-    "@checkstack/notification-frontend": [
-      "@checkstack/notification-frontend@workspace:core/notification-frontend"
-    ],
-    "@checkstack/notification-gotify-backend": [
-      "@checkstack/notification-gotify-backend@workspace:plugins/notification-gotify-backend"
-    ],
-    "@checkstack/notification-pushover-backend": [
-      "@checkstack/notification-pushover-backend@workspace:plugins/notification-pushover-backend"
-    ],
-    "@checkstack/notification-slack-backend": [
-      "@checkstack/notification-slack-backend@workspace:plugins/notification-slack-backend"
-    ],
-    "@checkstack/notification-smtp-backend": [
-      "@checkstack/notification-smtp-backend@workspace:plugins/notification-smtp-backend"
-    ],
-    "@checkstack/notification-teams-backend": [
-      "@checkstack/notification-teams-backend@workspace:plugins/notification-teams-backend"
-    ],
-    "@checkstack/notification-telegram-backend": [
-      "@checkstack/notification-telegram-backend@workspace:plugins/notification-telegram-backend"
-    ],
-    "@checkstack/notification-webex-backend": [
-      "@checkstack/notification-webex-backend@workspace:plugins/notification-webex-backend"
-    ],
-    "@checkstack/queue-api": [
-      "@checkstack/queue-api@workspace:core/queue-api"
-    ],
-    "@checkstack/queue-backend": [
-      "@checkstack/queue-backend@workspace:core/queue-backend"
-    ],
-    "@checkstack/queue-bullmq-backend": [
-      "@checkstack/queue-bullmq-backend@workspace:plugins/queue-bullmq-backend"
-    ],
-    "@checkstack/queue-bullmq-common": [
-      "@checkstack/queue-bullmq-common@workspace:plugins/queue-bullmq-common"
-    ],
-    "@checkstack/queue-common": [
-      "@checkstack/queue-common@workspace:core/queue-common"
-    ],
-    "@checkstack/queue-frontend": [
-      "@checkstack/queue-frontend@workspace:core/queue-frontend"
-    ],
-    "@checkstack/queue-memory-backend": [
-      "@checkstack/queue-memory-backend@workspace:plugins/queue-memory-backend"
-    ],
-    "@checkstack/queue-memory-common": [
-      "@checkstack/queue-memory-common@workspace:plugins/queue-memory-common"
-    ],
-    "@checkstack/release": [
-      "@checkstack/release@workspace:core/release"
-    ],
-    "@checkstack/satellite": [
-      "@checkstack/satellite@workspace:core/satellite"
-    ],
-    "@checkstack/satellite-backend": [
-      "@checkstack/satellite-backend@workspace:core/satellite-backend"
-    ],
-    "@checkstack/satellite-common": [
-      "@checkstack/satellite-common@workspace:core/satellite-common"
-    ],
-    "@checkstack/satellite-frontend": [
-      "@checkstack/satellite-frontend@workspace:core/satellite-frontend"
-    ],
-    "@checkstack/scripts": [
-      "@checkstack/scripts@workspace:core/scripts"
-    ],
-    "@checkstack/signal-backend": [
-      "@checkstack/signal-backend@workspace:core/signal-backend"
-    ],
-    "@checkstack/signal-common": [
-      "@checkstack/signal-common@workspace:core/signal-common"
-    ],
-    "@checkstack/signal-frontend": [
-      "@checkstack/signal-frontend@workspace:core/signal-frontend"
-    ],
-    "@checkstack/slo-backend": [
-      "@checkstack/slo-backend@workspace:core/slo-backend"
-    ],
-    "@checkstack/slo-common": [
-      "@checkstack/slo-common@workspace:core/slo-common"
-    ],
-    "@checkstack/slo-frontend": [
-      "@checkstack/slo-frontend@workspace:core/slo-frontend"
-    ],
-    "@checkstack/test-utils-backend": [
-      "@checkstack/test-utils-backend@workspace:core/test-utils-backend"
-    ],
-    "@checkstack/test-utils-frontend": [
-      "@checkstack/test-utils-frontend@workspace:core/test-utils-frontend"
-    ],
-    "@checkstack/theme-backend": [
-      "@checkstack/theme-backend@workspace:core/theme-backend"
-    ],
-    "@checkstack/theme-common": [
-      "@checkstack/theme-common@workspace:core/theme-common"
-    ],
-    "@checkstack/theme-frontend": [
-      "@checkstack/theme-frontend@workspace:core/theme-frontend"
-    ],
-    "@checkstack/tsconfig": [
-      "@checkstack/tsconfig@workspace:core/tsconfig"
-    ],
-    "@checkstack/ui": [
-      "@checkstack/ui@workspace:core/ui"
-    ],
-    "@colors/colors": [
-      "@colors/colors@1.6.0",
-      "",
-      {},
-      "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
-    ],
-    "@dabh/diagnostics": [
-      "@dabh/diagnostics@2.0.8",
-      "",
-      {
-        "dependencies": {
-          "@so-ric/colorspace": "^1.1.6",
-          "enabled": "2.0.x",
-          "kuler": "^2.0.0"
-        }
-      },
-      "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="
-    ],
-    "@date-fns/tz": [
-      "@date-fns/tz@1.4.1",
-      "",
-      {},
-      "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="
-    ],
-    "@dnd-kit/accessibility": [
-      "@dnd-kit/accessibility@3.1.1",
-      "",
-      {
-        "dependencies": {
-          "tslib": "^2.0.0"
-        },
-        "peerDependencies": {
-          "react": ">=16.8.0"
-        }
-      },
-      "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="
-    ],
-    "@dnd-kit/core": [
-      "@dnd-kit/core@6.3.1",
-      "",
-      {
-        "dependencies": {
-          "@dnd-kit/accessibility": "^3.1.1",
-          "@dnd-kit/utilities": "^3.2.2",
-          "tslib": "^2.0.0"
-        },
-        "peerDependencies": {
-          "react": ">=16.8.0",
-          "react-dom": ">=16.8.0"
-        }
-      },
-      "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="
-    ],
-    "@dnd-kit/utilities": [
-      "@dnd-kit/utilities@3.2.2",
-      "",
-      {
-        "dependencies": {
-          "tslib": "^2.0.0"
-        },
-        "peerDependencies": {
-          "react": ">=16.8.0"
-        }
-      },
-      "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="
-    ],
-    "@drizzle-team/brocli": [
-      "@drizzle-team/brocli@0.10.2",
-      "",
-      {},
-      "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="
-    ],
-    "@emnapi/core": [
-      "@emnapi/core@1.9.2",
-      "",
-      {
-        "dependencies": {
-          "@emnapi/wasi-threads": "1.2.1",
-          "tslib": "^2.4.0"
-        }
-      },
-      "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="
-    ],
-    "@emnapi/runtime": [
-      "@emnapi/runtime@1.9.2",
-      "",
-      {
-        "dependencies": {
-          "tslib": "^2.4.0"
-        }
-      },
-      "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="
-    ],
-    "@emnapi/wasi-threads": [
-      "@emnapi/wasi-threads@1.2.1",
-      "",
-      {
-        "dependencies": {
-          "tslib": "^2.4.0"
-        }
-      },
-      "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="
-    ],
-    "@esbuild-kit/core-utils": [
-      "@esbuild-kit/core-utils@3.3.2",
-      "",
-      {
-        "dependencies": {
-          "esbuild": "~0.18.20",
-          "source-map-support": "^0.5.21"
-        }
-      },
-      "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="
-    ],
-    "@esbuild-kit/esm-loader": [
-      "@esbuild-kit/esm-loader@2.6.5",
-      "",
-      {
-        "dependencies": {
-          "@esbuild-kit/core-utils": "^3.3.2",
-          "get-tsconfig": "^4.7.0"
-        }
-      },
-      "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="
-    ],
-    "@esbuild/aix-ppc64": [
-      "@esbuild/aix-ppc64@0.27.7",
-      "",
-      {
-        "os": "aix",
-        "cpu": "ppc64"
-      },
-      "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="
-    ],
-    "@esbuild/android-arm": [
-      "@esbuild/android-arm@0.27.7",
-      "",
-      {
-        "os": "android",
-        "cpu": "arm"
-      },
-      "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="
-    ],
-    "@esbuild/android-arm64": [
-      "@esbuild/android-arm64@0.27.7",
-      "",
-      {
-        "os": "android",
-        "cpu": "arm64"
-      },
-      "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="
-    ],
-    "@esbuild/android-x64": [
-      "@esbuild/android-x64@0.27.7",
-      "",
-      {
-        "os": "android",
-        "cpu": "x64"
-      },
-      "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="
-    ],
-    "@esbuild/darwin-arm64": [
-      "@esbuild/darwin-arm64@0.27.7",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "arm64"
-      },
-      "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="
-    ],
-    "@esbuild/darwin-x64": [
-      "@esbuild/darwin-x64@0.27.7",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "x64"
-      },
-      "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="
-    ],
-    "@esbuild/freebsd-arm64": [
-      "@esbuild/freebsd-arm64@0.27.7",
-      "",
-      {
-        "os": "freebsd",
-        "cpu": "arm64"
-      },
-      "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="
-    ],
-    "@esbuild/freebsd-x64": [
-      "@esbuild/freebsd-x64@0.27.7",
-      "",
-      {
-        "os": "freebsd",
-        "cpu": "x64"
-      },
-      "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="
-    ],
-    "@esbuild/linux-arm": [
-      "@esbuild/linux-arm@0.27.7",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm"
-      },
-      "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="
-    ],
-    "@esbuild/linux-arm64": [
-      "@esbuild/linux-arm64@0.27.7",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="
-    ],
-    "@esbuild/linux-ia32": [
-      "@esbuild/linux-ia32@0.27.7",
-      "",
-      {
-        "os": "linux",
-        "cpu": "ia32"
-      },
-      "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="
-    ],
-    "@esbuild/linux-loong64": [
-      "@esbuild/linux-loong64@0.27.7",
-      "",
-      {
-        "os": "linux",
-        "cpu": "none"
-      },
-      "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="
-    ],
-    "@esbuild/linux-mips64el": [
-      "@esbuild/linux-mips64el@0.27.7",
-      "",
-      {
-        "os": "linux",
-        "cpu": "none"
-      },
-      "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="
-    ],
-    "@esbuild/linux-ppc64": [
-      "@esbuild/linux-ppc64@0.27.7",
-      "",
-      {
-        "os": "linux",
-        "cpu": "ppc64"
-      },
-      "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="
-    ],
-    "@esbuild/linux-riscv64": [
-      "@esbuild/linux-riscv64@0.27.7",
-      "",
-      {
-        "os": "linux",
-        "cpu": "none"
-      },
-      "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="
-    ],
-    "@esbuild/linux-s390x": [
-      "@esbuild/linux-s390x@0.27.7",
-      "",
-      {
-        "os": "linux",
-        "cpu": "s390x"
-      },
-      "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="
-    ],
-    "@esbuild/linux-x64": [
-      "@esbuild/linux-x64@0.27.7",
-      "",
-      {
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="
-    ],
-    "@esbuild/netbsd-arm64": [
-      "@esbuild/netbsd-arm64@0.27.7",
-      "",
-      {
-        "os": "none",
-        "cpu": "arm64"
-      },
-      "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="
-    ],
-    "@esbuild/netbsd-x64": [
-      "@esbuild/netbsd-x64@0.27.7",
-      "",
-      {
-        "os": "none",
-        "cpu": "x64"
-      },
-      "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="
-    ],
-    "@esbuild/openbsd-arm64": [
-      "@esbuild/openbsd-arm64@0.27.7",
-      "",
-      {
-        "os": "openbsd",
-        "cpu": "arm64"
-      },
-      "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="
-    ],
-    "@esbuild/openbsd-x64": [
-      "@esbuild/openbsd-x64@0.27.7",
-      "",
-      {
-        "os": "openbsd",
-        "cpu": "x64"
-      },
-      "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="
-    ],
-    "@esbuild/openharmony-arm64": [
-      "@esbuild/openharmony-arm64@0.27.7",
-      "",
-      {
-        "os": "none",
-        "cpu": "arm64"
-      },
-      "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="
-    ],
-    "@esbuild/sunos-x64": [
-      "@esbuild/sunos-x64@0.27.7",
-      "",
-      {
-        "os": "sunos",
-        "cpu": "x64"
-      },
-      "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="
-    ],
-    "@esbuild/win32-arm64": [
-      "@esbuild/win32-arm64@0.27.7",
-      "",
-      {
-        "os": "win32",
-        "cpu": "arm64"
-      },
-      "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="
-    ],
-    "@esbuild/win32-ia32": [
-      "@esbuild/win32-ia32@0.27.7",
-      "",
-      {
-        "os": "win32",
-        "cpu": "ia32"
-      },
-      "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="
-    ],
-    "@esbuild/win32-x64": [
-      "@esbuild/win32-x64@0.27.7",
-      "",
-      {
-        "os": "win32",
-        "cpu": "x64"
-      },
-      "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="
-    ],
-    "@eslint-community/eslint-utils": [
-      "@eslint-community/eslint-utils@4.9.1",
-      "",
-      {
-        "dependencies": {
-          "eslint-visitor-keys": "^3.4.3"
-        },
-        "peerDependencies": {
-          "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-        }
-      },
-      "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="
-    ],
-    "@eslint-community/regexpp": [
-      "@eslint-community/regexpp@4.12.2",
-      "",
-      {},
-      "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="
-    ],
-    "@eslint/config-array": [
-      "@eslint/config-array@0.21.2",
-      "",
-      {
-        "dependencies": {
-          "@eslint/object-schema": "^2.1.7",
-          "debug": "^4.3.1",
-          "minimatch": "^3.1.5"
-        }
-      },
-      "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="
-    ],
-    "@eslint/config-helpers": [
-      "@eslint/config-helpers@0.4.2",
-      "",
-      {
-        "dependencies": {
-          "@eslint/core": "^0.17.0"
-        }
-      },
-      "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="
-    ],
-    "@eslint/core": [
-      "@eslint/core@0.17.0",
-      "",
-      {
-        "dependencies": {
-          "@types/json-schema": "^7.0.15"
-        }
-      },
-      "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="
-    ],
-    "@eslint/eslintrc": [
-      "@eslint/eslintrc@3.3.5",
-      "",
-      {
-        "dependencies": {
-          "ajv": "^6.14.0",
-          "debug": "^4.3.2",
-          "espree": "^10.0.1",
-          "globals": "^14.0.0",
-          "ignore": "^5.2.0",
-          "import-fresh": "^3.2.1",
-          "js-yaml": "^4.1.1",
-          "minimatch": "^3.1.5",
-          "strip-json-comments": "^3.1.1"
-        }
-      },
-      "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="
-    ],
-    "@eslint/js": [
-      "@eslint/js@9.39.4",
-      "",
-      {},
-      "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="
-    ],
-    "@eslint/object-schema": [
-      "@eslint/object-schema@2.1.7",
-      "",
-      {},
-      "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="
-    ],
-    "@eslint/plugin-kit": [
-      "@eslint/plugin-kit@0.4.1",
-      "",
-      {
-        "dependencies": {
-          "@eslint/core": "^0.17.0",
-          "levn": "^0.4.1"
-        }
-      },
-      "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="
-    ],
-    "@floating-ui/core": [
-      "@floating-ui/core@1.7.5",
-      "",
-      {
-        "dependencies": {
-          "@floating-ui/utils": "^0.2.11"
-        }
-      },
-      "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="
-    ],
-    "@floating-ui/dom": [
-      "@floating-ui/dom@1.7.6",
-      "",
-      {
-        "dependencies": {
-          "@floating-ui/core": "^1.7.5",
-          "@floating-ui/utils": "^0.2.11"
-        }
-      },
-      "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="
-    ],
-    "@floating-ui/react-dom": [
-      "@floating-ui/react-dom@2.1.8",
-      "",
-      {
-        "dependencies": {
-          "@floating-ui/dom": "^1.7.6"
-        },
-        "peerDependencies": {
-          "react": ">=16.8.0",
-          "react-dom": ">=16.8.0"
-        }
-      },
-      "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="
-    ],
-    "@floating-ui/utils": [
-      "@floating-ui/utils@0.2.11",
-      "",
-      {},
-      "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
-    ],
-    "@grammyjs/types": [
-      "@grammyjs/types@3.26.0",
-      "",
-      {},
-      "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A=="
-    ],
-    "@grpc/grpc-js": [
-      "@grpc/grpc-js@1.14.3",
-      "",
-      {
-        "dependencies": {
-          "@grpc/proto-loader": "^0.8.0",
-          "@js-sdsl/ordered-map": "^4.4.2"
-        }
-      },
-      "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="
-    ],
-    "@grpc/proto-loader": [
-      "@grpc/proto-loader@0.8.0",
-      "",
-      {
-        "dependencies": {
-          "lodash.camelcase": "^4.3.0",
-          "long": "^5.0.0",
-          "protobufjs": "^7.5.3",
-          "yargs": "^17.7.2"
-        },
-        "bin": {
-          "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-        }
-      },
-      "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="
-    ],
-    "@happy-dom/global-registrator": [
-      "@happy-dom/global-registrator@20.9.0",
-      "",
-      {
-        "dependencies": {
-          "@types/node": ">=20.0.0",
-          "happy-dom": "^20.9.0"
-        }
-      },
-      "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="
-    ],
-    "@hono/zod-validator": [
-      "@hono/zod-validator@0.7.6",
-      "",
-      {
-        "peerDependencies": {
-          "hono": ">=3.9.0",
-          "zod": "^3.25.0 || ^4.0.0"
-        }
-      },
-      "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="
-    ],
-    "@humanfs/core": [
-      "@humanfs/core@0.19.1",
-      "",
-      {},
-      "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="
-    ],
-    "@humanfs/node": [
-      "@humanfs/node@0.16.7",
-      "",
-      {
-        "dependencies": {
-          "@humanfs/core": "^0.19.1",
-          "@humanwhocodes/retry": "^0.4.0"
-        }
-      },
-      "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="
-    ],
-    "@humanwhocodes/module-importer": [
-      "@humanwhocodes/module-importer@1.0.1",
-      "",
-      {},
-      "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="
-    ],
-    "@humanwhocodes/retry": [
-      "@humanwhocodes/retry@0.4.3",
-      "",
-      {},
-      "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="
-    ],
-    "@inquirer/ansi": [
-      "@inquirer/ansi@2.0.5",
-      "",
-      {},
-      "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="
-    ],
-    "@inquirer/checkbox": [
-      "@inquirer/checkbox@5.1.3",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/ansi": "^2.0.5",
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/figures": "^2.0.5",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg=="
-    ],
-    "@inquirer/confirm": [
-      "@inquirer/confirm@6.0.11",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA=="
-    ],
-    "@inquirer/core": [
-      "@inquirer/core@11.1.8",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/ansi": "^2.0.5",
-          "@inquirer/figures": "^2.0.5",
-          "@inquirer/type": "^4.0.5",
-          "cli-width": "^4.1.0",
-          "fast-wrap-ansi": "^0.2.0",
-          "mute-stream": "^3.0.0",
-          "signal-exit": "^4.1.0"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA=="
-    ],
-    "@inquirer/editor": [
-      "@inquirer/editor@5.1.0",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/external-editor": "^3.0.0",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw=="
-    ],
-    "@inquirer/expand": [
-      "@inquirer/expand@5.0.12",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ=="
-    ],
-    "@inquirer/external-editor": [
-      "@inquirer/external-editor@1.0.3",
-      "",
-      {
-        "dependencies": {
-          "chardet": "^2.1.1",
-          "iconv-lite": "^0.7.0"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="
-    ],
-    "@inquirer/figures": [
-      "@inquirer/figures@2.0.5",
-      "",
-      {},
-      "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="
-    ],
-    "@inquirer/input": [
-      "@inquirer/input@5.0.11",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ=="
-    ],
-    "@inquirer/number": [
-      "@inquirer/number@4.0.11",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA=="
-    ],
-    "@inquirer/password": [
-      "@inquirer/password@5.0.11",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/ansi": "^2.0.5",
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg=="
-    ],
-    "@inquirer/prompts": [
-      "@inquirer/prompts@8.4.1",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/checkbox": "^5.1.3",
-          "@inquirer/confirm": "^6.0.11",
-          "@inquirer/editor": "^5.1.0",
-          "@inquirer/expand": "^5.0.12",
-          "@inquirer/input": "^5.0.11",
-          "@inquirer/number": "^4.0.11",
-          "@inquirer/password": "^5.0.11",
-          "@inquirer/rawlist": "^5.2.7",
-          "@inquirer/search": "^4.1.7",
-          "@inquirer/select": "^5.1.3"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ=="
-    ],
-    "@inquirer/rawlist": [
-      "@inquirer/rawlist@5.2.7",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w=="
-    ],
-    "@inquirer/search": [
-      "@inquirer/search@4.1.7",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/figures": "^2.0.5",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ=="
-    ],
-    "@inquirer/select": [
-      "@inquirer/select@5.1.3",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/ansi": "^2.0.5",
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/figures": "^2.0.5",
-          "@inquirer/type": "^4.0.5"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A=="
-    ],
-    "@inquirer/type": [
-      "@inquirer/type@4.0.5",
-      "",
-      {
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
-    ],
-    "@ioredis/as-callback": [
-      "@ioredis/as-callback@3.0.0",
-      "",
-      {},
-      "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg=="
-    ],
-    "@ioredis/commands": [
-      "@ioredis/commands@1.5.1",
-      "",
-      {},
-      "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="
-    ],
-    "@jridgewell/gen-mapping": [
-      "@jridgewell/gen-mapping@0.3.13",
-      "",
-      {
-        "dependencies": {
-          "@jridgewell/sourcemap-codec": "^1.5.0",
-          "@jridgewell/trace-mapping": "^0.3.24"
-        }
-      },
-      "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="
-    ],
-    "@jridgewell/remapping": [
-      "@jridgewell/remapping@2.3.5",
-      "",
-      {
-        "dependencies": {
-          "@jridgewell/gen-mapping": "^0.3.5",
-          "@jridgewell/trace-mapping": "^0.3.24"
-        }
-      },
-      "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="
-    ],
-    "@jridgewell/resolve-uri": [
-      "@jridgewell/resolve-uri@3.1.2",
-      "",
-      {},
-      "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
-    ],
-    "@jridgewell/sourcemap-codec": [
-      "@jridgewell/sourcemap-codec@1.5.5",
-      "",
-      {},
-      "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
-    ],
-    "@jridgewell/trace-mapping": [
-      "@jridgewell/trace-mapping@0.3.31",
-      "",
-      {
-        "dependencies": {
-          "@jridgewell/resolve-uri": "^3.1.0",
-          "@jridgewell/sourcemap-codec": "^1.4.14"
-        }
-      },
-      "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="
-    ],
-    "@js-sdsl/ordered-map": [
-      "@js-sdsl/ordered-map@4.4.2",
-      "",
-      {},
-      "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
-    ],
-    "@jsep-plugin/assignment": [
-      "@jsep-plugin/assignment@1.3.0",
-      "",
-      {
-        "peerDependencies": {
-          "jsep": "^0.4.0||^1.0.0"
-        }
-      },
-      "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ=="
-    ],
-    "@jsep-plugin/regex": [
-      "@jsep-plugin/regex@1.0.4",
-      "",
-      {
-        "peerDependencies": {
-          "jsep": "^0.4.0||^1.0.0"
-        }
-      },
-      "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg=="
-    ],
-    "@manypkg/find-root": [
-      "@manypkg/find-root@1.1.0",
-      "",
-      {
-        "dependencies": {
-          "@babel/runtime": "^7.5.5",
-          "@types/node": "^12.7.1",
-          "find-up": "^4.1.0",
-          "fs-extra": "^8.1.0"
-        }
-      },
-      "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="
-    ],
-    "@manypkg/get-packages": [
-      "@manypkg/get-packages@1.1.3",
-      "",
-      {
-        "dependencies": {
-          "@babel/runtime": "^7.5.5",
-          "@changesets/types": "^4.0.1",
-          "@manypkg/find-root": "^1.1.0",
-          "fs-extra": "^8.1.0",
-          "globby": "^11.0.0",
-          "read-yaml-file": "^1.1.0"
-        }
-      },
-      "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="
-    ],
-    "@monaco-editor/loader": [
-      "@monaco-editor/loader@1.7.0",
-      "",
-      {
-        "dependencies": {
-          "state-local": "^1.0.6"
-        }
-      },
-      "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="
-    ],
-    "@monaco-editor/react": [
-      "@monaco-editor/react@4.7.0",
-      "",
-      {
-        "dependencies": {
-          "@monaco-editor/loader": "^1.5.0"
-        },
-        "peerDependencies": {
-          "monaco-editor": ">= 0.25.0 < 1",
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-          "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-        }
-      },
-      "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA=="
-    ],
-    "@msgpackr-extract/msgpackr-extract-darwin-arm64": [
-      "@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "arm64"
-      },
-      "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="
-    ],
-    "@msgpackr-extract/msgpackr-extract-darwin-x64": [
-      "@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "x64"
-      },
-      "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="
-    ],
-    "@msgpackr-extract/msgpackr-extract-linux-arm": [
-      "@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm"
-      },
-      "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw=="
-    ],
-    "@msgpackr-extract/msgpackr-extract-linux-arm64": [
-      "@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg=="
-    ],
-    "@msgpackr-extract/msgpackr-extract-linux-x64": [
-      "@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3",
-      "",
-      {
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="
-    ],
-    "@msgpackr-extract/msgpackr-extract-win32-x64": [
-      "@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3",
-      "",
-      {
-        "os": "win32",
-        "cpu": "x64"
-      },
-      "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="
-    ],
-    "@napi-rs/wasm-runtime": [
-      "@napi-rs/wasm-runtime@1.1.4",
-      "",
-      {
-        "dependencies": {
-          "@tybys/wasm-util": "^0.10.1"
-        },
-        "peerDependencies": {
-          "@emnapi/core": "^1.7.1",
-          "@emnapi/runtime": "^1.7.1"
-        }
-      },
-      "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="
-    ],
-    "@noble/ciphers": [
-      "@noble/ciphers@2.2.0",
-      "",
-      {},
-      "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="
-    ],
-    "@noble/hashes": [
-      "@noble/hashes@2.2.0",
-      "",
-      {},
-      "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="
-    ],
-    "@nodelib/fs.scandir": [
-      "@nodelib/fs.scandir@2.1.5",
-      "",
-      {
-        "dependencies": {
-          "@nodelib/fs.stat": "2.0.5",
-          "run-parallel": "^1.1.9"
-        }
-      },
-      "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="
-    ],
-    "@nodelib/fs.stat": [
-      "@nodelib/fs.stat@2.0.5",
-      "",
-      {},
-      "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
-    ],
-    "@nodelib/fs.walk": [
-      "@nodelib/fs.walk@1.2.8",
-      "",
-      {
-        "dependencies": {
-          "@nodelib/fs.scandir": "2.1.5",
-          "fastq": "^1.6.0"
-        }
-      },
-      "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="
-    ],
-    "@opentelemetry/api": [
-      "@opentelemetry/api@1.9.1",
-      "",
-      {},
-      "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
-    ],
-    "@opentelemetry/semantic-conventions": [
-      "@opentelemetry/semantic-conventions@1.40.0",
-      "",
-      {},
-      "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="
-    ],
-    "@orpc/client": [
-      "@orpc/client@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.14",
-          "@orpc/standard-server": "1.13.14",
-          "@orpc/standard-server-fetch": "1.13.14",
-          "@orpc/standard-server-peer": "1.13.14"
-        }
-      },
-      "sha512-JQf3lO//UGHmmkd8+9fuWuh1gga1lhWuKnsT19cui7F6WizBy0NdFSVQerOsSy2c1kxOthlD7GnicGgSY2rhQA=="
-    ],
-    "@orpc/contract": [
-      "@orpc/contract@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/client": "1.13.14",
-          "@orpc/shared": "1.13.14",
-          "@standard-schema/spec": "^1.1.0",
-          "openapi-types": "^12.1.3"
-        }
-      },
-      "sha512-MfsjaQQDVcs4wHmdl5N/7vkwMnQ41nlojWXyRfRXNJHQczqBzM6sYaTJuUPXlw4YbIu64KHZ5nbbtwNCO5YXsg=="
-    ],
-    "@orpc/interop": [
-      "@orpc/interop@1.13.14",
-      "",
-      {},
-      "sha512-7umABTBzQMNTX8dTKrbIOu9g5XJuMeqijC6Gu6jlaVP90e8D57n7Zv6HfwSgPVq0oQXf9n/ENptzVj3TpxpXsQ=="
-    ],
-    "@orpc/json-schema": [
-      "@orpc/json-schema@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/contract": "1.13.14",
-          "@orpc/interop": "1.13.14",
-          "@orpc/openapi": "1.13.14",
-          "@orpc/server": "1.13.14",
-          "@orpc/shared": "1.13.14",
-          "json-schema-typed": "^8.0.2"
-        }
-      },
-      "sha512-BLGewxG0dv5AhLEwTmeXDNZ0PiRxvCzxcUtbo8FExwIR6wpknfWukeoymaHn8vtyfuOO9nvPfertNuNUReiufg=="
-    ],
-    "@orpc/openapi": [
-      "@orpc/openapi@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/client": "1.13.14",
-          "@orpc/contract": "1.13.14",
-          "@orpc/interop": "1.13.14",
-          "@orpc/openapi-client": "1.13.14",
-          "@orpc/server": "1.13.14",
-          "@orpc/shared": "1.13.14",
-          "@orpc/standard-server": "1.13.14",
-          "json-schema-typed": "^8.0.2",
-          "rou3": "^0.7.12"
-        }
-      },
-      "sha512-wwfq8CwOTxuNOfamHKTrXgUxxAhh8WSTpu2OgZhNDWxH0p6V/xLhlXl2iSjmzyO4QuBpE26fchDwaVAGic9zlQ=="
-    ],
-    "@orpc/openapi-client": [
-      "@orpc/openapi-client@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/client": "1.13.14",
-          "@orpc/contract": "1.13.14",
-          "@orpc/shared": "1.13.14",
-          "@orpc/standard-server": "1.13.14"
-        }
-      },
-      "sha512-mHuj/UL5qLqB1JqrRdlAoUYMidbsry8Cr9QOlOZk1mp7+OZhasFv75UNzxyjNNaSjyd3l2k4UkgpcHK4VSD7tQ=="
-    ],
-    "@orpc/react-query": [
-      "@orpc/react-query@1.13.4",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.4",
-          "@orpc/tanstack-query": "1.13.4"
-        },
-        "peerDependencies": {
-          "@orpc/client": "1.13.4",
-          "@tanstack/react-query": ">=5.80.2",
-          "react": ">=18.3.0"
-        }
-      },
-      "sha512-MD1uOIioGk2y94QjRlVkuodF6pFpXeobmESgmVPbfvM+UrWhvO5d1eEbgIVIsfDEpZKEi6I9pB0FDThKl0oWHg=="
-    ],
-    "@orpc/server": [
-      "@orpc/server@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/client": "1.13.14",
-          "@orpc/contract": "1.13.14",
-          "@orpc/interop": "1.13.14",
-          "@orpc/shared": "1.13.14",
-          "@orpc/standard-server": "1.13.14",
-          "@orpc/standard-server-aws-lambda": "1.13.14",
-          "@orpc/standard-server-fastify": "1.13.14",
-          "@orpc/standard-server-fetch": "1.13.14",
-          "@orpc/standard-server-node": "1.13.14",
-          "@orpc/standard-server-peer": "1.13.14",
-          "cookie": "^1.1.1"
-        },
-        "peerDependencies": {
-          "crossws": ">=0.3.4",
-          "ws": ">=8.18.1"
-        },
-        "optionalPeers": [
-          "crossws",
-          "ws"
-        ]
-      },
-      "sha512-bF+sNbSHBgs1uwzHXgTxcxWIG42ryX+w32l+FJRHrAmGma+S8PmS1X2HZ/J7XycyYVBJMUUzBr8M88pP+UcdxQ=="
-    ],
-    "@orpc/shared": [
-      "@orpc/shared@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "radash": "^12.1.1",
-          "type-fest": "^5.4.4"
-        },
-        "peerDependencies": {
-          "@opentelemetry/api": ">=1.9.0"
-        },
-        "optionalPeers": [
-          "@opentelemetry/api"
-        ]
-      },
-      "sha512-/ri8ttSX+ppoo01d3LdqQ4Xh6VZS5PYRYmHxTvO8tuyiqBJhN18d8P1VtEW4T9hetoK7JZKeU7EAeqVUnCF9WA=="
-    ],
-    "@orpc/standard-server": [
-      "@orpc/standard-server@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.14"
-        }
-      },
-      "sha512-o8PaDERiwREFQpIZO0mQ1PhguchyNzrf1w7m3eK1JB4rPjHu1VJUgqCpy/sV3Id5ji4bX/gKHEC3NZjDX6mEWQ=="
-    ],
-    "@orpc/standard-server-aws-lambda": [
-      "@orpc/standard-server-aws-lambda@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.14",
-          "@orpc/standard-server": "1.13.14",
-          "@orpc/standard-server-fetch": "1.13.14",
-          "@orpc/standard-server-node": "1.13.14"
-        }
-      },
-      "sha512-5P1ZzgS6zKTjjI0SaCgMlTF5PM4dbOlmP2Zm2Lh1ool/iNvjMzXSb86pbKrWOo5/V8dzn4GMyCgNso9za1nUMg=="
-    ],
-    "@orpc/standard-server-fastify": [
-      "@orpc/standard-server-fastify@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.14",
-          "@orpc/standard-server": "1.13.14",
-          "@orpc/standard-server-node": "1.13.14"
-        },
-        "peerDependencies": {
-          "fastify": ">=5.6.1"
-        },
-        "optionalPeers": [
-          "fastify"
-        ]
-      },
-      "sha512-DcgL5UFjHENGj1gWiQig4iObMNnnw8z7UrfTELTCejQ9NAWE8aGYdx4bZ/hk4JkieLJ+9aosGK57di6xXBtvPA=="
-    ],
-    "@orpc/standard-server-fetch": [
-      "@orpc/standard-server-fetch@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.14",
-          "@orpc/standard-server": "1.13.14"
-        }
-      },
-      "sha512-k2zkCi98qd3NkvWhUX/Yece/qjB+o07g/gHC509YB5HbOGtBV/da3eseYjFyzBx5LDxMz28BOALI8/q/YDhKZw=="
-    ],
-    "@orpc/standard-server-node": [
-      "@orpc/standard-server-node@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.14",
-          "@orpc/standard-server": "1.13.14",
-          "@orpc/standard-server-fetch": "1.13.14"
-        }
-      },
-      "sha512-GKMWfMuKX+dycpEFMoFrGY+zhZMKPoR9HSM66Ebn/ixr2qCVfQaoudPa9MAgP+fv/ctZx+nkt1rR7esUFMdMAg=="
-    ],
-    "@orpc/standard-server-peer": [
-      "@orpc/standard-server-peer@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.14",
-          "@orpc/standard-server": "1.13.14"
-        }
-      },
-      "sha512-jinseQ8bn7XQOHjsCXhR1HiF3wAwn1xEQPpnE/av0PoOi4h0ATvhZjDLaRHvRavs8YwrIqwSuAuYT/hDxON58A=="
-    ],
-    "@orpc/tanstack-query": [
-      "@orpc/tanstack-query@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.14"
-        },
-        "peerDependencies": {
-          "@orpc/client": "1.13.14",
-          "@tanstack/query-core": ">=5.80.2"
-        }
-      },
-      "sha512-5rq1Z1anVTVBseYeNBi5RJSgWPxpD0MqK7MYej3xnt56jjc6mFmWpUGNz9xy0BXPh3KmA/xDTNuB23kKgJ5JmQ=="
-    ],
-    "@orpc/zod": [
-      "@orpc/zod@1.13.14",
-      "",
-      {
-        "dependencies": {
-          "@orpc/json-schema": "1.13.14",
-          "@orpc/openapi": "1.13.14",
-          "@orpc/shared": "1.13.14",
-          "escape-string-regexp": "^5.0.0",
-          "wildcard-match": "^5.1.4"
-        },
-        "peerDependencies": {
-          "@orpc/contract": "1.13.14",
-          "@orpc/server": "1.13.14",
-          "zod": ">=3.25.0"
-        }
-      },
-      "sha512-lpF8Nyb+WdW0PieZcJB3KvKztGveXvckOqXMyWTWvyrylV3rCPmeUneVQghjZOLqJdAevo4jqV2/BgHWSt3EEA=="
-    ],
-    "@oxc-project/types": [
-      "@oxc-project/types@0.124.0",
-      "",
-      {},
-      "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="
-    ],
-    "@playwright/test": [
-      "@playwright/test@1.59.1",
-      "",
-      {
-        "dependencies": {
-          "playwright": "1.59.1"
-        },
-        "bin": {
-          "playwright": "cli.js"
-        }
-      },
-      "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="
-    ],
-    "@protobufjs/aspromise": [
-      "@protobufjs/aspromise@1.1.2",
-      "",
-      {},
-      "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    ],
-    "@protobufjs/base64": [
-      "@protobufjs/base64@1.1.2",
-      "",
-      {},
-      "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    ],
-    "@protobufjs/codegen": [
-      "@protobufjs/codegen@2.0.4",
-      "",
-      {},
-      "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    ],
-    "@protobufjs/eventemitter": [
-      "@protobufjs/eventemitter@1.1.0",
-      "",
-      {},
-      "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    ],
-    "@protobufjs/fetch": [
-      "@protobufjs/fetch@1.1.0",
-      "",
-      {
-        "dependencies": {
-          "@protobufjs/aspromise": "^1.1.1",
-          "@protobufjs/inquire": "^1.1.0"
-        }
-      },
-      "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="
-    ],
-    "@protobufjs/float": [
-      "@protobufjs/float@1.0.2",
-      "",
-      {},
-      "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    ],
-    "@protobufjs/inquire": [
-      "@protobufjs/inquire@1.1.0",
-      "",
-      {},
-      "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    ],
-    "@protobufjs/path": [
-      "@protobufjs/path@1.1.2",
-      "",
-      {},
-      "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    ],
-    "@protobufjs/pool": [
-      "@protobufjs/pool@1.1.0",
-      "",
-      {},
-      "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    ],
-    "@protobufjs/utf8": [
-      "@protobufjs/utf8@1.1.0",
-      "",
-      {},
-      "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    ],
-    "@radix-ui/number": [
-      "@radix-ui/number@1.1.1",
-      "",
-      {},
-      "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="
-    ],
-    "@radix-ui/primitive": [
-      "@radix-ui/primitive@1.1.3",
-      "",
-      {},
-      "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
-    ],
-    "@radix-ui/react-accordion": [
-      "@radix-ui/react-accordion@1.2.12",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/primitive": "1.1.3",
-          "@radix-ui/react-collapsible": "1.1.12",
-          "@radix-ui/react-collection": "1.1.7",
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-context": "1.1.2",
-          "@radix-ui/react-direction": "1.1.1",
-          "@radix-ui/react-id": "1.1.1",
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-use-controllable-state": "1.2.2"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA=="
-    ],
-    "@radix-ui/react-arrow": [
-      "@radix-ui/react-arrow@1.1.7",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-primitive": "2.1.3"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="
-    ],
-    "@radix-ui/react-collapsible": [
-      "@radix-ui/react-collapsible@1.1.12",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/primitive": "1.1.3",
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-context": "1.1.2",
-          "@radix-ui/react-id": "1.1.1",
-          "@radix-ui/react-presence": "1.1.5",
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-use-controllable-state": "1.2.2",
-          "@radix-ui/react-use-layout-effect": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA=="
-    ],
-    "@radix-ui/react-collection": [
-      "@radix-ui/react-collection@1.1.7",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-context": "1.1.2",
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-slot": "1.2.3"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="
-    ],
-    "@radix-ui/react-compose-refs": [
-      "@radix-ui/react-compose-refs@1.1.2",
-      "",
-      {
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="
-    ],
-    "@radix-ui/react-context": [
-      "@radix-ui/react-context@1.1.2",
-      "",
-      {
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="
-    ],
-    "@radix-ui/react-dialog": [
-      "@radix-ui/react-dialog@1.1.15",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/primitive": "1.1.3",
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-context": "1.1.2",
-          "@radix-ui/react-dismissable-layer": "1.1.11",
-          "@radix-ui/react-focus-guards": "1.1.3",
-          "@radix-ui/react-focus-scope": "1.1.7",
-          "@radix-ui/react-id": "1.1.1",
-          "@radix-ui/react-portal": "1.1.9",
-          "@radix-ui/react-presence": "1.1.5",
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-slot": "1.2.3",
-          "@radix-ui/react-use-controllable-state": "1.2.2",
-          "aria-hidden": "^1.2.4",
-          "react-remove-scroll": "^2.6.3"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw=="
-    ],
-    "@radix-ui/react-direction": [
-      "@radix-ui/react-direction@1.1.1",
-      "",
-      {
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw=="
-    ],
-    "@radix-ui/react-dismissable-layer": [
-      "@radix-ui/react-dismissable-layer@1.1.11",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/primitive": "1.1.3",
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-use-callback-ref": "1.1.1",
-          "@radix-ui/react-use-escape-keydown": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="
-    ],
-    "@radix-ui/react-focus-guards": [
-      "@radix-ui/react-focus-guards@1.1.3",
-      "",
-      {
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="
-    ],
-    "@radix-ui/react-focus-scope": [
-      "@radix-ui/react-focus-scope@1.1.7",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-use-callback-ref": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="
-    ],
-    "@radix-ui/react-id": [
-      "@radix-ui/react-id@1.1.1",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-use-layout-effect": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="
-    ],
-    "@radix-ui/react-popover": [
-      "@radix-ui/react-popover@1.1.15",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/primitive": "1.1.3",
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-context": "1.1.2",
-          "@radix-ui/react-dismissable-layer": "1.1.11",
-          "@radix-ui/react-focus-guards": "1.1.3",
-          "@radix-ui/react-focus-scope": "1.1.7",
-          "@radix-ui/react-id": "1.1.1",
-          "@radix-ui/react-popper": "1.2.8",
-          "@radix-ui/react-portal": "1.1.9",
-          "@radix-ui/react-presence": "1.1.5",
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-slot": "1.2.3",
-          "@radix-ui/react-use-controllable-state": "1.2.2",
-          "aria-hidden": "^1.2.4",
-          "react-remove-scroll": "^2.6.3"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA=="
-    ],
-    "@radix-ui/react-popper": [
-      "@radix-ui/react-popper@1.2.8",
-      "",
-      {
-        "dependencies": {
-          "@floating-ui/react-dom": "^2.0.0",
-          "@radix-ui/react-arrow": "1.1.7",
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-context": "1.1.2",
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-use-callback-ref": "1.1.1",
-          "@radix-ui/react-use-layout-effect": "1.1.1",
-          "@radix-ui/react-use-rect": "1.1.1",
-          "@radix-ui/react-use-size": "1.1.1",
-          "@radix-ui/rect": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="
-    ],
-    "@radix-ui/react-portal": [
-      "@radix-ui/react-portal@1.1.9",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-use-layout-effect": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="
-    ],
-    "@radix-ui/react-presence": [
-      "@radix-ui/react-presence@1.1.5",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-use-layout-effect": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="
-    ],
-    "@radix-ui/react-primitive": [
-      "@radix-ui/react-primitive@2.1.3",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-slot": "1.2.3"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="
-    ],
-    "@radix-ui/react-select": [
-      "@radix-ui/react-select@2.2.6",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/number": "1.1.1",
-          "@radix-ui/primitive": "1.1.3",
-          "@radix-ui/react-collection": "1.1.7",
-          "@radix-ui/react-compose-refs": "1.1.2",
-          "@radix-ui/react-context": "1.1.2",
-          "@radix-ui/react-direction": "1.1.1",
-          "@radix-ui/react-dismissable-layer": "1.1.11",
-          "@radix-ui/react-focus-guards": "1.1.3",
-          "@radix-ui/react-focus-scope": "1.1.7",
-          "@radix-ui/react-id": "1.1.1",
-          "@radix-ui/react-popper": "1.2.8",
-          "@radix-ui/react-portal": "1.1.9",
-          "@radix-ui/react-primitive": "2.1.3",
-          "@radix-ui/react-slot": "1.2.3",
-          "@radix-ui/react-use-callback-ref": "1.1.1",
-          "@radix-ui/react-use-controllable-state": "1.2.2",
-          "@radix-ui/react-use-layout-effect": "1.1.1",
-          "@radix-ui/react-use-previous": "1.1.1",
-          "@radix-ui/react-visually-hidden": "1.2.3",
-          "aria-hidden": "^1.2.4",
-          "react-remove-scroll": "^2.6.3"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="
-    ],
-    "@radix-ui/react-slot": [
-      "@radix-ui/react-slot@1.2.4",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-compose-refs": "1.1.2"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="
-    ],
-    "@radix-ui/react-use-callback-ref": [
-      "@radix-ui/react-use-callback-ref@1.1.1",
-      "",
-      {
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="
-    ],
-    "@radix-ui/react-use-controllable-state": [
-      "@radix-ui/react-use-controllable-state@1.2.2",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-use-effect-event": "0.0.2",
-          "@radix-ui/react-use-layout-effect": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="
-    ],
-    "@radix-ui/react-use-effect-event": [
-      "@radix-ui/react-use-effect-event@0.0.2",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-use-layout-effect": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="
-    ],
-    "@radix-ui/react-use-escape-keydown": [
-      "@radix-ui/react-use-escape-keydown@1.1.1",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-use-callback-ref": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="
-    ],
-    "@radix-ui/react-use-layout-effect": [
-      "@radix-ui/react-use-layout-effect@1.1.1",
-      "",
-      {
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="
-    ],
-    "@radix-ui/react-use-previous": [
-      "@radix-ui/react-use-previous@1.1.1",
-      "",
-      {
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ=="
-    ],
-    "@radix-ui/react-use-rect": [
-      "@radix-ui/react-use-rect@1.1.1",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/rect": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="
-    ],
-    "@radix-ui/react-use-size": [
-      "@radix-ui/react-use-size@1.1.1",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-use-layout-effect": "1.1.1"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="
-    ],
-    "@radix-ui/react-visually-hidden": [
-      "@radix-ui/react-visually-hidden@1.2.3",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-primitive": "2.1.3"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "@types/react-dom": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-          "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="
-    ],
-    "@radix-ui/rect": [
-      "@radix-ui/rect@1.1.1",
-      "",
-      {},
-      "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
-    ],
-    "@reduxjs/toolkit": [
-      "@reduxjs/toolkit@2.11.2",
-      "",
-      {
-        "dependencies": {
-          "@standard-schema/spec": "^1.0.0",
-          "@standard-schema/utils": "^0.3.0",
-          "immer": "^11.0.0",
-          "redux": "^5.0.1",
-          "redux-thunk": "^3.1.0",
-          "reselect": "^5.1.0"
-        },
-        "peerDependencies": {
-          "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-          "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-        },
-        "optionalPeers": [
-          "react",
-          "react-redux"
-        ]
-      },
-      "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="
-    ],
-    "@remix-run/router": [
-      "@remix-run/router@1.23.2",
-      "",
-      {},
-      "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="
-    ],
-    "@rolldown/binding-android-arm64": [
-      "@rolldown/binding-android-arm64@1.0.0-rc.15",
-      "",
-      {
-        "os": "android",
-        "cpu": "arm64"
-      },
-      "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="
-    ],
-    "@rolldown/binding-darwin-arm64": [
-      "@rolldown/binding-darwin-arm64@1.0.0-rc.15",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "arm64"
-      },
-      "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="
-    ],
-    "@rolldown/binding-darwin-x64": [
-      "@rolldown/binding-darwin-x64@1.0.0-rc.15",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "x64"
-      },
-      "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="
-    ],
-    "@rolldown/binding-freebsd-x64": [
-      "@rolldown/binding-freebsd-x64@1.0.0-rc.15",
-      "",
-      {
-        "os": "freebsd",
-        "cpu": "x64"
-      },
-      "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="
-    ],
-    "@rolldown/binding-linux-arm-gnueabihf": [
-      "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm"
-      },
-      "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="
-    ],
-    "@rolldown/binding-linux-arm64-gnu": [
-      "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="
-    ],
-    "@rolldown/binding-linux-arm64-musl": [
-      "@rolldown/binding-linux-arm64-musl@1.0.0-rc.15",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="
-    ],
-    "@rolldown/binding-linux-ppc64-gnu": [
-      "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15",
-      "",
-      {
-        "os": "linux",
-        "cpu": "ppc64"
-      },
-      "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="
-    ],
-    "@rolldown/binding-linux-s390x-gnu": [
-      "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15",
-      "",
-      {
-        "os": "linux",
-        "cpu": "s390x"
-      },
-      "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="
-    ],
-    "@rolldown/binding-linux-x64-gnu": [
-      "@rolldown/binding-linux-x64-gnu@1.0.0-rc.15",
-      "",
-      {
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="
-    ],
-    "@rolldown/binding-linux-x64-musl": [
-      "@rolldown/binding-linux-x64-musl@1.0.0-rc.15",
-      "",
-      {
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="
-    ],
-    "@rolldown/binding-openharmony-arm64": [
-      "@rolldown/binding-openharmony-arm64@1.0.0-rc.15",
-      "",
-      {
-        "os": "none",
-        "cpu": "arm64"
-      },
-      "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="
-    ],
-    "@rolldown/binding-wasm32-wasi": [
-      "@rolldown/binding-wasm32-wasi@1.0.0-rc.15",
-      "",
-      {
-        "dependencies": {
-          "@emnapi/core": "1.9.2",
-          "@emnapi/runtime": "1.9.2",
-          "@napi-rs/wasm-runtime": "^1.1.3"
-        },
-        "cpu": "none"
-      },
-      "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="
-    ],
-    "@rolldown/binding-win32-arm64-msvc": [
-      "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15",
-      "",
-      {
-        "os": "win32",
-        "cpu": "arm64"
-      },
-      "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="
-    ],
-    "@rolldown/binding-win32-x64-msvc": [
-      "@rolldown/binding-win32-x64-msvc@1.0.0-rc.15",
-      "",
-      {
-        "os": "win32",
-        "cpu": "x64"
-      },
-      "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="
-    ],
-    "@rolldown/pluginutils": [
-      "@rolldown/pluginutils@1.0.0-rc.7",
-      "",
-      {},
-      "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="
-    ],
-    "@so-ric/colorspace": [
-      "@so-ric/colorspace@1.1.6",
-      "",
-      {
-        "dependencies": {
-          "color": "^5.0.2",
-          "text-hex": "1.0.x"
-        }
-      },
-      "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="
-    ],
-    "@standard-schema/spec": [
-      "@standard-schema/spec@1.1.0",
-      "",
-      {},
-      "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
-    ],
-    "@standard-schema/utils": [
-      "@standard-schema/utils@0.3.0",
-      "",
-      {},
-      "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
-    ],
-    "@tabby_ai/hijri-converter": [
-      "@tabby_ai/hijri-converter@1.0.5",
-      "",
-      {},
-      "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ=="
-    ],
-    "@tanstack/query-core": [
-      "@tanstack/query-core@5.99.0",
-      "",
-      {},
-      "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ=="
-    ],
-    "@tanstack/query-devtools": [
-      "@tanstack/query-devtools@5.99.0",
-      "",
-      {},
-      "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ=="
-    ],
-    "@tanstack/react-query": [
-      "@tanstack/react-query@5.99.0",
-      "",
-      {
-        "dependencies": {
-          "@tanstack/query-core": "5.99.0"
-        },
-        "peerDependencies": {
-          "react": "^18 || ^19"
-        }
-      },
-      "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw=="
-    ],
-    "@tanstack/react-query-devtools": [
-      "@tanstack/react-query-devtools@5.99.0",
-      "",
-      {
-        "dependencies": {
-          "@tanstack/query-devtools": "5.99.0"
-        },
-        "peerDependencies": {
-          "@tanstack/react-query": "^5.99.0",
-          "react": "^18 || ^19"
-        }
-      },
-      "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA=="
-    ],
-    "@testing-library/dom": [
-      "@testing-library/dom@10.4.1",
-      "",
-      {
-        "dependencies": {
-          "@babel/code-frame": "^7.10.4",
-          "@babel/runtime": "^7.12.5",
-          "@types/aria-query": "^5.0.1",
-          "aria-query": "5.3.0",
-          "dom-accessibility-api": "^0.5.9",
-          "lz-string": "^1.5.0",
-          "picocolors": "1.1.1",
-          "pretty-format": "^27.0.2"
-        }
-      },
-      "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="
-    ],
-    "@testing-library/jest-dom": [
-      "@testing-library/jest-dom@6.9.1",
-      "",
-      {
-        "dependencies": {
-          "@adobe/css-tools": "^4.4.0",
-          "aria-query": "^5.0.0",
-          "css.escape": "^1.5.1",
-          "dom-accessibility-api": "^0.6.3",
-          "picocolors": "^1.1.1",
-          "redent": "^3.0.0"
-        }
-      },
-      "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="
-    ],
-    "@testing-library/react": [
-      "@testing-library/react@16.3.2",
-      "",
-      {
-        "dependencies": {
-          "@babel/runtime": "^7.12.5"
-        },
-        "peerDependencies": {
-          "@testing-library/dom": "^10.0.0",
-          "@types/react": "^18.0.0 || ^19.0.0",
-          "@types/react-dom": "^18.0.0 || ^19.0.0",
-          "react": "^18.0.0 || ^19.0.0",
-          "react-dom": "^18.0.0 || ^19.0.0"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "@types/react-dom"
-        ]
-      },
-      "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="
-    ],
-    "@tybys/wasm-util": [
-      "@tybys/wasm-util@0.10.1",
-      "",
-      {
-        "dependencies": {
-          "tslib": "^2.4.0"
-        }
-      },
-      "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="
-    ],
-    "@types/aria-query": [
-      "@types/aria-query@5.0.4",
-      "",
-      {},
-      "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
-    ],
-    "@types/bun": [
-      "@types/bun@1.3.12",
-      "",
-      {
-        "dependencies": {
-          "bun-types": "1.3.12"
-        }
-      },
-      "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="
-    ],
-    "@types/d3-array": [
-      "@types/d3-array@3.2.2",
-      "",
-      {},
-      "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
-    ],
-    "@types/d3-color": [
-      "@types/d3-color@3.1.3",
-      "",
-      {},
-      "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
-    ],
-    "@types/d3-drag": [
-      "@types/d3-drag@3.0.7",
-      "",
-      {
-        "dependencies": {
-          "@types/d3-selection": "*"
-        }
-      },
-      "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="
-    ],
-    "@types/d3-ease": [
-      "@types/d3-ease@3.0.2",
-      "",
-      {},
-      "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
-    ],
-    "@types/d3-interpolate": [
-      "@types/d3-interpolate@3.0.4",
-      "",
-      {
-        "dependencies": {
-          "@types/d3-color": "*"
-        }
-      },
-      "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="
-    ],
-    "@types/d3-path": [
-      "@types/d3-path@3.1.1",
-      "",
-      {},
-      "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
-    ],
-    "@types/d3-scale": [
-      "@types/d3-scale@4.0.9",
-      "",
-      {
-        "dependencies": {
-          "@types/d3-time": "*"
-        }
-      },
-      "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="
-    ],
-    "@types/d3-selection": [
-      "@types/d3-selection@3.0.11",
-      "",
-      {},
-      "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="
-    ],
-    "@types/d3-shape": [
-      "@types/d3-shape@3.1.8",
-      "",
-      {
-        "dependencies": {
-          "@types/d3-path": "*"
-        }
-      },
-      "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="
-    ],
-    "@types/d3-time": [
-      "@types/d3-time@3.0.4",
-      "",
-      {},
-      "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
-    ],
-    "@types/d3-timer": [
-      "@types/d3-timer@3.0.2",
-      "",
-      {},
-      "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
-    ],
-    "@types/d3-transition": [
-      "@types/d3-transition@3.0.9",
-      "",
-      {
-        "dependencies": {
-          "@types/d3-selection": "*"
-        }
-      },
-      "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="
-    ],
-    "@types/d3-zoom": [
-      "@types/d3-zoom@3.0.8",
-      "",
-      {
-        "dependencies": {
-          "@types/d3-interpolate": "*",
-          "@types/d3-selection": "*"
-        }
-      },
-      "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="
-    ],
-    "@types/debug": [
-      "@types/debug@4.1.13",
-      "",
-      {
-        "dependencies": {
-          "@types/ms": "*"
-        }
-      },
-      "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="
-    ],
-    "@types/estree": [
-      "@types/estree@1.0.8",
-      "",
-      {},
-      "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
-    ],
-    "@types/estree-jsx": [
-      "@types/estree-jsx@1.0.5",
-      "",
-      {
-        "dependencies": {
-          "@types/estree": "*"
-        }
-      },
-      "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="
-    ],
-    "@types/handlebars": [
-      "@types/handlebars@4.1.0",
-      "",
-      {
-        "dependencies": {
-          "handlebars": "*"
-        }
-      },
-      "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA=="
-    ],
-    "@types/hast": [
-      "@types/hast@3.0.4",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "*"
-        }
-      },
-      "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="
-    ],
-    "@types/inquirer": [
-      "@types/inquirer@8.2.12",
-      "",
-      {
-        "dependencies": {
-          "@types/through": "*",
-          "rxjs": "^7.2.0"
-        }
-      },
-      "sha512-YxURZF2ZsSjU5TAe06tW0M3sL4UI9AMPA6dd8I72uOtppzNafcY38xkYgCZ/vsVOAyNdzHmvtTpLWilOrbP0dQ=="
-    ],
-    "@types/ioredis-mock": [
-      "@types/ioredis-mock@8.2.7",
-      "",
-      {
-        "peerDependencies": {
-          "ioredis": ">=5"
-        }
-      },
-      "sha512-YsGiaOIYBKeVvu/7GYziAD8qX3LJem5LK00d5PKykzsQJMLysAqXA61AkNuYWCekYl64tbMTqVOMF4SYoCPbQg=="
-    ],
-    "@types/json-schema": [
-      "@types/json-schema@7.0.15",
-      "",
-      {},
-      "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
-    ],
-    "@types/mdast": [
-      "@types/mdast@4.0.4",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "*"
-        }
-      },
-      "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="
-    ],
-    "@types/ms": [
-      "@types/ms@2.1.0",
-      "",
-      {},
-      "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
-    ],
-    "@types/node": [
-      "@types/node@20.19.39",
-      "",
-      {
-        "dependencies": {
-          "undici-types": "~6.21.0"
-        }
-      },
-      "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="
-    ],
-    "@types/nodemailer": [
-      "@types/nodemailer@8.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/node": "*"
-        }
-      },
-      "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA=="
-    ],
-    "@types/pg": [
-      "@types/pg@8.20.0",
-      "",
-      {
-        "dependencies": {
-          "@types/node": "*",
-          "pg-protocol": "*",
-          "pg-types": "^2.2.0"
-        }
-      },
-      "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="
-    ],
-    "@types/prop-types": [
-      "@types/prop-types@15.7.15",
-      "",
-      {},
-      "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
-    ],
-    "@types/react": [
-      "@types/react@18.3.28",
-      "",
-      {
-        "dependencies": {
-          "@types/prop-types": "*",
-          "csstype": "^3.2.2"
-        }
-      },
-      "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="
-    ],
-    "@types/react-dom": [
-      "@types/react-dom@18.3.7",
-      "",
-      {
-        "peerDependencies": {
-          "@types/react": "^18.0.0"
-        }
-      },
-      "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="
-    ],
-    "@types/semver": [
-      "@types/semver@7.7.1",
-      "",
-      {},
-      "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="
-    ],
-    "@types/ssh2": [
-      "@types/ssh2@1.15.0",
-      "",
-      {
-        "dependencies": {
-          "@types/node": "^18.11.18"
-        }
-      },
-      "sha512-YcT8jP5F8NzWeevWvcyrrLB3zcneVjzYY9ZDSMAMboI+2zR1qYWFhwsyOFVzT7Jorn67vqxC0FRiw8YyG9P1ww=="
-    ],
-    "@types/tdigest": [
-      "@types/tdigest@0.1.5",
-      "",
-      {},
-      "sha512-89ZDvz0aw1Uwosx0JSV8qfB6q5PsyFHni2vzutiG6QOLqMt9W95VTaKRDD9f56oe2zRdD+3u3UGM3Zgu5708Sg=="
-    ],
-    "@types/through": [
-      "@types/through@0.0.33",
-      "",
-      {
-        "dependencies": {
-          "@types/node": "*"
-        }
-      },
-      "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ=="
-    ],
-    "@types/triple-beam": [
-      "@types/triple-beam@1.3.5",
-      "",
-      {},
-      "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    ],
-    "@types/trusted-types": [
-      "@types/trusted-types@2.0.7",
-      "",
-      {},
-      "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
-    ],
-    "@types/unist": [
-      "@types/unist@2.0.11",
-      "",
-      {},
-      "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
-    ],
-    "@types/use-sync-external-store": [
-      "@types/use-sync-external-store@0.0.6",
-      "",
-      {},
-      "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
-    ],
-    "@types/uuid": [
-      "@types/uuid@11.0.0",
-      "",
-      {
-        "dependencies": {
-          "uuid": "*"
-        }
-      },
-      "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="
-    ],
-    "@types/whatwg-mimetype": [
-      "@types/whatwg-mimetype@3.0.2",
-      "",
-      {},
-      "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="
-    ],
-    "@types/ws": [
-      "@types/ws@8.18.1",
-      "",
-      {
-        "dependencies": {
-          "@types/node": "*"
-        }
-      },
-      "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="
-    ],
-    "@typescript-eslint/eslint-plugin": [
-      "@typescript-eslint/eslint-plugin@8.58.2",
-      "",
-      {
-        "dependencies": {
-          "@eslint-community/regexpp": "^4.12.2",
-          "@typescript-eslint/scope-manager": "8.58.2",
-          "@typescript-eslint/type-utils": "8.58.2",
-          "@typescript-eslint/utils": "8.58.2",
-          "@typescript-eslint/visitor-keys": "8.58.2",
-          "ignore": "^7.0.5",
-          "natural-compare": "^1.4.0",
-          "ts-api-utils": "^2.5.0"
-        },
-        "peerDependencies": {
-          "@typescript-eslint/parser": "^8.58.2",
-          "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-          "typescript": ">=4.8.4 <6.1.0"
-        }
-      },
-      "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw=="
-    ],
-    "@typescript-eslint/parser": [
-      "@typescript-eslint/parser@8.58.2",
-      "",
-      {
-        "dependencies": {
-          "@typescript-eslint/scope-manager": "8.58.2",
-          "@typescript-eslint/types": "8.58.2",
-          "@typescript-eslint/typescript-estree": "8.58.2",
-          "@typescript-eslint/visitor-keys": "8.58.2",
-          "debug": "^4.4.3"
-        },
-        "peerDependencies": {
-          "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-          "typescript": ">=4.8.4 <6.1.0"
-        }
-      },
-      "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg=="
-    ],
-    "@typescript-eslint/project-service": [
-      "@typescript-eslint/project-service@8.58.2",
-      "",
-      {
-        "dependencies": {
-          "@typescript-eslint/tsconfig-utils": "^8.58.2",
-          "@typescript-eslint/types": "^8.58.2",
-          "debug": "^4.4.3"
-        },
-        "peerDependencies": {
-          "typescript": ">=4.8.4 <6.1.0"
-        }
-      },
-      "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg=="
-    ],
-    "@typescript-eslint/scope-manager": [
-      "@typescript-eslint/scope-manager@8.58.2",
-      "",
-      {
-        "dependencies": {
-          "@typescript-eslint/types": "8.58.2",
-          "@typescript-eslint/visitor-keys": "8.58.2"
-        }
-      },
-      "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q=="
-    ],
-    "@typescript-eslint/tsconfig-utils": [
-      "@typescript-eslint/tsconfig-utils@8.58.2",
-      "",
-      {
-        "peerDependencies": {
-          "typescript": ">=4.8.4 <6.1.0"
-        }
-      },
-      "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A=="
-    ],
-    "@typescript-eslint/type-utils": [
-      "@typescript-eslint/type-utils@8.58.2",
-      "",
-      {
-        "dependencies": {
-          "@typescript-eslint/types": "8.58.2",
-          "@typescript-eslint/typescript-estree": "8.58.2",
-          "@typescript-eslint/utils": "8.58.2",
-          "debug": "^4.4.3",
-          "ts-api-utils": "^2.5.0"
-        },
-        "peerDependencies": {
-          "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-          "typescript": ">=4.8.4 <6.1.0"
-        }
-      },
-      "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg=="
-    ],
-    "@typescript-eslint/types": [
-      "@typescript-eslint/types@8.58.2",
-      "",
-      {},
-      "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="
-    ],
-    "@typescript-eslint/typescript-estree": [
-      "@typescript-eslint/typescript-estree@8.58.2",
-      "",
-      {
-        "dependencies": {
-          "@typescript-eslint/project-service": "8.58.2",
-          "@typescript-eslint/tsconfig-utils": "8.58.2",
-          "@typescript-eslint/types": "8.58.2",
-          "@typescript-eslint/visitor-keys": "8.58.2",
-          "debug": "^4.4.3",
-          "minimatch": "^10.2.2",
-          "semver": "^7.7.3",
-          "tinyglobby": "^0.2.15",
-          "ts-api-utils": "^2.5.0"
-        },
-        "peerDependencies": {
-          "typescript": ">=4.8.4 <6.1.0"
-        }
-      },
-      "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw=="
-    ],
-    "@typescript-eslint/utils": [
-      "@typescript-eslint/utils@8.58.2",
-      "",
-      {
-        "dependencies": {
-          "@eslint-community/eslint-utils": "^4.9.1",
-          "@typescript-eslint/scope-manager": "8.58.2",
-          "@typescript-eslint/types": "8.58.2",
-          "@typescript-eslint/typescript-estree": "8.58.2"
-        },
-        "peerDependencies": {
-          "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-          "typescript": ">=4.8.4 <6.1.0"
-        }
-      },
-      "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA=="
-    ],
-    "@typescript-eslint/visitor-keys": [
-      "@typescript-eslint/visitor-keys@8.58.2",
-      "",
-      {
-        "dependencies": {
-          "@typescript-eslint/types": "8.58.2",
-          "eslint-visitor-keys": "^5.0.0"
-        }
-      },
-      "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA=="
-    ],
-    "@ungap/structured-clone": [
-      "@ungap/structured-clone@1.3.0",
-      "",
-      {},
-      "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
-    ],
-    "@vitejs/plugin-react": [
-      "@vitejs/plugin-react@6.0.1",
-      "",
-      {
-        "dependencies": {
-          "@rolldown/pluginutils": "1.0.0-rc.7"
-        },
-        "peerDependencies": {
-          "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
-          "babel-plugin-react-compiler": "^1.0.0",
-          "vite": "^8.0.0"
-        },
-        "optionalPeers": [
-          "@rolldown/plugin-babel",
-          "babel-plugin-react-compiler"
-        ]
-      },
-      "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="
-    ],
-    "@xmldom/is-dom-node": [
-      "@xmldom/is-dom-node@1.0.1",
-      "",
-      {},
-      "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q=="
-    ],
-    "@xmldom/xmldom": [
-      "@xmldom/xmldom@0.8.12",
-      "",
-      {},
-      "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg=="
-    ],
-    "@xyflow/react": [
-      "@xyflow/react@12.10.2",
-      "",
-      {
-        "dependencies": {
-          "@xyflow/system": "0.0.76",
-          "classcat": "^5.0.3",
-          "zustand": "^4.4.0"
-        },
-        "peerDependencies": {
-          "react": ">=17",
-          "react-dom": ">=17"
-        }
-      },
-      "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ=="
-    ],
-    "@xyflow/system": [
-      "@xyflow/system@0.0.76",
-      "",
-      {
-        "dependencies": {
-          "@types/d3-drag": "^3.0.7",
-          "@types/d3-interpolate": "^3.0.4",
-          "@types/d3-selection": "^3.0.10",
-          "@types/d3-transition": "^3.0.8",
-          "@types/d3-zoom": "^3.0.8",
-          "d3-drag": "^3.0.0",
-          "d3-interpolate": "^3.0.1",
-          "d3-selection": "^3.0.0",
-          "d3-zoom": "^3.0.0"
-        }
-      },
-      "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA=="
-    ],
-    "abort-controller": [
-      "abort-controller@3.0.0",
-      "",
-      {
-        "dependencies": {
-          "event-target-shim": "^5.0.0"
-        }
-      },
-      "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="
-    ],
-    "acorn": [
-      "acorn@8.16.0",
-      "",
-      {
-        "bin": {
-          "acorn": "bin/acorn"
-        }
-      },
-      "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="
-    ],
-    "acorn-jsx": [
-      "acorn-jsx@5.3.2",
-      "",
-      {
-        "peerDependencies": {
-          "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-        }
-      },
-      "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
-    ],
-    "ajv": [
-      "ajv@8.18.0",
-      "",
-      {
-        "dependencies": {
-          "fast-deep-equal": "^3.1.3",
-          "fast-uri": "^3.0.1",
-          "json-schema-traverse": "^1.0.0",
-          "require-from-string": "^2.0.2"
-        }
-      },
-      "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="
-    ],
-    "ajv-formats": [
-      "ajv-formats@3.0.1",
-      "",
-      {
-        "dependencies": {
-          "ajv": "^8.0.0"
-        }
-      },
-      "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="
-    ],
-    "ansi-colors": [
-      "ansi-colors@4.1.3",
-      "",
-      {},
-      "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
-    ],
-    "ansi-regex": [
-      "ansi-regex@5.0.1",
-      "",
-      {},
-      "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    ],
-    "ansi-styles": [
-      "ansi-styles@4.3.0",
-      "",
-      {
-        "dependencies": {
-          "color-convert": "^2.0.1"
-        }
-      },
-      "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="
-    ],
-    "any-promise": [
-      "any-promise@1.3.0",
-      "",
-      {},
-      "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
-    ],
-    "anymatch": [
-      "anymatch@3.1.3",
-      "",
-      {
-        "dependencies": {
-          "normalize-path": "^3.0.0",
-          "picomatch": "^2.0.4"
-        }
-      },
-      "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="
-    ],
-    "arg": [
-      "arg@5.0.2",
-      "",
-      {},
-      "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
-    ],
-    "argparse": [
-      "argparse@2.0.1",
-      "",
-      {},
-      "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    ],
-    "aria-hidden": [
-      "aria-hidden@1.2.6",
-      "",
-      {
-        "dependencies": {
-          "tslib": "^2.0.0"
-        }
-      },
-      "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="
-    ],
-    "aria-query": [
-      "aria-query@5.3.0",
-      "",
-      {
-        "dependencies": {
-          "dequal": "^2.0.3"
-        }
-      },
-      "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="
-    ],
-    "array-union": [
-      "array-union@2.1.0",
-      "",
-      {},
-      "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
-    ],
-    "asn1": [
-      "asn1@0.2.6",
-      "",
-      {
-        "dependencies": {
-          "safer-buffer": "~2.1.0"
-        }
-      },
-      "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="
-    ],
-    "async": [
-      "async@3.2.6",
-      "",
-      {},
-      "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
-    ],
-    "autoprefixer": [
-      "autoprefixer@10.5.0",
-      "",
-      {
-        "dependencies": {
-          "browserslist": "^4.28.2",
-          "caniuse-lite": "^1.0.30001787",
-          "fraction.js": "^5.3.4",
-          "picocolors": "^1.1.1",
-          "postcss-value-parser": "^4.2.0"
-        },
-        "peerDependencies": {
-          "postcss": "^8.1.0"
-        },
-        "bin": {
-          "autoprefixer": "bin/autoprefixer"
-        }
-      },
-      "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong=="
-    ],
-    "aws-ssl-profiles": [
-      "aws-ssl-profiles@1.1.2",
-      "",
-      {},
-      "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="
-    ],
-    "bail": [
-      "bail@1.0.5",
-      "",
-      {},
-      "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
-    ],
-    "balanced-match": [
-      "balanced-match@4.0.4",
-      "",
-      {},
-      "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
-    ],
-    "baseline-browser-mapping": [
-      "baseline-browser-mapping@2.10.19",
-      "",
-      {
-        "bin": {
-          "baseline-browser-mapping": "dist/cli.cjs"
-        }
-      },
-      "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="
-    ],
-    "bcrypt-pbkdf": [
-      "bcrypt-pbkdf@1.0.2",
-      "",
-      {
-        "dependencies": {
-          "tweetnacl": "^0.14.3"
-        }
-      },
-      "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="
-    ],
-    "better-auth": [
-      "better-auth@1.6.4",
-      "",
-      {
-        "dependencies": {
-          "@better-auth/core": "1.6.4",
-          "@better-auth/drizzle-adapter": "1.6.4",
-          "@better-auth/kysely-adapter": "1.6.4",
-          "@better-auth/memory-adapter": "1.6.4",
-          "@better-auth/mongo-adapter": "1.6.4",
-          "@better-auth/prisma-adapter": "1.6.4",
-          "@better-auth/telemetry": "1.6.4",
-          "@better-auth/utils": "0.4.0",
-          "@better-fetch/fetch": "1.1.21",
-          "@noble/ciphers": "^2.1.1",
-          "@noble/hashes": "^2.0.1",
-          "better-call": "1.3.5",
-          "defu": "^6.1.4",
-          "jose": "^6.1.3",
-          "kysely": "^0.28.14",
-          "nanostores": "^1.1.1",
-          "zod": "^4.3.6"
-        },
-        "peerDependencies": {
-          "@lynx-js/react": "*",
-          "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-          "@sveltejs/kit": "^2.0.0",
-          "@tanstack/react-start": "^1.0.0",
-          "@tanstack/solid-start": "^1.0.0",
-          "better-sqlite3": "^12.0.0",
-          "drizzle-kit": ">=0.31.4",
-          "drizzle-orm": "^0.45.2",
-          "mongodb": "^6.0.0 || ^7.0.0",
-          "mysql2": "^3.0.0",
-          "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
-          "pg": "^8.0.0",
-          "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
-          "react": "^18.0.0 || ^19.0.0",
-          "react-dom": "^18.0.0 || ^19.0.0",
-          "solid-js": "^1.0.0",
-          "svelte": "^4.0.0 || ^5.0.0",
-          "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
-          "vue": "^3.0.0"
-        },
-        "optionalPeers": [
-          "@lynx-js/react",
-          "@prisma/client",
-          "@sveltejs/kit",
-          "@tanstack/react-start",
-          "@tanstack/solid-start",
-          "better-sqlite3",
-          "drizzle-kit",
-          "drizzle-orm",
-          "mongodb",
-          "mysql2",
-          "next",
-          "pg",
-          "prisma",
-          "react",
-          "react-dom",
-          "solid-js",
-          "svelte",
-          "vitest",
-          "vue"
-        ]
-      },
-      "sha512-yb/IDzoheBcoP8vI4jB0KkGCg0UabvEKo8GDBjcHW/w2Bb9ltlHzWuwcIauowhPezDcyRWUr2ub2HNO2rp6p7A=="
-    ],
-    "better-call": [
-      "better-call@1.3.5",
-      "",
-      {
-        "dependencies": {
-          "@better-auth/utils": "^0.4.0",
-          "@better-fetch/fetch": "^1.1.21",
-          "rou3": "^0.7.12",
-          "set-cookie-parser": "^3.0.1"
-        },
-        "peerDependencies": {
-          "zod": "^4.0.0"
-        },
-        "optionalPeers": [
-          "zod"
-        ]
-      },
-      "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA=="
-    ],
-    "better-path-resolve": [
-      "better-path-resolve@1.0.0",
-      "",
-      {
-        "dependencies": {
-          "is-windows": "^1.0.0"
-        }
-      },
-      "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="
-    ],
-    "binary-extensions": [
-      "binary-extensions@2.3.0",
-      "",
-      {},
-      "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="
-    ],
-    "bintrees": [
-      "bintrees@1.0.2",
-      "",
-      {},
-      "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
-    ],
-    "brace-expansion": [
-      "brace-expansion@5.0.5",
-      "",
-      {
-        "dependencies": {
-          "balanced-match": "^4.0.2"
-        }
-      },
-      "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="
-    ],
-    "braces": [
-      "braces@3.0.3",
-      "",
-      {
-        "dependencies": {
-          "fill-range": "^7.1.1"
-        }
-      },
-      "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="
-    ],
-    "browserslist": [
-      "browserslist@4.28.2",
-      "",
-      {
-        "dependencies": {
-          "baseline-browser-mapping": "^2.10.12",
-          "caniuse-lite": "^1.0.30001782",
-          "electron-to-chromium": "^1.5.328",
-          "node-releases": "^2.0.36",
-          "update-browserslist-db": "^1.2.3"
-        },
-        "bin": {
-          "browserslist": "cli.js"
-        }
-      },
-      "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="
-    ],
-    "buffer-from": [
-      "buffer-from@1.1.2",
-      "",
-      {},
-      "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    ],
-    "buildcheck": [
-      "buildcheck@0.0.7",
-      "",
-      {},
-      "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="
-    ],
-    "builtin-modules": [
-      "builtin-modules@5.1.0",
-      "",
-      {},
-      "sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A=="
-    ],
-    "bullmq": [
-      "bullmq@5.74.1",
-      "",
-      {
-        "dependencies": {
-          "cron-parser": "4.9.0",
-          "ioredis": "5.10.1",
-          "msgpackr": "1.11.5",
-          "node-abort-controller": "3.1.1",
-          "semver": "7.7.4",
-          "tslib": "2.8.1",
-          "uuid": "11.1.0"
-        }
-      },
-      "sha512-GfJEos2zoOGM9xqkB7VZouwwFuejKFqm667cBcmbBekJXKqqXWk4QYP3Uy2pzgUwCbg1cR7GgGmGczM7fnhWSA=="
-    ],
-    "bun-types": [
-      "bun-types@1.3.12",
-      "",
-      {
-        "dependencies": {
-          "@types/node": "*"
-        }
-      },
-      "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="
-    ],
-    "callsites": [
-      "callsites@3.1.0",
-      "",
-      {},
-      "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-    ],
-    "camelcase-css": [
-      "camelcase-css@2.0.1",
-      "",
-      {},
-      "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
-    ],
-    "caniuse-lite": [
-      "caniuse-lite@1.0.30001788",
-      "",
-      {},
-      "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="
-    ],
-    "ccount": [
-      "ccount@2.0.1",
-      "",
-      {},
-      "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
-    ],
-    "chalk": [
-      "chalk@4.1.2",
-      "",
-      {
-        "dependencies": {
-          "ansi-styles": "^4.1.0",
-          "supports-color": "^7.1.0"
-        }
-      },
-      "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="
-    ],
-    "change-case": [
-      "change-case@5.4.4",
-      "",
-      {},
-      "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="
-    ],
-    "character-entities": [
-      "character-entities@1.2.4",
-      "",
-      {},
-      "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
-    ],
-    "character-entities-html4": [
-      "character-entities-html4@2.1.0",
-      "",
-      {},
-      "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
-    ],
-    "character-entities-legacy": [
-      "character-entities-legacy@1.1.4",
-      "",
-      {},
-      "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
-    ],
-    "character-reference-invalid": [
-      "character-reference-invalid@1.1.4",
-      "",
-      {},
-      "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
-    ],
-    "chardet": [
-      "chardet@2.1.1",
-      "",
-      {},
-      "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="
-    ],
-    "chokidar": [
-      "chokidar@3.6.0",
-      "",
-      {
-        "dependencies": {
-          "anymatch": "~3.1.2",
-          "braces": "~3.0.2",
-          "glob-parent": "~5.1.2",
-          "is-binary-path": "~2.1.0",
-          "is-glob": "~4.0.1",
-          "normalize-path": "~3.0.0",
-          "readdirp": "~3.6.0"
-        },
-        "optionalDependencies": {
-          "fsevents": "~2.3.2"
-        }
-      },
-      "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="
-    ],
-    "ci-info": [
-      "ci-info@4.4.0",
-      "",
-      {},
-      "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="
-    ],
-    "class-variance-authority": [
-      "class-variance-authority@0.7.1",
-      "",
-      {
-        "dependencies": {
-          "clsx": "^2.1.1"
-        }
-      },
-      "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="
-    ],
-    "classcat": [
-      "classcat@5.0.5",
-      "",
-      {},
-      "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="
-    ],
-    "clean-regexp": [
-      "clean-regexp@1.0.0",
-      "",
-      {
-        "dependencies": {
-          "escape-string-regexp": "^1.0.5"
-        }
-      },
-      "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw=="
-    ],
-    "cli-width": [
-      "cli-width@4.1.0",
-      "",
-      {},
-      "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
-    ],
-    "cliui": [
-      "cliui@8.0.1",
-      "",
-      {
-        "dependencies": {
-          "string-width": "^4.2.0",
-          "strip-ansi": "^6.0.1",
-          "wrap-ansi": "^7.0.0"
-        }
-      },
-      "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="
-    ],
-    "clsx": [
-      "clsx@2.1.1",
-      "",
-      {},
-      "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
-    ],
-    "cluster-key-slot": [
-      "cluster-key-slot@1.1.2",
-      "",
-      {},
-      "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
-    ],
-    "color": [
-      "color@5.0.3",
-      "",
-      {
-        "dependencies": {
-          "color-convert": "^3.1.3",
-          "color-string": "^2.1.3"
-        }
-      },
-      "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="
-    ],
-    "color-convert": [
-      "color-convert@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "color-name": "~1.1.4"
-        }
-      },
-      "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="
-    ],
-    "color-name": [
-      "color-name@1.1.4",
-      "",
-      {},
-      "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    ],
-    "color-string": [
-      "color-string@2.1.4",
-      "",
-      {
-        "dependencies": {
-          "color-name": "^2.0.0"
-        }
-      },
-      "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="
-    ],
-    "comma-separated-tokens": [
-      "comma-separated-tokens@2.0.3",
-      "",
-      {},
-      "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
-    ],
-    "commander": [
-      "commander@4.1.1",
-      "",
-      {},
-      "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
-    ],
-    "concat-map": [
-      "concat-map@0.0.1",
-      "",
-      {},
-      "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    ],
-    "convert-source-map": [
-      "convert-source-map@2.0.0",
-      "",
-      {},
-      "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
-    ],
-    "cookie": [
-      "cookie@1.1.1",
-      "",
-      {},
-      "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="
-    ],
-    "core-js-compat": [
-      "core-js-compat@3.49.0",
-      "",
-      {
-        "dependencies": {
-          "browserslist": "^4.28.1"
-        }
-      },
-      "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA=="
-    ],
-    "cpu-features": [
-      "cpu-features@0.0.10",
-      "",
-      {
-        "dependencies": {
-          "buildcheck": "~0.0.6",
-          "nan": "^2.19.0"
-        }
-      },
-      "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="
-    ],
-    "cron-parser": [
-      "cron-parser@4.9.0",
-      "",
-      {
-        "dependencies": {
-          "luxon": "^3.2.1"
-        }
-      },
-      "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="
-    ],
-    "cross-spawn": [
-      "cross-spawn@7.0.6",
-      "",
-      {
-        "dependencies": {
-          "path-key": "^3.1.0",
-          "shebang-command": "^2.0.0",
-          "which": "^2.0.1"
-        }
-      },
-      "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="
-    ],
-    "css.escape": [
-      "css.escape@1.5.1",
-      "",
-      {},
-      "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="
-    ],
-    "cssesc": [
-      "cssesc@3.0.0",
-      "",
-      {
-        "bin": {
-          "cssesc": "bin/cssesc"
-        }
-      },
-      "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
-    ],
-    "csstype": [
-      "csstype@3.2.3",
-      "",
-      {},
-      "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
-    ],
-    "d3-array": [
-      "d3-array@3.2.4",
-      "",
-      {
-        "dependencies": {
-          "internmap": "1 - 2"
-        }
-      },
-      "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="
-    ],
-    "d3-color": [
-      "d3-color@3.1.0",
-      "",
-      {},
-      "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
-    ],
-    "d3-dispatch": [
-      "d3-dispatch@3.0.1",
-      "",
-      {},
-      "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
-    ],
-    "d3-drag": [
-      "d3-drag@3.0.0",
-      "",
-      {
-        "dependencies": {
-          "d3-dispatch": "1 - 3",
-          "d3-selection": "3"
-        }
-      },
-      "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="
-    ],
-    "d3-ease": [
-      "d3-ease@3.0.1",
-      "",
-      {},
-      "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
-    ],
-    "d3-format": [
-      "d3-format@3.1.2",
-      "",
-      {},
-      "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="
-    ],
-    "d3-interpolate": [
-      "d3-interpolate@3.0.1",
-      "",
-      {
-        "dependencies": {
-          "d3-color": "1 - 3"
-        }
-      },
-      "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="
-    ],
-    "d3-path": [
-      "d3-path@3.1.0",
-      "",
-      {},
-      "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
-    ],
-    "d3-scale": [
-      "d3-scale@4.0.2",
-      "",
-      {
-        "dependencies": {
-          "d3-array": "2.10.0 - 3",
-          "d3-format": "1 - 3",
-          "d3-interpolate": "1.2.0 - 3",
-          "d3-time": "2.1.1 - 3",
-          "d3-time-format": "2 - 4"
-        }
-      },
-      "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="
-    ],
-    "d3-selection": [
-      "d3-selection@3.0.0",
-      "",
-      {},
-      "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
-    ],
-    "d3-shape": [
-      "d3-shape@3.2.0",
-      "",
-      {
-        "dependencies": {
-          "d3-path": "^3.1.0"
-        }
-      },
-      "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="
-    ],
-    "d3-time": [
-      "d3-time@3.1.0",
-      "",
-      {
-        "dependencies": {
-          "d3-array": "2 - 3"
-        }
-      },
-      "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="
-    ],
-    "d3-time-format": [
-      "d3-time-format@4.1.0",
-      "",
-      {
-        "dependencies": {
-          "d3-time": "1 - 3"
-        }
-      },
-      "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="
-    ],
-    "d3-timer": [
-      "d3-timer@3.0.1",
-      "",
-      {},
-      "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
-    ],
-    "d3-transition": [
-      "d3-transition@3.0.1",
-      "",
-      {
-        "dependencies": {
-          "d3-color": "1 - 3",
-          "d3-dispatch": "1 - 3",
-          "d3-ease": "1 - 3",
-          "d3-interpolate": "1 - 3",
-          "d3-timer": "1 - 3"
-        },
-        "peerDependencies": {
-          "d3-selection": "2 - 3"
-        }
-      },
-      "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="
-    ],
-    "d3-zoom": [
-      "d3-zoom@3.0.0",
-      "",
-      {
-        "dependencies": {
-          "d3-dispatch": "1 - 3",
-          "d3-drag": "2 - 3",
-          "d3-interpolate": "1 - 3",
-          "d3-selection": "2 - 3",
-          "d3-transition": "2 - 3"
-        }
-      },
-      "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="
-    ],
-    "date-fns": [
-      "date-fns@4.1.0",
-      "",
-      {},
-      "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
-    ],
-    "date-fns-jalali": [
-      "date-fns-jalali@4.1.0-0",
-      "",
-      {},
-      "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="
-    ],
-    "debug": [
-      "debug@4.4.3",
-      "",
-      {
-        "dependencies": {
-          "ms": "^2.1.3"
-        }
-      },
-      "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="
-    ],
-    "decimal.js-light": [
-      "decimal.js-light@2.5.1",
-      "",
-      {},
-      "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
-    ],
-    "decode-named-character-reference": [
-      "decode-named-character-reference@1.3.0",
-      "",
-      {
-        "dependencies": {
-          "character-entities": "^2.0.0"
-        }
-      },
-      "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="
-    ],
-    "deep-is": [
-      "deep-is@0.1.4",
-      "",
-      {},
-      "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
-    ],
-    "defu": [
-      "defu@6.1.7",
-      "",
-      {},
-      "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="
-    ],
-    "denque": [
-      "denque@2.1.0",
-      "",
-      {},
-      "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
-    ],
-    "dequal": [
-      "dequal@2.0.3",
-      "",
-      {},
-      "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
-    ],
-    "detect-indent": [
-      "detect-indent@6.1.0",
-      "",
-      {},
-      "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
-    ],
-    "detect-libc": [
-      "detect-libc@2.1.2",
-      "",
-      {},
-      "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
-    ],
-    "detect-node-es": [
-      "detect-node-es@1.1.0",
-      "",
-      {},
-      "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
-    ],
-    "devlop": [
-      "devlop@1.1.0",
-      "",
-      {
-        "dependencies": {
-          "dequal": "^2.0.0"
-        }
-      },
-      "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="
-    ],
-    "didyoumean": [
-      "didyoumean@1.2.2",
-      "",
-      {},
-      "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
-    ],
-    "dir-glob": [
-      "dir-glob@3.0.1",
-      "",
-      {
-        "dependencies": {
-          "path-type": "^4.0.0"
-        }
-      },
-      "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="
-    ],
-    "dlv": [
-      "dlv@1.1.3",
-      "",
-      {},
-      "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
-    ],
-    "dom-accessibility-api": [
-      "dom-accessibility-api@0.5.16",
-      "",
-      {},
-      "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="
-    ],
-    "dompurify": [
-      "dompurify@3.2.7",
-      "",
-      {
-        "optionalDependencies": {
-          "@types/trusted-types": "^2.0.7"
-        }
-      },
-      "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="
-    ],
-    "drizzle-kit": [
-      "drizzle-kit@0.31.10",
-      "",
-      {
-        "dependencies": {
-          "@drizzle-team/brocli": "^0.10.2",
-          "@esbuild-kit/esm-loader": "^2.5.5",
-          "esbuild": "^0.25.4",
-          "tsx": "^4.21.0"
-        },
-        "bin": {
-          "drizzle-kit": "bin.cjs"
-        }
-      },
-      "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="
-    ],
-    "drizzle-orm": [
-      "drizzle-orm@0.45.2",
-      "",
-      {
-        "peerDependencies": {
-          "@aws-sdk/client-rds-data": ">=3",
-          "@cloudflare/workers-types": ">=4",
-          "@electric-sql/pglite": ">=0.2.0",
-          "@libsql/client": ">=0.10.0",
-          "@libsql/client-wasm": ">=0.10.0",
-          "@neondatabase/serverless": ">=0.10.0",
-          "@op-engineering/op-sqlite": ">=2",
-          "@opentelemetry/api": "^1.4.1",
-          "@planetscale/database": ">=1.13",
-          "@prisma/client": "*",
-          "@tidbcloud/serverless": "*",
-          "@types/better-sqlite3": "*",
-          "@types/pg": "*",
-          "@types/sql.js": "*",
-          "@upstash/redis": ">=1.34.7",
-          "@vercel/postgres": ">=0.8.0",
-          "@xata.io/client": "*",
-          "better-sqlite3": ">=7",
-          "bun-types": "*",
-          "expo-sqlite": ">=14.0.0",
-          "gel": ">=2",
-          "knex": "*",
-          "kysely": "*",
-          "mysql2": ">=2",
-          "pg": ">=8",
-          "postgres": ">=3",
-          "sql.js": ">=1",
-          "sqlite3": ">=5"
-        },
-        "optionalPeers": [
-          "@aws-sdk/client-rds-data",
-          "@cloudflare/workers-types",
-          "@electric-sql/pglite",
-          "@libsql/client",
-          "@libsql/client-wasm",
-          "@neondatabase/serverless",
-          "@op-engineering/op-sqlite",
-          "@opentelemetry/api",
-          "@planetscale/database",
-          "@prisma/client",
-          "@tidbcloud/serverless",
-          "@types/better-sqlite3",
-          "@types/pg",
-          "@types/sql.js",
-          "@upstash/redis",
-          "@vercel/postgres",
-          "@xata.io/client",
-          "better-sqlite3",
-          "bun-types",
-          "expo-sqlite",
-          "gel",
-          "knex",
-          "kysely",
-          "mysql2",
-          "pg",
-          "postgres",
-          "sql.js",
-          "sqlite3"
-        ]
-      },
-      "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="
-    ],
-    "electron-to-chromium": [
-      "electron-to-chromium@1.5.336",
-      "",
-      {},
-      "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ=="
-    ],
-    "emoji-regex": [
-      "emoji-regex@8.0.0",
-      "",
-      {},
-      "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    ],
-    "enabled": [
-      "enabled@2.0.0",
-      "",
-      {},
-      "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-    ],
-    "enquirer": [
-      "enquirer@2.4.1",
-      "",
-      {
-        "dependencies": {
-          "ansi-colors": "^4.1.1",
-          "strip-ansi": "^6.0.1"
-        }
-      },
-      "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="
-    ],
-    "entities": [
-      "entities@7.0.1",
-      "",
-      {},
-      "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="
-    ],
-    "es-errors": [
-      "es-errors@1.3.0",
-      "",
-      {},
-      "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    ],
-    "es-toolkit": [
-      "es-toolkit@1.45.1",
-      "",
-      {},
-      "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="
-    ],
-    "esbuild": [
-      "esbuild@0.27.7",
-      "",
-      {
-        "optionalDependencies": {
-          "@esbuild/aix-ppc64": "0.27.7",
-          "@esbuild/android-arm": "0.27.7",
-          "@esbuild/android-arm64": "0.27.7",
-          "@esbuild/android-x64": "0.27.7",
-          "@esbuild/darwin-arm64": "0.27.7",
-          "@esbuild/darwin-x64": "0.27.7",
-          "@esbuild/freebsd-arm64": "0.27.7",
-          "@esbuild/freebsd-x64": "0.27.7",
-          "@esbuild/linux-arm": "0.27.7",
-          "@esbuild/linux-arm64": "0.27.7",
-          "@esbuild/linux-ia32": "0.27.7",
-          "@esbuild/linux-loong64": "0.27.7",
-          "@esbuild/linux-mips64el": "0.27.7",
-          "@esbuild/linux-ppc64": "0.27.7",
-          "@esbuild/linux-riscv64": "0.27.7",
-          "@esbuild/linux-s390x": "0.27.7",
-          "@esbuild/linux-x64": "0.27.7",
-          "@esbuild/netbsd-arm64": "0.27.7",
-          "@esbuild/netbsd-x64": "0.27.7",
-          "@esbuild/openbsd-arm64": "0.27.7",
-          "@esbuild/openbsd-x64": "0.27.7",
-          "@esbuild/openharmony-arm64": "0.27.7",
-          "@esbuild/sunos-x64": "0.27.7",
-          "@esbuild/win32-arm64": "0.27.7",
-          "@esbuild/win32-ia32": "0.27.7",
-          "@esbuild/win32-x64": "0.27.7"
-        },
-        "bin": {
-          "esbuild": "bin/esbuild"
-        }
-      },
-      "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="
-    ],
-    "escalade": [
-      "escalade@3.2.0",
-      "",
-      {},
-      "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
-    ],
-    "escape-html": [
-      "escape-html@1.0.3",
-      "",
-      {},
-      "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-    ],
-    "escape-string-regexp": [
-      "escape-string-regexp@4.0.0",
-      "",
-      {},
-      "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-    ],
-    "eslint": [
-      "eslint@9.39.4",
-      "",
-      {
-        "dependencies": {
-          "@eslint-community/eslint-utils": "^4.8.0",
-          "@eslint-community/regexpp": "^4.12.1",
-          "@eslint/config-array": "^0.21.2",
-          "@eslint/config-helpers": "^0.4.2",
-          "@eslint/core": "^0.17.0",
-          "@eslint/eslintrc": "^3.3.5",
-          "@eslint/js": "9.39.4",
-          "@eslint/plugin-kit": "^0.4.1",
-          "@humanfs/node": "^0.16.6",
-          "@humanwhocodes/module-importer": "^1.0.1",
-          "@humanwhocodes/retry": "^0.4.2",
-          "@types/estree": "^1.0.6",
-          "ajv": "^6.14.0",
-          "chalk": "^4.0.0",
-          "cross-spawn": "^7.0.6",
-          "debug": "^4.3.2",
-          "escape-string-regexp": "^4.0.0",
-          "eslint-scope": "^8.4.0",
-          "eslint-visitor-keys": "^4.2.1",
-          "espree": "^10.4.0",
-          "esquery": "^1.5.0",
-          "esutils": "^2.0.2",
-          "fast-deep-equal": "^3.1.3",
-          "file-entry-cache": "^8.0.0",
-          "find-up": "^5.0.0",
-          "glob-parent": "^6.0.2",
-          "ignore": "^5.2.0",
-          "imurmurhash": "^0.1.4",
-          "is-glob": "^4.0.0",
-          "json-stable-stringify-without-jsonify": "^1.0.1",
-          "lodash.merge": "^4.6.2",
-          "minimatch": "^3.1.5",
-          "natural-compare": "^1.4.0",
-          "optionator": "^0.9.3"
-        },
-        "peerDependencies": {
-          "jiti": "*"
-        },
-        "optionalPeers": [
-          "jiti"
-        ],
-        "bin": {
-          "eslint": "bin/eslint.js"
-        }
-      },
-      "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="
-    ],
-    "eslint-plugin-react-hooks": [
-      "eslint-plugin-react-hooks@7.1.1",
-      "",
-      {
-        "dependencies": {
-          "@babel/core": "^7.24.4",
-          "@babel/parser": "^7.24.4",
-          "hermes-parser": "^0.25.1",
-          "zod": "^3.25.0 || ^4.0.0",
-          "zod-validation-error": "^3.5.0 || ^4.0.0"
-        },
-        "peerDependencies": {
-          "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-        }
-      },
-      "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="
-    ],
-    "eslint-plugin-unicorn": [
-      "eslint-plugin-unicorn@62.0.0",
-      "",
-      {
-        "dependencies": {
-          "@babel/helper-validator-identifier": "^7.28.5",
-          "@eslint-community/eslint-utils": "^4.9.0",
-          "@eslint/plugin-kit": "^0.4.0",
-          "change-case": "^5.4.4",
-          "ci-info": "^4.3.1",
-          "clean-regexp": "^1.0.0",
-          "core-js-compat": "^3.46.0",
-          "esquery": "^1.6.0",
-          "find-up-simple": "^1.0.1",
-          "globals": "^16.4.0",
-          "indent-string": "^5.0.0",
-          "is-builtin-module": "^5.0.0",
-          "jsesc": "^3.1.0",
-          "pluralize": "^8.0.0",
-          "regexp-tree": "^0.1.27",
-          "regjsparser": "^0.13.0",
-          "semver": "^7.7.3",
-          "strip-indent": "^4.1.1"
-        },
-        "peerDependencies": {
-          "eslint": ">=9.38.0"
-        }
-      },
-      "sha512-HIlIkGLkvf29YEiS/ImuDZQbP12gWyx5i3C6XrRxMvVdqMroCI9qoVYCoIl17ChN+U89pn9sVwLxhIWj5nEc7g=="
-    ],
-    "eslint-scope": [
-      "eslint-scope@8.4.0",
-      "",
-      {
-        "dependencies": {
-          "esrecurse": "^4.3.0",
-          "estraverse": "^5.2.0"
-        }
-      },
-      "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="
-    ],
-    "eslint-visitor-keys": [
-      "eslint-visitor-keys@4.2.1",
-      "",
-      {},
-      "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="
-    ],
-    "espree": [
-      "espree@10.4.0",
-      "",
-      {
-        "dependencies": {
-          "acorn": "^8.15.0",
-          "acorn-jsx": "^5.3.2",
-          "eslint-visitor-keys": "^4.2.1"
-        }
-      },
-      "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="
-    ],
-    "esprima": [
-      "esprima@4.0.1",
-      "",
-      {
-        "bin": {
-          "esparse": "./bin/esparse.js",
-          "esvalidate": "./bin/esvalidate.js"
-        }
-      },
-      "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    ],
-    "esquery": [
-      "esquery@1.7.0",
-      "",
-      {
-        "dependencies": {
-          "estraverse": "^5.1.0"
-        }
-      },
-      "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="
-    ],
-    "esrecurse": [
-      "esrecurse@4.3.0",
-      "",
-      {
-        "dependencies": {
-          "estraverse": "^5.2.0"
-        }
-      },
-      "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="
-    ],
-    "estraverse": [
-      "estraverse@5.3.0",
-      "",
-      {},
-      "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-    ],
-    "estree-util-is-identifier-name": [
-      "estree-util-is-identifier-name@3.0.0",
-      "",
-      {},
-      "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="
-    ],
-    "esutils": [
-      "esutils@2.0.3",
-      "",
-      {},
-      "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
-    ],
-    "event-target-shim": [
-      "event-target-shim@5.0.1",
-      "",
-      {},
-      "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    ],
-    "eventemitter3": [
-      "eventemitter3@5.0.4",
-      "",
-      {},
-      "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
-    ],
-    "extend": [
-      "extend@3.0.2",
-      "",
-      {},
-      "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    ],
-    "extendable-error": [
-      "extendable-error@0.1.7",
-      "",
-      {},
-      "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="
-    ],
-    "fast-deep-equal": [
-      "fast-deep-equal@3.1.3",
-      "",
-      {},
-      "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    ],
-    "fast-glob": [
-      "fast-glob@3.3.3",
-      "",
-      {
-        "dependencies": {
-          "@nodelib/fs.stat": "^2.0.2",
-          "@nodelib/fs.walk": "^1.2.3",
-          "glob-parent": "^5.1.2",
-          "merge2": "^1.3.0",
-          "micromatch": "^4.0.8"
-        }
-      },
-      "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="
-    ],
-    "fast-json-stable-stringify": [
-      "fast-json-stable-stringify@2.1.0",
-      "",
-      {},
-      "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    ],
-    "fast-levenshtein": [
-      "fast-levenshtein@2.0.6",
-      "",
-      {},
-      "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-    ],
-    "fast-string-truncated-width": [
-      "fast-string-truncated-width@3.0.3",
-      "",
-      {},
-      "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="
-    ],
-    "fast-string-width": [
-      "fast-string-width@3.0.2",
-      "",
-      {
-        "dependencies": {
-          "fast-string-truncated-width": "^3.0.2"
-        }
-      },
-      "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="
-    ],
-    "fast-uri": [
-      "fast-uri@3.1.0",
-      "",
-      {},
-      "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
-    ],
-    "fast-wrap-ansi": [
-      "fast-wrap-ansi@0.2.0",
-      "",
-      {
-        "dependencies": {
-          "fast-string-width": "^3.0.2"
-        }
-      },
-      "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="
-    ],
-    "fastq": [
-      "fastq@1.20.1",
-      "",
-      {
-        "dependencies": {
-          "reusify": "^1.0.4"
-        }
-      },
-      "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="
-    ],
-    "fdir": [
-      "fdir@6.5.0",
-      "",
-      {
-        "peerDependencies": {
-          "picomatch": "^3 || ^4"
-        },
-        "optionalPeers": [
-          "picomatch"
-        ]
-      },
-      "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="
-    ],
-    "fecha": [
-      "fecha@4.2.3",
-      "",
-      {},
-      "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
-    ],
-    "fengari": [
-      "fengari@0.1.5",
-      "",
-      {
-        "dependencies": {
-          "readline-sync": "^1.4.10",
-          "sprintf-js": "^1.1.3",
-          "tmp": "^0.2.5"
-        }
-      },
-      "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ=="
-    ],
-    "fengari-interop": [
-      "fengari-interop@0.1.4",
-      "",
-      {
-        "peerDependencies": {
-          "fengari": "^0.1.0"
-        }
-      },
-      "sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q=="
-    ],
-    "file-entry-cache": [
-      "file-entry-cache@8.0.0",
-      "",
-      {
-        "dependencies": {
-          "flat-cache": "^4.0.0"
-        }
-      },
-      "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="
-    ],
-    "fill-range": [
-      "fill-range@7.1.1",
-      "",
-      {
-        "dependencies": {
-          "to-regex-range": "^5.0.1"
-        }
-      },
-      "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="
-    ],
-    "find-up": [
-      "find-up@5.0.0",
-      "",
-      {
-        "dependencies": {
-          "locate-path": "^6.0.0",
-          "path-exists": "^4.0.0"
-        }
-      },
-      "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="
-    ],
-    "find-up-simple": [
-      "find-up-simple@1.0.1",
-      "",
-      {},
-      "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="
-    ],
-    "flat-cache": [
-      "flat-cache@4.0.1",
-      "",
-      {
-        "dependencies": {
-          "flatted": "^3.2.9",
-          "keyv": "^4.5.4"
-        }
-      },
-      "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="
-    ],
-    "flatted": [
-      "flatted@3.4.2",
-      "",
-      {},
-      "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="
-    ],
-    "fn.name": [
-      "fn.name@1.1.0",
-      "",
-      {},
-      "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
-    ],
-    "fraction.js": [
-      "fraction.js@5.3.4",
-      "",
-      {},
-      "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="
-    ],
-    "fs-extra": [
-      "fs-extra@7.0.1",
-      "",
-      {
-        "dependencies": {
-          "graceful-fs": "^4.1.2",
-          "jsonfile": "^4.0.0",
-          "universalify": "^0.1.0"
-        }
-      },
-      "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="
-    ],
-    "fsevents": [
-      "fsevents@2.3.3",
-      "",
-      {
-        "os": "darwin"
-      },
-      "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="
-    ],
-    "function-bind": [
-      "function-bind@1.1.2",
-      "",
-      {},
-      "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    ],
-    "generate-function": [
-      "generate-function@2.3.1",
-      "",
-      {
-        "dependencies": {
-          "is-property": "^1.0.2"
-        }
-      },
-      "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="
-    ],
-    "gensync": [
-      "gensync@1.0.0-beta.2",
-      "",
-      {},
-      "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
-    ],
-    "get-caller-file": [
-      "get-caller-file@2.0.5",
-      "",
-      {},
-      "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    ],
-    "get-nonce": [
-      "get-nonce@1.0.1",
-      "",
-      {},
-      "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
-    ],
-    "get-tsconfig": [
-      "get-tsconfig@4.14.0",
-      "",
-      {
-        "dependencies": {
-          "resolve-pkg-maps": "^1.0.0"
-        }
-      },
-      "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="
-    ],
-    "glob-parent": [
-      "glob-parent@6.0.2",
-      "",
-      {
-        "dependencies": {
-          "is-glob": "^4.0.3"
-        }
-      },
-      "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="
-    ],
-    "globals": [
-      "globals@16.5.0",
-      "",
-      {},
-      "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="
-    ],
-    "globby": [
-      "globby@11.1.0",
-      "",
-      {
-        "dependencies": {
-          "array-union": "^2.1.0",
-          "dir-glob": "^3.0.1",
-          "fast-glob": "^3.2.9",
-          "ignore": "^5.2.0",
-          "merge2": "^1.4.1",
-          "slash": "^3.0.0"
-        }
-      },
-      "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="
-    ],
-    "graceful-fs": [
-      "graceful-fs@4.2.11",
-      "",
-      {},
-      "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    ],
-    "grammy": [
-      "grammy@1.42.0",
-      "",
-      {
-        "dependencies": {
-          "@grammyjs/types": "3.26.0",
-          "abort-controller": "^3.0.0",
-          "debug": "^4.4.3",
-          "node-fetch": "^2.7.0"
-        }
-      },
-      "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g=="
-    ],
-    "handlebars": [
-      "handlebars@4.7.9",
-      "",
-      {
-        "dependencies": {
-          "minimist": "^1.2.5",
-          "neo-async": "^2.6.2",
-          "source-map": "^0.6.1",
-          "wordwrap": "^1.0.0"
-        },
-        "optionalDependencies": {
-          "uglify-js": "^3.1.4"
-        },
-        "bin": {
-          "handlebars": "bin/handlebars"
-        }
-      },
-      "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="
-    ],
-    "happy-dom": [
-      "happy-dom@20.9.0",
-      "",
-      {
-        "dependencies": {
-          "@types/node": ">=20.0.0",
-          "@types/whatwg-mimetype": "^3.0.2",
-          "@types/ws": "^8.18.1",
-          "entities": "^7.0.1",
-          "whatwg-mimetype": "^3.0.0",
-          "ws": "^8.18.3"
-        }
-      },
-      "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="
-    ],
-    "has-flag": [
-      "has-flag@4.0.0",
-      "",
-      {},
-      "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-    ],
-    "hasown": [
-      "hasown@2.0.2",
-      "",
-      {
-        "dependencies": {
-          "function-bind": "^1.1.2"
-        }
-      },
-      "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="
-    ],
-    "hast-util-to-jsx-runtime": [
-      "hast-util-to-jsx-runtime@2.3.6",
-      "",
-      {
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "@types/hast": "^3.0.0",
-          "@types/unist": "^3.0.0",
-          "comma-separated-tokens": "^2.0.0",
-          "devlop": "^1.0.0",
-          "estree-util-is-identifier-name": "^3.0.0",
-          "hast-util-whitespace": "^3.0.0",
-          "mdast-util-mdx-expression": "^2.0.0",
-          "mdast-util-mdx-jsx": "^3.0.0",
-          "mdast-util-mdxjs-esm": "^2.0.0",
-          "property-information": "^7.0.0",
-          "space-separated-tokens": "^2.0.0",
-          "style-to-js": "^1.0.0",
-          "unist-util-position": "^5.0.0",
-          "vfile-message": "^4.0.0"
-        }
-      },
-      "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="
-    ],
-    "hast-util-whitespace": [
-      "hast-util-whitespace@3.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/hast": "^3.0.0"
-        }
-      },
-      "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="
-    ],
-    "hermes-estree": [
-      "hermes-estree@0.25.1",
-      "",
-      {},
-      "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="
-    ],
-    "hermes-parser": [
-      "hermes-parser@0.25.1",
-      "",
-      {
-        "dependencies": {
-          "hermes-estree": "0.25.1"
-        }
-      },
-      "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="
-    ],
-    "hono": [
-      "hono@4.12.14",
-      "",
-      {},
-      "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="
-    ],
-    "html-comment-regex": [
-      "html-comment-regex@1.1.2",
-      "",
-      {},
-      "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
-    ],
-    "html-url-attributes": [
-      "html-url-attributes@3.0.1",
-      "",
-      {},
-      "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="
-    ],
-    "human-id": [
-      "human-id@4.1.3",
-      "",
-      {
-        "bin": {
-          "human-id": "dist/cli.js"
-        }
-      },
-      "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="
-    ],
-    "iconv-lite": [
-      "iconv-lite@0.7.2",
-      "",
-      {
-        "dependencies": {
-          "safer-buffer": ">= 2.1.2 < 3.0.0"
-        }
-      },
-      "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="
-    ],
-    "ignore": [
-      "ignore@7.0.5",
-      "",
-      {},
-      "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
-    ],
-    "immer": [
-      "immer@10.2.0",
-      "",
-      {},
-      "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="
-    ],
-    "import-fresh": [
-      "import-fresh@3.3.1",
-      "",
-      {
-        "dependencies": {
-          "parent-module": "^1.0.0",
-          "resolve-from": "^4.0.0"
-        }
-      },
-      "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="
-    ],
-    "imurmurhash": [
-      "imurmurhash@0.1.4",
-      "",
-      {},
-      "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
-    ],
-    "indent-string": [
-      "indent-string@5.0.0",
-      "",
-      {},
-      "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
-    ],
-    "inherits": [
-      "inherits@2.0.4",
-      "",
-      {},
-      "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    ],
-    "inline-style-parser": [
-      "inline-style-parser@0.2.7",
-      "",
-      {},
-      "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="
-    ],
-    "inquirer": [
-      "inquirer@13.4.1",
-      "",
-      {
-        "dependencies": {
-          "@inquirer/ansi": "^2.0.5",
-          "@inquirer/core": "^11.1.8",
-          "@inquirer/prompts": "^8.4.1",
-          "@inquirer/type": "^4.0.5",
-          "mute-stream": "^3.0.0",
-          "run-async": "^4.0.6",
-          "rxjs": "^7.8.2"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-IUopujY77lFiSaLz0fx6FHEOEANz0nAsqv+vQJddnVshi6wdos984qwjb42mZbH3zCJS4f9ioIGDqSPqMMMXjw=="
-    ],
-    "internmap": [
-      "internmap@2.0.3",
-      "",
-      {},
-      "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
-    ],
-    "ioredis": [
-      "ioredis@5.10.1",
-      "",
-      {
-        "dependencies": {
-          "@ioredis/commands": "1.5.1",
-          "cluster-key-slot": "^1.1.0",
-          "debug": "^4.3.4",
-          "denque": "^2.1.0",
-          "lodash.defaults": "^4.2.0",
-          "lodash.isarguments": "^3.1.0",
-          "redis-errors": "^1.2.0",
-          "redis-parser": "^3.0.0",
-          "standard-as-callback": "^2.1.0"
-        }
-      },
-      "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="
-    ],
-    "ioredis-mock": [
-      "ioredis-mock@8.13.1",
-      "",
-      {
-        "dependencies": {
-          "@ioredis/as-callback": "^3.0.0",
-          "@ioredis/commands": "^1.4.0",
-          "fengari": "^0.1.4",
-          "fengari-interop": "^0.1.3",
-          "semver": "^7.7.2"
-        },
-        "peerDependencies": {
-          "@types/ioredis-mock": "^8",
-          "ioredis": "^5"
-        }
-      },
-      "sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw=="
-    ],
-    "is-alphabetical": [
-      "is-alphabetical@1.0.4",
-      "",
-      {},
-      "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
-    ],
-    "is-alphanumerical": [
-      "is-alphanumerical@1.0.4",
-      "",
-      {
-        "dependencies": {
-          "is-alphabetical": "^1.0.0",
-          "is-decimal": "^1.0.0"
-        }
-      },
-      "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A=="
-    ],
-    "is-binary-path": [
-      "is-binary-path@2.1.0",
-      "",
-      {
-        "dependencies": {
-          "binary-extensions": "^2.0.0"
-        }
-      },
-      "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="
-    ],
-    "is-buffer": [
-      "is-buffer@2.0.5",
-      "",
-      {},
-      "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
-    ],
-    "is-builtin-module": [
-      "is-builtin-module@5.0.0",
-      "",
-      {
-        "dependencies": {
-          "builtin-modules": "^5.0.0"
-        }
-      },
-      "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA=="
-    ],
-    "is-core-module": [
-      "is-core-module@2.16.1",
-      "",
-      {
-        "dependencies": {
-          "hasown": "^2.0.2"
-        }
-      },
-      "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="
-    ],
-    "is-decimal": [
-      "is-decimal@1.0.4",
-      "",
-      {},
-      "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
-    ],
-    "is-extglob": [
-      "is-extglob@2.1.1",
-      "",
-      {},
-      "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
-    ],
-    "is-fullwidth-code-point": [
-      "is-fullwidth-code-point@3.0.0",
-      "",
-      {},
-      "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    ],
-    "is-glob": [
-      "is-glob@4.0.3",
-      "",
-      {
-        "dependencies": {
-          "is-extglob": "^2.1.1"
-        }
-      },
-      "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="
-    ],
-    "is-hexadecimal": [
-      "is-hexadecimal@1.0.4",
-      "",
-      {},
-      "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
-    ],
-    "is-number": [
-      "is-number@7.0.0",
-      "",
-      {},
-      "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-    ],
-    "is-plain-obj": [
-      "is-plain-obj@2.1.0",
-      "",
-      {},
-      "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-    ],
-    "is-property": [
-      "is-property@1.0.2",
-      "",
-      {},
-      "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
-    ],
-    "is-stream": [
-      "is-stream@2.0.1",
-      "",
-      {},
-      "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
-    ],
-    "is-subdir": [
-      "is-subdir@1.2.0",
-      "",
-      {
-        "dependencies": {
-          "better-path-resolve": "1.0.0"
-        }
-      },
-      "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw=="
-    ],
-    "is-windows": [
-      "is-windows@1.0.2",
-      "",
-      {},
-      "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-    ],
-    "isexe": [
-      "isexe@2.0.0",
-      "",
-      {},
-      "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    ],
-    "jiti": [
-      "jiti@1.21.7",
-      "",
-      {
-        "bin": {
-          "jiti": "bin/jiti.js"
-        }
-      },
-      "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="
-    ],
-    "jose": [
-      "jose@6.2.2",
-      "",
-      {},
-      "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
-    ],
-    "js-tokens": [
-      "js-tokens@4.0.0",
-      "",
-      {},
-      "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    ],
-    "js-yaml": [
-      "js-yaml@4.1.1",
-      "",
-      {
-        "dependencies": {
-          "argparse": "^2.0.1"
-        },
-        "bin": {
-          "js-yaml": "bin/js-yaml.js"
-        }
-      },
-      "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="
-    ],
-    "jsep": [
-      "jsep@1.4.0",
-      "",
-      {},
-      "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="
-    ],
-    "jsesc": [
-      "jsesc@3.1.0",
-      "",
-      {
-        "bin": {
-          "jsesc": "bin/jsesc"
-        }
-      },
-      "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="
-    ],
-    "json-buffer": [
-      "json-buffer@3.0.1",
-      "",
-      {},
-      "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
-    ],
-    "json-schema-traverse": [
-      "json-schema-traverse@1.0.0",
-      "",
-      {},
-      "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    ],
-    "json-schema-typed": [
-      "json-schema-typed@8.0.2",
-      "",
-      {},
-      "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
-    ],
-    "json-stable-stringify-without-jsonify": [
-      "json-stable-stringify-without-jsonify@1.0.1",
-      "",
-      {},
-      "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
-    ],
-    "json5": [
-      "json5@2.2.3",
-      "",
-      {
-        "bin": {
-          "json5": "lib/cli.js"
-        }
-      },
-      "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
-    ],
-    "jsonfile": [
-      "jsonfile@4.0.0",
-      "",
-      {
-        "optionalDependencies": {
-          "graceful-fs": "^4.1.6"
-        }
-      },
-      "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="
-    ],
-    "jsonpath-plus": [
-      "jsonpath-plus@10.4.0",
-      "",
-      {
-        "dependencies": {
-          "@jsep-plugin/assignment": "^1.3.0",
-          "@jsep-plugin/regex": "^1.0.4",
-          "jsep": "^1.4.0"
-        },
-        "bin": {
-          "jsonpath": "bin/jsonpath-cli.js",
-          "jsonpath-plus": "bin/jsonpath-cli.js"
-        }
-      },
-      "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="
-    ],
-    "keyv": [
-      "keyv@4.5.4",
-      "",
-      {
-        "dependencies": {
-          "json-buffer": "3.0.1"
-        }
-      },
-      "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="
-    ],
-    "kuler": [
-      "kuler@2.0.0",
-      "",
-      {},
-      "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-    ],
-    "kysely": [
-      "kysely@0.28.16",
-      "",
-      {},
-      "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww=="
-    ],
-    "ldapts": [
-      "ldapts@8.1.7",
-      "",
-      {
-        "dependencies": {
-          "strict-event-emitter-types": "2.0.0"
-        }
-      },
-      "sha512-TJl6T92eIwMf/OJ0hDfKVa6ISwzo+lqCWCI5Mf//ARlKa3LKQZaSrme/H2rCRBhW0DZCQlrsV+fgoW5YHRNLUw=="
-    ],
-    "levn": [
-      "levn@0.4.1",
-      "",
-      {
-        "dependencies": {
-          "prelude-ls": "^1.2.1",
-          "type-check": "~0.4.0"
-        }
-      },
-      "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="
-    ],
-    "lightningcss": [
-      "lightningcss@1.32.0",
-      "",
-      {
-        "dependencies": {
-          "detect-libc": "^2.0.3"
-        },
-        "optionalDependencies": {
-          "lightningcss-android-arm64": "1.32.0",
-          "lightningcss-darwin-arm64": "1.32.0",
-          "lightningcss-darwin-x64": "1.32.0",
-          "lightningcss-freebsd-x64": "1.32.0",
-          "lightningcss-linux-arm-gnueabihf": "1.32.0",
-          "lightningcss-linux-arm64-gnu": "1.32.0",
-          "lightningcss-linux-arm64-musl": "1.32.0",
-          "lightningcss-linux-x64-gnu": "1.32.0",
-          "lightningcss-linux-x64-musl": "1.32.0",
-          "lightningcss-win32-arm64-msvc": "1.32.0",
-          "lightningcss-win32-x64-msvc": "1.32.0"
-        }
-      },
-      "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="
-    ],
-    "lightningcss-android-arm64": [
-      "lightningcss-android-arm64@1.32.0",
-      "",
-      {
-        "os": "android",
-        "cpu": "arm64"
-      },
-      "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="
-    ],
-    "lightningcss-darwin-arm64": [
-      "lightningcss-darwin-arm64@1.32.0",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "arm64"
-      },
-      "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="
-    ],
-    "lightningcss-darwin-x64": [
-      "lightningcss-darwin-x64@1.32.0",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "x64"
-      },
-      "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="
-    ],
-    "lightningcss-freebsd-x64": [
-      "lightningcss-freebsd-x64@1.32.0",
-      "",
-      {
-        "os": "freebsd",
-        "cpu": "x64"
-      },
-      "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="
-    ],
-    "lightningcss-linux-arm-gnueabihf": [
-      "lightningcss-linux-arm-gnueabihf@1.32.0",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm"
-      },
-      "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="
-    ],
-    "lightningcss-linux-arm64-gnu": [
-      "lightningcss-linux-arm64-gnu@1.32.0",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="
-    ],
-    "lightningcss-linux-arm64-musl": [
-      "lightningcss-linux-arm64-musl@1.32.0",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="
-    ],
-    "lightningcss-linux-x64-gnu": [
-      "lightningcss-linux-x64-gnu@1.32.0",
-      "",
-      {
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="
-    ],
-    "lightningcss-linux-x64-musl": [
-      "lightningcss-linux-x64-musl@1.32.0",
-      "",
-      {
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="
-    ],
-    "lightningcss-win32-arm64-msvc": [
-      "lightningcss-win32-arm64-msvc@1.32.0",
-      "",
-      {
-        "os": "win32",
-        "cpu": "arm64"
-      },
-      "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="
-    ],
-    "lightningcss-win32-x64-msvc": [
-      "lightningcss-win32-x64-msvc@1.32.0",
-      "",
-      {
-        "os": "win32",
-        "cpu": "x64"
-      },
-      "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="
-    ],
-    "lilconfig": [
-      "lilconfig@3.1.3",
-      "",
-      {},
-      "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="
-    ],
-    "lines-and-columns": [
-      "lines-and-columns@1.2.4",
-      "",
-      {},
-      "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    ],
-    "locate-path": [
-      "locate-path@6.0.0",
-      "",
-      {
-        "dependencies": {
-          "p-locate": "^5.0.0"
-        }
-      },
-      "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="
-    ],
-    "lodash.camelcase": [
-      "lodash.camelcase@4.3.0",
-      "",
-      {},
-      "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
-    ],
-    "lodash.defaults": [
-      "lodash.defaults@4.2.0",
-      "",
-      {},
-      "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
-    ],
-    "lodash.isarguments": [
-      "lodash.isarguments@3.1.0",
-      "",
-      {},
-      "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
-    ],
-    "lodash.merge": [
-      "lodash.merge@4.6.2",
-      "",
-      {},
-      "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    ],
-    "lodash.startcase": [
-      "lodash.startcase@4.4.0",
-      "",
-      {},
-      "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="
-    ],
-    "logform": [
-      "logform@2.7.0",
-      "",
-      {
-        "dependencies": {
-          "@colors/colors": "1.6.0",
-          "@types/triple-beam": "^1.3.2",
-          "fecha": "^4.2.0",
-          "ms": "^2.1.1",
-          "safe-stable-stringify": "^2.3.1",
-          "triple-beam": "^1.3.0"
-        }
-      },
-      "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ=="
-    ],
-    "long": [
-      "long@5.3.2",
-      "",
-      {},
-      "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
-    ],
-    "longest-streak": [
-      "longest-streak@2.0.4",
-      "",
-      {},
-      "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
-    ],
-    "loose-envify": [
-      "loose-envify@1.4.0",
-      "",
-      {
-        "dependencies": {
-          "js-tokens": "^3.0.0 || ^4.0.0"
-        },
-        "bin": {
-          "loose-envify": "cli.js"
-        }
-      },
-      "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="
-    ],
-    "lru-cache": [
-      "lru-cache@5.1.1",
-      "",
-      {
-        "dependencies": {
-          "yallist": "^3.0.2"
-        }
-      },
-      "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="
-    ],
-    "lru.min": [
-      "lru.min@1.1.4",
-      "",
-      {},
-      "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="
-    ],
-    "lucide-react": [
-      "lucide-react@0.344.0",
-      "",
-      {
-        "peerDependencies": {
-          "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
-        }
-      },
-      "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ=="
-    ],
-    "luxon": [
-      "luxon@3.7.2",
-      "",
-      {},
-      "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
-    ],
-    "lz-string": [
-      "lz-string@1.5.0",
-      "",
-      {
-        "bin": {
-          "lz-string": "bin/bin.js"
-        }
-      },
-      "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
-    ],
-    "markdown-table": [
-      "markdown-table@2.0.0",
-      "",
-      {
-        "dependencies": {
-          "repeat-string": "^1.0.0"
-        }
-      },
-      "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A=="
-    ],
-    "marked": [
-      "marked@17.0.6",
-      "",
-      {
-        "bin": {
-          "marked": "bin/marked.js"
-        }
-      },
-      "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="
-    ],
-    "mdast-util-find-and-replace": [
-      "mdast-util-find-and-replace@1.1.1",
-      "",
-      {
-        "dependencies": {
-          "escape-string-regexp": "^4.0.0",
-          "unist-util-is": "^4.0.0",
-          "unist-util-visit-parents": "^3.0.0"
-        }
-      },
-      "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA=="
-    ],
-    "mdast-util-from-markdown": [
-      "mdast-util-from-markdown@0.8.5",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^3.0.0",
-          "mdast-util-to-string": "^2.0.0",
-          "micromark": "~2.11.0",
-          "parse-entities": "^2.0.0",
-          "unist-util-stringify-position": "^2.0.0"
-        }
-      },
-      "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ=="
-    ],
-    "mdast-util-gfm": [
-      "mdast-util-gfm@0.1.2",
-      "",
-      {
-        "dependencies": {
-          "mdast-util-gfm-autolink-literal": "^0.1.0",
-          "mdast-util-gfm-strikethrough": "^0.2.0",
-          "mdast-util-gfm-table": "^0.1.0",
-          "mdast-util-gfm-task-list-item": "^0.1.0",
-          "mdast-util-to-markdown": "^0.6.1"
-        }
-      },
-      "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ=="
-    ],
-    "mdast-util-gfm-autolink-literal": [
-      "mdast-util-gfm-autolink-literal@0.1.3",
-      "",
-      {
-        "dependencies": {
-          "ccount": "^1.0.0",
-          "mdast-util-find-and-replace": "^1.1.0",
-          "micromark": "^2.11.3"
-        }
-      },
-      "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A=="
-    ],
-    "mdast-util-gfm-strikethrough": [
-      "mdast-util-gfm-strikethrough@0.2.3",
-      "",
-      {
-        "dependencies": {
-          "mdast-util-to-markdown": "^0.6.0"
-        }
-      },
-      "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA=="
-    ],
-    "mdast-util-gfm-table": [
-      "mdast-util-gfm-table@0.1.6",
-      "",
-      {
-        "dependencies": {
-          "markdown-table": "^2.0.0",
-          "mdast-util-to-markdown": "~0.6.0"
-        }
-      },
-      "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ=="
-    ],
-    "mdast-util-gfm-task-list-item": [
-      "mdast-util-gfm-task-list-item@0.1.6",
-      "",
-      {
-        "dependencies": {
-          "mdast-util-to-markdown": "~0.6.0"
-        }
-      },
-      "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A=="
-    ],
-    "mdast-util-mdx-expression": [
-      "mdast-util-mdx-expression@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "@types/estree-jsx": "^1.0.0",
-          "@types/hast": "^3.0.0",
-          "@types/mdast": "^4.0.0",
-          "devlop": "^1.0.0",
-          "mdast-util-from-markdown": "^2.0.0",
-          "mdast-util-to-markdown": "^2.0.0"
-        }
-      },
-      "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="
-    ],
-    "mdast-util-mdx-jsx": [
-      "mdast-util-mdx-jsx@3.2.0",
-      "",
-      {
-        "dependencies": {
-          "@types/estree-jsx": "^1.0.0",
-          "@types/hast": "^3.0.0",
-          "@types/mdast": "^4.0.0",
-          "@types/unist": "^3.0.0",
-          "ccount": "^2.0.0",
-          "devlop": "^1.1.0",
-          "mdast-util-from-markdown": "^2.0.0",
-          "mdast-util-to-markdown": "^2.0.0",
-          "parse-entities": "^4.0.0",
-          "stringify-entities": "^4.0.0",
-          "unist-util-stringify-position": "^4.0.0",
-          "vfile-message": "^4.0.0"
-        }
-      },
-      "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="
-    ],
-    "mdast-util-mdxjs-esm": [
-      "mdast-util-mdxjs-esm@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "@types/estree-jsx": "^1.0.0",
-          "@types/hast": "^3.0.0",
-          "@types/mdast": "^4.0.0",
-          "devlop": "^1.0.0",
-          "mdast-util-from-markdown": "^2.0.0",
-          "mdast-util-to-markdown": "^2.0.0"
-        }
-      },
-      "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="
-    ],
-    "mdast-util-phrasing": [
-      "mdast-util-phrasing@4.1.0",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "unist-util-is": "^6.0.0"
-        }
-      },
-      "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="
-    ],
-    "mdast-util-to-hast": [
-      "mdast-util-to-hast@13.2.1",
-      "",
-      {
-        "dependencies": {
-          "@types/hast": "^3.0.0",
-          "@types/mdast": "^4.0.0",
-          "@ungap/structured-clone": "^1.0.0",
-          "devlop": "^1.0.0",
-          "micromark-util-sanitize-uri": "^2.0.0",
-          "trim-lines": "^3.0.0",
-          "unist-util-position": "^5.0.0",
-          "unist-util-visit": "^5.0.0",
-          "vfile": "^6.0.0"
-        }
-      },
-      "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="
-    ],
-    "mdast-util-to-markdown": [
-      "mdast-util-to-markdown@0.6.5",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^2.0.0",
-          "longest-streak": "^2.0.0",
-          "mdast-util-to-string": "^2.0.0",
-          "parse-entities": "^2.0.0",
-          "repeat-string": "^1.0.0",
-          "zwitch": "^1.0.0"
-        }
-      },
-      "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ=="
-    ],
-    "mdast-util-to-string": [
-      "mdast-util-to-string@2.0.0",
-      "",
-      {},
-      "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
-    ],
-    "merge2": [
-      "merge2@1.4.1",
-      "",
-      {},
-      "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
-    ],
-    "micromark": [
-      "micromark@2.11.4",
-      "",
-      {
-        "dependencies": {
-          "debug": "^4.0.0",
-          "parse-entities": "^2.0.0"
-        }
-      },
-      "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA=="
-    ],
-    "micromark-core-commonmark": [
-      "micromark-core-commonmark@2.0.3",
-      "",
-      {
-        "dependencies": {
-          "decode-named-character-reference": "^1.0.0",
-          "devlop": "^1.0.0",
-          "micromark-factory-destination": "^2.0.0",
-          "micromark-factory-label": "^2.0.0",
-          "micromark-factory-space": "^2.0.0",
-          "micromark-factory-title": "^2.0.0",
-          "micromark-factory-whitespace": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-chunked": "^2.0.0",
-          "micromark-util-classify-character": "^2.0.0",
-          "micromark-util-html-tag-name": "^2.0.0",
-          "micromark-util-normalize-identifier": "^2.0.0",
-          "micromark-util-resolve-all": "^2.0.0",
-          "micromark-util-subtokenize": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="
-    ],
-    "micromark-extension-gfm": [
-      "micromark-extension-gfm@0.3.3",
-      "",
-      {
-        "dependencies": {
-          "micromark": "~2.11.0",
-          "micromark-extension-gfm-autolink-literal": "~0.5.0",
-          "micromark-extension-gfm-strikethrough": "~0.6.5",
-          "micromark-extension-gfm-table": "~0.4.0",
-          "micromark-extension-gfm-tagfilter": "~0.3.0",
-          "micromark-extension-gfm-task-list-item": "~0.3.0"
-        }
-      },
-      "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A=="
-    ],
-    "micromark-extension-gfm-autolink-literal": [
-      "micromark-extension-gfm-autolink-literal@0.5.7",
-      "",
-      {
-        "dependencies": {
-          "micromark": "~2.11.3"
-        }
-      },
-      "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw=="
-    ],
-    "micromark-extension-gfm-strikethrough": [
-      "micromark-extension-gfm-strikethrough@0.6.5",
-      "",
-      {
-        "dependencies": {
-          "micromark": "~2.11.0"
-        }
-      },
-      "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw=="
-    ],
-    "micromark-extension-gfm-table": [
-      "micromark-extension-gfm-table@0.4.3",
-      "",
-      {
-        "dependencies": {
-          "micromark": "~2.11.0"
-        }
-      },
-      "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA=="
-    ],
-    "micromark-extension-gfm-tagfilter": [
-      "micromark-extension-gfm-tagfilter@0.3.0",
-      "",
-      {},
-      "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q=="
-    ],
-    "micromark-extension-gfm-task-list-item": [
-      "micromark-extension-gfm-task-list-item@0.3.3",
-      "",
-      {
-        "dependencies": {
-          "micromark": "~2.11.0"
-        }
-      },
-      "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ=="
-    ],
-    "micromark-factory-destination": [
-      "micromark-factory-destination@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="
-    ],
-    "micromark-factory-label": [
-      "micromark-factory-label@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "devlop": "^1.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="
-    ],
-    "micromark-factory-space": [
-      "micromark-factory-space@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="
-    ],
-    "micromark-factory-title": [
-      "micromark-factory-title@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-factory-space": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="
-    ],
-    "micromark-factory-whitespace": [
-      "micromark-factory-whitespace@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-factory-space": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="
-    ],
-    "micromark-util-character": [
-      "micromark-util-character@2.1.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="
-    ],
-    "micromark-util-chunked": [
-      "micromark-util-chunked@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-symbol": "^2.0.0"
-        }
-      },
-      "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="
-    ],
-    "micromark-util-classify-character": [
-      "micromark-util-classify-character@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="
-    ],
-    "micromark-util-combine-extensions": [
-      "micromark-util-combine-extensions@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-chunked": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="
-    ],
-    "micromark-util-decode-numeric-character-reference": [
-      "micromark-util-decode-numeric-character-reference@2.0.2",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-symbol": "^2.0.0"
-        }
-      },
-      "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="
-    ],
-    "micromark-util-decode-string": [
-      "micromark-util-decode-string@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "decode-named-character-reference": "^1.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-decode-numeric-character-reference": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0"
-        }
-      },
-      "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="
-    ],
-    "micromark-util-encode": [
-      "micromark-util-encode@2.0.1",
-      "",
-      {},
-      "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="
-    ],
-    "micromark-util-html-tag-name": [
-      "micromark-util-html-tag-name@2.0.1",
-      "",
-      {},
-      "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="
-    ],
-    "micromark-util-normalize-identifier": [
-      "micromark-util-normalize-identifier@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-symbol": "^2.0.0"
-        }
-      },
-      "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="
-    ],
-    "micromark-util-resolve-all": [
-      "micromark-util-resolve-all@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="
-    ],
-    "micromark-util-sanitize-uri": [
-      "micromark-util-sanitize-uri@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-encode": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0"
-        }
-      },
-      "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="
-    ],
-    "micromark-util-subtokenize": [
-      "micromark-util-subtokenize@2.1.0",
-      "",
-      {
-        "dependencies": {
-          "devlop": "^1.0.0",
-          "micromark-util-chunked": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="
-    ],
-    "micromark-util-symbol": [
-      "micromark-util-symbol@2.0.1",
-      "",
-      {},
-      "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="
-    ],
-    "micromark-util-types": [
-      "micromark-util-types@2.0.2",
-      "",
-      {},
-      "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="
-    ],
-    "micromatch": [
-      "micromatch@4.0.8",
-      "",
-      {
-        "dependencies": {
-          "braces": "^3.0.3",
-          "picomatch": "^2.3.1"
-        }
-      },
-      "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="
-    ],
-    "min-indent": [
-      "min-indent@1.0.1",
-      "",
-      {},
-      "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
-    ],
-    "minimatch": [
-      "minimatch@10.2.5",
-      "",
-      {
-        "dependencies": {
-          "brace-expansion": "^5.0.5"
-        }
-      },
-      "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="
-    ],
-    "minimist": [
-      "minimist@1.2.8",
-      "",
-      {},
-      "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
-    ],
-    "monaco-editor": [
-      "monaco-editor@0.55.1",
-      "",
-      {
-        "dependencies": {
-          "dompurify": "3.2.7",
-          "marked": "14.0.0"
-        }
-      },
-      "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="
-    ],
-    "mri": [
-      "mri@1.2.0",
-      "",
-      {},
-      "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
-    ],
-    "ms": [
-      "ms@2.1.3",
-      "",
-      {},
-      "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    ],
-    "msgpackr": [
-      "msgpackr@1.11.5",
-      "",
-      {
-        "optionalDependencies": {
-          "msgpackr-extract": "^3.0.2"
-        }
-      },
-      "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA=="
-    ],
-    "msgpackr-extract": [
-      "msgpackr-extract@3.0.3",
-      "",
-      {
-        "dependencies": {
-          "node-gyp-build-optional-packages": "5.2.2"
-        },
-        "optionalDependencies": {
-          "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-          "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-          "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-          "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-          "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-          "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
-        },
-        "bin": {
-          "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
-        }
-      },
-      "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="
-    ],
-    "mute-stream": [
-      "mute-stream@3.0.0",
-      "",
-      {},
-      "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="
-    ],
-    "mysql2": [
-      "mysql2@3.22.0",
-      "",
-      {
-        "dependencies": {
-          "aws-ssl-profiles": "^1.1.2",
-          "denque": "^2.1.0",
-          "generate-function": "^2.3.1",
-          "iconv-lite": "^0.7.2",
-          "long": "^5.3.2",
-          "lru.min": "^1.1.4",
-          "named-placeholders": "^1.1.6",
-          "sql-escaper": "^1.3.3"
-        },
-        "peerDependencies": {
-          "@types/node": ">= 8"
-        }
-      },
-      "sha512-4jaJYBObj7FhD3lnZhqX1yDMuZN4mQNz+IolDySDXT7fbozMBpeGQNcuWXKUqo4ahkAEfkjUHPjnwuDI0/6VKw=="
-    ],
-    "mz": [
-      "mz@2.7.0",
-      "",
-      {
-        "dependencies": {
-          "any-promise": "^1.0.0",
-          "object-assign": "^4.0.1",
-          "thenify-all": "^1.0.0"
-        }
-      },
-      "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="
-    ],
-    "named-placeholders": [
-      "named-placeholders@1.1.6",
-      "",
-      {
-        "dependencies": {
-          "lru.min": "^1.1.0"
-        }
-      },
-      "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="
-    ],
-    "nan": [
-      "nan@2.26.2",
-      "",
-      {},
-      "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw=="
-    ],
-    "nanoid": [
-      "nanoid@3.3.11",
-      "",
-      {
-        "bin": {
-          "nanoid": "bin/nanoid.cjs"
-        }
-      },
-      "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
-    ],
-    "nanostores": [
-      "nanostores@1.2.0",
-      "",
-      {},
-      "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg=="
-    ],
-    "natural-compare": [
-      "natural-compare@1.4.0",
-      "",
-      {},
-      "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
-    ],
-    "neo-async": [
-      "neo-async@2.6.2",
-      "",
-      {},
-      "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    ],
-    "node-abort-controller": [
-      "node-abort-controller@3.1.1",
-      "",
-      {},
-      "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
-    ],
-    "node-fetch": [
-      "node-fetch@2.7.0",
-      "",
-      {
-        "dependencies": {
-          "whatwg-url": "^5.0.0"
-        },
-        "peerDependencies": {
-          "encoding": "^0.1.0"
-        },
-        "optionalPeers": [
-          "encoding"
-        ]
-      },
-      "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="
-    ],
-    "node-gyp-build-optional-packages": [
-      "node-gyp-build-optional-packages@5.2.2",
-      "",
-      {
-        "dependencies": {
-          "detect-libc": "^2.0.1"
-        },
-        "bin": {
-          "node-gyp-build-optional-packages": "bin.js",
-          "node-gyp-build-optional-packages-optional": "optional.js",
-          "node-gyp-build-optional-packages-test": "build-test.js"
-        }
-      },
-      "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="
-    ],
-    "node-releases": [
-      "node-releases@2.0.37",
-      "",
-      {},
-      "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="
-    ],
-    "node-rsa": [
-      "node-rsa@1.1.1",
-      "",
-      {
-        "dependencies": {
-          "asn1": "^0.2.4"
-        }
-      },
-      "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw=="
-    ],
-    "nodemailer": [
-      "nodemailer@8.0.5",
-      "",
-      {},
-      "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="
-    ],
-    "normalize-path": [
-      "normalize-path@3.0.0",
-      "",
-      {},
-      "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-    ],
-    "object-assign": [
-      "object-assign@4.1.1",
-      "",
-      {},
-      "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-    ],
-    "object-hash": [
-      "object-hash@3.0.0",
-      "",
-      {},
-      "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
-    ],
-    "one-time": [
-      "one-time@1.0.0",
-      "",
-      {
-        "dependencies": {
-          "fn.name": "1.x.x"
-        }
-      },
-      "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="
-    ],
-    "openapi-types": [
-      "openapi-types@12.1.3",
-      "",
-      {},
-      "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
-    ],
-    "optionator": [
-      "optionator@0.9.4",
-      "",
-      {
-        "dependencies": {
-          "deep-is": "^0.1.3",
-          "fast-levenshtein": "^2.0.6",
-          "levn": "^0.4.1",
-          "prelude-ls": "^1.2.1",
-          "type-check": "^0.4.0",
-          "word-wrap": "^1.2.5"
-        }
-      },
-      "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="
-    ],
-    "outdent": [
-      "outdent@0.5.0",
-      "",
-      {},
-      "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="
-    ],
-    "p-filter": [
-      "p-filter@2.1.0",
-      "",
-      {
-        "dependencies": {
-          "p-map": "^2.0.0"
-        }
-      },
-      "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="
-    ],
-    "p-limit": [
-      "p-limit@3.1.0",
-      "",
-      {
-        "dependencies": {
-          "yocto-queue": "^0.1.0"
-        }
-      },
-      "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="
-    ],
-    "p-locate": [
-      "p-locate@5.0.0",
-      "",
-      {
-        "dependencies": {
-          "p-limit": "^3.0.2"
-        }
-      },
-      "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="
-    ],
-    "p-map": [
-      "p-map@2.1.0",
-      "",
-      {},
-      "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
-    ],
-    "p-try": [
-      "p-try@2.2.0",
-      "",
-      {},
-      "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-    ],
-    "package-manager-detector": [
-      "package-manager-detector@0.2.11",
-      "",
-      {
-        "dependencies": {
-          "quansync": "^0.2.7"
-        }
-      },
-      "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="
-    ],
-    "parent-module": [
-      "parent-module@1.0.1",
-      "",
-      {
-        "dependencies": {
-          "callsites": "^3.0.0"
-        }
-      },
-      "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="
-    ],
-    "parse-entities": [
-      "parse-entities@2.0.0",
-      "",
-      {
-        "dependencies": {
-          "character-entities": "^1.0.0",
-          "character-entities-legacy": "^1.0.0",
-          "character-reference-invalid": "^1.0.0",
-          "is-alphanumerical": "^1.0.0",
-          "is-decimal": "^1.0.0",
-          "is-hexadecimal": "^1.0.0"
-        }
-      },
-      "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ=="
-    ],
-    "path-exists": [
-      "path-exists@4.0.0",
-      "",
-      {},
-      "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-    ],
-    "path-key": [
-      "path-key@3.1.1",
-      "",
-      {},
-      "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-    ],
-    "path-parse": [
-      "path-parse@1.0.7",
-      "",
-      {},
-      "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    ],
-    "path-type": [
-      "path-type@4.0.0",
-      "",
-      {},
-      "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-    ],
-    "pg": [
-      "pg@8.20.0",
-      "",
-      {
-        "dependencies": {
-          "pg-connection-string": "^2.12.0",
-          "pg-pool": "^3.13.0",
-          "pg-protocol": "^1.13.0",
-          "pg-types": "2.2.0",
-          "pgpass": "1.0.5"
-        },
-        "optionalDependencies": {
-          "pg-cloudflare": "^1.3.0"
-        },
-        "peerDependencies": {
-          "pg-native": ">=3.0.1"
-        },
-        "optionalPeers": [
-          "pg-native"
-        ]
-      },
-      "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="
-    ],
-    "pg-cloudflare": [
-      "pg-cloudflare@1.3.0",
-      "",
-      {},
-      "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="
-    ],
-    "pg-connection-string": [
-      "pg-connection-string@2.12.0",
-      "",
-      {},
-      "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="
-    ],
-    "pg-int8": [
-      "pg-int8@1.0.1",
-      "",
-      {},
-      "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
-    ],
-    "pg-pool": [
-      "pg-pool@3.13.0",
-      "",
-      {
-        "peerDependencies": {
-          "pg": ">=8.0"
-        }
-      },
-      "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="
-    ],
-    "pg-protocol": [
-      "pg-protocol@1.13.0",
-      "",
-      {},
-      "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="
-    ],
-    "pg-types": [
-      "pg-types@2.2.0",
-      "",
-      {
-        "dependencies": {
-          "pg-int8": "1.0.1",
-          "postgres-array": "~2.0.0",
-          "postgres-bytea": "~1.0.0",
-          "postgres-date": "~1.0.4",
-          "postgres-interval": "^1.1.0"
-        }
-      },
-      "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="
-    ],
-    "pgpass": [
-      "pgpass@1.0.5",
-      "",
-      {
-        "dependencies": {
-          "split2": "^4.1.0"
-        }
-      },
-      "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="
-    ],
-    "picocolors": [
-      "picocolors@1.1.1",
-      "",
-      {},
-      "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
-    ],
-    "picomatch": [
-      "picomatch@4.0.4",
-      "",
-      {},
-      "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
-    ],
-    "pify": [
-      "pify@4.0.1",
-      "",
-      {},
-      "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-    ],
-    "pirates": [
-      "pirates@4.0.7",
-      "",
-      {},
-      "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="
-    ],
-    "playwright": [
-      "playwright@1.59.1",
-      "",
-      {
-        "dependencies": {
-          "playwright-core": "1.59.1"
-        },
-        "optionalDependencies": {
-          "fsevents": "2.3.2"
-        },
-        "bin": {
-          "playwright": "cli.js"
-        }
-      },
-      "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="
-    ],
-    "playwright-core": [
-      "playwright-core@1.59.1",
-      "",
-      {
-        "bin": {
-          "playwright-core": "cli.js"
-        }
-      },
-      "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="
-    ],
-    "pluralize": [
-      "pluralize@8.0.0",
-      "",
-      {},
-      "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
-    ],
-    "postcss": [
-      "postcss@8.5.10",
-      "",
-      {
-        "dependencies": {
-          "nanoid": "^3.3.11",
-          "picocolors": "^1.1.1",
-          "source-map-js": "^1.2.1"
-        }
-      },
-      "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="
-    ],
-    "postcss-import": [
-      "postcss-import@15.1.0",
-      "",
-      {
-        "dependencies": {
-          "postcss-value-parser": "^4.0.0",
-          "read-cache": "^1.0.0",
-          "resolve": "^1.1.7"
-        },
-        "peerDependencies": {
-          "postcss": "^8.0.0"
-        }
-      },
-      "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="
-    ],
-    "postcss-js": [
-      "postcss-js@4.1.0",
-      "",
-      {
-        "dependencies": {
-          "camelcase-css": "^2.0.1"
-        },
-        "peerDependencies": {
-          "postcss": "^8.4.21"
-        }
-      },
-      "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw=="
-    ],
-    "postcss-load-config": [
-      "postcss-load-config@6.0.1",
-      "",
-      {
-        "dependencies": {
-          "lilconfig": "^3.1.1"
-        },
-        "peerDependencies": {
-          "jiti": ">=1.21.0",
-          "postcss": ">=8.0.9",
-          "tsx": "^4.8.1",
-          "yaml": "^2.4.2"
-        },
-        "optionalPeers": [
-          "jiti",
-          "postcss",
-          "tsx",
-          "yaml"
-        ]
-      },
-      "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="
-    ],
-    "postcss-nested": [
-      "postcss-nested@6.2.0",
-      "",
-      {
-        "dependencies": {
-          "postcss-selector-parser": "^6.1.1"
-        },
-        "peerDependencies": {
-          "postcss": "^8.2.14"
-        }
-      },
-      "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="
-    ],
-    "postcss-selector-parser": [
-      "postcss-selector-parser@6.1.2",
-      "",
-      {
-        "dependencies": {
-          "cssesc": "^3.0.0",
-          "util-deprecate": "^1.0.2"
-        }
-      },
-      "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="
-    ],
-    "postcss-value-parser": [
-      "postcss-value-parser@4.2.0",
-      "",
-      {},
-      "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-    ],
-    "postgres-array": [
-      "postgres-array@2.0.0",
-      "",
-      {},
-      "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
-    ],
-    "postgres-bytea": [
-      "postgres-bytea@1.0.1",
-      "",
-      {},
-      "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="
-    ],
-    "postgres-date": [
-      "postgres-date@1.0.7",
-      "",
-      {},
-      "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
-    ],
-    "postgres-interval": [
-      "postgres-interval@1.2.0",
-      "",
-      {
-        "dependencies": {
-          "xtend": "^4.0.0"
-        }
-      },
-      "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="
-    ],
-    "prelude-ls": [
-      "prelude-ls@1.2.1",
-      "",
-      {},
-      "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
-    ],
-    "prettier": [
-      "prettier@2.8.8",
-      "",
-      {
-        "bin": {
-          "prettier": "bin-prettier.js"
-        }
-      },
-      "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
-    ],
-    "pretty-format": [
-      "pretty-format@27.5.1",
-      "",
-      {
-        "dependencies": {
-          "ansi-regex": "^5.0.1",
-          "ansi-styles": "^5.0.0",
-          "react-is": "^17.0.1"
-        }
-      },
-      "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="
-    ],
-    "property-information": [
-      "property-information@7.1.0",
-      "",
-      {},
-      "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="
-    ],
-    "protobufjs": [
-      "protobufjs@7.5.5",
-      "",
-      {
-        "dependencies": {
-          "@protobufjs/aspromise": "^1.1.2",
-          "@protobufjs/base64": "^1.1.2",
-          "@protobufjs/codegen": "^2.0.4",
-          "@protobufjs/eventemitter": "^1.1.0",
-          "@protobufjs/fetch": "^1.1.0",
-          "@protobufjs/float": "^1.0.2",
-          "@protobufjs/inquire": "^1.1.0",
-          "@protobufjs/path": "^1.1.2",
-          "@protobufjs/pool": "^1.1.0",
-          "@protobufjs/utf8": "^1.1.0",
-          "@types/node": ">=13.7.0",
-          "long": "^5.0.0"
-        }
-      },
-      "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="
-    ],
-    "punycode": [
-      "punycode@2.3.1",
-      "",
-      {},
-      "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
-    ],
-    "quansync": [
-      "quansync@0.2.11",
-      "",
-      {},
-      "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="
-    ],
-    "queue-microtask": [
-      "queue-microtask@1.2.3",
-      "",
-      {},
-      "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
-    ],
-    "radash": [
-      "radash@12.1.1",
-      "",
-      {},
-      "sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA=="
-    ],
-    "rcon-srcds": [
-      "rcon-srcds@2.1.1",
-      "",
-      {},
-      "sha512-qXFImo6HVrXIS8EZm/MNlSGsqy9yTzxXXtOIU4z3PtWz6PFG325lVk5zpkwBvz5Kp9AgOn18RgMoljQRSbL0Qg=="
-    ],
-    "react": [
-      "react@18.3.1",
-      "",
-      {
-        "dependencies": {
-          "loose-envify": "^1.1.0"
-        }
-      },
-      "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="
-    ],
-    "react-day-picker": [
-      "react-day-picker@9.14.0",
-      "",
-      {
-        "dependencies": {
-          "@date-fns/tz": "^1.4.1",
-          "@tabby_ai/hijri-converter": "1.0.5",
-          "date-fns": "^4.1.0",
-          "date-fns-jalali": "4.1.0-0"
-        },
-        "peerDependencies": {
-          "react": ">=16.8.0"
-        }
-      },
-      "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA=="
-    ],
-    "react-dom": [
-      "react-dom@18.3.1",
-      "",
-      {
-        "dependencies": {
-          "loose-envify": "^1.1.0",
-          "scheduler": "^0.23.2"
-        },
-        "peerDependencies": {
-          "react": "^18.3.1"
-        }
-      },
-      "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="
-    ],
-    "react-is": [
-      "react-is@17.0.2",
-      "",
-      {},
-      "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    ],
-    "react-markdown": [
-      "react-markdown@10.1.0",
-      "",
-      {
-        "dependencies": {
-          "@types/hast": "^3.0.0",
-          "@types/mdast": "^4.0.0",
-          "devlop": "^1.0.0",
-          "hast-util-to-jsx-runtime": "^2.0.0",
-          "html-url-attributes": "^3.0.0",
-          "mdast-util-to-hast": "^13.0.0",
-          "remark-parse": "^11.0.0",
-          "remark-rehype": "^11.0.0",
-          "unified": "^11.0.0",
-          "unist-util-visit": "^5.0.0",
-          "vfile": "^6.0.0"
-        },
-        "peerDependencies": {
-          "@types/react": ">=18",
-          "react": ">=18"
-        }
-      },
-      "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="
-    ],
-    "react-redux": [
-      "react-redux@9.2.0",
-      "",
-      {
-        "dependencies": {
-          "@types/use-sync-external-store": "^0.0.6",
-          "use-sync-external-store": "^1.4.0"
-        },
-        "peerDependencies": {
-          "@types/react": "^18.2.25 || ^19",
-          "react": "^18.0 || ^19",
-          "redux": "^5.0.0"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "redux"
-        ]
-      },
-      "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="
-    ],
-    "react-remove-scroll": [
-      "react-remove-scroll@2.7.2",
-      "",
-      {
-        "dependencies": {
-          "react-remove-scroll-bar": "^2.3.7",
-          "react-style-singleton": "^2.2.3",
-          "tslib": "^2.1.0",
-          "use-callback-ref": "^1.3.3",
-          "use-sidecar": "^1.1.3"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="
-    ],
-    "react-remove-scroll-bar": [
-      "react-remove-scroll-bar@2.3.8",
-      "",
-      {
-        "dependencies": {
-          "react-style-singleton": "^2.2.2",
-          "tslib": "^2.0.0"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="
-    ],
-    "react-router": [
-      "react-router@6.30.3",
-      "",
-      {
-        "dependencies": {
-          "@remix-run/router": "1.23.2"
-        },
-        "peerDependencies": {
-          "react": ">=16.8"
-        }
-      },
-      "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw=="
-    ],
-    "react-router-dom": [
-      "react-router-dom@6.30.3",
-      "",
-      {
-        "dependencies": {
-          "@remix-run/router": "1.23.2",
-          "react-router": "6.30.3"
-        },
-        "peerDependencies": {
-          "react": ">=16.8",
-          "react-dom": ">=16.8"
-        }
-      },
-      "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag=="
-    ],
-    "react-style-singleton": [
-      "react-style-singleton@2.2.3",
-      "",
-      {
-        "dependencies": {
-          "get-nonce": "^1.0.0",
-          "tslib": "^2.0.0"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="
-    ],
-    "read-cache": [
-      "read-cache@1.0.0",
-      "",
-      {
-        "dependencies": {
-          "pify": "^2.3.0"
-        }
-      },
-      "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="
-    ],
-    "read-yaml-file": [
-      "read-yaml-file@1.1.0",
-      "",
-      {
-        "dependencies": {
-          "graceful-fs": "^4.1.5",
-          "js-yaml": "^3.6.1",
-          "pify": "^4.0.1",
-          "strip-bom": "^3.0.0"
-        }
-      },
-      "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="
-    ],
-    "readable-stream": [
-      "readable-stream@3.6.2",
-      "",
-      {
-        "dependencies": {
-          "inherits": "^2.0.3",
-          "string_decoder": "^1.1.1",
-          "util-deprecate": "^1.0.1"
-        }
-      },
-      "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="
-    ],
-    "readdirp": [
-      "readdirp@3.6.0",
-      "",
-      {
-        "dependencies": {
-          "picomatch": "^2.2.1"
-        }
-      },
-      "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="
-    ],
-    "readline-sync": [
-      "readline-sync@1.4.10",
-      "",
-      {},
-      "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
-    ],
-    "recharts": [
-      "recharts@3.8.1",
-      "",
-      {
-        "dependencies": {
-          "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
-          "clsx": "^2.1.1",
-          "decimal.js-light": "^2.5.1",
-          "es-toolkit": "^1.39.3",
-          "eventemitter3": "^5.0.1",
-          "immer": "^10.1.1",
-          "react-redux": "8.x.x || 9.x.x",
-          "reselect": "5.1.1",
-          "tiny-invariant": "^1.3.3",
-          "use-sync-external-store": "^1.2.2",
-          "victory-vendor": "^37.0.2"
-        },
-        "peerDependencies": {
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-          "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-          "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-        }
-      },
-      "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="
-    ],
-    "redent": [
-      "redent@3.0.0",
-      "",
-      {
-        "dependencies": {
-          "indent-string": "^4.0.0",
-          "strip-indent": "^3.0.0"
-        }
-      },
-      "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="
-    ],
-    "redis-errors": [
-      "redis-errors@1.2.0",
-      "",
-      {},
-      "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
-    ],
-    "redis-parser": [
-      "redis-parser@3.0.0",
-      "",
-      {
-        "dependencies": {
-          "redis-errors": "^1.0.0"
-        }
-      },
-      "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="
-    ],
-    "redux": [
-      "redux@5.0.1",
-      "",
-      {},
-      "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
-    ],
-    "redux-thunk": [
-      "redux-thunk@3.1.0",
-      "",
-      {
-        "peerDependencies": {
-          "redux": "^5.0.0"
-        }
-      },
-      "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="
-    ],
-    "regexp-tree": [
-      "regexp-tree@0.1.27",
-      "",
-      {
-        "bin": {
-          "regexp-tree": "bin/regexp-tree"
-        }
-      },
-      "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="
-    ],
-    "regjsparser": [
-      "regjsparser@0.13.1",
-      "",
-      {
-        "dependencies": {
-          "jsesc": "~3.1.0"
-        },
-        "bin": {
-          "regjsparser": "bin/parser"
-        }
-      },
-      "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw=="
-    ],
-    "remark-gfm": [
-      "remark-gfm@1.0.0",
-      "",
-      {
-        "dependencies": {
-          "mdast-util-gfm": "^0.1.0",
-          "micromark-extension-gfm": "^0.3.0"
-        }
-      },
-      "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA=="
-    ],
-    "remark-parse": [
-      "remark-parse@9.0.0",
-      "",
-      {
-        "dependencies": {
-          "mdast-util-from-markdown": "^0.8.0"
-        }
-      },
-      "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw=="
-    ],
-    "remark-rehype": [
-      "remark-rehype@11.1.2",
-      "",
-      {
-        "dependencies": {
-          "@types/hast": "^3.0.0",
-          "@types/mdast": "^4.0.0",
-          "mdast-util-to-hast": "^13.0.0",
-          "unified": "^11.0.0",
-          "vfile": "^6.0.0"
-        }
-      },
-      "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="
-    ],
-    "remark-remove-comments": [
-      "remark-remove-comments@0.2.0",
-      "",
-      {
-        "dependencies": {
-          "html-comment-regex": "^1.1.2",
-          "unist-util-visit": "^2.0.3"
-        }
-      },
-      "sha512-faGaTeqp0bvDgE0uTofa90EBHD4HXeHN+EUaPDR9datgFvaPkYcLxakaJud9LnomFPkOhx0A9NMYFk/lln/etQ=="
-    ],
-    "remark-stringify": [
-      "remark-stringify@9.0.1",
-      "",
-      {
-        "dependencies": {
-          "mdast-util-to-markdown": "^0.6.0"
-        }
-      },
-      "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg=="
-    ],
-    "repeat-string": [
-      "repeat-string@1.6.1",
-      "",
-      {},
-      "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
-    ],
-    "require-directory": [
-      "require-directory@2.1.1",
-      "",
-      {},
-      "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
-    ],
-    "require-from-string": [
-      "require-from-string@2.0.2",
-      "",
-      {},
-      "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    ],
-    "reselect": [
-      "reselect@5.1.1",
-      "",
-      {},
-      "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
-    ],
-    "resolve": [
-      "resolve@1.22.12",
-      "",
-      {
-        "dependencies": {
-          "es-errors": "^1.3.0",
-          "is-core-module": "^2.16.1",
-          "path-parse": "^1.0.7",
-          "supports-preserve-symlinks-flag": "^1.0.0"
-        },
-        "bin": {
-          "resolve": "bin/resolve"
-        }
-      },
-      "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="
-    ],
-    "resolve-from": [
-      "resolve-from@5.0.0",
-      "",
-      {},
-      "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-    ],
-    "resolve-pkg-maps": [
-      "resolve-pkg-maps@1.0.0",
-      "",
-      {},
-      "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="
-    ],
-    "reusify": [
-      "reusify@1.1.0",
-      "",
-      {},
-      "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
-    ],
-    "rolldown": [
-      "rolldown@1.0.0-rc.15",
-      "",
-      {
-        "dependencies": {
-          "@oxc-project/types": "=0.124.0",
-          "@rolldown/pluginutils": "1.0.0-rc.15"
-        },
-        "optionalDependencies": {
-          "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-          "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-          "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-          "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-          "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-          "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-          "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-          "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-          "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-          "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-          "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-          "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-          "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-          "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-          "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
-        },
-        "bin": {
-          "rolldown": "bin/cli.mjs"
-        }
-      },
-      "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="
-    ],
-    "rou3": [
-      "rou3@0.7.12",
-      "",
-      {},
-      "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="
-    ],
-    "run-async": [
-      "run-async@4.0.6",
-      "",
-      {},
-      "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ=="
-    ],
-    "run-parallel": [
-      "run-parallel@1.2.0",
-      "",
-      {
-        "dependencies": {
-          "queue-microtask": "^1.2.2"
-        }
-      },
-      "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="
-    ],
-    "rxjs": [
-      "rxjs@7.8.2",
-      "",
-      {
-        "dependencies": {
-          "tslib": "^2.1.0"
-        }
-      },
-      "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="
-    ],
-    "safe-buffer": [
-      "safe-buffer@5.2.1",
-      "",
-      {},
-      "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    ],
-    "safe-stable-stringify": [
-      "safe-stable-stringify@2.5.0",
-      "",
-      {},
-      "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="
-    ],
-    "safer-buffer": [
-      "safer-buffer@2.1.2",
-      "",
-      {},
-      "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    ],
-    "samlify": [
-      "samlify@2.12.0",
-      "",
-      {
-        "dependencies": {
-          "@authenio/xml-encryption": "^2.0.2",
-          "@xmldom/xmldom": "^0.8.11",
-          "node-rsa": "^1.1.1",
-          "xml": "^1.0.1",
-          "xml-crypto": "^6.1.2",
-          "xml-escape": "^1.1.0",
-          "xpath": "^0.0.34"
-        }
-      },
-      "sha512-ewGsHyY4kInDH0BfprlAZ1rHpH1jBmbqYiXDbuI3t1Y8h71gqEt4Z7jdCFyPHFR8jItJkbdckTijUZGg14CDlg=="
-    ],
-    "scheduler": [
-      "scheduler@0.23.2",
-      "",
-      {
-        "dependencies": {
-          "loose-envify": "^1.1.0"
-        }
-      },
-      "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="
-    ],
-    "semver": [
-      "semver@7.7.4",
-      "",
-      {
-        "bin": {
-          "semver": "bin/semver.js"
-        }
-      },
-      "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
-    ],
-    "set-cookie-parser": [
-      "set-cookie-parser@3.1.0",
-      "",
-      {},
-      "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="
-    ],
-    "shebang-command": [
-      "shebang-command@2.0.0",
-      "",
-      {
-        "dependencies": {
-          "shebang-regex": "^3.0.0"
-        }
-      },
-      "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="
-    ],
-    "shebang-regex": [
-      "shebang-regex@3.0.0",
-      "",
-      {},
-      "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    ],
-    "signal-exit": [
-      "signal-exit@4.1.0",
-      "",
-      {},
-      "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-    ],
-    "slash": [
-      "slash@3.0.0",
-      "",
-      {},
-      "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-    ],
-    "source-map": [
-      "source-map@0.6.1",
-      "",
-      {},
-      "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    ],
-    "source-map-js": [
-      "source-map-js@1.2.1",
-      "",
-      {},
-      "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
-    ],
-    "source-map-support": [
-      "source-map-support@0.5.21",
-      "",
-      {
-        "dependencies": {
-          "buffer-from": "^1.0.0",
-          "source-map": "^0.6.0"
-        }
-      },
-      "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="
-    ],
-    "space-separated-tokens": [
-      "space-separated-tokens@2.0.2",
-      "",
-      {},
-      "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
-    ],
-    "spawndamnit": [
-      "spawndamnit@3.0.1",
-      "",
-      {
-        "dependencies": {
-          "cross-spawn": "^7.0.5",
-          "signal-exit": "^4.0.1"
-        }
-      },
-      "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="
-    ],
-    "split2": [
-      "split2@4.2.0",
-      "",
-      {},
-      "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
-    ],
-    "sprintf-js": [
-      "sprintf-js@1.1.3",
-      "",
-      {},
-      "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
-    ],
-    "sql-escaper": [
-      "sql-escaper@1.3.3",
-      "",
-      {},
-      "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw=="
-    ],
-    "ssh2": [
-      "ssh2@1.16.0",
-      "",
-      {
-        "dependencies": {
-          "asn1": "^0.2.6",
-          "bcrypt-pbkdf": "^1.0.2"
-        },
-        "optionalDependencies": {
-          "cpu-features": "~0.0.10",
-          "nan": "^2.20.0"
-        }
-      },
-      "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg=="
-    ],
-    "stack-trace": [
-      "stack-trace@0.0.10",
-      "",
-      {},
-      "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
-    ],
-    "standard-as-callback": [
-      "standard-as-callback@2.1.0",
-      "",
-      {},
-      "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
-    ],
-    "state-local": [
-      "state-local@1.0.7",
-      "",
-      {},
-      "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
-    ],
-    "strict-event-emitter-types": [
-      "strict-event-emitter-types@2.0.0",
-      "",
-      {},
-      "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
-    ],
-    "string-width": [
-      "string-width@4.2.3",
-      "",
-      {
-        "dependencies": {
-          "emoji-regex": "^8.0.0",
-          "is-fullwidth-code-point": "^3.0.0",
-          "strip-ansi": "^6.0.1"
-        }
-      },
-      "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="
-    ],
-    "string_decoder": [
-      "string_decoder@1.3.0",
-      "",
-      {
-        "dependencies": {
-          "safe-buffer": "~5.2.0"
-        }
-      },
-      "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="
-    ],
-    "stringify-entities": [
-      "stringify-entities@4.0.4",
-      "",
-      {
-        "dependencies": {
-          "character-entities-html4": "^2.0.0",
-          "character-entities-legacy": "^3.0.0"
-        }
-      },
-      "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="
-    ],
-    "strip-ansi": [
-      "strip-ansi@6.0.1",
-      "",
-      {
-        "dependencies": {
-          "ansi-regex": "^5.0.1"
-        }
-      },
-      "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="
-    ],
-    "strip-bom": [
-      "strip-bom@3.0.0",
-      "",
-      {},
-      "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
-    ],
-    "strip-indent": [
-      "strip-indent@4.1.1",
-      "",
-      {},
-      "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA=="
-    ],
-    "strip-json-comments": [
-      "strip-json-comments@3.1.1",
-      "",
-      {},
-      "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
-    ],
-    "style-to-js": [
-      "style-to-js@1.1.21",
-      "",
-      {
-        "dependencies": {
-          "style-to-object": "1.0.14"
-        }
-      },
-      "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="
-    ],
-    "style-to-object": [
-      "style-to-object@1.0.14",
-      "",
-      {
-        "dependencies": {
-          "inline-style-parser": "0.2.7"
-        }
-      },
-      "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="
-    ],
-    "sucrase": [
-      "sucrase@3.35.1",
-      "",
-      {
-        "dependencies": {
-          "@jridgewell/gen-mapping": "^0.3.2",
-          "commander": "^4.0.0",
-          "lines-and-columns": "^1.1.6",
-          "mz": "^2.7.0",
-          "pirates": "^4.0.1",
-          "tinyglobby": "^0.2.11",
-          "ts-interface-checker": "^0.1.9"
-        },
-        "bin": {
-          "sucrase": "bin/sucrase",
-          "sucrase-node": "bin/sucrase-node"
-        }
-      },
-      "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="
-    ],
-    "supports-color": [
-      "supports-color@7.2.0",
-      "",
-      {
-        "dependencies": {
-          "has-flag": "^4.0.0"
-        }
-      },
-      "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="
-    ],
-    "supports-preserve-symlinks-flag": [
-      "supports-preserve-symlinks-flag@1.0.0",
-      "",
-      {},
-      "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
-    ],
-    "tagged-tag": [
-      "tagged-tag@1.0.0",
-      "",
-      {},
-      "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="
-    ],
-    "tailwind-merge": [
-      "tailwind-merge@2.6.1",
-      "",
-      {},
-      "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="
-    ],
-    "tailwindcss": [
-      "tailwindcss@3.4.19",
-      "",
-      {
-        "dependencies": {
-          "@alloc/quick-lru": "^5.2.0",
-          "arg": "^5.0.2",
-          "chokidar": "^3.6.0",
-          "didyoumean": "^1.2.2",
-          "dlv": "^1.1.3",
-          "fast-glob": "^3.3.2",
-          "glob-parent": "^6.0.2",
-          "is-glob": "^4.0.3",
-          "jiti": "^1.21.7",
-          "lilconfig": "^3.1.3",
-          "micromatch": "^4.0.8",
-          "normalize-path": "^3.0.0",
-          "object-hash": "^3.0.0",
-          "picocolors": "^1.1.1",
-          "postcss": "^8.4.47",
-          "postcss-import": "^15.1.0",
-          "postcss-js": "^4.0.1",
-          "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
-          "postcss-nested": "^6.2.0",
-          "postcss-selector-parser": "^6.1.2",
-          "resolve": "^1.22.8",
-          "sucrase": "^3.35.0"
-        },
-        "bin": {
-          "tailwind": "lib/cli.js",
-          "tailwindcss": "lib/cli.js"
-        }
-      },
-      "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="
-    ],
-    "tailwindcss-animate": [
-      "tailwindcss-animate@1.0.7",
-      "",
-      {
-        "peerDependencies": {
-          "tailwindcss": ">=3.0.0 || insiders"
-        }
-      },
-      "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="
-    ],
-    "tdigest": [
-      "tdigest@0.1.2",
-      "",
-      {
-        "dependencies": {
-          "bintrees": "1.0.2"
-        }
-      },
-      "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA=="
-    ],
-    "telegramify-markdown": [
-      "telegramify-markdown@1.3.3",
-      "",
-      {
-        "dependencies": {
-          "mdast-util-gfm-table": "^0.1.6",
-          "mdast-util-to-markdown": "^0.6.2",
-          "remark-gfm": "^1.0.0",
-          "remark-parse": "^9.0.0",
-          "remark-remove-comments": "^0.2.0",
-          "remark-stringify": "^9.0.1",
-          "unified": "^9.0.0",
-          "unist-util-remove": "^2.0.1",
-          "unist-util-visit": "^2.0.3"
-        }
-      },
-      "sha512-cyMqOrXFJfKzOrrUc1JlnfRwvC7HR+DzzlUItQs+I9bGTO9TSyvpgt27UQ9YXm2sXb3ltzBvvAq/IEWqdk6xkg=="
-    ],
-    "term-size": [
-      "term-size@2.2.1",
-      "",
-      {},
-      "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="
-    ],
-    "text-hex": [
-      "text-hex@1.0.0",
-      "",
-      {},
-      "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-    ],
-    "thenify": [
-      "thenify@3.3.1",
-      "",
-      {
-        "dependencies": {
-          "any-promise": "^1.0.0"
-        }
-      },
-      "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="
-    ],
-    "thenify-all": [
-      "thenify-all@1.6.0",
-      "",
-      {
-        "dependencies": {
-          "thenify": ">= 3.1.0 < 4"
-        }
-      },
-      "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="
-    ],
-    "tiny-invariant": [
-      "tiny-invariant@1.3.3",
-      "",
-      {},
-      "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
-    ],
-    "tinyglobby": [
-      "tinyglobby@0.2.16",
-      "",
-      {
-        "dependencies": {
-          "fdir": "^6.5.0",
-          "picomatch": "^4.0.4"
-        }
-      },
-      "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="
-    ],
-    "tmp": [
-      "tmp@0.2.5",
-      "",
-      {},
-      "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="
-    ],
-    "to-regex-range": [
-      "to-regex-range@5.0.1",
-      "",
-      {
-        "dependencies": {
-          "is-number": "^7.0.0"
-        }
-      },
-      "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="
-    ],
-    "tr46": [
-      "tr46@0.0.3",
-      "",
-      {},
-      "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    ],
-    "trim-lines": [
-      "trim-lines@3.0.1",
-      "",
-      {},
-      "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
-    ],
-    "triple-beam": [
-      "triple-beam@1.4.1",
-      "",
-      {},
-      "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="
-    ],
-    "trough": [
-      "trough@1.0.5",
-      "",
-      {},
-      "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
-    ],
-    "ts-api-utils": [
-      "ts-api-utils@2.5.0",
-      "",
-      {
-        "peerDependencies": {
-          "typescript": ">=4.8.4"
-        }
-      },
-      "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="
-    ],
-    "ts-interface-checker": [
-      "ts-interface-checker@0.1.13",
-      "",
-      {},
-      "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
-    ],
-    "tslib": [
-      "tslib@2.8.1",
-      "",
-      {},
-      "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    ],
-    "tsx": [
-      "tsx@4.21.0",
-      "",
-      {
-        "dependencies": {
-          "esbuild": "~0.27.0",
-          "get-tsconfig": "^4.7.5"
-        },
-        "optionalDependencies": {
-          "fsevents": "~2.3.3"
-        },
-        "bin": {
-          "tsx": "dist/cli.mjs"
-        }
-      },
-      "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="
-    ],
-    "tweetnacl": [
-      "tweetnacl@0.14.5",
-      "",
-      {},
-      "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-    ],
-    "type-check": [
-      "type-check@0.4.0",
-      "",
-      {
-        "dependencies": {
-          "prelude-ls": "^1.2.1"
-        }
-      },
-      "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="
-    ],
-    "type-fest": [
-      "type-fest@5.5.0",
-      "",
-      {
-        "dependencies": {
-          "tagged-tag": "^1.0.0"
-        }
-      },
-      "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="
-    ],
-    "typescript": [
-      "typescript@5.9.3",
-      "",
-      {
-        "bin": {
-          "tsc": "bin/tsc",
-          "tsserver": "bin/tsserver"
-        }
-      },
-      "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
-    ],
-    "typescript-eslint": [
-      "typescript-eslint@8.58.2",
-      "",
-      {
-        "dependencies": {
-          "@typescript-eslint/eslint-plugin": "8.58.2",
-          "@typescript-eslint/parser": "8.58.2",
-          "@typescript-eslint/typescript-estree": "8.58.2",
-          "@typescript-eslint/utils": "8.58.2"
-        },
-        "peerDependencies": {
-          "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-          "typescript": ">=4.8.4 <6.1.0"
-        }
-      },
-      "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ=="
-    ],
-    "uglify-js": [
-      "uglify-js@3.19.3",
-      "",
-      {
-        "bin": {
-          "uglifyjs": "bin/uglifyjs"
-        }
-      },
-      "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="
-    ],
-    "undici-types": [
-      "undici-types@6.21.0",
-      "",
-      {},
-      "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
-    ],
-    "unified": [
-      "unified@9.2.2",
-      "",
-      {
-        "dependencies": {
-          "bail": "^1.0.0",
-          "extend": "^3.0.0",
-          "is-buffer": "^2.0.0",
-          "is-plain-obj": "^2.0.0",
-          "trough": "^1.0.0",
-          "vfile": "^4.0.0"
-        }
-      },
-      "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ=="
-    ],
-    "unist-util-is": [
-      "unist-util-is@4.1.0",
-      "",
-      {},
-      "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
-    ],
-    "unist-util-position": [
-      "unist-util-position@5.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="
-    ],
-    "unist-util-remove": [
-      "unist-util-remove@2.1.0",
-      "",
-      {
-        "dependencies": {
-          "unist-util-is": "^4.0.0"
-        }
-      },
-      "sha512-J8NYPyBm4baYLdCbjmf1bhPu45Cr1MWTm77qd9istEkzWpnN6O9tMsEbB2JhNnBCqGENRqEWomQ+He6au0B27Q=="
-    ],
-    "unist-util-stringify-position": [
-      "unist-util-stringify-position@2.0.3",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^2.0.2"
-        }
-      },
-      "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g=="
-    ],
-    "unist-util-visit": [
-      "unist-util-visit@2.0.3",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^2.0.0",
-          "unist-util-is": "^4.0.0",
-          "unist-util-visit-parents": "^3.0.0"
-        }
-      },
-      "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q=="
-    ],
-    "unist-util-visit-parents": [
-      "unist-util-visit-parents@3.1.1",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^2.0.0",
-          "unist-util-is": "^4.0.0"
-        }
-      },
-      "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg=="
-    ],
-    "universalify": [
-      "universalify@0.1.2",
-      "",
-      {},
-      "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-    ],
-    "update-browserslist-db": [
-      "update-browserslist-db@1.2.3",
-      "",
-      {
-        "dependencies": {
-          "escalade": "^3.2.0",
-          "picocolors": "^1.1.1"
-        },
-        "peerDependencies": {
-          "browserslist": ">= 4.21.0"
-        },
-        "bin": {
-          "update-browserslist-db": "cli.js"
-        }
-      },
-      "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="
-    ],
-    "uri-js": [
-      "uri-js@4.4.1",
-      "",
-      {
-        "dependencies": {
-          "punycode": "^2.1.0"
-        }
-      },
-      "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="
-    ],
-    "use-callback-ref": [
-      "use-callback-ref@1.3.3",
-      "",
-      {
-        "dependencies": {
-          "tslib": "^2.0.0"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="
-    ],
-    "use-sidecar": [
-      "use-sidecar@1.1.3",
-      "",
-      {
-        "dependencies": {
-          "detect-node-es": "^1.1.0",
-          "tslib": "^2.0.0"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="
-    ],
-    "use-sync-external-store": [
-      "use-sync-external-store@1.6.0",
-      "",
-      {
-        "peerDependencies": {
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-        }
-      },
-      "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="
-    ],
-    "util-deprecate": [
-      "util-deprecate@1.0.2",
-      "",
-      {},
-      "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    ],
-    "uuid": [
-      "uuid@13.0.0",
-      "",
-      {
-        "bin": {
-          "uuid": "dist-node/bin/uuid"
-        }
-      },
-      "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="
-    ],
-    "vfile": [
-      "vfile@6.0.3",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "vfile-message": "^4.0.0"
-        }
-      },
-      "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="
-    ],
-    "vfile-message": [
-      "vfile-message@4.0.3",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-stringify-position": "^4.0.0"
-        }
-      },
-      "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="
-    ],
-    "victory-vendor": [
-      "victory-vendor@37.3.6",
-      "",
-      {
-        "dependencies": {
-          "@types/d3-array": "^3.0.3",
-          "@types/d3-ease": "^3.0.0",
-          "@types/d3-interpolate": "^3.0.1",
-          "@types/d3-scale": "^4.0.2",
-          "@types/d3-shape": "^3.1.0",
-          "@types/d3-time": "^3.0.0",
-          "@types/d3-timer": "^3.0.0",
-          "d3-array": "^3.1.6",
-          "d3-ease": "^3.0.1",
-          "d3-interpolate": "^3.0.1",
-          "d3-scale": "^4.0.2",
-          "d3-shape": "^3.1.0",
-          "d3-time": "^3.0.0",
-          "d3-timer": "^3.0.1"
-        }
-      },
-      "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="
-    ],
-    "vite": [
-      "vite@8.0.8",
-      "",
-      {
-        "dependencies": {
-          "lightningcss": "^1.32.0",
-          "picomatch": "^4.0.4",
-          "postcss": "^8.5.8",
-          "rolldown": "1.0.0-rc.15",
-          "tinyglobby": "^0.2.15"
-        },
-        "optionalDependencies": {
-          "fsevents": "~2.3.3"
-        },
-        "peerDependencies": {
-          "@types/node": "^20.19.0 || >=22.12.0",
-          "@vitejs/devtools": "^0.1.0",
-          "esbuild": "^0.27.0 || ^0.28.0",
-          "jiti": ">=1.21.0",
-          "less": "^4.0.0",
-          "sass": "^1.70.0",
-          "sass-embedded": "^1.70.0",
-          "stylus": ">=0.54.8",
-          "sugarss": "^5.0.0",
-          "terser": "^5.16.0",
-          "tsx": "^4.8.1",
-          "yaml": "^2.4.2"
-        },
-        "optionalPeers": [
-          "@types/node",
-          "@vitejs/devtools",
-          "esbuild",
-          "jiti",
-          "less",
-          "sass",
-          "sass-embedded",
-          "stylus",
-          "sugarss",
-          "terser",
-          "tsx",
-          "yaml"
-        ],
-        "bin": {
-          "vite": "bin/vite.js"
-        }
-      },
-      "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="
-    ],
-    "webidl-conversions": [
-      "webidl-conversions@3.0.1",
-      "",
-      {},
-      "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    ],
-    "whatwg-mimetype": [
-      "whatwg-mimetype@3.0.0",
-      "",
-      {},
-      "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
-    ],
-    "whatwg-url": [
-      "whatwg-url@5.0.0",
-      "",
-      {
-        "dependencies": {
-          "tr46": "~0.0.3",
-          "webidl-conversions": "^3.0.0"
-        }
-      },
-      "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="
-    ],
-    "which": [
-      "which@2.0.2",
-      "",
-      {
-        "dependencies": {
-          "isexe": "^2.0.0"
-        },
-        "bin": {
-          "node-which": "./bin/node-which"
-        }
-      },
-      "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="
-    ],
-    "wildcard-match": [
-      "wildcard-match@5.1.4",
-      "",
-      {},
-      "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g=="
-    ],
-    "winston": [
-      "winston@3.19.0",
-      "",
-      {
-        "dependencies": {
-          "@colors/colors": "^1.6.0",
-          "@dabh/diagnostics": "^2.0.8",
-          "async": "^3.2.3",
-          "is-stream": "^2.0.0",
-          "logform": "^2.7.0",
-          "one-time": "^1.0.0",
-          "readable-stream": "^3.4.0",
-          "safe-stable-stringify": "^2.3.1",
-          "stack-trace": "0.0.x",
-          "triple-beam": "^1.3.0",
-          "winston-transport": "^4.9.0"
-        }
-      },
-      "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="
-    ],
-    "winston-transport": [
-      "winston-transport@4.9.0",
-      "",
-      {
-        "dependencies": {
-          "logform": "^2.7.0",
-          "readable-stream": "^3.6.2",
-          "triple-beam": "^1.3.0"
-        }
-      },
-      "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="
-    ],
-    "word-wrap": [
-      "word-wrap@1.2.5",
-      "",
-      {},
-      "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
-    ],
-    "wordwrap": [
-      "wordwrap@1.0.0",
-      "",
-      {},
-      "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
-    ],
-    "wrap-ansi": [
-      "wrap-ansi@7.0.0",
-      "",
-      {
-        "dependencies": {
-          "ansi-styles": "^4.0.0",
-          "string-width": "^4.1.0",
-          "strip-ansi": "^6.0.0"
-        }
-      },
-      "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="
-    ],
-    "ws": [
-      "ws@8.20.0",
-      "",
-      {
-        "peerDependencies": {
-          "bufferutil": "^4.0.1",
-          "utf-8-validate": ">=5.0.2"
-        },
-        "optionalPeers": [
-          "bufferutil",
-          "utf-8-validate"
-        ]
-      },
-      "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
-    ],
-    "xml": [
-      "xml@1.0.1",
-      "",
-      {},
-      "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
-    ],
-    "xml-crypto": [
-      "xml-crypto@6.1.2",
-      "",
-      {
-        "dependencies": {
-          "@xmldom/is-dom-node": "^1.0.1",
-          "@xmldom/xmldom": "^0.8.10",
-          "xpath": "^0.0.33"
-        }
-      },
-      "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w=="
-    ],
-    "xml-escape": [
-      "xml-escape@1.1.0",
-      "",
-      {},
-      "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg=="
-    ],
-    "xpath": [
-      "xpath@0.0.34",
-      "",
-      {},
-      "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA=="
-    ],
-    "xtend": [
-      "xtend@4.0.2",
-      "",
-      {},
-      "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    ],
-    "y18n": [
-      "y18n@5.0.8",
-      "",
-      {},
-      "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    ],
-    "yallist": [
-      "yallist@3.1.1",
-      "",
-      {},
-      "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    ],
-    "yaml": [
-      "yaml@2.8.3",
-      "",
-      {
-        "bin": {
-          "yaml": "bin.mjs"
-        }
-      },
-      "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="
-    ],
-    "yargs": [
-      "yargs@17.7.2",
-      "",
-      {
-        "dependencies": {
-          "cliui": "^8.0.1",
-          "escalade": "^3.1.1",
-          "get-caller-file": "^2.0.5",
-          "require-directory": "^2.1.1",
-          "string-width": "^4.2.3",
-          "y18n": "^5.0.5",
-          "yargs-parser": "^21.1.1"
-        }
-      },
-      "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="
-    ],
-    "yargs-parser": [
-      "yargs-parser@21.1.1",
-      "",
-      {},
-      "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
-    ],
-    "yocto-queue": [
-      "yocto-queue@0.1.0",
-      "",
-      {},
-      "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-    ],
-    "zod": [
-      "zod@4.3.6",
-      "",
-      {},
-      "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
-    ],
-    "zod-validation-error": [
-      "zod-validation-error@4.0.2",
-      "",
-      {
-        "peerDependencies": {
-          "zod": "^3.25.0 || ^4.0.0"
-        }
-      },
-      "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="
-    ],
-    "zustand": [
-      "zustand@4.5.7",
-      "",
-      {
-        "dependencies": {
-          "use-sync-external-store": "^1.2.2"
-        },
-        "peerDependencies": {
-          "@types/react": ">=16.8",
-          "immer": ">=9.0.6",
-          "react": ">=16.8"
-        },
-        "optionalPeers": [
-          "@types/react",
-          "immer",
-          "react"
-        ]
-      },
-      "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="
-    ],
-    "zwitch": [
-      "zwitch@1.0.5",
-      "",
-      {},
-      "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
-    ],
-    "@authenio/xml-encryption/xpath": [
-      "xpath@0.0.32",
-      "",
-      {},
-      "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
-    ],
-    "@babel/core/semver": [
-      "semver@6.3.1",
-      "",
-      {
-        "bin": {
-          "semver": "bin/semver.js"
-        }
-      },
-      "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
-    ],
-    "@babel/helper-compilation-targets/semver": [
-      "semver@6.3.1",
-      "",
-      {
-        "bin": {
-          "semver": "bin/semver.js"
-        }
-      },
-      "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
-    ],
-    "@checkstack/command-frontend/lucide-react": [
-      "lucide-react@0.468.0",
-      "",
-      {
-        "peerDependencies": {
-          "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
-        }
-      },
-      "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="
-    ],
-    "@checkstack/command-frontend/react-router-dom": [
-      "react-router-dom@7.14.1",
-      "",
-      {
-        "dependencies": {
-          "react-router": "7.14.1"
-        },
-        "peerDependencies": {
-          "react": ">=18",
-          "react-dom": ">=18"
-        }
-      },
-      "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA=="
-    ],
-    "@checkstack/common/lucide-react": [
-      "lucide-react@0.562.0",
-      "",
-      {
-        "peerDependencies": {
-          "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-        }
-      },
-      "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="
-    ],
-    "@checkstack/queue-backend/@hono/zod-validator": [
-      "@hono/zod-validator@0.4.3",
-      "",
-      {
-        "peerDependencies": {
-          "hono": ">=3.9.0",
-          "zod": "^3.19.1"
-        }
-      },
-      "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="
-    ],
-    "@checkstack/queue-frontend/lucide-react": [
-      "lucide-react@0.468.0",
-      "",
-      {
-        "peerDependencies": {
-          "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
-        }
-      },
-      "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="
-    ],
-    "@checkstack/queue-frontend/react-router-dom": [
-      "react-router-dom@7.14.1",
-      "",
-      {
-        "dependencies": {
-          "react-router": "7.14.1"
-        },
-        "peerDependencies": {
-          "react": ">=18",
-          "react-dom": ">=18"
-        }
-      },
-      "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA=="
-    ],
-    "@checkstack/ui/@types/react-dom": [
-      "@types/react-dom@19.2.3",
-      "",
-      {
-        "peerDependencies": {
-          "@types/react": "^19.2.0"
-        }
-      },
-      "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="
-    ],
-    "@checkstack/ui/lucide-react": [
-      "lucide-react@0.562.0",
-      "",
-      {
-        "peerDependencies": {
-          "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-        }
-      },
-      "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="
-    ],
-    "@checkstack/ui/react-dom": [
-      "react-dom@19.2.5",
-      "",
-      {
-        "dependencies": {
-          "scheduler": "^0.27.0"
-        },
-        "peerDependencies": {
-          "react": "^19.2.5"
-        }
-      },
-      "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="
-    ],
-    "@eslint-community/eslint-utils/eslint-visitor-keys": [
-      "eslint-visitor-keys@3.4.3",
-      "",
-      {},
-      "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
-    ],
-    "@eslint/config-array/minimatch": [
-      "minimatch@3.1.5",
-      "",
-      {
-        "dependencies": {
-          "brace-expansion": "^1.1.7"
-        }
-      },
-      "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="
-    ],
-    "@eslint/eslintrc/ajv": [
-      "ajv@6.14.0",
-      "",
-      {
-        "dependencies": {
-          "fast-deep-equal": "^3.1.1",
-          "fast-json-stable-stringify": "^2.0.0",
-          "json-schema-traverse": "^0.4.1",
-          "uri-js": "^4.2.2"
-        }
-      },
-      "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="
-    ],
-    "@eslint/eslintrc/globals": [
-      "globals@14.0.0",
-      "",
-      {},
-      "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="
-    ],
-    "@eslint/eslintrc/ignore": [
-      "ignore@5.3.2",
-      "",
-      {},
-      "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
-    ],
-    "@eslint/eslintrc/minimatch": [
-      "minimatch@3.1.5",
-      "",
-      {
-        "dependencies": {
-          "brace-expansion": "^1.1.7"
-        }
-      },
-      "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="
-    ],
-    "@inquirer/editor/@inquirer/external-editor": [
-      "@inquirer/external-editor@3.0.0",
-      "",
-      {
-        "dependencies": {
-          "chardet": "^2.1.1",
-          "iconv-lite": "^0.7.2"
-        },
-        "peerDependencies": {
-          "@types/node": ">=18"
-        },
-        "optionalPeers": [
-          "@types/node"
-        ]
-      },
-      "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg=="
-    ],
-    "@manypkg/find-root/@types/node": [
-      "@types/node@12.20.55",
-      "",
-      {},
-      "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-    ],
-    "@manypkg/find-root/find-up": [
-      "find-up@4.1.0",
-      "",
-      {
-        "dependencies": {
-          "locate-path": "^5.0.0",
-          "path-exists": "^4.0.0"
-        }
-      },
-      "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="
-    ],
-    "@manypkg/find-root/fs-extra": [
-      "fs-extra@8.1.0",
-      "",
-      {
-        "dependencies": {
-          "graceful-fs": "^4.2.0",
-          "jsonfile": "^4.0.0",
-          "universalify": "^0.1.0"
-        }
-      },
-      "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="
-    ],
-    "@manypkg/get-packages/@changesets/types": [
-      "@changesets/types@4.1.0",
-      "",
-      {},
-      "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="
-    ],
-    "@manypkg/get-packages/fs-extra": [
-      "fs-extra@8.1.0",
-      "",
-      {
-        "dependencies": {
-          "graceful-fs": "^4.2.0",
-          "jsonfile": "^4.0.0",
-          "universalify": "^0.1.0"
-        }
-      },
-      "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="
-    ],
-    "@orpc/react-query/@orpc/shared": [
-      "@orpc/shared@1.13.4",
-      "",
-      {
-        "dependencies": {
-          "radash": "^12.1.1",
-          "type-fest": "^5.3.1"
-        },
-        "peerDependencies": {
-          "@opentelemetry/api": ">=1.9.0"
-        },
-        "optionalPeers": [
-          "@opentelemetry/api"
-        ]
-      },
-      "sha512-TYt9rLG/BUkNQBeQ6C1tEiHS/Seb8OojHgj9GlvqyjHJhMZx5qjsIyTW6RqLPZJ4U2vgK6x4Her36+tlFCKJug=="
-    ],
-    "@orpc/react-query/@orpc/tanstack-query": [
-      "@orpc/tanstack-query@1.13.4",
-      "",
-      {
-        "dependencies": {
-          "@orpc/shared": "1.13.4"
-        },
-        "peerDependencies": {
-          "@orpc/client": "1.13.4",
-          "@tanstack/query-core": ">=5.80.2"
-        }
-      },
-      "sha512-gCL/kh3kf6OUGKfXxSoOZpcX1jNYzxGfo/PkLQKX7ui4xiTbfWw3sCDF30sNS4I7yAOnBwDwJ3N2xzfkTftOBg=="
-    ],
-    "@orpc/zod/escape-string-regexp": [
-      "escape-string-regexp@5.0.0",
-      "",
-      {},
-      "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-    ],
-    "@radix-ui/react-collection/@radix-ui/react-slot": [
-      "@radix-ui/react-slot@1.2.3",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-compose-refs": "1.1.2"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="
-    ],
-    "@radix-ui/react-dialog/@radix-ui/react-slot": [
-      "@radix-ui/react-slot@1.2.3",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-compose-refs": "1.1.2"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="
-    ],
-    "@radix-ui/react-popover/@radix-ui/react-slot": [
-      "@radix-ui/react-slot@1.2.3",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-compose-refs": "1.1.2"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="
-    ],
-    "@radix-ui/react-primitive/@radix-ui/react-slot": [
-      "@radix-ui/react-slot@1.2.3",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-compose-refs": "1.1.2"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="
-    ],
-    "@radix-ui/react-select/@radix-ui/react-slot": [
-      "@radix-ui/react-slot@1.2.3",
-      "",
-      {
-        "dependencies": {
-          "@radix-ui/react-compose-refs": "1.1.2"
-        },
-        "peerDependencies": {
-          "@types/react": "*",
-          "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-        },
-        "optionalPeers": [
-          "@types/react"
-        ]
-      },
-      "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="
-    ],
-    "@reduxjs/toolkit/immer": [
-      "immer@11.1.4",
-      "",
-      {},
-      "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="
-    ],
-    "@testing-library/jest-dom/dom-accessibility-api": [
-      "dom-accessibility-api@0.6.3",
-      "",
-      {},
-      "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="
-    ],
-    "@types/hast/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "@types/mdast/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "@types/ssh2/@types/node": [
-      "@types/node@18.19.130",
-      "",
-      {
-        "dependencies": {
-          "undici-types": "~5.26.4"
-        }
-      },
-      "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="
-    ],
-    "@typescript-eslint/visitor-keys/eslint-visitor-keys": [
-      "eslint-visitor-keys@5.0.1",
-      "",
-      {},
-      "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="
-    ],
-    "anymatch/picomatch": [
-      "picomatch@2.3.2",
-      "",
-      {},
-      "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
-    ],
-    "bullmq/uuid": [
-      "uuid@11.1.0",
-      "",
-      {
-        "bin": {
-          "uuid": "dist/esm/bin/uuid"
-        }
-      },
-      "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
-    ],
-    "chokidar/glob-parent": [
-      "glob-parent@5.1.2",
-      "",
-      {
-        "dependencies": {
-          "is-glob": "^4.0.1"
-        }
-      },
-      "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="
-    ],
-    "clean-regexp/escape-string-regexp": [
-      "escape-string-regexp@1.0.5",
-      "",
-      {},
-      "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
-    ],
-    "color/color-convert": [
-      "color-convert@3.1.3",
-      "",
-      {
-        "dependencies": {
-          "color-name": "^2.0.0"
-        }
-      },
-      "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="
-    ],
-    "color-string/color-name": [
-      "color-name@2.1.0",
-      "",
-      {},
-      "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="
-    ],
-    "decode-named-character-reference/character-entities": [
-      "character-entities@2.0.2",
-      "",
-      {},
-      "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
-    ],
-    "eslint/ajv": [
-      "ajv@6.14.0",
-      "",
-      {
-        "dependencies": {
-          "fast-deep-equal": "^3.1.1",
-          "fast-json-stable-stringify": "^2.0.0",
-          "json-schema-traverse": "^0.4.1",
-          "uri-js": "^4.2.2"
-        }
-      },
-      "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="
-    ],
-    "eslint/ignore": [
-      "ignore@5.3.2",
-      "",
-      {},
-      "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
-    ],
-    "eslint/minimatch": [
-      "minimatch@3.1.5",
-      "",
-      {
-        "dependencies": {
-          "brace-expansion": "^1.1.7"
-        }
-      },
-      "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="
-    ],
-    "fast-glob/glob-parent": [
-      "glob-parent@5.1.2",
-      "",
-      {
-        "dependencies": {
-          "is-glob": "^4.0.1"
-        }
-      },
-      "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="
-    ],
-    "globby/ignore": [
-      "ignore@5.3.2",
-      "",
-      {},
-      "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
-    ],
-    "hast-util-to-jsx-runtime/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "import-fresh/resolve-from": [
-      "resolve-from@4.0.0",
-      "",
-      {},
-      "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
-    ],
-    "ioredis-mock/@ioredis/commands": [
-      "@ioredis/commands@1.6.0",
-      "",
-      {},
-      "sha512-lNa3bQBsR2OQ+IopxlSydDNSPKD4TGUaSBBs+f68ugyTJBtXhcxQE8oqrDflRv2kKOT/QnBQcSPQ7/T2mSMLxQ=="
-    ],
-    "mdast-util-from-markdown/@types/mdast": [
-      "@types/mdast@3.0.15",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^2"
-        }
-      },
-      "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ=="
-    ],
-    "mdast-util-gfm-autolink-literal/ccount": [
-      "ccount@1.1.0",
-      "",
-      {},
-      "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-from-markdown": [
-      "mdast-util-from-markdown@2.0.3",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "@types/unist": "^3.0.0",
-          "decode-named-character-reference": "^1.0.0",
-          "devlop": "^1.0.0",
-          "mdast-util-to-string": "^4.0.0",
-          "micromark": "^4.0.0",
-          "micromark-util-decode-numeric-character-reference": "^2.0.0",
-          "micromark-util-decode-string": "^2.0.0",
-          "micromark-util-normalize-identifier": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "unist-util-stringify-position": "^4.0.0"
-        }
-      },
-      "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-to-markdown": [
-      "mdast-util-to-markdown@2.1.2",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "@types/unist": "^3.0.0",
-          "longest-streak": "^3.0.0",
-          "mdast-util-phrasing": "^4.0.0",
-          "mdast-util-to-string": "^4.0.0",
-          "micromark-util-classify-character": "^2.0.0",
-          "micromark-util-decode-string": "^2.0.0",
-          "unist-util-visit": "^5.0.0",
-          "zwitch": "^2.0.0"
-        }
-      },
-      "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="
-    ],
-    "mdast-util-mdx-jsx/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-from-markdown": [
-      "mdast-util-from-markdown@2.0.3",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "@types/unist": "^3.0.0",
-          "decode-named-character-reference": "^1.0.0",
-          "devlop": "^1.0.0",
-          "mdast-util-to-string": "^4.0.0",
-          "micromark": "^4.0.0",
-          "micromark-util-decode-numeric-character-reference": "^2.0.0",
-          "micromark-util-decode-string": "^2.0.0",
-          "micromark-util-normalize-identifier": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "unist-util-stringify-position": "^4.0.0"
-        }
-      },
-      "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-to-markdown": [
-      "mdast-util-to-markdown@2.1.2",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "@types/unist": "^3.0.0",
-          "longest-streak": "^3.0.0",
-          "mdast-util-phrasing": "^4.0.0",
-          "mdast-util-to-string": "^4.0.0",
-          "micromark-util-classify-character": "^2.0.0",
-          "micromark-util-decode-string": "^2.0.0",
-          "unist-util-visit": "^5.0.0",
-          "zwitch": "^2.0.0"
-        }
-      },
-      "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="
-    ],
-    "mdast-util-mdx-jsx/parse-entities": [
-      "parse-entities@4.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^2.0.0",
-          "character-entities-legacy": "^3.0.0",
-          "character-reference-invalid": "^2.0.0",
-          "decode-named-character-reference": "^1.0.0",
-          "is-alphanumerical": "^2.0.0",
-          "is-decimal": "^2.0.0",
-          "is-hexadecimal": "^2.0.0"
-        }
-      },
-      "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="
-    ],
-    "mdast-util-mdx-jsx/unist-util-stringify-position": [
-      "unist-util-stringify-position@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-from-markdown": [
-      "mdast-util-from-markdown@2.0.3",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "@types/unist": "^3.0.0",
-          "decode-named-character-reference": "^1.0.0",
-          "devlop": "^1.0.0",
-          "mdast-util-to-string": "^4.0.0",
-          "micromark": "^4.0.0",
-          "micromark-util-decode-numeric-character-reference": "^2.0.0",
-          "micromark-util-decode-string": "^2.0.0",
-          "micromark-util-normalize-identifier": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "unist-util-stringify-position": "^4.0.0"
-        }
-      },
-      "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-to-markdown": [
-      "mdast-util-to-markdown@2.1.2",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "@types/unist": "^3.0.0",
-          "longest-streak": "^3.0.0",
-          "mdast-util-phrasing": "^4.0.0",
-          "mdast-util-to-string": "^4.0.0",
-          "micromark-util-classify-character": "^2.0.0",
-          "micromark-util-decode-string": "^2.0.0",
-          "unist-util-visit": "^5.0.0",
-          "zwitch": "^2.0.0"
-        }
-      },
-      "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="
-    ],
-    "mdast-util-phrasing/unist-util-is": [
-      "unist-util-is@6.0.1",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="
-    ],
-    "mdast-util-to-hast/unist-util-visit": [
-      "unist-util-visit@5.1.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0",
-          "unist-util-visit-parents": "^6.0.0"
-        }
-      },
-      "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="
-    ],
-    "micromatch/picomatch": [
-      "picomatch@2.3.2",
-      "",
-      {},
-      "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
-    ],
-    "monaco-editor/marked": [
-      "marked@14.0.0",
-      "",
-      {
-        "bin": {
-          "marked": "bin/marked.js"
-        }
-      },
-      "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="
-    ],
-    "playwright/fsevents": [
-      "fsevents@2.3.2",
-      "",
-      {
-        "os": "darwin"
-      },
-      "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-    ],
-    "pretty-format/ansi-styles": [
-      "ansi-styles@5.2.0",
-      "",
-      {},
-      "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
-    ],
-    "react-markdown/remark-parse": [
-      "remark-parse@11.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "mdast-util-from-markdown": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "unified": "^11.0.0"
-        }
-      },
-      "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="
-    ],
-    "react-markdown/unified": [
-      "unified@11.0.5",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "bail": "^2.0.0",
-          "devlop": "^1.0.0",
-          "extend": "^3.0.0",
-          "is-plain-obj": "^4.0.0",
-          "trough": "^2.0.0",
-          "vfile": "^6.0.0"
-        }
-      },
-      "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="
-    ],
-    "react-markdown/unist-util-visit": [
-      "unist-util-visit@5.1.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0",
-          "unist-util-visit-parents": "^6.0.0"
-        }
-      },
-      "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="
-    ],
-    "read-cache/pify": [
-      "pify@2.3.0",
-      "",
-      {},
-      "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
-    ],
-    "read-yaml-file/js-yaml": [
-      "js-yaml@3.14.2",
-      "",
-      {
-        "dependencies": {
-          "argparse": "^1.0.7",
-          "esprima": "^4.0.0"
-        },
-        "bin": {
-          "js-yaml": "bin/js-yaml.js"
-        }
-      },
-      "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="
-    ],
-    "readdirp/picomatch": [
-      "picomatch@2.3.2",
-      "",
-      {},
-      "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
-    ],
-    "redent/indent-string": [
-      "indent-string@4.0.0",
-      "",
-      {},
-      "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
-    ],
-    "redent/strip-indent": [
-      "strip-indent@3.0.0",
-      "",
-      {
-        "dependencies": {
-          "min-indent": "^1.0.0"
-        }
-      },
-      "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="
-    ],
-    "remark-rehype/unified": [
-      "unified@11.0.5",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "bail": "^2.0.0",
-          "devlop": "^1.0.0",
-          "extend": "^3.0.0",
-          "is-plain-obj": "^4.0.0",
-          "trough": "^2.0.0",
-          "vfile": "^6.0.0"
-        }
-      },
-      "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="
-    ],
-    "rolldown/@rolldown/pluginutils": [
-      "@rolldown/pluginutils@1.0.0-rc.15",
-      "",
-      {},
-      "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="
-    ],
-    "stringify-entities/character-entities-legacy": [
-      "character-entities-legacy@3.0.0",
-      "",
-      {},
-      "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
-    ],
-    "unified/vfile": [
-      "vfile@4.2.1",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^2.0.0",
-          "is-buffer": "^2.0.0",
-          "unist-util-stringify-position": "^2.0.0",
-          "vfile-message": "^2.0.0"
-        }
-      },
-      "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA=="
-    ],
-    "unist-util-position/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "vfile/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "vfile-message/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "vfile-message/unist-util-stringify-position": [
-      "unist-util-stringify-position@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="
-    ],
-    "xml-crypto/xpath": [
-      "xpath@0.0.33",
-      "",
-      {},
-      "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="
-    ],
-    "@checkstack/command-frontend/react-router-dom/react-router": [
-      "react-router@7.14.1",
-      "",
-      {
-        "dependencies": {
-          "cookie": "^1.0.1",
-          "set-cookie-parser": "^2.6.0"
-        },
-        "peerDependencies": {
-          "react": ">=18",
-          "react-dom": ">=18"
-        },
-        "optionalPeers": [
-          "react-dom"
-        ]
-      },
-      "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="
-    ],
-    "@checkstack/queue-frontend/react-router-dom/react-router": [
-      "react-router@7.14.1",
-      "",
-      {
-        "dependencies": {
-          "cookie": "^1.0.1",
-          "set-cookie-parser": "^2.6.0"
-        },
-        "peerDependencies": {
-          "react": ">=18",
-          "react-dom": ">=18"
-        },
-        "optionalPeers": [
-          "react-dom"
-        ]
-      },
-      "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="
-    ],
-    "@checkstack/ui/react-dom/scheduler": [
-      "scheduler@0.27.0",
-      "",
-      {},
-      "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    ],
-    "@eslint/eslintrc/ajv/json-schema-traverse": [
-      "json-schema-traverse@0.4.1",
-      "",
-      {},
-      "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    ],
-    "@eslint/eslintrc/minimatch/brace-expansion": [
-      "brace-expansion@1.1.14",
-      "",
-      {
-        "dependencies": {
-          "balanced-match": "^1.0.0",
-          "concat-map": "0.0.1"
-        }
-      },
-      "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="
-    ],
-    "@manypkg/find-root/find-up/locate-path": [
-      "locate-path@5.0.0",
-      "",
-      {
-        "dependencies": {
-          "p-locate": "^4.1.0"
-        }
-      },
-      "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="
-    ],
-    "@types/ssh2/@types/node/undici-types": [
-      "undici-types@5.26.5",
-      "",
-      {},
-      "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
-    ],
-    "color/color-convert/color-name": [
-      "color-name@2.1.0",
-      "",
-      {},
-      "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="
-    ],
-    "eslint/ajv/json-schema-traverse": [
-      "json-schema-traverse@0.4.1",
-      "",
-      {},
-      "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    ],
-    "eslint/minimatch/brace-expansion": [
-      "brace-expansion@1.1.14",
-      "",
-      {
-        "dependencies": {
-          "balanced-match": "^1.0.0",
-          "concat-map": "0.0.1"
-        }
-      },
-      "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-from-markdown/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-from-markdown/mdast-util-to-string": [
-      "mdast-util-to-string@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0"
-        }
-      },
-      "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-from-markdown/micromark": [
-      "micromark@4.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/debug": "^4.0.0",
-          "debug": "^4.0.0",
-          "decode-named-character-reference": "^1.0.0",
-          "devlop": "^1.0.0",
-          "micromark-core-commonmark": "^2.0.0",
-          "micromark-factory-space": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-chunked": "^2.0.0",
-          "micromark-util-combine-extensions": "^2.0.0",
-          "micromark-util-decode-numeric-character-reference": "^2.0.0",
-          "micromark-util-encode": "^2.0.0",
-          "micromark-util-normalize-identifier": "^2.0.0",
-          "micromark-util-resolve-all": "^2.0.0",
-          "micromark-util-sanitize-uri": "^2.0.0",
-          "micromark-util-subtokenize": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-from-markdown/unist-util-stringify-position": [
-      "unist-util-stringify-position@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-to-markdown/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-to-markdown/longest-streak": [
-      "longest-streak@3.1.0",
-      "",
-      {},
-      "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-to-markdown/mdast-util-to-string": [
-      "mdast-util-to-string@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0"
-        }
-      },
-      "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-to-markdown/unist-util-visit": [
-      "unist-util-visit@5.1.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0",
-          "unist-util-visit-parents": "^6.0.0"
-        }
-      },
-      "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-to-markdown/zwitch": [
-      "zwitch@2.0.4",
-      "",
-      {},
-      "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-from-markdown/mdast-util-to-string": [
-      "mdast-util-to-string@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0"
-        }
-      },
-      "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-from-markdown/micromark": [
-      "micromark@4.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/debug": "^4.0.0",
-          "debug": "^4.0.0",
-          "decode-named-character-reference": "^1.0.0",
-          "devlop": "^1.0.0",
-          "micromark-core-commonmark": "^2.0.0",
-          "micromark-factory-space": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-chunked": "^2.0.0",
-          "micromark-util-combine-extensions": "^2.0.0",
-          "micromark-util-decode-numeric-character-reference": "^2.0.0",
-          "micromark-util-encode": "^2.0.0",
-          "micromark-util-normalize-identifier": "^2.0.0",
-          "micromark-util-resolve-all": "^2.0.0",
-          "micromark-util-sanitize-uri": "^2.0.0",
-          "micromark-util-subtokenize": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-to-markdown/longest-streak": [
-      "longest-streak@3.1.0",
-      "",
-      {},
-      "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-to-markdown/mdast-util-to-string": [
-      "mdast-util-to-string@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0"
-        }
-      },
-      "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-to-markdown/unist-util-visit": [
-      "unist-util-visit@5.1.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0",
-          "unist-util-visit-parents": "^6.0.0"
-        }
-      },
-      "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-to-markdown/zwitch": [
-      "zwitch@2.0.4",
-      "",
-      {},
-      "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
-    ],
-    "mdast-util-mdx-jsx/parse-entities/@types/unist": [
-      "@types/unist@2.0.11",
-      "",
-      {},
-      "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
-    ],
-    "mdast-util-mdx-jsx/parse-entities/character-entities-legacy": [
-      "character-entities-legacy@3.0.0",
-      "",
-      {},
-      "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
-    ],
-    "mdast-util-mdx-jsx/parse-entities/character-reference-invalid": [
-      "character-reference-invalid@2.0.1",
-      "",
-      {},
-      "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
-    ],
-    "mdast-util-mdx-jsx/parse-entities/is-alphanumerical": [
-      "is-alphanumerical@2.0.1",
-      "",
-      {
-        "dependencies": {
-          "is-alphabetical": "^2.0.0",
-          "is-decimal": "^2.0.0"
-        }
-      },
-      "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="
-    ],
-    "mdast-util-mdx-jsx/parse-entities/is-decimal": [
-      "is-decimal@2.0.1",
-      "",
-      {},
-      "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
-    ],
-    "mdast-util-mdx-jsx/parse-entities/is-hexadecimal": [
-      "is-hexadecimal@2.0.1",
-      "",
-      {},
-      "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-from-markdown/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-from-markdown/mdast-util-to-string": [
-      "mdast-util-to-string@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0"
-        }
-      },
-      "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-from-markdown/micromark": [
-      "micromark@4.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/debug": "^4.0.0",
-          "debug": "^4.0.0",
-          "decode-named-character-reference": "^1.0.0",
-          "devlop": "^1.0.0",
-          "micromark-core-commonmark": "^2.0.0",
-          "micromark-factory-space": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-chunked": "^2.0.0",
-          "micromark-util-combine-extensions": "^2.0.0",
-          "micromark-util-decode-numeric-character-reference": "^2.0.0",
-          "micromark-util-encode": "^2.0.0",
-          "micromark-util-normalize-identifier": "^2.0.0",
-          "micromark-util-resolve-all": "^2.0.0",
-          "micromark-util-sanitize-uri": "^2.0.0",
-          "micromark-util-subtokenize": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-from-markdown/unist-util-stringify-position": [
-      "unist-util-stringify-position@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-to-markdown/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-to-markdown/longest-streak": [
-      "longest-streak@3.1.0",
-      "",
-      {},
-      "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-to-markdown/mdast-util-to-string": [
-      "mdast-util-to-string@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0"
-        }
-      },
-      "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-to-markdown/unist-util-visit": [
-      "unist-util-visit@5.1.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0",
-          "unist-util-visit-parents": "^6.0.0"
-        }
-      },
-      "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-to-markdown/zwitch": [
-      "zwitch@2.0.4",
-      "",
-      {},
-      "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
-    ],
-    "mdast-util-phrasing/unist-util-is/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "mdast-util-to-hast/unist-util-visit/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "mdast-util-to-hast/unist-util-visit/unist-util-is": [
-      "unist-util-is@6.0.1",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="
-    ],
-    "mdast-util-to-hast/unist-util-visit/unist-util-visit-parents": [
-      "unist-util-visit-parents@6.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0"
-        }
-      },
-      "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="
-    ],
-    "react-markdown/remark-parse/mdast-util-from-markdown": [
-      "mdast-util-from-markdown@2.0.3",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "@types/unist": "^3.0.0",
-          "decode-named-character-reference": "^1.0.0",
-          "devlop": "^1.0.0",
-          "mdast-util-to-string": "^4.0.0",
-          "micromark": "^4.0.0",
-          "micromark-util-decode-numeric-character-reference": "^2.0.0",
-          "micromark-util-decode-string": "^2.0.0",
-          "micromark-util-normalize-identifier": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "unist-util-stringify-position": "^4.0.0"
-        }
-      },
-      "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="
-    ],
-    "react-markdown/unified/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "react-markdown/unified/bail": [
-      "bail@2.0.2",
-      "",
-      {},
-      "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
-    ],
-    "react-markdown/unified/is-plain-obj": [
-      "is-plain-obj@4.1.0",
-      "",
-      {},
-      "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
-    ],
-    "react-markdown/unified/trough": [
-      "trough@2.2.0",
-      "",
-      {},
-      "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
-    ],
-    "react-markdown/unist-util-visit/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "react-markdown/unist-util-visit/unist-util-is": [
-      "unist-util-is@6.0.1",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="
-    ],
-    "react-markdown/unist-util-visit/unist-util-visit-parents": [
-      "unist-util-visit-parents@6.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0"
-        }
-      },
-      "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="
-    ],
-    "read-yaml-file/js-yaml/argparse": [
-      "argparse@1.0.10",
-      "",
-      {
-        "dependencies": {
-          "sprintf-js": "~1.0.2"
-        }
-      },
-      "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="
-    ],
-    "remark-rehype/unified/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "remark-rehype/unified/bail": [
-      "bail@2.0.2",
-      "",
-      {},
-      "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
-    ],
-    "remark-rehype/unified/is-plain-obj": [
-      "is-plain-obj@4.1.0",
-      "",
-      {},
-      "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
-    ],
-    "remark-rehype/unified/trough": [
-      "trough@2.2.0",
-      "",
-      {},
-      "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
-    ],
-    "unified/vfile/vfile-message": [
-      "vfile-message@2.0.4",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^2.0.0",
-          "unist-util-stringify-position": "^2.0.0"
-        }
-      },
-      "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ=="
-    ],
-    "@checkstack/command-frontend/react-router-dom/react-router/set-cookie-parser": [
-      "set-cookie-parser@2.7.2",
-      "",
-      {},
-      "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
-    ],
-    "@checkstack/queue-frontend/react-router-dom/react-router/set-cookie-parser": [
-      "set-cookie-parser@2.7.2",
-      "",
-      {},
-      "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
-    ],
-    "@eslint/config-array/minimatch/brace-expansion/balanced-match": [
-      "balanced-match@1.0.2",
-      "",
-      {},
-      "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    ],
-    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": [
-      "balanced-match@1.0.2",
-      "",
-      {},
-      "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    ],
-    "@manypkg/find-root/find-up/locate-path/p-locate": [
-      "p-locate@4.1.0",
-      "",
-      {
-        "dependencies": {
-          "p-limit": "^2.2.0"
-        }
-      },
-      "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="
-    ],
-    "eslint/minimatch/brace-expansion/balanced-match": [
-      "balanced-match@1.0.2",
-      "",
-      {},
-      "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-to-markdown/unist-util-visit/unist-util-is": [
-      "unist-util-is@6.0.1",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="
-    ],
-    "mdast-util-mdx-expression/mdast-util-to-markdown/unist-util-visit/unist-util-visit-parents": [
-      "unist-util-visit-parents@6.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0"
-        }
-      },
-      "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-to-markdown/unist-util-visit/unist-util-is": [
-      "unist-util-is@6.0.1",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="
-    ],
-    "mdast-util-mdx-jsx/mdast-util-to-markdown/unist-util-visit/unist-util-visit-parents": [
-      "unist-util-visit-parents@6.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0"
-        }
-      },
-      "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="
-    ],
-    "mdast-util-mdx-jsx/parse-entities/is-alphanumerical/is-alphabetical": [
-      "is-alphabetical@2.0.1",
-      "",
-      {},
-      "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-to-markdown/unist-util-visit/unist-util-is": [
-      "unist-util-is@6.0.1",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="
-    ],
-    "mdast-util-mdxjs-esm/mdast-util-to-markdown/unist-util-visit/unist-util-visit-parents": [
-      "unist-util-visit-parents@6.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0",
-          "unist-util-is": "^6.0.0"
-        }
-      },
-      "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="
-    ],
-    "react-markdown/remark-parse/mdast-util-from-markdown/@types/unist": [
-      "@types/unist@3.0.3",
-      "",
-      {},
-      "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    ],
-    "react-markdown/remark-parse/mdast-util-from-markdown/mdast-util-to-string": [
-      "mdast-util-to-string@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/mdast": "^4.0.0"
-        }
-      },
-      "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="
-    ],
-    "react-markdown/remark-parse/mdast-util-from-markdown/micromark": [
-      "micromark@4.0.2",
-      "",
-      {
-        "dependencies": {
-          "@types/debug": "^4.0.0",
-          "debug": "^4.0.0",
-          "decode-named-character-reference": "^1.0.0",
-          "devlop": "^1.0.0",
-          "micromark-core-commonmark": "^2.0.0",
-          "micromark-factory-space": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-chunked": "^2.0.0",
-          "micromark-util-combine-extensions": "^2.0.0",
-          "micromark-util-decode-numeric-character-reference": "^2.0.0",
-          "micromark-util-encode": "^2.0.0",
-          "micromark-util-normalize-identifier": "^2.0.0",
-          "micromark-util-resolve-all": "^2.0.0",
-          "micromark-util-sanitize-uri": "^2.0.0",
-          "micromark-util-subtokenize": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      },
-      "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="
-    ],
-    "react-markdown/remark-parse/mdast-util-from-markdown/unist-util-stringify-position": [
-      "unist-util-stringify-position@4.0.0",
-      "",
-      {
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      },
-      "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="
-    ],
-    "read-yaml-file/js-yaml/argparse/sprintf-js": [
-      "sprintf-js@1.0.3",
-      "",
-      {},
-      "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
-    ],
-    "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": [
-      "p-limit@2.3.0",
-      "",
-      {
-        "dependencies": {
-          "p-try": "^2.0.0"
-        }
-      },
-      "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="
-    ],
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@authenio/xml-encryption": ["@authenio/xml-encryption@2.0.2", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "escape-html": "^1.0.3", "xpath": "0.0.32" } }, "sha512-cTlrKttbrRHEw3W+0/I609A2Matj5JQaRvfLtEIGZvlN0RaPi+3ANsMeqAyCAVlH/lUIW2tmtBlSMni74lcXeg=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@better-auth/core": ["@better-auth/core@1.6.4", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-G52PXrx+qQcwkmP5Kmjjl8kWl15DFaZF5H1n9jY7kuCJiVIJMnr4WTSGMIOt07OwD+CSy9b4IA5DpuADZC5znA=="],
+
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.4", "", { "peerDependencies": { "@better-auth/core": "^1.6.4", "@better-auth/utils": "0.4.0", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-LYyFTTZD/VcSh59taYZ2V5clHP4+udQYYZlW0KTiLTzljZcmuETuflGB7++WKSdCJg7KtLQzoM0rMo9PgT/Prw=="],
+
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.4", "", { "peerDependencies": { "@better-auth/core": "^1.6.4", "@better-auth/utils": "0.4.0", "kysely": "^0.28.14" }, "optionalPeers": ["kysely"] }, "sha512-CVuvhy81gs66oHjjMTVKV1bfVCPivJzf9za8xghGB9wrkeMaZnPVKVqDobHf8juDfT5XRMQJmrcGLxubI2le/A=="],
+
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.4", "", { "peerDependencies": { "@better-auth/core": "^1.6.4", "@better-auth/utils": "0.4.0" } }, "sha512-eV6jw1roUohNHRo4qdUXJdaRpNmyWqtC1ADC2AMSRF3f6d4XPW+FqtAYhE87ZBq7nWDVgjrtawoUSVHREc8PrQ=="],
+
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.4", "", { "peerDependencies": { "@better-auth/core": "^1.6.4", "@better-auth/utils": "0.4.0", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-N2pjOSuZHeNeRuqCXuEzSN2WFqexzb7KbtuxHislkXMIQtUiMNhM8NJMxCqnVj4t22qryim4hv0K59QfqqGXWQ=="],
+
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.4", "", { "peerDependencies": { "@better-auth/core": "^1.6.4", "@better-auth/utils": "0.4.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-h6zuYYI+p5yK1TLci0V9JKfIitThBDmRK88ipoZzmZH3EyWUQfXcgC05WwOMCuM3mH+A9Auu/hLiiM7/VRfJgw=="],
+
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.4", "", { "peerDependencies": { "@better-auth/core": "^1.6.4", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21" } }, "sha512-x6ctfiHcdUshXvrAgGaAprxJI6obZP09BUmQn0LcQX4KYbx0B5M8+DToyVmv30iEL8rEmGyL187XamXbY4FwYw=="],
+
+    "@better-auth/utils": ["@better-auth/utils@0.4.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="],
+
+    "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
+
+    "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.0", "", { "dependencies": { "@changesets/config": "^3.1.3", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ=="],
+
+    "@changesets/assemble-release-plan": ["@changesets/assemble-release-plan@6.0.9", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.3", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "semver": "^7.5.3" } }, "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ=="],
+
+    "@changesets/changelog-git": ["@changesets/changelog-git@0.2.1", "", { "dependencies": { "@changesets/types": "^6.1.0" } }, "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q=="],
+
+    "@changesets/cli": ["@changesets/cli@2.30.0", "", { "dependencies": { "@changesets/apply-release-plan": "^7.1.0", "@changesets/assemble-release-plan": "^6.0.9", "@changesets/changelog-git": "^0.2.1", "@changesets/config": "^3.1.3", "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.3", "@changesets/get-release-plan": "^4.0.15", "@changesets/git": "^3.0.4", "@changesets/logger": "^0.1.1", "@changesets/pre": "^2.0.2", "@changesets/read": "^0.6.7", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@changesets/write": "^0.4.0", "@inquirer/external-editor": "^1.0.2", "@manypkg/get-packages": "^1.1.3", "ansi-colors": "^4.1.3", "enquirer": "^2.4.1", "fs-extra": "^7.0.1", "mri": "^1.2.0", "package-manager-detector": "^0.2.0", "picocolors": "^1.1.0", "resolve-from": "^5.0.0", "semver": "^7.5.3", "spawndamnit": "^3.0.1", "term-size": "^2.1.0" }, "bin": { "changeset": "bin.js" } }, "sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA=="],
+
+    "@changesets/config": ["@changesets/config@3.1.3", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.3", "@changesets/logger": "^0.1.1", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "fs-extra": "^7.0.1", "micromatch": "^4.0.8" } }, "sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw=="],
+
+    "@changesets/errors": ["@changesets/errors@0.2.0", "", { "dependencies": { "extendable-error": "^0.1.5" } }, "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow=="],
+
+    "@changesets/get-dependents-graph": ["@changesets/get-dependents-graph@2.1.3", "", { "dependencies": { "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "picocolors": "^1.1.0", "semver": "^7.5.3" } }, "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ=="],
+
+    "@changesets/get-release-plan": ["@changesets/get-release-plan@4.0.15", "", { "dependencies": { "@changesets/assemble-release-plan": "^6.0.9", "@changesets/config": "^3.1.3", "@changesets/pre": "^2.0.2", "@changesets/read": "^0.6.7", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3" } }, "sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g=="],
+
+    "@changesets/get-version-range-type": ["@changesets/get-version-range-type@0.4.0", "", {}, "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ=="],
+
+    "@changesets/git": ["@changesets/git@3.0.4", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@manypkg/get-packages": "^1.1.3", "is-subdir": "^1.1.1", "micromatch": "^4.0.8", "spawndamnit": "^3.0.1" } }, "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw=="],
+
+    "@changesets/logger": ["@changesets/logger@0.1.1", "", { "dependencies": { "picocolors": "^1.1.0" } }, "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg=="],
+
+    "@changesets/parse": ["@changesets/parse@0.4.3", "", { "dependencies": { "@changesets/types": "^6.1.0", "js-yaml": "^4.1.1" } }, "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A=="],
+
+    "@changesets/pre": ["@changesets/pre@2.0.2", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "fs-extra": "^7.0.1" } }, "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug=="],
+
+    "@changesets/read": ["@changesets/read@0.6.7", "", { "dependencies": { "@changesets/git": "^3.0.4", "@changesets/logger": "^0.1.1", "@changesets/parse": "^0.4.3", "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "p-filter": "^2.1.0", "picocolors": "^1.1.0" } }, "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA=="],
+
+    "@changesets/should-skip-package": ["@changesets/should-skip-package@0.1.2", "", { "dependencies": { "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3" } }, "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw=="],
+
+    "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
+
+    "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@checkstack/about-common": ["@checkstack/about-common@workspace:core/about-common"],
+
+    "@checkstack/about-frontend": ["@checkstack/about-frontend@workspace:core/about-frontend"],
+
+    "@checkstack/announcement-backend": ["@checkstack/announcement-backend@workspace:core/announcement-backend"],
+
+    "@checkstack/announcement-common": ["@checkstack/announcement-common@workspace:core/announcement-common"],
+
+    "@checkstack/announcement-frontend": ["@checkstack/announcement-frontend@workspace:core/announcement-frontend"],
+
+    "@checkstack/api-docs-common": ["@checkstack/api-docs-common@workspace:core/api-docs-common"],
+
+    "@checkstack/api-docs-frontend": ["@checkstack/api-docs-frontend@workspace:core/api-docs-frontend"],
+
+    "@checkstack/auth-backend": ["@checkstack/auth-backend@workspace:core/auth-backend"],
+
+    "@checkstack/auth-common": ["@checkstack/auth-common@workspace:core/auth-common"],
+
+    "@checkstack/auth-credential-backend": ["@checkstack/auth-credential-backend@workspace:plugins/auth-credential-backend"],
+
+    "@checkstack/auth-frontend": ["@checkstack/auth-frontend@workspace:core/auth-frontend"],
+
+    "@checkstack/auth-github-backend": ["@checkstack/auth-github-backend@workspace:plugins/auth-github-backend"],
+
+    "@checkstack/auth-ldap-backend": ["@checkstack/auth-ldap-backend@workspace:plugins/auth-ldap-backend"],
+
+    "@checkstack/auth-saml-backend": ["@checkstack/auth-saml-backend@workspace:plugins/auth-saml-backend"],
+
+    "@checkstack/backend": ["@checkstack/backend@workspace:core/backend"],
+
+    "@checkstack/backend-api": ["@checkstack/backend-api@workspace:core/backend-api"],
+
+    "@checkstack/catalog-backend": ["@checkstack/catalog-backend@workspace:core/catalog-backend"],
+
+    "@checkstack/catalog-common": ["@checkstack/catalog-common@workspace:core/catalog-common"],
+
+    "@checkstack/catalog-frontend": ["@checkstack/catalog-frontend@workspace:core/catalog-frontend"],
+
+    "@checkstack/collector-hardware-backend": ["@checkstack/collector-hardware-backend@workspace:plugins/collector-hardware-backend"],
+
+    "@checkstack/command-backend": ["@checkstack/command-backend@workspace:core/command-backend"],
+
+    "@checkstack/command-common": ["@checkstack/command-common@workspace:core/command-common"],
+
+    "@checkstack/command-frontend": ["@checkstack/command-frontend@workspace:core/command-frontend"],
+
+    "@checkstack/common": ["@checkstack/common@workspace:core/common"],
+
+    "@checkstack/dashboard-frontend": ["@checkstack/dashboard-frontend@workspace:core/dashboard-frontend"],
+
+    "@checkstack/dependency-backend": ["@checkstack/dependency-backend@workspace:core/dependency-backend"],
+
+    "@checkstack/dependency-common": ["@checkstack/dependency-common@workspace:core/dependency-common"],
+
+    "@checkstack/dependency-frontend": ["@checkstack/dependency-frontend@workspace:core/dependency-frontend"],
+
+    "@checkstack/drizzle-helper": ["@checkstack/drizzle-helper@workspace:core/drizzle-helper"],
+
+    "@checkstack/frontend": ["@checkstack/frontend@workspace:core/frontend"],
+
+    "@checkstack/frontend-api": ["@checkstack/frontend-api@workspace:core/frontend-api"],
+
+    "@checkstack/gitops-backend": ["@checkstack/gitops-backend@workspace:core/gitops-backend"],
+
+    "@checkstack/gitops-common": ["@checkstack/gitops-common@workspace:core/gitops-common"],
+
+    "@checkstack/gitops-frontend": ["@checkstack/gitops-frontend@workspace:core/gitops-frontend"],
+
+    "@checkstack/healthcheck-backend": ["@checkstack/healthcheck-backend@workspace:core/healthcheck-backend"],
+
+    "@checkstack/healthcheck-common": ["@checkstack/healthcheck-common@workspace:core/healthcheck-common"],
+
+    "@checkstack/healthcheck-dns-backend": ["@checkstack/healthcheck-dns-backend@workspace:plugins/healthcheck-dns-backend"],
+
+    "@checkstack/healthcheck-frontend": ["@checkstack/healthcheck-frontend@workspace:core/healthcheck-frontend"],
+
+    "@checkstack/healthcheck-grpc-backend": ["@checkstack/healthcheck-grpc-backend@workspace:plugins/healthcheck-grpc-backend"],
+
+    "@checkstack/healthcheck-http-backend": ["@checkstack/healthcheck-http-backend@workspace:plugins/healthcheck-http-backend"],
+
+    "@checkstack/healthcheck-jenkins-backend": ["@checkstack/healthcheck-jenkins-backend@workspace:plugins/healthcheck-jenkins-backend"],
+
+    "@checkstack/healthcheck-mysql-backend": ["@checkstack/healthcheck-mysql-backend@workspace:plugins/healthcheck-mysql-backend"],
+
+    "@checkstack/healthcheck-ping-backend": ["@checkstack/healthcheck-ping-backend@workspace:plugins/healthcheck-ping-backend"],
+
+    "@checkstack/healthcheck-postgres-backend": ["@checkstack/healthcheck-postgres-backend@workspace:plugins/healthcheck-postgres-backend"],
+
+    "@checkstack/healthcheck-rcon-backend": ["@checkstack/healthcheck-rcon-backend@workspace:plugins/healthcheck-rcon-backend"],
+
+    "@checkstack/healthcheck-rcon-common": ["@checkstack/healthcheck-rcon-common@workspace:plugins/healthcheck-rcon-common"],
+
+    "@checkstack/healthcheck-redis-backend": ["@checkstack/healthcheck-redis-backend@workspace:plugins/healthcheck-redis-backend"],
+
+    "@checkstack/healthcheck-script-backend": ["@checkstack/healthcheck-script-backend@workspace:plugins/healthcheck-script-backend"],
+
+    "@checkstack/healthcheck-ssh-backend": ["@checkstack/healthcheck-ssh-backend@workspace:plugins/healthcheck-ssh-backend"],
+
+    "@checkstack/healthcheck-ssh-common": ["@checkstack/healthcheck-ssh-common@workspace:plugins/healthcheck-ssh-common"],
+
+    "@checkstack/healthcheck-tcp-backend": ["@checkstack/healthcheck-tcp-backend@workspace:plugins/healthcheck-tcp-backend"],
+
+    "@checkstack/healthcheck-tls-backend": ["@checkstack/healthcheck-tls-backend@workspace:plugins/healthcheck-tls-backend"],
+
+    "@checkstack/incident-backend": ["@checkstack/incident-backend@workspace:core/incident-backend"],
+
+    "@checkstack/incident-common": ["@checkstack/incident-common@workspace:core/incident-common"],
+
+    "@checkstack/incident-frontend": ["@checkstack/incident-frontend@workspace:core/incident-frontend"],
+
+    "@checkstack/integration-backend": ["@checkstack/integration-backend@workspace:core/integration-backend"],
+
+    "@checkstack/integration-common": ["@checkstack/integration-common@workspace:core/integration-common"],
+
+    "@checkstack/integration-frontend": ["@checkstack/integration-frontend@workspace:core/integration-frontend"],
+
+    "@checkstack/integration-jira-backend": ["@checkstack/integration-jira-backend@workspace:plugins/integration-jira-backend"],
+
+    "@checkstack/integration-jira-common": ["@checkstack/integration-jira-common@workspace:plugins/integration-jira-common"],
+
+    "@checkstack/integration-script-backend": ["@checkstack/integration-script-backend@workspace:plugins/integration-script-backend"],
+
+    "@checkstack/integration-teams-backend": ["@checkstack/integration-teams-backend@workspace:plugins/integration-teams-backend"],
+
+    "@checkstack/integration-webex-backend": ["@checkstack/integration-webex-backend@workspace:plugins/integration-webex-backend"],
+
+    "@checkstack/integration-webhook-backend": ["@checkstack/integration-webhook-backend@workspace:plugins/integration-webhook-backend"],
+
+    "@checkstack/maintenance-backend": ["@checkstack/maintenance-backend@workspace:core/maintenance-backend"],
+
+    "@checkstack/maintenance-common": ["@checkstack/maintenance-common@workspace:core/maintenance-common"],
+
+    "@checkstack/maintenance-frontend": ["@checkstack/maintenance-frontend@workspace:core/maintenance-frontend"],
+
+    "@checkstack/notification-backend": ["@checkstack/notification-backend@workspace:core/notification-backend"],
+
+    "@checkstack/notification-backstage-backend": ["@checkstack/notification-backstage-backend@workspace:plugins/notification-backstage-backend"],
+
+    "@checkstack/notification-common": ["@checkstack/notification-common@workspace:core/notification-common"],
+
+    "@checkstack/notification-discord-backend": ["@checkstack/notification-discord-backend@workspace:plugins/notification-discord-backend"],
+
+    "@checkstack/notification-frontend": ["@checkstack/notification-frontend@workspace:core/notification-frontend"],
+
+    "@checkstack/notification-gotify-backend": ["@checkstack/notification-gotify-backend@workspace:plugins/notification-gotify-backend"],
+
+    "@checkstack/notification-pushover-backend": ["@checkstack/notification-pushover-backend@workspace:plugins/notification-pushover-backend"],
+
+    "@checkstack/notification-slack-backend": ["@checkstack/notification-slack-backend@workspace:plugins/notification-slack-backend"],
+
+    "@checkstack/notification-smtp-backend": ["@checkstack/notification-smtp-backend@workspace:plugins/notification-smtp-backend"],
+
+    "@checkstack/notification-teams-backend": ["@checkstack/notification-teams-backend@workspace:plugins/notification-teams-backend"],
+
+    "@checkstack/notification-telegram-backend": ["@checkstack/notification-telegram-backend@workspace:plugins/notification-telegram-backend"],
+
+    "@checkstack/notification-webex-backend": ["@checkstack/notification-webex-backend@workspace:plugins/notification-webex-backend"],
+
+    "@checkstack/queue-api": ["@checkstack/queue-api@workspace:core/queue-api"],
+
+    "@checkstack/queue-backend": ["@checkstack/queue-backend@workspace:core/queue-backend"],
+
+    "@checkstack/queue-bullmq-backend": ["@checkstack/queue-bullmq-backend@workspace:plugins/queue-bullmq-backend"],
+
+    "@checkstack/queue-bullmq-common": ["@checkstack/queue-bullmq-common@workspace:plugins/queue-bullmq-common"],
+
+    "@checkstack/queue-common": ["@checkstack/queue-common@workspace:core/queue-common"],
+
+    "@checkstack/queue-frontend": ["@checkstack/queue-frontend@workspace:core/queue-frontend"],
+
+    "@checkstack/queue-memory-backend": ["@checkstack/queue-memory-backend@workspace:plugins/queue-memory-backend"],
+
+    "@checkstack/queue-memory-common": ["@checkstack/queue-memory-common@workspace:plugins/queue-memory-common"],
+
+    "@checkstack/release": ["@checkstack/release@workspace:core/release"],
+
+    "@checkstack/satellite": ["@checkstack/satellite@workspace:core/satellite"],
+
+    "@checkstack/satellite-backend": ["@checkstack/satellite-backend@workspace:core/satellite-backend"],
+
+    "@checkstack/satellite-common": ["@checkstack/satellite-common@workspace:core/satellite-common"],
+
+    "@checkstack/satellite-frontend": ["@checkstack/satellite-frontend@workspace:core/satellite-frontend"],
+
+    "@checkstack/scripts": ["@checkstack/scripts@workspace:core/scripts"],
+
+    "@checkstack/signal-backend": ["@checkstack/signal-backend@workspace:core/signal-backend"],
+
+    "@checkstack/signal-common": ["@checkstack/signal-common@workspace:core/signal-common"],
+
+    "@checkstack/signal-frontend": ["@checkstack/signal-frontend@workspace:core/signal-frontend"],
+
+    "@checkstack/slo-backend": ["@checkstack/slo-backend@workspace:core/slo-backend"],
+
+    "@checkstack/slo-common": ["@checkstack/slo-common@workspace:core/slo-common"],
+
+    "@checkstack/slo-frontend": ["@checkstack/slo-frontend@workspace:core/slo-frontend"],
+
+    "@checkstack/test-utils-backend": ["@checkstack/test-utils-backend@workspace:core/test-utils-backend"],
+
+    "@checkstack/test-utils-frontend": ["@checkstack/test-utils-frontend@workspace:core/test-utils-frontend"],
+
+    "@checkstack/theme-backend": ["@checkstack/theme-backend@workspace:core/theme-backend"],
+
+    "@checkstack/theme-common": ["@checkstack/theme-common@workspace:core/theme-common"],
+
+    "@checkstack/theme-frontend": ["@checkstack/theme-frontend@workspace:core/theme-frontend"],
+
+    "@checkstack/tsconfig": ["@checkstack/tsconfig@workspace:core/tsconfig"],
+
+    "@checkstack/ui": ["@checkstack/ui@workspace:core/ui"],
+
+    "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
+
+    "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
+
+    "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
+
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@grammyjs/types": ["@grammyjs/types@3.26.0", "", {}, "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A=="],
+
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+
+    "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
+
+    "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "@inquirer/checkbox": ["@inquirer/checkbox@5.1.3", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.8", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.11", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA=="],
+
+    "@inquirer/core": ["@inquirer/core@11.1.8", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA=="],
+
+    "@inquirer/editor": ["@inquirer/editor@5.1.0", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/external-editor": "^3.0.0", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw=="],
+
+    "@inquirer/expand": ["@inquirer/expand@5.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ=="],
+
+    "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "@inquirer/input": ["@inquirer/input@5.0.11", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ=="],
+
+    "@inquirer/number": ["@inquirer/number@4.0.11", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA=="],
+
+    "@inquirer/password": ["@inquirer/password@5.0.11", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@8.4.1", "", { "dependencies": { "@inquirer/checkbox": "^5.1.3", "@inquirer/confirm": "^6.0.11", "@inquirer/editor": "^5.1.0", "@inquirer/expand": "^5.0.12", "@inquirer/input": "^5.0.11", "@inquirer/number": "^4.0.11", "@inquirer/password": "^5.0.11", "@inquirer/rawlist": "^5.2.7", "@inquirer/search": "^4.1.7", "@inquirer/select": "^5.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@5.2.7", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w=="],
+
+    "@inquirer/search": ["@inquirer/search@4.1.7", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ=="],
+
+    "@inquirer/select": ["@inquirer/select@5.1.3", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.8", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "@ioredis/as-callback": ["@ioredis/as-callback@3.0.0", "", {}, "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@jsep-plugin/assignment": ["@jsep-plugin/assignment@1.3.0", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ=="],
+
+    "@jsep-plugin/regex": ["@jsep-plugin/regex@1.0.4", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg=="],
+
+    "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
+
+    "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
+
+    "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
+
+    "@monaco-editor/react": ["@monaco-editor/react@4.7.0", "", { "dependencies": { "@monaco-editor/loader": "^1.5.0" }, "peerDependencies": { "monaco-editor": ">= 0.25.0 < 1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
+
+    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
+
+    "@orpc/client": ["@orpc/client@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14", "@orpc/standard-server-fetch": "1.13.14", "@orpc/standard-server-peer": "1.13.14" } }, "sha512-JQf3lO//UGHmmkd8+9fuWuh1gga1lhWuKnsT19cui7F6WizBy0NdFSVQerOsSy2c1kxOthlD7GnicGgSY2rhQA=="],
+
+    "@orpc/contract": ["@orpc/contract@1.13.14", "", { "dependencies": { "@orpc/client": "1.13.14", "@orpc/shared": "1.13.14", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-MfsjaQQDVcs4wHmdl5N/7vkwMnQ41nlojWXyRfRXNJHQczqBzM6sYaTJuUPXlw4YbIu64KHZ5nbbtwNCO5YXsg=="],
+
+    "@orpc/interop": ["@orpc/interop@1.13.14", "", {}, "sha512-7umABTBzQMNTX8dTKrbIOu9g5XJuMeqijC6Gu6jlaVP90e8D57n7Zv6HfwSgPVq0oQXf9n/ENptzVj3TpxpXsQ=="],
+
+    "@orpc/json-schema": ["@orpc/json-schema@1.13.14", "", { "dependencies": { "@orpc/contract": "1.13.14", "@orpc/interop": "1.13.14", "@orpc/openapi": "1.13.14", "@orpc/server": "1.13.14", "@orpc/shared": "1.13.14", "json-schema-typed": "^8.0.2" } }, "sha512-BLGewxG0dv5AhLEwTmeXDNZ0PiRxvCzxcUtbo8FExwIR6wpknfWukeoymaHn8vtyfuOO9nvPfertNuNUReiufg=="],
+
+    "@orpc/openapi": ["@orpc/openapi@1.13.14", "", { "dependencies": { "@orpc/client": "1.13.14", "@orpc/contract": "1.13.14", "@orpc/interop": "1.13.14", "@orpc/openapi-client": "1.13.14", "@orpc/server": "1.13.14", "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14", "json-schema-typed": "^8.0.2", "rou3": "^0.7.12" } }, "sha512-wwfq8CwOTxuNOfamHKTrXgUxxAhh8WSTpu2OgZhNDWxH0p6V/xLhlXl2iSjmzyO4QuBpE26fchDwaVAGic9zlQ=="],
+
+    "@orpc/openapi-client": ["@orpc/openapi-client@1.13.14", "", { "dependencies": { "@orpc/client": "1.13.14", "@orpc/contract": "1.13.14", "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14" } }, "sha512-mHuj/UL5qLqB1JqrRdlAoUYMidbsry8Cr9QOlOZk1mp7+OZhasFv75UNzxyjNNaSjyd3l2k4UkgpcHK4VSD7tQ=="],
+
+    "@orpc/react-query": ["@orpc/react-query@1.13.4", "", { "dependencies": { "@orpc/shared": "1.13.4", "@orpc/tanstack-query": "1.13.4" }, "peerDependencies": { "@orpc/client": "1.13.4", "@tanstack/react-query": ">=5.80.2", "react": ">=18.3.0" } }, "sha512-MD1uOIioGk2y94QjRlVkuodF6pFpXeobmESgmVPbfvM+UrWhvO5d1eEbgIVIsfDEpZKEi6I9pB0FDThKl0oWHg=="],
+
+    "@orpc/server": ["@orpc/server@1.13.14", "", { "dependencies": { "@orpc/client": "1.13.14", "@orpc/contract": "1.13.14", "@orpc/interop": "1.13.14", "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14", "@orpc/standard-server-aws-lambda": "1.13.14", "@orpc/standard-server-fastify": "1.13.14", "@orpc/standard-server-fetch": "1.13.14", "@orpc/standard-server-node": "1.13.14", "@orpc/standard-server-peer": "1.13.14", "cookie": "^1.1.1" }, "peerDependencies": { "crossws": ">=0.3.4", "ws": ">=8.18.1" }, "optionalPeers": ["crossws", "ws"] }, "sha512-bF+sNbSHBgs1uwzHXgTxcxWIG42ryX+w32l+FJRHrAmGma+S8PmS1X2HZ/J7XycyYVBJMUUzBr8M88pP+UcdxQ=="],
+
+    "@orpc/shared": ["@orpc/shared@1.13.14", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-/ri8ttSX+ppoo01d3LdqQ4Xh6VZS5PYRYmHxTvO8tuyiqBJhN18d8P1VtEW4T9hetoK7JZKeU7EAeqVUnCF9WA=="],
+
+    "@orpc/standard-server": ["@orpc/standard-server@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14" } }, "sha512-o8PaDERiwREFQpIZO0mQ1PhguchyNzrf1w7m3eK1JB4rPjHu1VJUgqCpy/sV3Id5ji4bX/gKHEC3NZjDX6mEWQ=="],
+
+    "@orpc/standard-server-aws-lambda": ["@orpc/standard-server-aws-lambda@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14", "@orpc/standard-server-fetch": "1.13.14", "@orpc/standard-server-node": "1.13.14" } }, "sha512-5P1ZzgS6zKTjjI0SaCgMlTF5PM4dbOlmP2Zm2Lh1ool/iNvjMzXSb86pbKrWOo5/V8dzn4GMyCgNso9za1nUMg=="],
+
+    "@orpc/standard-server-fastify": ["@orpc/standard-server-fastify@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14", "@orpc/standard-server-node": "1.13.14" }, "peerDependencies": { "fastify": ">=5.6.1" }, "optionalPeers": ["fastify"] }, "sha512-DcgL5UFjHENGj1gWiQig4iObMNnnw8z7UrfTELTCejQ9NAWE8aGYdx4bZ/hk4JkieLJ+9aosGK57di6xXBtvPA=="],
+
+    "@orpc/standard-server-fetch": ["@orpc/standard-server-fetch@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14" } }, "sha512-k2zkCi98qd3NkvWhUX/Yece/qjB+o07g/gHC509YB5HbOGtBV/da3eseYjFyzBx5LDxMz28BOALI8/q/YDhKZw=="],
+
+    "@orpc/standard-server-node": ["@orpc/standard-server-node@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14", "@orpc/standard-server-fetch": "1.13.14" } }, "sha512-GKMWfMuKX+dycpEFMoFrGY+zhZMKPoR9HSM66Ebn/ixr2qCVfQaoudPa9MAgP+fv/ctZx+nkt1rR7esUFMdMAg=="],
+
+    "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14" } }, "sha512-jinseQ8bn7XQOHjsCXhR1HiF3wAwn1xEQPpnE/av0PoOi4h0ATvhZjDLaRHvRavs8YwrIqwSuAuYT/hDxON58A=="],
+
+    "@orpc/tanstack-query": ["@orpc/tanstack-query@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14" }, "peerDependencies": { "@orpc/client": "1.13.14", "@tanstack/query-core": ">=5.80.2" } }, "sha512-5rq1Z1anVTVBseYeNBi5RJSgWPxpD0MqK7MYej3xnt56jjc6mFmWpUGNz9xy0BXPh3KmA/xDTNuB23kKgJ5JmQ=="],
+
+    "@orpc/zod": ["@orpc/zod@1.13.14", "", { "dependencies": { "@orpc/json-schema": "1.13.14", "@orpc/openapi": "1.13.14", "@orpc/shared": "1.13.14", "escape-string-regexp": "^5.0.0", "wildcard-match": "^5.1.4" }, "peerDependencies": { "@orpc/contract": "1.13.14", "@orpc/server": "1.13.14", "zod": ">=3.25.0" } }, "sha512-lpF8Nyb+WdW0PieZcJB3KvKztGveXvckOqXMyWTWvyrylV3rCPmeUneVQghjZOLqJdAevo4jqV2/BgHWSt3EEA=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
+    "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
+
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-accordion": ["@radix-ui/react-accordion@1.2.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
+    "@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA=="],
+
+    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw=="],
+
+    "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
+
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
+    "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
+
+    "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
+    "@tabby_ai/hijri-converter": ["@tabby_ai/hijri-converter@1.0.5", "", {}, "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.99.0", "", {}, "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ=="],
+
+    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.99.0", "", {}, "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.99.0", "", { "dependencies": { "@tanstack/query-core": "5.99.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw=="],
+
+    "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.99.0", "", { "dependencies": { "@tanstack/query-devtools": "5.99.0" }, "peerDependencies": { "@tanstack/react-query": "^5.99.0", "react": "^18 || ^19" } }, "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/handlebars": ["@types/handlebars@4.1.0", "", { "dependencies": { "handlebars": "*" } }, "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/inquirer": ["@types/inquirer@8.2.12", "", { "dependencies": { "@types/through": "*", "rxjs": "^7.2.0" } }, "sha512-YxURZF2ZsSjU5TAe06tW0M3sL4UI9AMPA6dd8I72uOtppzNafcY38xkYgCZ/vsVOAyNdzHmvtTpLWilOrbP0dQ=="],
+
+    "@types/ioredis-mock": ["@types/ioredis-mock@8.2.7", "", { "peerDependencies": { "ioredis": ">=5" } }, "sha512-YsGiaOIYBKeVvu/7GYziAD8qX3LJem5LK00d5PKykzsQJMLysAqXA61AkNuYWCekYl64tbMTqVOMF4SYoCPbQg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+
+    "@types/nodemailer": ["@types/nodemailer@8.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA=="],
+
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
+    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+
+    "@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
+
+    "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
+    "@types/ssh2": ["@types/ssh2@1.15.0", "", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-YcT8jP5F8NzWeevWvcyrrLB3zcneVjzYY9ZDSMAMboI+2zR1qYWFhwsyOFVzT7Jorn67vqxC0FRiw8YyG9P1ww=="],
+
+    "@types/tdigest": ["@types/tdigest@0.1.5", "", {}, "sha512-89ZDvz0aw1Uwosx0JSV8qfB6q5PsyFHni2vzutiG6QOLqMt9W95VTaKRDD9f56oe2zRdD+3u3UGM3Zgu5708Sg=="],
+
+    "@types/through": ["@types/through@0.0.33", "", { "dependencies": { "@types/node": "*" } }, "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ=="],
+
+    "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
+
+    "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/type-utils": "8.58.2", "@typescript-eslint/utils": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.2", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/types": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.2", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.2", "@typescript-eslint/types": "^8.58.2", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2" } }, "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.2", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2", "@typescript-eslint/utils": "8.58.2", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.2", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.2", "@typescript-eslint/tsconfig-utils": "8.58.2", "@typescript-eslint/types": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/types": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
+
+    "@xmldom/is-dom-node": ["@xmldom/is-dom-node@1.0.1", "", {}, "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q=="],
+
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.12", "", {}, "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg=="],
+
+    "@xyflow/react": ["@xyflow/react@12.10.2", "", { "dependencies": { "@xyflow/system": "0.0.76", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ=="],
+
+    "@xyflow/system": ["@xyflow/system@0.0.76", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
+
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+
+    "autoprefixer": ["autoprefixer@10.5.0", "", { "dependencies": { "browserslist": "^4.28.2", "caniuse-lite": "^1.0.30001787", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong=="],
+
+    "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
+
+    "bail": ["bail@1.0.5", "", {}, "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
+
+    "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
+
+    "better-auth": ["better-auth@1.6.4", "", { "dependencies": { "@better-auth/core": "1.6.4", "@better-auth/drizzle-adapter": "1.6.4", "@better-auth/kysely-adapter": "1.6.4", "@better-auth/memory-adapter": "1.6.4", "@better-auth/mongo-adapter": "1.6.4", "@better-auth/prisma-adapter": "1.6.4", "@better-auth/telemetry": "1.6.4", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.14", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-yb/IDzoheBcoP8vI4jB0KkGCg0UabvEKo8GDBjcHW/w2Bb9ltlHzWuwcIauowhPezDcyRWUr2ub2HNO2rp6p7A=="],
+
+    "better-call": ["better-call@1.3.5", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA=="],
+
+    "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
+
+    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
+
+    "builtin-modules": ["builtin-modules@5.1.0", "", {}, "sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A=="],
+
+    "bullmq": ["bullmq@5.74.1", "", { "dependencies": { "cron-parser": "4.9.0", "ioredis": "5.10.1", "msgpackr": "1.11.5", "node-abort-controller": "3.1.1", "semver": "7.7.4", "tslib": "2.8.1", "uuid": "11.1.0" } }, "sha512-GfJEos2zoOGM9xqkB7VZouwwFuejKFqm667cBcmbBekJXKqqXWk4QYP3Uy2pzgUwCbg1cR7GgGmGczM7fnhWSA=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
+
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
+
+    "character-entities": ["character-entities@1.2.4", "", {}, "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@1.1.4", "", {}, "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="],
+
+    "character-reference-invalid": ["character-reference-invalid@1.1.4", "", {}, "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="],
+
+    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
+    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
+
+    "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
+    "clean-regexp": ["clean-regexp@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
+    "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "core-js-compat": ["core-js-compat@3.49.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA=="],
+
+    "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
+
+    "cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
+
+    "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
+
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
+
+    "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.336", "", {}, "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
+
+    "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
+
+    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@62.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "@eslint-community/eslint-utils": "^4.9.0", "@eslint/plugin-kit": "^0.4.0", "change-case": "^5.4.4", "ci-info": "^4.3.1", "clean-regexp": "^1.0.0", "core-js-compat": "^3.46.0", "esquery": "^1.6.0", "find-up-simple": "^1.0.1", "globals": "^16.4.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regexp-tree": "^0.1.27", "regjsparser": "^0.13.0", "semver": "^7.7.3", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-HIlIkGLkvf29YEiS/ImuDZQbP12gWyx5i3C6XrRxMvVdqMroCI9qoVYCoIl17ChN+U89pn9sVwLxhIWj5nEc7g=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fecha": ["fecha@4.2.3", "", {}, "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="],
+
+    "fengari": ["fengari@0.1.5", "", { "dependencies": { "readline-sync": "^1.4.10", "sprintf-js": "^1.1.3", "tmp": "^0.2.5" } }, "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ=="],
+
+    "fengari-interop": ["fengari-interop@0.1.4", "", { "peerDependencies": { "fengari": "^0.1.0" } }, "sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
+
+    "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
+
+    "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
+
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "grammy": ["grammy@1.42.0", "", { "dependencies": { "@grammyjs/types": "3.26.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g=="],
+
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "html-comment-regex": ["html-comment-regex@1.1.2", "", {}, "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "inquirer": ["inquirer@13.4.1", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.8", "@inquirer/prompts": "^8.4.1", "@inquirer/type": "^4.0.5", "mute-stream": "^3.0.0", "run-async": "^4.0.6", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-IUopujY77lFiSaLz0fx6FHEOEANz0nAsqv+vQJddnVshi6wdos984qwjb42mZbH3zCJS4f9ioIGDqSPqMMMXjw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
+
+    "ioredis-mock": ["ioredis-mock@8.13.1", "", { "dependencies": { "@ioredis/as-callback": "^3.0.0", "@ioredis/commands": "^1.4.0", "fengari": "^0.1.4", "fengari-interop": "^0.1.3", "semver": "^7.7.2" }, "peerDependencies": { "@types/ioredis-mock": "^8", "ioredis": "^5" } }, "sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw=="],
+
+    "is-alphabetical": ["is-alphabetical@1.0.4", "", {}, "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="],
+
+    "is-alphanumerical": ["is-alphanumerical@1.0.4", "", { "dependencies": { "is-alphabetical": "^1.0.0", "is-decimal": "^1.0.0" } }, "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A=="],
+
+    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
+
+    "is-builtin-module": ["is-builtin-module@5.0.0", "", { "dependencies": { "builtin-modules": "^5.0.0" } }, "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "is-decimal": ["is-decimal@1.0.4", "", {}, "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-hexadecimal": ["is-hexadecimal@1.0.4", "", {}, "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
+
+    "is-property": ["is-property@1.0.2", "", {}, "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "is-subdir": ["is-subdir@1.2.0", "", { "dependencies": { "better-path-resolve": "1.0.0" } }, "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw=="],
+
+    "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsep": ["jsep@1.4.0", "", {}, "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
+
+    "jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
+
+    "kysely": ["kysely@0.28.16", "", {}, "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww=="],
+
+    "ldapts": ["ldapts@8.1.7", "", { "dependencies": { "strict-event-emitter-types": "2.0.0" } }, "sha512-TJl6T92eIwMf/OJ0hDfKVa6ISwzo+lqCWCI5Mf//ARlKa3LKQZaSrme/H2rCRBhW0DZCQlrsV+fgoW5YHRNLUw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
+
+    "logform": ["logform@2.7.0", "", { "dependencies": { "@colors/colors": "1.6.0", "@types/triple-beam": "^1.3.2", "fecha": "^4.2.0", "ms": "^2.1.1", "safe-stable-stringify": "^2.3.1", "triple-beam": "^1.3.0" } }, "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "longest-streak": ["longest-streak@2.0.4", "", {}, "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
+
+    "lucide-react": ["lucide-react@0.344.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0" } }, "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "markdown-table": ["markdown-table@2.0.0", "", { "dependencies": { "repeat-string": "^1.0.0" } }, "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A=="],
+
+    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@1.1.1", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "unist-util-is": "^4.0.0", "unist-util-visit-parents": "^3.0.0" } }, "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@0.8.5", "", { "dependencies": { "@types/mdast": "^3.0.0", "mdast-util-to-string": "^2.0.0", "micromark": "~2.11.0", "parse-entities": "^2.0.0", "unist-util-stringify-position": "^2.0.0" } }, "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@0.1.2", "", { "dependencies": { "mdast-util-gfm-autolink-literal": "^0.1.0", "mdast-util-gfm-strikethrough": "^0.2.0", "mdast-util-gfm-table": "^0.1.0", "mdast-util-gfm-task-list-item": "^0.1.0", "mdast-util-to-markdown": "^0.6.1" } }, "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@0.1.3", "", { "dependencies": { "ccount": "^1.0.0", "mdast-util-find-and-replace": "^1.1.0", "micromark": "^2.11.3" } }, "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@0.2.3", "", { "dependencies": { "mdast-util-to-markdown": "^0.6.0" } }, "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@0.1.6", "", { "dependencies": { "markdown-table": "^2.0.0", "mdast-util-to-markdown": "~0.6.0" } }, "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@0.1.6", "", { "dependencies": { "mdast-util-to-markdown": "~0.6.0" } }, "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@0.6.5", "", { "dependencies": { "@types/unist": "^2.0.0", "longest-streak": "^2.0.0", "mdast-util-to-string": "^2.0.0", "parse-entities": "^2.0.0", "repeat-string": "^1.0.0", "zwitch": "^1.0.0" } }, "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@2.0.0", "", {}, "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@2.11.4", "", { "dependencies": { "debug": "^4.0.0", "parse-entities": "^2.0.0" } }, "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@0.3.3", "", { "dependencies": { "micromark": "~2.11.0", "micromark-extension-gfm-autolink-literal": "~0.5.0", "micromark-extension-gfm-strikethrough": "~0.6.5", "micromark-extension-gfm-table": "~0.4.0", "micromark-extension-gfm-tagfilter": "~0.3.0", "micromark-extension-gfm-task-list-item": "~0.3.0" } }, "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@0.5.7", "", { "dependencies": { "micromark": "~2.11.3" } }, "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@0.6.5", "", { "dependencies": { "micromark": "~2.11.0" } }, "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@0.4.3", "", { "dependencies": { "micromark": "~2.11.0" } }, "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@0.3.0", "", {}, "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@0.3.3", "", { "dependencies": { "micromark": "~2.11.0" } }, "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "monaco-editor": ["monaco-editor@0.55.1", "", { "dependencies": { "dompurify": "3.2.7", "marked": "14.0.0" } }, "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "msgpackr": ["msgpackr@1.11.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
+
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
+    "mysql2": ["mysql2@3.22.0", "", { "dependencies": { "aws-ssl-profiles": "^1.1.2", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.2", "long": "^5.3.2", "lru.min": "^1.1.4", "named-placeholders": "^1.1.6", "sql-escaper": "^1.3.3" }, "peerDependencies": { "@types/node": ">= 8" } }, "sha512-4jaJYBObj7FhD3lnZhqX1yDMuZN4mQNz+IolDySDXT7fbozMBpeGQNcuWXKUqo4ahkAEfkjUHPjnwuDI0/6VKw=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
+
+    "nan": ["nan@2.26.2", "", {}, "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "nanostores": ["nanostores@1.2.0", "", {}, "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "node-abort-controller": ["node-abort-controller@3.1.1", "", {}, "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
+
+    "node-rsa": ["node-rsa@1.1.1", "", { "dependencies": { "asn1": "^0.2.4" } }, "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw=="],
+
+    "nodemailer": ["nodemailer@8.0.5", "", {}, "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
+
+    "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "p-map": ["p-map@2.1.0", "", {}, "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-entities": ["parse-entities@2.0.0", "", { "dependencies": { "character-entities": "^1.0.0", "character-entities-legacy": "^1.0.0", "character-reference-invalid": "^1.0.0", "is-alphanumerical": "^1.0.0", "is-decimal": "^1.0.0", "is-hexadecimal": "^1.0.0" } }, "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+
+    "pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
+    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
+
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
+    "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
+
+    "postcss-js": ["postcss-js@4.1.0", "", { "dependencies": { "camelcase-css": "^2.0.1" }, "peerDependencies": { "postcss": "^8.4.21" } }, "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw=="],
+
+    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
+
+    "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "radash": ["radash@12.1.1", "", {}, "sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA=="],
+
+    "rcon-srcds": ["rcon-srcds@2.1.1", "", {}, "sha512-qXFImo6HVrXIS8EZm/MNlSGsqy9yTzxXXtOIU4z3PtWz6PFG325lVk5zpkwBvz5Kp9AgOn18RgMoljQRSbL0Qg=="],
+
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-day-picker": ["react-day-picker@9.14.0", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "@tabby_ai/hijri-converter": "1.0.5", "date-fns": "^4.1.0", "date-fns-jalali": "4.1.0-0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA=="],
+
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-router": ["react-router@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw=="],
+
+    "react-router-dom": ["react-router-dom@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2", "react-router": "6.30.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
+
+    "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "readline-sync": ["readline-sync@1.4.10", "", {}, "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="],
+
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
+
+    "regjsparser": ["regjsparser@0.13.1", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw=="],
+
+    "remark-gfm": ["remark-gfm@1.0.0", "", { "dependencies": { "mdast-util-gfm": "^0.1.0", "micromark-extension-gfm": "^0.3.0" } }, "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA=="],
+
+    "remark-parse": ["remark-parse@9.0.0", "", { "dependencies": { "mdast-util-from-markdown": "^0.8.0" } }, "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-remove-comments": ["remark-remove-comments@0.2.0", "", { "dependencies": { "html-comment-regex": "^1.1.2", "unist-util-visit": "^2.0.3" } }, "sha512-faGaTeqp0bvDgE0uTofa90EBHD4HXeHN+EUaPDR9datgFvaPkYcLxakaJud9LnomFPkOhx0A9NMYFk/lln/etQ=="],
+
+    "remark-stringify": ["remark-stringify@9.0.1", "", { "dependencies": { "mdast-util-to-markdown": "^0.6.0" } }, "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg=="],
+
+    "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
+
+    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+
+    "run-async": ["run-async@4.0.6", "", {}, "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "samlify": ["samlify@2.12.0", "", { "dependencies": { "@authenio/xml-encryption": "^2.0.2", "@xmldom/xmldom": "^0.8.11", "node-rsa": "^1.1.1", "xml": "^1.0.1", "xml-crypto": "^6.1.2", "xml-escape": "^1.1.0", "xpath": "^0.0.34" } }, "sha512-ewGsHyY4kInDH0BfprlAZ1rHpH1jBmbqYiXDbuI3t1Y8h71gqEt4Z7jdCFyPHFR8jItJkbdckTijUZGg14CDlg=="],
+
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
+    "sql-escaper": ["sql-escaper@1.3.3", "", {}, "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw=="],
+
+    "ssh2": ["ssh2@1.16.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.20.0" } }, "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg=="],
+
+    "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
+
+    "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
+
+    "strict-event-emitter-types": ["strict-event-emitter-types@2.0.0", "", {}, "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-indent": ["strip-indent@4.1.1", "", {}, "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "tailwind-merge": ["tailwind-merge@2.6.1", "", {}, "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="],
+
+    "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
+
+    "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
+
+    "tdigest": ["tdigest@0.1.2", "", { "dependencies": { "bintrees": "1.0.2" } }, "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA=="],
+
+    "telegramify-markdown": ["telegramify-markdown@1.3.3", "", { "dependencies": { "mdast-util-gfm-table": "^0.1.6", "mdast-util-to-markdown": "^0.6.2", "remark-gfm": "^1.0.0", "remark-parse": "^9.0.0", "remark-remove-comments": "^0.2.0", "remark-stringify": "^9.0.1", "unified": "^9.0.0", "unist-util-remove": "^2.0.1", "unist-util-visit": "^2.0.3" } }, "sha512-cyMqOrXFJfKzOrrUc1JlnfRwvC7HR+DzzlUItQs+I9bGTO9TSyvpgt27UQ9YXm2sXb3ltzBvvAq/IEWqdk6xkg=="],
+
+    "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
+
+    "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "triple-beam": ["triple-beam@1.4.1", "", {}, "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="],
+
+    "trough": ["trough@1.0.5", "", {}, "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.58.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.2", "@typescript-eslint/parser": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2", "@typescript-eslint/utils": "8.58.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ=="],
+
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unified": ["unified@9.2.2", "", { "dependencies": { "bail": "^1.0.0", "extend": "^3.0.0", "is-buffer": "^2.0.0", "is-plain-obj": "^2.0.0", "trough": "^1.0.0", "vfile": "^4.0.0" } }, "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ=="],
+
+    "unist-util-is": ["unist-util-is@4.1.0", "", {}, "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-remove": ["unist-util-remove@2.1.0", "", { "dependencies": { "unist-util-is": "^4.0.0" } }, "sha512-J8NYPyBm4baYLdCbjmf1bhPu45Cr1MWTm77qd9istEkzWpnN6O9tMsEbB2JhNnBCqGENRqEWomQ+He6au0B27Q=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@2.0.3", "", { "dependencies": { "@types/unist": "^2.0.2" } }, "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g=="],
+
+    "unist-util-visit": ["unist-util-visit@2.0.3", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-is": "^4.0.0", "unist-util-visit-parents": "^3.0.0" } }, "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@3.1.1", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-is": "^4.0.0" } }, "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg=="],
+
+    "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
+    "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wildcard-match": ["wildcard-match@5.1.4", "", {}, "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g=="],
+
+    "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
+
+    "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
+
+    "xml-crypto": ["xml-crypto@6.1.2", "", { "dependencies": { "@xmldom/is-dom-node": "^1.0.1", "@xmldom/xmldom": "^0.8.10", "xpath": "^0.0.33" } }, "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w=="],
+
+    "xml-escape": ["xml-escape@1.1.0", "", {}, "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg=="],
+
+    "xpath": ["xpath@0.0.34", "", {}, "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+
+    "zwitch": ["zwitch@1.0.5", "", {}, "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="],
+
+    "@authenio/xml-encryption/xpath": ["xpath@0.0.32", "", {}, "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@checkstack/command-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
+
+    "@checkstack/command-frontend/react-router-dom": ["react-router-dom@7.14.1", "", { "dependencies": { "react-router": "7.14.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA=="],
+
+    "@checkstack/common/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
+
+    "@checkstack/queue-backend/@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
+
+    "@checkstack/queue-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
+
+    "@checkstack/queue-frontend/react-router-dom": ["react-router-dom@7.14.1", "", { "dependencies": { "react-router": "7.14.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA=="],
+
+    "@checkstack/ui/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@checkstack/ui/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
+
+    "@checkstack/ui/react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@inquirer/editor/@inquirer/external-editor": ["@inquirer/external-editor@3.0.0", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg=="],
+
+    "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
+    "@manypkg/find-root/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
+
+    "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "@orpc/react-query/@orpc/shared": ["@orpc/shared@1.13.4", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.3.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-TYt9rLG/BUkNQBeQ6C1tEiHS/Seb8OojHgj9GlvqyjHJhMZx5qjsIyTW6RqLPZJ4U2vgK6x4Her36+tlFCKJug=="],
+
+    "@orpc/react-query/@orpc/tanstack-query": ["@orpc/tanstack-query@1.13.4", "", { "dependencies": { "@orpc/shared": "1.13.4" }, "peerDependencies": { "@orpc/client": "1.13.4", "@tanstack/query-core": ">=5.80.2" } }, "sha512-gCL/kh3kf6OUGKfXxSoOZpcX1jNYzxGfo/PkLQKX7ui4xiTbfWw3sCDF30sNS4I7yAOnBwDwJ3N2xzfkTftOBg=="],
+
+    "@orpc/zod/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
+
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "@types/hast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/mdast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "bullmq/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "color/color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
+
+    "color-string/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
+
+    "decode-named-character-reference/character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "hast-util-to-jsx-runtime/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "ioredis-mock/@ioredis/commands": ["@ioredis/commands@1.6.0", "", {}, "sha512-lNa3bQBsR2OQ+IopxlSydDNSPKD4TGUaSBBs+f68ugyTJBtXhcxQE8oqrDflRv2kKOT/QnBQcSPQ7/T2mSMLxQ=="],
+
+    "mdast-util-from-markdown/@types/mdast": ["@types/mdast@3.0.15", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ=="],
+
+    "mdast-util-gfm-autolink-literal/ccount": ["ccount@1.1.0", "", {}, "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg=="],
+
+    "mdast-util-mdx-expression/mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-mdx-expression/mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-mdx-jsx/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "mdast-util-mdx-jsx/mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-mdx-jsx/mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-mdx-jsx/parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "mdast-util-mdx-jsx/unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-phrasing/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "mdast-util-to-hast/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "monaco-editor/marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "react-markdown/remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "react-markdown/unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "react-markdown/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "read-cache/pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
+
+    "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "remark-rehype/unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
+
+    "stringify-entities/character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "unified/vfile": ["vfile@4.2.1", "", { "dependencies": { "@types/unist": "^2.0.0", "is-buffer": "^2.0.0", "unist-util-stringify-position": "^2.0.0", "vfile-message": "^2.0.0" } }, "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA=="],
+
+    "unist-util-position/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "vfile/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "vfile-message/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "vfile-message/unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "xml-crypto/xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
+
+    "@checkstack/command-frontend/react-router-dom/react-router": ["react-router@7.14.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="],
+
+    "@checkstack/queue-frontend/react-router-dom/react-router": ["react-router@7.14.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="],
+
+    "@checkstack/ui/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
+
+    "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "eslint/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "mdast-util-mdx-expression/mdast-util-from-markdown/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "mdast-util-mdx-expression/mdast-util-from-markdown/mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdast-util-mdx-expression/mdast-util-from-markdown/micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "mdast-util-mdx-expression/mdast-util-from-markdown/unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "mdast-util-mdx-expression/mdast-util-to-markdown/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "mdast-util-mdx-expression/mdast-util-to-markdown/longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "mdast-util-mdx-expression/mdast-util-to-markdown/mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdast-util-mdx-expression/mdast-util-to-markdown/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "mdast-util-mdx-expression/mdast-util-to-markdown/zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "mdast-util-mdx-jsx/mdast-util-from-markdown/mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdast-util-mdx-jsx/mdast-util-from-markdown/micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "mdast-util-mdx-jsx/mdast-util-to-markdown/longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "mdast-util-mdx-jsx/mdast-util-to-markdown/mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdast-util-mdx-jsx/mdast-util-to-markdown/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "mdast-util-mdx-jsx/mdast-util-to-markdown/zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "mdast-util-mdx-jsx/parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "mdast-util-mdx-jsx/parse-entities/character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "mdast-util-mdx-jsx/parse-entities/character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "mdast-util-mdx-jsx/parse-entities/is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
+    "mdast-util-mdx-jsx/parse-entities/is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
+    "mdast-util-mdx-jsx/parse-entities/is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-from-markdown/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-from-markdown/mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-from-markdown/micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-from-markdown/unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-to-markdown/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-to-markdown/longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-to-markdown/mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-to-markdown/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-to-markdown/zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "mdast-util-phrasing/unist-util-is/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "mdast-util-to-hast/unist-util-visit/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "mdast-util-to-hast/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "mdast-util-to-hast/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "react-markdown/remark-parse/mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "react-markdown/unified/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "react-markdown/unified/bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
+    "react-markdown/unified/is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "react-markdown/unified/trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "react-markdown/unist-util-visit/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "react-markdown/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "react-markdown/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "remark-rehype/unified/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "remark-rehype/unified/bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
+    "remark-rehype/unified/is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "remark-rehype/unified/trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "unified/vfile/vfile-message": ["vfile-message@2.0.4", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-stringify-position": "^2.0.0" } }, "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ=="],
+
+    "@checkstack/command-frontend/react-router-dom/react-router/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "@checkstack/queue-frontend/react-router-dom/react-router/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "mdast-util-mdx-expression/mdast-util-to-markdown/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "mdast-util-mdx-expression/mdast-util-to-markdown/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "mdast-util-mdx-jsx/mdast-util-to-markdown/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "mdast-util-mdx-jsx/mdast-util-to-markdown/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "mdast-util-mdx-jsx/parse-entities/is-alphanumerical/is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-to-markdown/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "mdast-util-mdxjs-esm/mdast-util-to-markdown/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "react-markdown/remark-parse/mdast-util-from-markdown/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "react-markdown/remark-parse/mdast-util-from-markdown/mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "react-markdown/remark-parse/mdast-util-from-markdown/micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "react-markdown/remark-parse/mdast-util-from-markdown/unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "read-yaml-file/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }
 }

--- a/core/catalog-backend/package.json
+++ b/core/catalog-backend/package.json
@@ -18,6 +18,8 @@
     "@checkstack/catalog-common": "workspace:*",
     "@checkstack/command-backend": "workspace:*",
     "@checkstack/auth-backend": "workspace:*",
+    "@checkstack/gitops-backend": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
     "@checkstack/notification-common": "workspace:*",
     "@orpc/server": "^1.13.2",
     "drizzle-orm": "^0.45.0",

--- a/core/catalog-backend/src/catalog-gitops-kinds.test.ts
+++ b/core/catalog-backend/src/catalog-gitops-kinds.test.ts
@@ -11,8 +11,11 @@ import type {
  *
  * These tests exercise the reconcile/delete logic in isolation by
  * reconstructing the same kind definitions that catalog-backend registers
- * with the entity kind extension point. The actual database operations
- * are validated via a mock EntityService.
+ * with the entity kind extension point.
+ *
+ * The generic entityId pattern: reconcile() returns { entityId }, the
+ * reconciler engine stores it in provenance, and passes it back as
+ * existingEntityId on subsequent reconciles.
  */
 
 // ─── Mock EntityService ────────────────────────────────────────────────────
@@ -21,7 +24,6 @@ interface MockSystem {
   id: string;
   name: string;
   description?: string;
-  metadata: Record<string, unknown>;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -29,7 +31,6 @@ interface MockSystem {
 interface MockGroup {
   id: string;
   name: string;
-  metadata: Record<string, unknown>;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -41,71 +42,47 @@ function createMockEntityService() {
   return {
     systems,
     groups,
-    findSystemByGitOpsName: mock(async (entityName: string) =>
-      systems.find(
-        (s) =>
-          (s.metadata as Record<string, unknown>)?.gitops_entity_name ===
-          entityName,
-      ),
-    ),
-    createSystem: mock(async (data: { name: string; description?: string; metadata?: Record<string, unknown> }) => {
+    createSystem: mock(async (data: { name: string; description?: string }) => {
       const system: MockSystem = {
         id: `sys-${systems.length + 1}`,
         name: data.name,
         description: data.description,
-        metadata: data.metadata ?? {},
         createdAt: new Date(),
         updatedAt: new Date(),
       };
       systems.push(system);
       return system;
     }),
-    updateSystem: mock(async (id: string, data: Partial<{ name: string; description?: string; metadata?: Record<string, unknown> }>) => {
+    updateSystem: mock(async (id: string, data: Partial<{ name: string; description?: string }>) => {
       const system = systems.find((s) => s.id === id);
       if (system) {
         Object.assign(system, data);
       }
       return system;
     }),
-    deleteSystemByGitOpsName: mock(async (entityName: string) => {
-      const idx = systems.findIndex(
-        (s) =>
-          (s.metadata as Record<string, unknown>)?.gitops_entity_name ===
-          entityName,
-      );
+    deleteSystem: mock(async (id: string) => {
+      const idx = systems.findIndex((s) => s.id === id);
       if (idx >= 0) systems.splice(idx, 1);
     }),
-    findGroupByGitOpsName: mock(async (entityName: string) =>
-      groups.find(
-        (g) =>
-          (g.metadata as Record<string, unknown>)?.gitops_entity_name ===
-          entityName,
-      ),
-    ),
-    createGroup: mock(async (data: { name: string; metadata?: Record<string, unknown> }) => {
+    createGroup: mock(async (data: { name: string }) => {
       const group: MockGroup = {
         id: `grp-${groups.length + 1}`,
         name: data.name,
-        metadata: data.metadata ?? {},
         createdAt: new Date(),
         updatedAt: new Date(),
       };
       groups.push(group);
       return group;
     }),
-    updateGroup: mock(async (id: string, data: Partial<{ name: string; metadata?: Record<string, unknown> }>) => {
+    updateGroup: mock(async (id: string, data: Partial<{ name: string }>) => {
       const group = groups.find((g) => g.id === id);
       if (group) {
         Object.assign(group, data);
       }
       return group;
     }),
-    deleteGroupByGitOpsName: mock(async (entityName: string) => {
-      const idx = groups.findIndex(
-        (g) =>
-          (g.metadata as Record<string, unknown>)?.gitops_entity_name ===
-          entityName,
-      );
+    deleteGroup: mock(async (id: string) => {
+      const idx = groups.findIndex((g) => g.id === id);
       if (idx >= 0) groups.splice(idx, 1);
     }),
   };
@@ -125,9 +102,7 @@ const mockLogger: ReconcileContext["logger"] = {
 describe("Catalog GitOps Kind: System", () => {
   let mockService: ReturnType<typeof createMockEntityService>;
 
-  // Recreate the reconcile logic matching catalog-backend's registration
   const systemSpecSchema = z.object({});
-
   type SystemSpec = z.infer<typeof systemSpecSchema>;
 
   function buildSystemKind(
@@ -137,33 +112,28 @@ describe("Catalog GitOps Kind: System", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema: systemSpecSchema,
-      reconcile: async ({ entity, context }) => {
-        const entityName = entity.metadata.name;
-        const displayName = entity.metadata.title ?? entityName;
+      reconcile: async ({ entity, existingEntityId, context }) => {
+        const displayName = entity.metadata.title ?? entity.metadata.name;
         const description = entity.metadata.description;
 
-        const existing = await svc.findSystemByGitOpsName(entityName);
-        if (existing) {
-          await svc.updateSystem(existing.id, {
+        if (existingEntityId) {
+          await svc.updateSystem(existingEntityId, {
             name: displayName,
             description,
-            metadata: {
-              ...(existing.metadata as Record<string, unknown> | undefined),
-              gitops_entity_name: entityName,
-            },
           });
-          context.logger.info(`Updated system ${entityName}`);
-        } else {
-          await svc.createSystem({
-            name: displayName,
-            description,
-            metadata: { gitops_entity_name: entityName },
-          });
-          context.logger.info(`Created system ${entityName}`);
+          context.logger.info(`Updated system (id: ${existingEntityId})`);
+          return { entityId: existingEntityId };
         }
+
+        const system = await svc.createSystem({
+          name: displayName,
+          description,
+        });
+        context.logger.info(`Created system (id: ${system.id})`);
+        return { entityId: system.id };
       },
-      delete: async ({ entityName }) => {
-        await svc.deleteSystemByGitOpsName(entityName);
+      delete: async ({ entityId }) => {
+        if (entityId) await svc.deleteSystem(entityId);
       },
     };
   }
@@ -172,10 +142,10 @@ describe("Catalog GitOps Kind: System", () => {
     mockService = createMockEntityService();
   });
 
-  it("creates a new system when none exists", async () => {
+  it("creates a new system and returns entityId", async () => {
     const kind = buildSystemKind(mockService);
 
-    await kind.reconcile({
+    const result = await kind.reconcile({
       entity: {
         apiVersion: CHECKSTACK_API_VERSION,
         kind: "System",
@@ -189,32 +159,31 @@ describe("Catalog GitOps Kind: System", () => {
       context: { logger: mockLogger },
     });
 
+    expect(result.entityId).toBe("sys-1");
     expect(mockService.createSystem).toHaveBeenCalledTimes(1);
     expect(mockService.systems).toHaveLength(1);
     expect(mockService.systems[0].name).toBe("Payment Service");
     expect(mockService.systems[0].description).toBe("Handles payments");
-    expect(mockService.systems[0].metadata.gitops_entity_name).toBe(
-      "payment-service",
-    );
   });
 
   it("uses metadata.description for the catalog description", async () => {
     const kind = buildSystemKind(mockService);
 
-    await kind.reconcile({
+    const result = await kind.reconcile({
       entity: {
         apiVersion: CHECKSTACK_API_VERSION,
         kind: "System",
         metadata: {
           name: "api-gateway",
-          description: "Metadata description",
+          description: "Gateway description",
         },
         spec: {},
       },
       context: { logger: mockLogger },
     });
 
-    expect(mockService.systems[0].description).toBe("Metadata description");
+    expect(result.entityId).toBe("sys-1");
+    expect(mockService.systems[0].description).toBe("Gateway description");
   });
 
   it("falls back to metadata.name when title is missing", async () => {
@@ -233,20 +202,19 @@ describe("Catalog GitOps Kind: System", () => {
     expect(mockService.systems[0].name).toBe("my-service");
   });
 
-  it("updates an existing system by GitOps name", async () => {
+  it("updates an existing system using existingEntityId", async () => {
     const kind = buildSystemKind(mockService);
 
-    // Create initial
+    // Pre-populate a system
     mockService.systems.push({
       id: "sys-existing",
       name: "Old Name",
       description: "Old description",
-      metadata: { gitops_entity_name: "payment-service" },
       createdAt: new Date(),
       updatedAt: new Date(),
     });
 
-    await kind.reconcile({
+    const result = await kind.reconcile({
       entity: {
         apiVersion: CHECKSTACK_API_VERSION,
         kind: "System",
@@ -257,35 +225,46 @@ describe("Catalog GitOps Kind: System", () => {
         },
         spec: {},
       },
+      existingEntityId: "sys-existing",
       context: { logger: mockLogger },
     });
 
+    expect(result.entityId).toBe("sys-existing");
     expect(mockService.createSystem).not.toHaveBeenCalled();
     expect(mockService.updateSystem).toHaveBeenCalledTimes(1);
     expect(mockService.systems[0].name).toBe("Payment Service v2");
     expect(mockService.systems[0].description).toBe("Updated description");
   });
 
-  it("deletes a system by GitOps entity name", async () => {
+  it("deletes a system by entityId", async () => {
     const kind = buildSystemKind(mockService);
 
     mockService.systems.push({
       id: "sys-del",
       name: "To Delete",
-      metadata: { gitops_entity_name: "old-service" },
       createdAt: new Date(),
       updatedAt: new Date(),
     });
 
     await kind.delete!({
       entityName: "old-service",
+      entityId: "sys-del",
       context: { logger: mockLogger },
     });
 
-    expect(mockService.deleteSystemByGitOpsName).toHaveBeenCalledWith(
-      "old-service",
-    );
+    expect(mockService.deleteSystem).toHaveBeenCalledWith("sys-del");
     expect(mockService.systems).toHaveLength(0);
+  });
+
+  it("skips delete when entityId is missing", async () => {
+    const kind = buildSystemKind(mockService);
+
+    await kind.delete!({
+      entityName: "unknown-service",
+      context: { logger: mockLogger },
+    });
+
+    expect(mockService.deleteSystem).not.toHaveBeenCalled();
   });
 });
 
@@ -293,7 +272,6 @@ describe("Catalog GitOps Kind: Group", () => {
   let mockService: ReturnType<typeof createMockEntityService>;
 
   const groupSpecSchema = z.object({});
-
   type GroupSpec = z.infer<typeof groupSpecSchema>;
 
   function buildGroupKind(
@@ -303,30 +281,21 @@ describe("Catalog GitOps Kind: Group", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "Group",
       specSchema: groupSpecSchema,
-      reconcile: async ({ entity, context }) => {
-        const entityName = entity.metadata.name;
-        const displayName = entity.metadata.title ?? entityName;
+      reconcile: async ({ entity, existingEntityId, context }) => {
+        const displayName = entity.metadata.title ?? entity.metadata.name;
 
-        const existing = await svc.findGroupByGitOpsName(entityName);
-        if (existing) {
-          await svc.updateGroup(existing.id, {
-            name: displayName,
-            metadata: {
-              ...(existing.metadata as Record<string, unknown> | undefined),
-              gitops_entity_name: entityName,
-            },
-          });
-          context.logger.info(`Updated group ${entityName}`);
-        } else {
-          await svc.createGroup({
-            name: displayName,
-            metadata: { gitops_entity_name: entityName },
-          });
-          context.logger.info(`Created group ${entityName}`);
+        if (existingEntityId) {
+          await svc.updateGroup(existingEntityId, { name: displayName });
+          context.logger.info(`Updated group (id: ${existingEntityId})`);
+          return { entityId: existingEntityId };
         }
+
+        const group = await svc.createGroup({ name: displayName });
+        context.logger.info(`Created group (id: ${group.id})`);
+        return { entityId: group.id };
       },
-      delete: async ({ entityName }) => {
-        await svc.deleteGroupByGitOpsName(entityName);
+      delete: async ({ entityId }) => {
+        if (entityId) await svc.deleteGroup(entityId);
       },
     };
   }
@@ -335,10 +304,10 @@ describe("Catalog GitOps Kind: Group", () => {
     mockService = createMockEntityService();
   });
 
-  it("creates a new group when none exists", async () => {
+  it("creates a new group and returns entityId", async () => {
     const kind = buildGroupKind(mockService);
 
-    await kind.reconcile({
+    const result = await kind.reconcile({
       entity: {
         apiVersion: CHECKSTACK_API_VERSION,
         kind: "Group",
@@ -351,26 +320,23 @@ describe("Catalog GitOps Kind: Group", () => {
       context: { logger: mockLogger },
     });
 
+    expect(result.entityId).toBe("grp-1");
     expect(mockService.createGroup).toHaveBeenCalledTimes(1);
     expect(mockService.groups).toHaveLength(1);
     expect(mockService.groups[0].name).toBe("Platform Team");
-    expect(mockService.groups[0].metadata.gitops_entity_name).toBe(
-      "platform-team",
-    );
   });
 
-  it("updates an existing group by GitOps name", async () => {
+  it("updates an existing group using existingEntityId", async () => {
     const kind = buildGroupKind(mockService);
 
     mockService.groups.push({
       id: "grp-existing",
       name: "Old Group",
-      metadata: { gitops_entity_name: "platform-team" },
       createdAt: new Date(),
       updatedAt: new Date(),
     });
 
-    await kind.reconcile({
+    const result = await kind.reconcile({
       entity: {
         apiVersion: CHECKSTACK_API_VERSION,
         kind: "Group",
@@ -380,33 +346,33 @@ describe("Catalog GitOps Kind: Group", () => {
         },
         spec: {},
       },
+      existingEntityId: "grp-existing",
       context: { logger: mockLogger },
     });
 
+    expect(result.entityId).toBe("grp-existing");
     expect(mockService.createGroup).not.toHaveBeenCalled();
     expect(mockService.updateGroup).toHaveBeenCalledTimes(1);
     expect(mockService.groups[0].name).toBe("Platform Engineering");
   });
 
-  it("deletes a group by GitOps entity name", async () => {
+  it("deletes a group by entityId", async () => {
     const kind = buildGroupKind(mockService);
 
     mockService.groups.push({
       id: "grp-del",
       name: "To Delete",
-      metadata: { gitops_entity_name: "old-team" },
       createdAt: new Date(),
       updatedAt: new Date(),
     });
 
     await kind.delete!({
       entityName: "old-team",
+      entityId: "grp-del",
       context: { logger: mockLogger },
     });
 
-    expect(mockService.deleteGroupByGitOpsName).toHaveBeenCalledWith(
-      "old-team",
-    );
+    expect(mockService.deleteGroup).toHaveBeenCalledWith("grp-del");
     expect(mockService.groups).toHaveLength(0);
   });
 });

--- a/core/catalog-backend/src/catalog-gitops-kinds.test.ts
+++ b/core/catalog-backend/src/catalog-gitops-kinds.test.ts
@@ -90,11 +90,14 @@ function createMockEntityService() {
 
 // ─── Test Context ──────────────────────────────────────────────────────────
 
-const mockLogger: ReconcileContext["logger"] = {
-  debug: () => {},
-  info: () => {},
-  warn: () => {},
-  error: () => {},
+const mockContext: ReconcileContext = {
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+  resolveEntityRef: async () => undefined,
 };
 
 // ─── Tests ─────────────────────────────────────────────────────────────────
@@ -156,7 +159,7 @@ describe("Catalog GitOps Kind: System", () => {
         },
         spec: {},
       },
-      context: { logger: mockLogger },
+      context: mockContext,
     });
 
     expect(result.entityId).toBe("sys-1");
@@ -179,7 +182,7 @@ describe("Catalog GitOps Kind: System", () => {
         },
         spec: {},
       },
-      context: { logger: mockLogger },
+      context: mockContext,
     });
 
     expect(result.entityId).toBe("sys-1");
@@ -196,7 +199,7 @@ describe("Catalog GitOps Kind: System", () => {
         metadata: { name: "my-service" },
         spec: {},
       },
-      context: { logger: mockLogger },
+      context: mockContext,
     });
 
     expect(mockService.systems[0].name).toBe("my-service");
@@ -226,7 +229,7 @@ describe("Catalog GitOps Kind: System", () => {
         spec: {},
       },
       existingEntityId: "sys-existing",
-      context: { logger: mockLogger },
+      context: mockContext,
     });
 
     expect(result.entityId).toBe("sys-existing");
@@ -249,7 +252,7 @@ describe("Catalog GitOps Kind: System", () => {
     await kind.delete!({
       entityName: "old-service",
       entityId: "sys-del",
-      context: { logger: mockLogger },
+      context: mockContext,
     });
 
     expect(mockService.deleteSystem).toHaveBeenCalledWith("sys-del");
@@ -261,7 +264,7 @@ describe("Catalog GitOps Kind: System", () => {
 
     await kind.delete!({
       entityName: "unknown-service",
-      context: { logger: mockLogger },
+      context: mockContext,
     });
 
     expect(mockService.deleteSystem).not.toHaveBeenCalled();
@@ -317,7 +320,7 @@ describe("Catalog GitOps Kind: Group", () => {
         },
         spec: {},
       },
-      context: { logger: mockLogger },
+      context: mockContext,
     });
 
     expect(result.entityId).toBe("grp-1");
@@ -347,7 +350,7 @@ describe("Catalog GitOps Kind: Group", () => {
         spec: {},
       },
       existingEntityId: "grp-existing",
-      context: { logger: mockLogger },
+      context: mockContext,
     });
 
     expect(result.entityId).toBe("grp-existing");
@@ -369,7 +372,7 @@ describe("Catalog GitOps Kind: Group", () => {
     await kind.delete!({
       entityName: "old-team",
       entityId: "grp-del",
-      context: { logger: mockLogger },
+      context: mockContext,
     });
 
     expect(mockService.deleteGroup).toHaveBeenCalledWith("grp-del");

--- a/core/catalog-backend/src/catalog-gitops-kinds.test.ts
+++ b/core/catalog-backend/src/catalog-gitops-kinds.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { z } from "zod";
+import { CHECKSTACK_API_VERSION } from "@checkstack/gitops-common";
+import type {
+  EntityKindDefinition,
+  ReconcileContext,
+} from "@checkstack/gitops-common";
+
+/**
+ * Tests for the catalog-backend's GitOps entity kind registrations.
+ *
+ * These tests exercise the reconcile/delete logic in isolation by
+ * reconstructing the same kind definitions that catalog-backend registers
+ * with the entity kind extension point. The actual database operations
+ * are validated via a mock EntityService.
+ */
+
+// ─── Mock EntityService ────────────────────────────────────────────────────
+
+interface MockSystem {
+  id: string;
+  name: string;
+  description?: string;
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface MockGroup {
+  id: string;
+  name: string;
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function createMockEntityService() {
+  const systems: MockSystem[] = [];
+  const groups: MockGroup[] = [];
+
+  return {
+    systems,
+    groups,
+    findSystemByGitOpsName: mock(async (entityName: string) =>
+      systems.find(
+        (s) =>
+          (s.metadata as Record<string, unknown>)?.gitops_entity_name ===
+          entityName,
+      ),
+    ),
+    createSystem: mock(async (data: { name: string; description?: string; metadata?: Record<string, unknown> }) => {
+      const system: MockSystem = {
+        id: `sys-${systems.length + 1}`,
+        name: data.name,
+        description: data.description,
+        metadata: data.metadata ?? {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      systems.push(system);
+      return system;
+    }),
+    updateSystem: mock(async (id: string, data: Partial<{ name: string; description?: string; metadata?: Record<string, unknown> }>) => {
+      const system = systems.find((s) => s.id === id);
+      if (system) {
+        Object.assign(system, data);
+      }
+      return system;
+    }),
+    deleteSystemByGitOpsName: mock(async (entityName: string) => {
+      const idx = systems.findIndex(
+        (s) =>
+          (s.metadata as Record<string, unknown>)?.gitops_entity_name ===
+          entityName,
+      );
+      if (idx >= 0) systems.splice(idx, 1);
+    }),
+    findGroupByGitOpsName: mock(async (entityName: string) =>
+      groups.find(
+        (g) =>
+          (g.metadata as Record<string, unknown>)?.gitops_entity_name ===
+          entityName,
+      ),
+    ),
+    createGroup: mock(async (data: { name: string; metadata?: Record<string, unknown> }) => {
+      const group: MockGroup = {
+        id: `grp-${groups.length + 1}`,
+        name: data.name,
+        metadata: data.metadata ?? {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      groups.push(group);
+      return group;
+    }),
+    updateGroup: mock(async (id: string, data: Partial<{ name: string; metadata?: Record<string, unknown> }>) => {
+      const group = groups.find((g) => g.id === id);
+      if (group) {
+        Object.assign(group, data);
+      }
+      return group;
+    }),
+    deleteGroupByGitOpsName: mock(async (entityName: string) => {
+      const idx = groups.findIndex(
+        (g) =>
+          (g.metadata as Record<string, unknown>)?.gitops_entity_name ===
+          entityName,
+      );
+      if (idx >= 0) groups.splice(idx, 1);
+    }),
+  };
+}
+
+// ─── Test Context ──────────────────────────────────────────────────────────
+
+const mockLogger: ReconcileContext["logger"] = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe("Catalog GitOps Kind: System", () => {
+  let mockService: ReturnType<typeof createMockEntityService>;
+
+  // Recreate the reconcile logic matching catalog-backend's registration
+  const systemSpecSchema = z.object({});
+
+  type SystemSpec = z.infer<typeof systemSpecSchema>;
+
+  function buildSystemKind(
+    svc: ReturnType<typeof createMockEntityService>,
+  ): EntityKindDefinition<SystemSpec> {
+    return {
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: systemSpecSchema,
+      reconcile: async ({ entity, context }) => {
+        const entityName = entity.metadata.name;
+        const displayName = entity.metadata.title ?? entityName;
+        const description = entity.metadata.description;
+
+        const existing = await svc.findSystemByGitOpsName(entityName);
+        if (existing) {
+          await svc.updateSystem(existing.id, {
+            name: displayName,
+            description,
+            metadata: {
+              ...(existing.metadata as Record<string, unknown> | undefined),
+              gitops_entity_name: entityName,
+            },
+          });
+          context.logger.info(`Updated system ${entityName}`);
+        } else {
+          await svc.createSystem({
+            name: displayName,
+            description,
+            metadata: { gitops_entity_name: entityName },
+          });
+          context.logger.info(`Created system ${entityName}`);
+        }
+      },
+      delete: async ({ entityName }) => {
+        await svc.deleteSystemByGitOpsName(entityName);
+      },
+    };
+  }
+
+  beforeEach(() => {
+    mockService = createMockEntityService();
+  });
+
+  it("creates a new system when none exists", async () => {
+    const kind = buildSystemKind(mockService);
+
+    await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        metadata: {
+          name: "payment-service",
+          title: "Payment Service",
+          description: "Handles payments",
+        },
+        spec: {},
+      },
+      context: { logger: mockLogger },
+    });
+
+    expect(mockService.createSystem).toHaveBeenCalledTimes(1);
+    expect(mockService.systems).toHaveLength(1);
+    expect(mockService.systems[0].name).toBe("Payment Service");
+    expect(mockService.systems[0].description).toBe("Handles payments");
+    expect(mockService.systems[0].metadata.gitops_entity_name).toBe(
+      "payment-service",
+    );
+  });
+
+  it("uses metadata.description for the catalog description", async () => {
+    const kind = buildSystemKind(mockService);
+
+    await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        metadata: {
+          name: "api-gateway",
+          description: "Metadata description",
+        },
+        spec: {},
+      },
+      context: { logger: mockLogger },
+    });
+
+    expect(mockService.systems[0].description).toBe("Metadata description");
+  });
+
+  it("falls back to metadata.name when title is missing", async () => {
+    const kind = buildSystemKind(mockService);
+
+    await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        metadata: { name: "my-service" },
+        spec: {},
+      },
+      context: { logger: mockLogger },
+    });
+
+    expect(mockService.systems[0].name).toBe("my-service");
+  });
+
+  it("updates an existing system by GitOps name", async () => {
+    const kind = buildSystemKind(mockService);
+
+    // Create initial
+    mockService.systems.push({
+      id: "sys-existing",
+      name: "Old Name",
+      description: "Old description",
+      metadata: { gitops_entity_name: "payment-service" },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        metadata: {
+          name: "payment-service",
+          title: "Payment Service v2",
+          description: "Updated description",
+        },
+        spec: {},
+      },
+      context: { logger: mockLogger },
+    });
+
+    expect(mockService.createSystem).not.toHaveBeenCalled();
+    expect(mockService.updateSystem).toHaveBeenCalledTimes(1);
+    expect(mockService.systems[0].name).toBe("Payment Service v2");
+    expect(mockService.systems[0].description).toBe("Updated description");
+  });
+
+  it("deletes a system by GitOps entity name", async () => {
+    const kind = buildSystemKind(mockService);
+
+    mockService.systems.push({
+      id: "sys-del",
+      name: "To Delete",
+      metadata: { gitops_entity_name: "old-service" },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await kind.delete!({
+      entityName: "old-service",
+      context: { logger: mockLogger },
+    });
+
+    expect(mockService.deleteSystemByGitOpsName).toHaveBeenCalledWith(
+      "old-service",
+    );
+    expect(mockService.systems).toHaveLength(0);
+  });
+});
+
+describe("Catalog GitOps Kind: Group", () => {
+  let mockService: ReturnType<typeof createMockEntityService>;
+
+  const groupSpecSchema = z.object({});
+
+  type GroupSpec = z.infer<typeof groupSpecSchema>;
+
+  function buildGroupKind(
+    svc: ReturnType<typeof createMockEntityService>,
+  ): EntityKindDefinition<GroupSpec> {
+    return {
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "Group",
+      specSchema: groupSpecSchema,
+      reconcile: async ({ entity, context }) => {
+        const entityName = entity.metadata.name;
+        const displayName = entity.metadata.title ?? entityName;
+
+        const existing = await svc.findGroupByGitOpsName(entityName);
+        if (existing) {
+          await svc.updateGroup(existing.id, {
+            name: displayName,
+            metadata: {
+              ...(existing.metadata as Record<string, unknown> | undefined),
+              gitops_entity_name: entityName,
+            },
+          });
+          context.logger.info(`Updated group ${entityName}`);
+        } else {
+          await svc.createGroup({
+            name: displayName,
+            metadata: { gitops_entity_name: entityName },
+          });
+          context.logger.info(`Created group ${entityName}`);
+        }
+      },
+      delete: async ({ entityName }) => {
+        await svc.deleteGroupByGitOpsName(entityName);
+      },
+    };
+  }
+
+  beforeEach(() => {
+    mockService = createMockEntityService();
+  });
+
+  it("creates a new group when none exists", async () => {
+    const kind = buildGroupKind(mockService);
+
+    await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Group",
+        metadata: {
+          name: "platform-team",
+          title: "Platform Team",
+        },
+        spec: {},
+      },
+      context: { logger: mockLogger },
+    });
+
+    expect(mockService.createGroup).toHaveBeenCalledTimes(1);
+    expect(mockService.groups).toHaveLength(1);
+    expect(mockService.groups[0].name).toBe("Platform Team");
+    expect(mockService.groups[0].metadata.gitops_entity_name).toBe(
+      "platform-team",
+    );
+  });
+
+  it("updates an existing group by GitOps name", async () => {
+    const kind = buildGroupKind(mockService);
+
+    mockService.groups.push({
+      id: "grp-existing",
+      name: "Old Group",
+      metadata: { gitops_entity_name: "platform-team" },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Group",
+        metadata: {
+          name: "platform-team",
+          title: "Platform Engineering",
+        },
+        spec: {},
+      },
+      context: { logger: mockLogger },
+    });
+
+    expect(mockService.createGroup).not.toHaveBeenCalled();
+    expect(mockService.updateGroup).toHaveBeenCalledTimes(1);
+    expect(mockService.groups[0].name).toBe("Platform Engineering");
+  });
+
+  it("deletes a group by GitOps entity name", async () => {
+    const kind = buildGroupKind(mockService);
+
+    mockService.groups.push({
+      id: "grp-del",
+      name: "To Delete",
+      metadata: { gitops_entity_name: "old-team" },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await kind.delete!({
+      entityName: "old-team",
+      context: { logger: mockLogger },
+    });
+
+    expect(mockService.deleteGroupByGitOpsName).toHaveBeenCalledWith(
+      "old-team",
+    );
+    expect(mockService.groups).toHaveLength(0);
+  });
+});

--- a/core/catalog-backend/src/index.ts
+++ b/core/catalog-backend/src/index.ts
@@ -17,6 +17,9 @@ import { authHooks } from "@checkstack/auth-backend";
 import { resolveRoute, type InferClient, extractErrorMessage} from "@checkstack/common";
 import { registerSearchProvider } from "@checkstack/command-backend";
 import { EntityService } from "./services/entity-service";
+import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
+import { CHECKSTACK_API_VERSION } from "@checkstack/gitops-common";
+import { z } from "zod";
 
 // Database schema is still needed for types in creating the router
 import * as schema from "./schema";
@@ -31,6 +34,99 @@ export default createBackendPlugin({
   register(env) {
     env.registerAccessRules(catalogAccessRules);
 
+    // ─── GitOps Entity Kind Registration ───────────────────────────────
+    // Mutable DB reference — populated during init(), consumed by reconcile closures.
+    // Safe because reconcile is only called during sync (afterPluginsReady), by which
+    // point init() has already completed.
+    let gitopsDb: SafeDatabase<typeof schema> | undefined;
+
+    const kindRegistry = env.getExtensionPoint(entityKindExtensionPoint);
+
+    // Register kind: System
+    kindRegistry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: z.object({}),
+      reconcile: async ({ entity, context }) => {
+        if (!gitopsDb) throw new Error("Catalog database not initialized");
+        const entityService = new EntityService(gitopsDb);
+        const entityName = entity.metadata.name;
+        const displayName = entity.metadata.title ?? entityName;
+        const description = entity.metadata.description;
+
+        const existing = await entityService.findSystemByGitOpsName(entityName);
+        if (existing) {
+          await entityService.updateSystem(existing.id, {
+            name: displayName,
+            description,
+            metadata: {
+              ...(existing.metadata as Record<string, unknown> | undefined),
+              gitops_entity_name: entityName,
+            },
+          });
+          context.logger.info(
+            `GitOps: updated System "${displayName}" (entity: ${entityName})`,
+          );
+        } else {
+          await entityService.createSystem({
+            name: displayName,
+            description,
+            metadata: { gitops_entity_name: entityName },
+          });
+          context.logger.info(
+            `GitOps: created System "${displayName}" (entity: ${entityName})`,
+          );
+        }
+      },
+      delete: async ({ entityName, context }) => {
+        if (!gitopsDb) throw new Error("Catalog database not initialized");
+        const entityService = new EntityService(gitopsDb);
+        await entityService.deleteSystemByGitOpsName(entityName);
+        context.logger.info(`GitOps: deleted System entity "${entityName}"`);
+      },
+    });
+
+    // Register kind: Group
+    kindRegistry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "Group",
+      specSchema: z.object({}),
+      reconcile: async ({ entity, context }) => {
+        if (!gitopsDb) throw new Error("Catalog database not initialized");
+        const entityService = new EntityService(gitopsDb);
+        const entityName = entity.metadata.name;
+        const displayName = entity.metadata.title ?? entityName;
+
+        const existing = await entityService.findGroupByGitOpsName(entityName);
+        if (existing) {
+          await entityService.updateGroup(existing.id, {
+            name: displayName,
+            metadata: {
+              ...(existing.metadata as Record<string, unknown> | undefined),
+              gitops_entity_name: entityName,
+            },
+          });
+          context.logger.info(
+            `GitOps: updated Group "${displayName}" (entity: ${entityName})`,
+          );
+        } else {
+          await entityService.createGroup({
+            name: displayName,
+            metadata: { gitops_entity_name: entityName },
+          });
+          context.logger.info(
+            `GitOps: created Group "${displayName}" (entity: ${entityName})`,
+          );
+        }
+      },
+      delete: async ({ entityName, context }) => {
+        if (!gitopsDb) throw new Error("Catalog database not initialized");
+        const entityService = new EntityService(gitopsDb);
+        await entityService.deleteGroupByGitOpsName(entityName);
+        context.logger.info(`GitOps: deleted Group entity "${entityName}"`);
+      },
+    });
+
     env.registerInit({
       schema,
       deps: {
@@ -41,6 +137,9 @@ export default createBackendPlugin({
       // Phase 2: Register router only - no RPC calls to other plugins
       init: async ({ database, rpc, rpcClient, logger }) => {
         logger.debug("Initializing Catalog Backend...");
+
+        // Populate the mutable DB reference for GitOps reconcile closures
+        gitopsDb = database as SafeDatabase<typeof schema>;
 
         const typedDb = database as SafeDatabase<typeof schema>;
 

--- a/core/catalog-backend/src/index.ts
+++ b/core/catalog-backend/src/index.ts
@@ -47,42 +47,38 @@ export default createBackendPlugin({
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema: z.object({}),
-      reconcile: async ({ entity, context }) => {
+      reconcile: async ({ entity, existingEntityId, context }) => {
         if (!gitopsDb) throw new Error("Catalog database not initialized");
         const entityService = new EntityService(gitopsDb);
-        const entityName = entity.metadata.name;
-        const displayName = entity.metadata.title ?? entityName;
+        const displayName = entity.metadata.title ?? entity.metadata.name;
         const description = entity.metadata.description;
 
-        const existing = await entityService.findSystemByGitOpsName(entityName);
-        if (existing) {
-          await entityService.updateSystem(existing.id, {
+        if (existingEntityId) {
+          await entityService.updateSystem(existingEntityId, {
             name: displayName,
             description,
-            metadata: {
-              ...(existing.metadata as Record<string, unknown> | undefined),
-              gitops_entity_name: entityName,
-            },
           });
           context.logger.info(
-            `GitOps: updated System "${displayName}" (entity: ${entityName})`,
+            `GitOps: updated System "${displayName}" (id: ${existingEntityId})`,
           );
-        } else {
-          await entityService.createSystem({
-            name: displayName,
-            description,
-            metadata: { gitops_entity_name: entityName },
-          });
-          context.logger.info(
-            `GitOps: created System "${displayName}" (entity: ${entityName})`,
-          );
+          return { entityId: existingEntityId };
         }
+
+        const system = await entityService.createSystem({
+          name: displayName,
+          description,
+        });
+        context.logger.info(
+          `GitOps: created System "${displayName}" (id: ${system.id})`,
+        );
+        return { entityId: system.id };
       },
-      delete: async ({ entityName, context }) => {
+      delete: async ({ entityId, context }) => {
         if (!gitopsDb) throw new Error("Catalog database not initialized");
+        if (!entityId) return;
         const entityService = new EntityService(gitopsDb);
-        await entityService.deleteSystemByGitOpsName(entityName);
-        context.logger.info(`GitOps: deleted System entity "${entityName}"`);
+        await entityService.deleteSystem(entityId);
+        context.logger.info(`GitOps: deleted System (id: ${entityId})`);
       },
     });
 
@@ -91,39 +87,35 @@ export default createBackendPlugin({
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "Group",
       specSchema: z.object({}),
-      reconcile: async ({ entity, context }) => {
+      reconcile: async ({ entity, existingEntityId, context }) => {
         if (!gitopsDb) throw new Error("Catalog database not initialized");
         const entityService = new EntityService(gitopsDb);
-        const entityName = entity.metadata.name;
-        const displayName = entity.metadata.title ?? entityName;
+        const displayName = entity.metadata.title ?? entity.metadata.name;
 
-        const existing = await entityService.findGroupByGitOpsName(entityName);
-        if (existing) {
-          await entityService.updateGroup(existing.id, {
+        if (existingEntityId) {
+          await entityService.updateGroup(existingEntityId, {
             name: displayName,
-            metadata: {
-              ...(existing.metadata as Record<string, unknown> | undefined),
-              gitops_entity_name: entityName,
-            },
           });
           context.logger.info(
-            `GitOps: updated Group "${displayName}" (entity: ${entityName})`,
+            `GitOps: updated Group "${displayName}" (id: ${existingEntityId})`,
           );
-        } else {
-          await entityService.createGroup({
-            name: displayName,
-            metadata: { gitops_entity_name: entityName },
-          });
-          context.logger.info(
-            `GitOps: created Group "${displayName}" (entity: ${entityName})`,
-          );
+          return { entityId: existingEntityId };
         }
+
+        const group = await entityService.createGroup({
+          name: displayName,
+        });
+        context.logger.info(
+          `GitOps: created Group "${displayName}" (id: ${group.id})`,
+        );
+        return { entityId: group.id };
       },
-      delete: async ({ entityName, context }) => {
+      delete: async ({ entityId, context }) => {
         if (!gitopsDb) throw new Error("Catalog database not initialized");
+        if (!entityId) return;
         const entityService = new EntityService(gitopsDb);
-        await entityService.deleteGroupByGitOpsName(entityName);
-        context.logger.info(`GitOps: deleted Group entity "${entityName}"`);
+        await entityService.deleteGroup(entityId);
+        context.logger.info(`GitOps: deleted Group (id: ${entityId})`);
       },
     });
 

--- a/core/catalog-backend/src/services/entity-service.ts
+++ b/core/catalog-backend/src/services/entity-service.ts
@@ -164,41 +164,6 @@ export class EntityService {
       );
   }
 
-  // GitOps entity name lookups
-  // These methods support the GitOps reconciliation engine by finding catalog entities
-  // that were created/managed via GitOps, identified by a `gitops_entity_name` marker
-  // stored in the metadata JSON column.
-
-  async findSystemByGitOpsName(entityName: string) {
-    const allSystems = await this.database.select().from(schema.systems);
-    return allSystems.find((s) => {
-      const meta = s.metadata as Record<string, unknown> | null;
-      return meta?.gitops_entity_name === entityName;
-    });
-  }
-
-  async findGroupByGitOpsName(entityName: string) {
-    const allGroups = await this.database.select().from(schema.groups);
-    return allGroups.find((g) => {
-      const meta = g.metadata as Record<string, unknown> | null;
-      return meta?.gitops_entity_name === entityName;
-    });
-  }
-
-  async deleteSystemByGitOpsName(entityName: string) {
-    const system = await this.findSystemByGitOpsName(entityName);
-    if (system) {
-      await this.deleteSystem(system.id);
-    }
-  }
-
-  async deleteGroupByGitOpsName(entityName: string) {
-    const group = await this.findGroupByGitOpsName(entityName);
-    if (group) {
-      await this.deleteGroup(group.id);
-    }
-  }
-
   // Views
   async getViews() {
     return this.database.select().from(schema.views);

--- a/core/catalog-backend/src/services/entity-service.ts
+++ b/core/catalog-backend/src/services/entity-service.ts
@@ -164,6 +164,41 @@ export class EntityService {
       );
   }
 
+  // GitOps entity name lookups
+  // These methods support the GitOps reconciliation engine by finding catalog entities
+  // that were created/managed via GitOps, identified by a `gitops_entity_name` marker
+  // stored in the metadata JSON column.
+
+  async findSystemByGitOpsName(entityName: string) {
+    const allSystems = await this.database.select().from(schema.systems);
+    return allSystems.find((s) => {
+      const meta = s.metadata as Record<string, unknown> | null;
+      return meta?.gitops_entity_name === entityName;
+    });
+  }
+
+  async findGroupByGitOpsName(entityName: string) {
+    const allGroups = await this.database.select().from(schema.groups);
+    return allGroups.find((g) => {
+      const meta = g.metadata as Record<string, unknown> | null;
+      return meta?.gitops_entity_name === entityName;
+    });
+  }
+
+  async deleteSystemByGitOpsName(entityName: string) {
+    const system = await this.findSystemByGitOpsName(entityName);
+    if (system) {
+      await this.deleteSystem(system.id);
+    }
+  }
+
+  async deleteGroupByGitOpsName(entityName: string) {
+    const group = await this.findGroupByGitOpsName(entityName);
+    if (group) {
+      await this.deleteGroup(group.id);
+    }
+  }
+
   // Views
   async getViews() {
     return this.database.select().from(schema.views);

--- a/core/catalog-frontend/src/components/DraggableSystem.tsx
+++ b/core/catalog-frontend/src/components/DraggableSystem.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { useDraggable } from "@dnd-kit/core";
-import { GripVertical, Edit, Trash2, FolderPlus } from "lucide-react";
+import { GripVertical, Edit, Trash2, FolderPlus, GitBranch } from "lucide-react";
 import { Button } from "@checkstack/ui";
 import { ExtensionSlot } from "@checkstack/frontend-api";
 import { CatalogSystemActionsSlot } from "@checkstack/catalog-common";
+import { useProvenanceLock } from "@checkstack/gitops-frontend";
 import type { Group, System } from "../api";
 
 interface DraggableSystemProps {
@@ -38,8 +39,14 @@ export const DraggableSystem = ({
 }: DraggableSystemProps) => {
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
+  const { isLocked } = useProvenanceLock({
+    kind: "System",
+    entityId: system.id,
+  });
+
   const { attributes, listeners, setNodeRef } = useDraggable({
     id: system.id,
+    disabled: isLocked,
   });
 
   const availableGroups = groups.filter((g) => !assignedGroupIds.includes(g.id));
@@ -55,10 +62,18 @@ export const DraggableSystem = ({
         <div
           {...listeners}
           {...attributes}
-          className="flex-shrink-0 mt-0.5 cursor-grab active:cursor-grabbing text-muted-foreground/40 hover:text-muted-foreground touch-none"
-          aria-label={`Drag ${system.name}`}
+          className={`flex-shrink-0 mt-0.5 text-muted-foreground/40 touch-none ${
+            isLocked
+              ? "cursor-not-allowed opacity-30"
+              : "cursor-grab active:cursor-grabbing hover:text-muted-foreground"
+          }`}
+          aria-label={isLocked ? `${system.name} is managed by GitOps` : `Drag ${system.name}`}
         >
-          <GripVertical className="w-4 h-4" />
+          {isLocked ? (
+            <GitBranch className="w-4 h-4 text-primary" />
+          ) : (
+            <GripVertical className="w-4 h-4" />
+          )}
         </div>
 
         {/* Name + description — gets all remaining width, never truncated */}
@@ -142,6 +157,8 @@ export const DraggableSystem = ({
             size="sm"
             className="h-7 w-7 p-0"
             onClick={() => onEdit(system)}
+            disabled={isLocked}
+            title={isLocked ? "Managed by GitOps" : undefined}
             aria-label={`Edit ${system.name}`}
           >
             <Edit className="w-3.5 h-3.5" />
@@ -152,6 +169,8 @@ export const DraggableSystem = ({
             size="sm"
             className="text-destructive hover:text-destructive/90 hover:bg-destructive/10 h-7 w-7 p-0"
             onClick={() => onDelete(system.id)}
+            disabled={isLocked}
+            title={isLocked ? "Managed by GitOps" : undefined}
             aria-label={`Delete ${system.name}`}
           >
             <Trash2 className="w-3.5 h-3.5" />

--- a/core/catalog-frontend/src/components/DroppableGroup.tsx
+++ b/core/catalog-frontend/src/components/DroppableGroup.tsx
@@ -1,6 +1,7 @@
 import { useDroppable } from "@dnd-kit/core";
 import { EditableText, Button } from "@checkstack/ui";
-import { Trash2 } from "lucide-react";
+import { Trash2, GitBranch } from "lucide-react";
+import { useProvenanceLock } from "@checkstack/gitops-frontend";
 import type { Group, System } from "../api";
 
 interface DroppableGroupProps {
@@ -35,6 +36,11 @@ export const DroppableGroup = ({
 }: DroppableGroupProps) => {
   const { setNodeRef } = useDroppable({ id: group.id });
 
+  const { isLocked } = useProvenanceLock({
+    kind: "Group",
+    entityId: group.id,
+  });
+
   const groupSystems = (group.systemIds ?? [])
     .map((sysId) => systems.find((s) => s.id === sysId))
     .filter((sys): sys is System => !!sys);
@@ -56,18 +62,28 @@ export const DroppableGroup = ({
     >
       {/* Group header */}
       <div className="flex items-center justify-between">
-        <div className="flex-1">
-          <EditableText
-            value={group.name}
-            onSave={(newName) => onUpdateGroupName(group.id, newName)}
-            className="font-medium text-foreground"
-          />
-          <p className="text-xs text-muted-foreground font-mono">{group.id}</p>
+        <div className="flex items-center gap-2 flex-1">
+          {isLocked && (
+            <span title="Managed by GitOps">
+              <GitBranch className="w-4 h-4 text-primary shrink-0" />
+            </span>
+          )}
+          <div className="flex-1">
+            <EditableText
+              value={group.name}
+              onSave={(newName) => onUpdateGroupName(group.id, newName)}
+              className="font-medium text-foreground"
+              disabled={isLocked}
+            />
+            <p className="text-xs text-muted-foreground font-mono">{group.id}</p>
+          </div>
         </div>
         <Button
           variant="ghost"
           className="text-destructive hover:text-destructive/90 hover:bg-destructive/10 h-8 w-8 p-0"
           onClick={() => onDeleteGroup(group.id)}
+          disabled={isLocked}
+          title={isLocked ? "Managed by GitOps" : undefined}
           aria-label={`Delete group ${group.name}`}
         >
           <Trash2 className="w-4 h-4" />

--- a/core/gitops-backend/drizzle.config.ts
+++ b/core/gitops-backend/drizzle.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/schema.ts",
+  out: "./drizzle",
+  dialect: "postgresql",
+});

--- a/core/gitops-backend/drizzle/0000_tense_stryfe.sql
+++ b/core/gitops-backend/drizzle/0000_tense_stryfe.sql
@@ -1,6 +1,6 @@
-CREATE TYPE "public"."deletion_policy" AS ENUM('orphan', 'auto');--> statement-breakpoint
-CREATE TYPE "public"."provenance_status" AS ENUM('synced', 'error', 'orphaned');--> statement-breakpoint
-CREATE TYPE "public"."provider_type" AS ENUM('github', 'gitlab');--> statement-breakpoint
+CREATE TYPE "deletion_policy" AS ENUM('orphan', 'auto');--> statement-breakpoint
+CREATE TYPE "provenance_status" AS ENUM('synced', 'error', 'orphaned');--> statement-breakpoint
+CREATE TYPE "provider_type" AS ENUM('github', 'gitlab');--> statement-breakpoint
 CREATE TABLE "provenance" (
 	"id" text PRIMARY KEY NOT NULL,
 	"api_version" text NOT NULL,
@@ -43,4 +43,4 @@ CREATE TABLE "secrets" (
 	CONSTRAINT "secrets_name_unique" UNIQUE("name")
 );
 --> statement-breakpoint
-ALTER TABLE "provenance" ADD CONSTRAINT "provenance_provider_id_providers_id_fk" FOREIGN KEY ("provider_id") REFERENCES "public"."providers"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "provenance" ADD CONSTRAINT "provenance_provider_id_providers_id_fk" FOREIGN KEY ("provider_id") REFERENCES "providers"("id") ON DELETE cascade ON UPDATE no action;

--- a/core/gitops-backend/drizzle/0000_tense_stryfe.sql
+++ b/core/gitops-backend/drizzle/0000_tense_stryfe.sql
@@ -1,0 +1,46 @@
+CREATE TYPE "public"."deletion_policy" AS ENUM('orphan', 'auto');--> statement-breakpoint
+CREATE TYPE "public"."provenance_status" AS ENUM('synced', 'error', 'orphaned');--> statement-breakpoint
+CREATE TYPE "public"."provider_type" AS ENUM('github', 'gitlab');--> statement-breakpoint
+CREATE TABLE "provenance" (
+	"id" text PRIMARY KEY NOT NULL,
+	"api_version" text NOT NULL,
+	"kind" text NOT NULL,
+	"entity_name" text NOT NULL,
+	"entity_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"repository" text NOT NULL,
+	"file_path" text NOT NULL,
+	"last_sync_hash" text NOT NULL,
+	"status" "provenance_status" DEFAULT 'synced' NOT NULL,
+	"error_message" text,
+	"last_synced_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "providers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"type" "provider_type" NOT NULL,
+	"target" text NOT NULL,
+	"path_pattern" text NOT NULL,
+	"auth_token" text,
+	"base_url" text,
+	"sync_interval" integer DEFAULT 300 NOT NULL,
+	"deletion_policy" "deletion_policy" DEFAULT 'orphan' NOT NULL,
+	"last_sync_at" timestamp,
+	"last_sync_error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "secrets" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"encrypted_value" text NOT NULL,
+	"description" text,
+	"created_by" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "secrets_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+ALTER TABLE "provenance" ADD CONSTRAINT "provenance_provider_id_providers_id_fk" FOREIGN KEY ("provider_id") REFERENCES "public"."providers"("id") ON DELETE cascade ON UPDATE no action;

--- a/core/gitops-backend/drizzle/meta/0000_snapshot.json
+++ b/core/gitops-backend/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,310 @@
+{
+  "id": "01bbd45b-d962-4e98-b25d-53310f487822",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.provenance": {
+      "name": "provenance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_hash": {
+          "name": "last_sync_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "provenance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provenance_provider_id_providers_id_fk": {
+          "name": "provenance_provider_id_providers_id_fk",
+          "tableFrom": "provenance",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_token": {
+          "name": "auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "deletion_policy": {
+          "name": "deletion_policy",
+          "type": "deletion_policy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'orphan'"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.deletion_policy": {
+      "name": "deletion_policy",
+      "schema": "public",
+      "values": [
+        "orphan",
+        "auto"
+      ]
+    },
+    "public.provenance_status": {
+      "name": "provenance_status",
+      "schema": "public",
+      "values": [
+        "synced",
+        "error",
+        "orphaned"
+      ]
+    },
+    "public.provider_type": {
+      "name": "provider_type",
+      "schema": "public",
+      "values": [
+        "github",
+        "gitlab"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/core/gitops-backend/drizzle/meta/_journal.json
+++ b/core/gitops-backend/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1776797758378,
+      "tag": "0000_tense_stryfe",
+      "breakpoints": true
+    }
+  ]
+}

--- a/core/gitops-backend/package.json
+++ b/core/gitops-backend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@checkstack/gitops-backend",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "checkstack": {
+    "type": "backend"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "generate": "drizzle-kit generate",
+    "lint": "bun run lint:code",
+    "lint:code": "eslint . --max-warnings 0"
+  },
+  "dependencies": {
+    "@checkstack/backend-api": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
+    "@checkstack/common": "workspace:*",
+    "@checkstack/command-backend": "workspace:*",
+    "@orpc/server": "^1.13.2",
+    "drizzle-orm": "^0.45.0",
+    "uuid": "^13.0.0",
+    "zod": "^4.2.1",
+    "yaml": "^2.7.0"
+  },
+  "devDependencies": {
+    "@checkstack/drizzle-helper": "workspace:*",
+    "@checkstack/scripts": "workspace:*",
+    "@checkstack/tsconfig": "workspace:*",
+    "@types/bun": "^1.3.5",
+    "@types/node": "^20.0.0",
+    "@types/uuid": "^11.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/core/gitops-backend/package.json
+++ b/core/gitops-backend/package.json
@@ -17,8 +17,10 @@
     "@checkstack/gitops-common": "workspace:*",
     "@checkstack/common": "workspace:*",
     "@checkstack/command-backend": "workspace:*",
+    "@checkstack/queue-api": "workspace:*",
     "@orpc/server": "^1.13.2",
     "drizzle-orm": "^0.45.0",
+    "minimatch": "^10.0.0",
     "uuid": "^13.0.0",
     "zod": "^4.2.1",
     "yaml": "^2.7.0"

--- a/core/gitops-backend/src/index.ts
+++ b/core/gitops-backend/src/index.ts
@@ -86,7 +86,7 @@ export default createBackendPlugin({
 
         const db = database as SafeDatabase<typeof schema>;
 
-        const router = createGitOpsRouter({ database: db, queueManager });
+        const router = createGitOpsRouter({ database: db, queueManager, kindRegistry });
         rpc.registerRouter(router, gitopsContract);
 
         logger.debug("✅ GitOps Backend initialized.");

--- a/core/gitops-backend/src/index.ts
+++ b/core/gitops-backend/src/index.ts
@@ -16,7 +16,10 @@ import type {
 } from "@checkstack/gitops-common";
 import { createEntityKindRegistry } from "./kind-registry";
 import { createGitOpsRouter } from "./router";
+import { setupSyncWorker } from "./sync/sync-worker";
+import { decrypt } from "@checkstack/backend-api";
 import * as schema from "./schema";
+import { eq } from "drizzle-orm";
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // Extension Points
@@ -76,23 +79,49 @@ export default createBackendPlugin({
       deps: {
         logger: coreServices.logger,
         rpc: coreServices.rpc,
+        queueManager: coreServices.queueManager,
       },
-      init: async ({ logger, database, rpc }) => {
+      init: async ({ logger, database, rpc, queueManager }) => {
         logger.debug("🔄 Initializing GitOps Backend...");
 
-        const router = createGitOpsRouter({
-          database: database as SafeDatabase<typeof schema>,
-        });
+        const db = database as SafeDatabase<typeof schema>;
+
+        const router = createGitOpsRouter({ database: db, queueManager });
         rpc.registerRouter(router, gitopsContract);
 
         logger.debug("✅ GitOps Backend initialized.");
       },
-      afterPluginsReady: async ({ logger }) => {
+      afterPluginsReady: async ({ logger, database, queueManager }) => {
         const registeredKinds = kindRegistry.getKinds();
         logger.debug(
           `🔄 GitOps: ${registeredKinds.length} entity kinds registered: ${registeredKinds.map((k) => k.kind).join(", ")}`,
         );
-        // TODO(phase-2): Bootstrap sync workers for each provider
+
+        const db = database as SafeDatabase<typeof schema>;
+
+        // Create a SecretStore backed by the secrets table
+        const secretStore = {
+          resolve: async (name: string): Promise<string> => {
+            const rows = await db
+              .select()
+              .from(schema.secrets)
+              .where(eq(schema.secrets.name, name));
+            const secret = rows[0];
+            if (!secret) {
+              throw new Error(`Secret not found: ${name}`);
+            }
+            return decrypt(secret.encryptedValue);
+          },
+        };
+
+        // Bootstrap sync worker
+        await setupSyncWorker({
+          db,
+          logger,
+          queueManager,
+          kindRegistry,
+          secretStore,
+        });
       },
     });
   },

--- a/core/gitops-backend/src/index.ts
+++ b/core/gitops-backend/src/index.ts
@@ -1,0 +1,107 @@
+import {
+  createBackendPlugin,
+  createExtensionPoint,
+  coreServices,
+} from "@checkstack/backend-api";
+import type { SafeDatabase } from "@checkstack/backend-api";
+import {
+  pluginMetadata,
+  gitopsAccessRules,
+  gitopsContract,
+} from "@checkstack/gitops-common";
+import type {
+  EntityKindDefinition,
+  EntityKindExtensionDefinition,
+  EntityKindRegistry,
+} from "@checkstack/gitops-common";
+import { createEntityKindRegistry } from "./kind-registry";
+import { createGitOpsRouter } from "./router";
+import * as schema from "./schema";
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Extension Points
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/**
+ * Extension point for the Entity Kind Registry.
+ * Plugins use this during their `register()` phase to register entity kinds
+ * and spec extensions for the GitOps system.
+ *
+ * @example
+ * ```typescript
+ * import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
+ *
+ * // In your plugin's register() function:
+ * const registry = env.getExtensionPoint(entityKindExtensionPoint);
+ * registry.registerKind({
+ *   apiVersion: "checkstack.io/v1alpha1",
+ *   kind: "System",
+ *   specSchema: z.object({ description: z.string().optional() }),
+ *   reconcile: async ({ entity }) => { ... },
+ * });
+ * ```
+ */
+export const entityKindExtensionPoint =
+  createExtensionPoint<EntityKindRegistry>("gitops.entity-kind-registry");
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Plugin Definition
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export default createBackendPlugin({
+  metadata: pluginMetadata,
+
+  register(env) {
+    // Create the kind registry
+    const kindRegistry = createEntityKindRegistry();
+
+    // Register access rules
+    env.registerAccessRules(gitopsAccessRules);
+
+    // Register the Entity Kind Extension Point
+    // Other plugins call this to register their entity kinds and extensions
+    env.registerExtensionPoint(entityKindExtensionPoint, {
+      registerKind<TSpec>(definition: EntityKindDefinition<TSpec>) {
+        kindRegistry.registerKind(definition);
+      },
+      registerKindExtension<TExtensionSpec>(
+        definition: EntityKindExtensionDefinition<TExtensionSpec>,
+      ) {
+        kindRegistry.registerKindExtension(definition);
+      },
+    });
+
+    env.registerInit({
+      schema,
+      deps: {
+        logger: coreServices.logger,
+        rpc: coreServices.rpc,
+      },
+      init: async ({ logger, database, rpc }) => {
+        logger.debug("🔄 Initializing GitOps Backend...");
+
+        const router = createGitOpsRouter({
+          database: database as SafeDatabase<typeof schema>,
+        });
+        rpc.registerRouter(router, gitopsContract);
+
+        logger.debug("✅ GitOps Backend initialized.");
+      },
+      afterPluginsReady: async ({ logger }) => {
+        const registeredKinds = kindRegistry.getKinds();
+        logger.debug(
+          `🔄 GitOps: ${registeredKinds.length} entity kinds registered: ${registeredKinds.map((k) => k.kind).join(", ")}`,
+        );
+        // TODO(phase-2): Bootstrap sync workers for each provider
+      },
+    });
+  },
+});
+
+// Re-export types for consumer plugins
+export type {
+  EntityKindDefinition,
+  EntityKindExtensionDefinition,
+  EntityKindRegistry,
+  ReconcileContext,
+} from "@checkstack/gitops-common";

--- a/core/gitops-backend/src/kind-registry.test.ts
+++ b/core/gitops-backend/src/kind-registry.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "bun:test";
+import { z } from "zod";
+import { createEntityKindRegistry } from "./kind-registry";
+import { CHECKSTACK_API_VERSION } from "@checkstack/gitops-common";
+
+describe("EntityKindRegistry", () => {
+  it("registers a kind and retrieves it", () => {
+    const registry = createEntityKindRegistry();
+    const specSchema = z.object({ description: z.string().optional() });
+
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema,
+      reconcile: async () => {},
+    });
+
+    const kind = registry.getKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+    });
+    expect(kind).toBeDefined();
+    expect(kind?.kind).toBe("System");
+  });
+
+  it("throws on duplicate kind registration", () => {
+    const registry = createEntityKindRegistry();
+    const def = {
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: z.object({}),
+      reconcile: async () => {},
+    };
+
+    registry.registerKind(def);
+    expect(() => registry.registerKind(def)).toThrow(/already registered/);
+  });
+
+  it("registers a kind extension", () => {
+    const registry = createEntityKindRegistry();
+
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: z.object({ description: z.string().optional() }),
+      reconcile: async () => {},
+    });
+
+    registry.registerKindExtension({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      namespace: "healthcheck",
+      specSchema: z.array(z.object({ ref: z.string() })).optional(),
+      reconcile: async () => {},
+    });
+
+    const extensions = registry.getExtensions({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+    });
+    expect(extensions).toHaveLength(1);
+    expect(extensions[0].namespace).toBe("healthcheck");
+  });
+
+  it("throws on duplicate extension namespace", () => {
+    const registry = createEntityKindRegistry();
+
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: z.object({}),
+      reconcile: async () => {},
+    });
+
+    const extDef = {
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      namespace: "healthcheck",
+      specSchema: z.object({}).optional(),
+      reconcile: async () => {},
+    };
+
+    registry.registerKindExtension(extDef);
+    expect(() => registry.registerKindExtension(extDef)).toThrow(
+      /already registered/,
+    );
+  });
+
+  it("allows registering extensions before the kind itself", () => {
+    const registry = createEntityKindRegistry();
+
+    // Extension first
+    registry.registerKindExtension({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      namespace: "healthcheck",
+      specSchema: z.array(z.object({ ref: z.string() })).optional(),
+      reconcile: async () => {},
+    });
+
+    // Kind after
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: z.object({ description: z.string().optional() }),
+      reconcile: async () => {},
+    });
+
+    const kind = registry.getKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+    });
+    expect(kind).toBeDefined();
+
+    const extensions = registry.getExtensions({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+    });
+    expect(extensions).toHaveLength(1);
+  });
+
+  it("builds a merged spec schema with extensions", () => {
+    const registry = createEntityKindRegistry();
+
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: z.object({ description: z.string().optional() }),
+      reconcile: async () => {},
+    });
+
+    registry.registerKindExtension({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      namespace: "healthcheck",
+      specSchema: z.array(z.object({ ref: z.string() })).optional(),
+      reconcile: async () => {},
+    });
+
+    const merged = registry.getMergedSpecSchema({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+    });
+
+    // Should validate base spec fields
+    const result1 = merged.safeParse({ description: "test" });
+    expect(result1.success).toBe(true);
+
+    // Should validate extension namespace fields
+    const result2 = merged.safeParse({
+      description: "test",
+      healthcheck: [{ ref: "my-check" }],
+    });
+    expect(result2.success).toBe(true);
+
+    // Extension namespace should be optional
+    const result3 = merged.safeParse({});
+    expect(result3.success).toBe(true);
+  });
+
+  it("lists all registered kinds", () => {
+    const registry = createEntityKindRegistry();
+
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: z.object({}),
+      reconcile: async () => {},
+    });
+
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "Healthcheck",
+      specSchema: z.object({}),
+      reconcile: async () => {},
+    });
+
+    expect(registry.getKinds()).toHaveLength(2);
+  });
+
+  it("returns empty array for extensions of unregistered kind", () => {
+    const registry = createEntityKindRegistry();
+    const extensions = registry.getExtensions({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "Unknown",
+    });
+    expect(extensions).toHaveLength(0);
+  });
+});

--- a/core/gitops-backend/src/kind-registry.test.ts
+++ b/core/gitops-backend/src/kind-registry.test.ts
@@ -12,7 +12,7 @@ describe("EntityKindRegistry", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema,
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
     });
 
     const kind = registry.getKind({
@@ -29,7 +29,7 @@ describe("EntityKindRegistry", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema: z.object({}),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
     };
 
     registry.registerKind(def);
@@ -43,7 +43,7 @@ describe("EntityKindRegistry", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema: z.object({ description: z.string().optional() }),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
     });
 
     registry.registerKindExtension({
@@ -69,7 +69,7 @@ describe("EntityKindRegistry", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema: z.object({}),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
     });
 
     const extDef = {
@@ -103,7 +103,7 @@ describe("EntityKindRegistry", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema: z.object({ description: z.string().optional() }),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
     });
 
     const kind = registry.getKind({
@@ -126,7 +126,7 @@ describe("EntityKindRegistry", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema: z.object({ description: z.string().optional() }),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
     });
 
     registry.registerKindExtension({
@@ -165,14 +165,14 @@ describe("EntityKindRegistry", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema: z.object({}),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
     });
 
     registry.registerKind({
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "Healthcheck",
       specSchema: z.object({}),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
     });
 
     expect(registry.getKinds()).toHaveLength(2);

--- a/core/gitops-backend/src/kind-registry.test.ts
+++ b/core/gitops-backend/src/kind-registry.test.ts
@@ -186,4 +186,77 @@ describe("EntityKindRegistry", () => {
     });
     expect(extensions).toHaveLength(0);
   });
+
+  describe("describeKinds", () => {
+    it("returns JSON Schema representations of registered kinds", () => {
+      const registry = createEntityKindRegistry();
+
+      registry.registerKind({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        specSchema: z.object({
+          description: z.string().optional(),
+          tier: z.enum(["critical", "standard"]),
+        }),
+        reconcile: async () => ({ entityId: "test-id" }),
+      });
+
+      const described = registry.describeKinds();
+      expect(described).toHaveLength(1);
+
+      const sys = described[0];
+      expect(sys.apiVersion).toBe(CHECKSTACK_API_VERSION);
+      expect(sys.kind).toBe("System");
+      expect(sys.specSchema).toBeDefined();
+      expect(sys.extensions).toHaveLength(0);
+
+      // Verify JSON Schema structure
+      const schema = sys.specSchema as Record<string, unknown>;
+      expect(schema.type).toBe("object");
+      const props = schema.properties as Record<string, Record<string, unknown>>;
+      expect(props.description).toBeDefined();
+      expect(props.tier).toBeDefined();
+    });
+
+    it("includes extensions in the description", () => {
+      const registry = createEntityKindRegistry();
+
+      registry.registerKind({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        specSchema: z.object({ description: z.string().optional() }),
+        reconcile: async () => ({ entityId: "test-id" }),
+      });
+
+      registry.registerKindExtension({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        namespace: "healthcheck",
+        specSchema: z.array(z.object({ ref: z.string() })).optional(),
+        reconcile: async () => {},
+      });
+
+      const described = registry.describeKinds();
+      expect(described).toHaveLength(1);
+      expect(described[0].extensions).toHaveLength(1);
+      expect(described[0].extensions[0].namespace).toBe("healthcheck");
+      expect(described[0].extensions[0].specSchema).toBeDefined();
+    });
+
+    it("skips kinds without a base definition", () => {
+      const registry = createEntityKindRegistry();
+
+      // Only register an extension — no base kind
+      registry.registerKindExtension({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Orphaned",
+        namespace: "test",
+        specSchema: z.object({}).optional(),
+        reconcile: async () => {},
+      });
+
+      const described = registry.describeKinds();
+      expect(described).toHaveLength(0);
+    });
+  });
 });

--- a/core/gitops-backend/src/kind-registry.ts
+++ b/core/gitops-backend/src/kind-registry.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+import type {
+  EntityKindDefinition,
+  EntityKindExtensionDefinition,
+  EntityKindRegistry,
+} from "@checkstack/gitops-common";
+
+/** Internal storage for a registered kind with its extensions. */
+interface RegisteredKind {
+  definition: EntityKindDefinition<unknown> | undefined;
+  extensions: Map<string, EntityKindExtensionDefinition<unknown>>;
+}
+
+/** Composite key for looking up kinds by apiVersion + kind. */
+function kindKey(params: { apiVersion: string; kind: string }): string {
+  return `${params.apiVersion}::${params.kind}`;
+}
+
+/**
+ * Creates a new Entity Kind Registry.
+ * This is the backing implementation for the `entityKindExtensionPoint`.
+ */
+export function createEntityKindRegistry() {
+  const kinds = new Map<string, RegisteredKind>();
+
+  const registry: EntityKindRegistry & {
+    /** Get a registered kind definition. */
+    getKind: (params: {
+      apiVersion: string;
+      kind: string;
+    }) => EntityKindDefinition<unknown> | undefined;
+    /** Get all extensions for a kind. */
+    getExtensions: (params: {
+      apiVersion: string;
+      kind: string;
+    }) => EntityKindExtensionDefinition<unknown>[];
+    /** Get the merged spec schema (base + all extensions). */
+    getMergedSpecSchema: (params: {
+      apiVersion: string;
+      kind: string;
+    }) => z.ZodType<unknown>;
+    /** List all registered kinds. */
+    getKinds: () => EntityKindDefinition<unknown>[];
+  } = {
+    registerKind<TSpec>(definition: EntityKindDefinition<TSpec>) {
+      const key = kindKey(definition);
+      const existing = kinds.get(key);
+
+      if (existing?.definition) {
+        throw new Error(
+          `Entity kind "${definition.kind}" (${definition.apiVersion}) is already registered`,
+        );
+      }
+
+      if (existing) {
+        // Extensions were registered before the kind — attach the definition
+        existing.definition = definition as EntityKindDefinition<unknown>;
+      } else {
+        kinds.set(key, {
+          definition: definition as EntityKindDefinition<unknown>,
+          extensions: new Map(),
+        });
+      }
+    },
+
+    registerKindExtension<TExtensionSpec>(
+      definition: EntityKindExtensionDefinition<TExtensionSpec>,
+    ) {
+      const key = kindKey(definition);
+      const registered = kinds.get(key);
+
+      if (!registered) {
+        // Allow registering extensions before the kind itself.
+        // The kind might be registered by a plugin that loads later.
+        kinds.set(key, {
+          definition: undefined,
+          extensions: new Map([
+            [
+              definition.namespace,
+              definition as EntityKindExtensionDefinition<unknown>,
+            ],
+          ]),
+        });
+        return;
+      }
+
+      if (registered.extensions.has(definition.namespace)) {
+        throw new Error(
+          `Extension namespace "${definition.namespace}" for kind "${definition.kind}" (${definition.apiVersion}) is already registered`,
+        );
+      }
+
+      registered.extensions.set(
+        definition.namespace,
+        definition as EntityKindExtensionDefinition<unknown>,
+      );
+    },
+
+    getKind(params) {
+      return kinds.get(kindKey(params))?.definition;
+    },
+
+    getExtensions(params) {
+      const registered = kinds.get(kindKey(params));
+      if (!registered) return [];
+      return [...registered.extensions.values()];
+    },
+
+    getMergedSpecSchema(params) {
+      const registered = kinds.get(kindKey(params));
+      if (!registered?.definition) {
+        throw new Error(
+          `Cannot build merged schema: kind "${params.kind}" (${params.apiVersion}) has no base definition`,
+        );
+      }
+
+      // Start with the base spec schema
+      let merged = registered.definition
+        .specSchema as z.ZodObject<z.ZodRawShape>;
+
+      // Merge each extension's schema under its namespace key
+      for (const [namespace, ext] of registered.extensions) {
+        merged = merged.extend({
+          [namespace]: ext.specSchema,
+        }) as z.ZodObject<z.ZodRawShape>;
+      }
+
+      return merged;
+    },
+
+    getKinds() {
+      return [...kinds.values()]
+        .map((r) => r.definition)
+        .filter((d): d is EntityKindDefinition<unknown> => d !== undefined);
+    },
+  };
+
+  return registry;
+}
+
+export type InternalEntityKindRegistry = ReturnType<
+  typeof createEntityKindRegistry
+>;

--- a/core/gitops-backend/src/kind-registry.ts
+++ b/core/gitops-backend/src/kind-registry.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { toJsonSchema } from "@checkstack/backend-api";
 import type {
   EntityKindDefinition,
   EntityKindExtensionDefinition,
@@ -41,6 +42,16 @@ export function createEntityKindRegistry() {
     }) => z.ZodType<unknown>;
     /** List all registered kinds. */
     getKinds: () => EntityKindDefinition<unknown>[];
+    /** Describe all registered kinds with JSON Schema representations. */
+    describeKinds: () => Array<{
+      apiVersion: string;
+      kind: string;
+      specSchema: Record<string, unknown>;
+      extensions: Array<{
+        namespace: string;
+        specSchema: Record<string, unknown>;
+      }>;
+    }>;
   } = {
     registerKind<TSpec>(definition: EntityKindDefinition<TSpec>) {
       const key = kindKey(definition);
@@ -132,6 +143,43 @@ export function createEntityKindRegistry() {
       return [...kinds.values()]
         .map((r) => r.definition)
         .filter((d): d is EntityKindDefinition<unknown> => d !== undefined);
+    },
+
+    describeKinds() {
+      const result: Array<{
+        apiVersion: string;
+        kind: string;
+        specSchema: Record<string, unknown>;
+        extensions: Array<{
+          namespace: string;
+          specSchema: Record<string, unknown>;
+        }>;
+      }> = [];
+
+      for (const registered of kinds.values()) {
+        if (!registered.definition) continue;
+
+        const def = registered.definition;
+        const baseSchema = toJsonSchema(
+          def.specSchema as z.ZodTypeAny,
+        );
+
+        const extensions = [...registered.extensions.entries()].map(
+          ([namespace, ext]) => ({
+            namespace,
+            specSchema: toJsonSchema(ext.specSchema as z.ZodTypeAny),
+          }),
+        );
+
+        result.push({
+          apiVersion: def.apiVersion,
+          kind: def.kind,
+          specSchema: baseSchema,
+          extensions,
+        });
+      }
+
+      return result;
     },
   };
 

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -325,6 +325,12 @@ export const createGitOpsRouter = ({
     return { value: decrypt(secret.encryptedValue) };
   });
 
+  // ─── Kind Registry ────────────────────────────────────────────────────
+
+  const listKinds = os.listKinds.handler(async () => {
+    return kindRegistry.describeKinds();
+  });
+
   // ─── Build Router ────────────────────────────────────────────────────
 
   return os.router({
@@ -342,6 +348,7 @@ export const createGitOpsRouter = ({
     rotateSecret,
     deleteSecret,
     resolveSecret,
+    listKinds,
   });
 };
 

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -26,7 +26,11 @@ export interface GitOpsRouterDeps {
   kindRegistry: InternalEntityKindRegistry;
 }
 
-export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }: GitOpsRouterDeps) => {
+export const createGitOpsRouter = ({
+  database: db,
+  queueManager,
+  kindRegistry,
+}: GitOpsRouterDeps) => {
   // ─── Provenance ──────────────────────────────────────────────────────
 
   const getProvenance = os.getProvenance.handler(async ({ input }) => {
@@ -105,11 +109,15 @@ export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }:
 
     const updates: Record<string, unknown> = { updatedAt: new Date() };
     if (input.data.target !== undefined) updates.target = input.data.target;
-    if (input.data.pathPattern !== undefined) updates.pathPattern = input.data.pathPattern;
+    if (input.data.pathPattern !== undefined)
+      updates.pathPattern = input.data.pathPattern;
     if (input.data.baseUrl !== undefined) updates.baseUrl = input.data.baseUrl;
-    if (input.data.authToken !== undefined) updates.authToken = encrypt(input.data.authToken);
-    if (input.data.syncInterval !== undefined) updates.syncInterval = input.data.syncInterval;
-    if (input.data.deletionPolicy !== undefined) updates.deletionPolicy = input.data.deletionPolicy;
+    if (input.data.authToken !== undefined)
+      updates.authToken = encrypt(input.data.authToken);
+    if (input.data.syncInterval !== undefined)
+      updates.syncInterval = input.data.syncInterval;
+    if (input.data.deletionPolicy !== undefined)
+      updates.deletionPolicy = input.data.deletionPolicy;
 
     await db
       .update(schema.providers)
@@ -132,9 +140,7 @@ export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }:
     }
 
     // Provenance entries are cascade-deleted via FK constraint
-    await db
-      .delete(schema.providers)
-      .where(eq(schema.providers.id, input.id));
+    await db.delete(schema.providers).where(eq(schema.providers.id, input.id));
 
     return { success: true };
   });
@@ -198,6 +204,10 @@ export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }:
                 info: () => {},
                 warn: () => {},
                 error: () => {},
+              },
+              resolveEntityRef: async () => {
+                // eslint-disable-next-line unicorn/no-useless-undefined
+                return undefined;
               },
             },
           });
@@ -294,9 +304,7 @@ export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }:
   });
 
   const deleteSecret = os.deleteSecret.handler(async ({ input }) => {
-    await db
-      .delete(schema.secrets)
-      .where(eq(schema.secrets.id, input.id));
+    await db.delete(schema.secrets).where(eq(schema.secrets.id, input.id));
 
     return { success: true };
   });

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -1,0 +1,233 @@
+import { implement, ORPCError } from "@orpc/server";
+import { autoAuthMiddleware, type RpcContext } from "@checkstack/backend-api";
+import { encrypt, decrypt } from "@checkstack/backend-api";
+import { gitopsContract } from "@checkstack/gitops-common";
+import type { SafeDatabase } from "@checkstack/backend-api";
+import * as schema from "./schema";
+import { eq, and } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Creates the GitOps router using contract-based implementation.
+ *
+ * Auth and access rules are automatically enforced via autoAuthMiddleware
+ * based on the contract's meta.userType and meta.access.
+ */
+const os = implement(gitopsContract)
+  .$context<RpcContext>()
+  .use(autoAuthMiddleware);
+
+export interface GitOpsRouterDeps {
+  database: SafeDatabase<typeof schema>;
+}
+
+export const createGitOpsRouter = ({ database: db }: GitOpsRouterDeps) => {
+  // ─── Provenance ──────────────────────────────────────────────────────
+
+  const getProvenance = os.getProvenance.handler(async ({ input }) => {
+    const result = await db
+      .select()
+      .from(schema.provenance)
+      .where(
+        and(
+          eq(schema.provenance.kind, input.kind),
+          eq(schema.provenance.entityName, input.entityName),
+        ),
+      );
+    // eslint-disable-next-line unicorn/no-null
+    return result[0] ?? null;
+  });
+
+  const listProvenance = os.listProvenance.handler(async ({ input }) => {
+    const rows = await db.select().from(schema.provenance);
+    if (!input) return rows;
+
+    return rows.filter((row) => {
+      if (input.status && row.status !== input.status) return false;
+      if (input.providerId && row.providerId !== input.providerId) return false;
+      return true;
+    });
+  });
+
+  // ─── Provider Management ─────────────────────────────────────────────
+
+  const listProviders = os.listProviders.handler(async () => {
+    const rows = await db.select().from(schema.providers);
+    return rows.map((r) => ({
+      id: r.id,
+      type: r.type,
+      target: r.target,
+      pathPattern: r.pathPattern,
+      syncInterval: r.syncInterval,
+      deletionPolicy: r.deletionPolicy,
+      lastSyncAt: r.lastSyncAt,
+      lastSyncError: r.lastSyncError,
+      createdAt: r.createdAt,
+    }));
+  });
+
+  // TODO(phase-2): Implement actual sync dispatch via queue job
+  const triggerSync = os.triggerSync.handler(async ({ input }) => {
+    // Verify provider exists
+    const provider = await db
+      .select()
+      .from(schema.providers)
+      .where(eq(schema.providers.id, input.providerId));
+
+    if (!provider[0]) {
+      throw new ORPCError("NOT_FOUND", {
+        message: `Provider not found: ${input.providerId}`,
+      });
+    }
+
+    return { success: true };
+  });
+
+  const confirmOrphanDeletion = os.confirmOrphanDeletion.handler(
+    async ({ input }) => {
+      const rows = await db
+        .select()
+        .from(schema.provenance)
+        .where(eq(schema.provenance.id, input.provenanceId));
+
+      const prov = rows[0];
+      if (!prov) {
+        throw new ORPCError("NOT_FOUND", {
+          message: `Provenance entry not found: ${input.provenanceId}`,
+        });
+      }
+
+      if (prov.status !== "orphaned") {
+        throw new ORPCError("BAD_REQUEST", {
+          message: "Only orphaned entities can be confirmed for deletion",
+        });
+      }
+
+      // TODO(phase-2): Call the kind's delete reconciler before removing provenance
+      await db
+        .delete(schema.provenance)
+        .where(eq(schema.provenance.id, input.provenanceId));
+
+      return { success: true };
+    },
+  );
+
+  const dismissOrphan = os.dismissOrphan.handler(async ({ input }) => {
+    const rows = await db
+      .select()
+      .from(schema.provenance)
+      .where(eq(schema.provenance.id, input.provenanceId));
+
+    if (!rows[0]) {
+      throw new ORPCError("NOT_FOUND", {
+        message: `Provenance entry not found: ${input.provenanceId}`,
+      });
+    }
+
+    await db
+      .delete(schema.provenance)
+      .where(eq(schema.provenance.id, input.provenanceId));
+
+    return { success: true };
+  });
+
+  // ─── Secret Management ───────────────────────────────────────────────
+
+  const listSecrets = os.listSecrets.handler(async () => {
+    const rows = await db.select().from(schema.secrets);
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      description: r.description,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    }));
+  });
+
+  const createSecret = os.createSecret.handler(async ({ input }) => {
+    // Check for duplicate name
+    const existing = await db
+      .select()
+      .from(schema.secrets)
+      .where(eq(schema.secrets.name, input.name));
+
+    if (existing[0]) {
+      throw new ORPCError("CONFLICT", {
+        message: `Secret with name "${input.name}" already exists`,
+      });
+    }
+
+    const id = uuidv4();
+    const encryptedValue = encrypt(input.value);
+    await db.insert(schema.secrets).values({
+      id,
+      name: input.name,
+      encryptedValue,
+      description: input.description,
+    });
+    return { id, name: input.name };
+  });
+
+  const rotateSecret = os.rotateSecret.handler(async ({ input }) => {
+    const existing = await db
+      .select()
+      .from(schema.secrets)
+      .where(eq(schema.secrets.id, input.id));
+
+    if (!existing[0]) {
+      throw new ORPCError("NOT_FOUND", {
+        message: `Secret not found: ${input.id}`,
+      });
+    }
+
+    const encryptedValue = encrypt(input.value);
+    await db
+      .update(schema.secrets)
+      .set({ encryptedValue, updatedAt: new Date() })
+      .where(eq(schema.secrets.id, input.id));
+
+    return { success: true };
+  });
+
+  const deleteSecret = os.deleteSecret.handler(async ({ input }) => {
+    await db
+      .delete(schema.secrets)
+      .where(eq(schema.secrets.id, input.id));
+
+    return { success: true };
+  });
+
+  const resolveSecret = os.resolveSecret.handler(async ({ input }) => {
+    const rows = await db
+      .select()
+      .from(schema.secrets)
+      .where(eq(schema.secrets.name, input.name));
+
+    const secret = rows[0];
+    if (!secret) {
+      throw new ORPCError("NOT_FOUND", {
+        message: `Secret not found: ${input.name}`,
+      });
+    }
+
+    return { value: decrypt(secret.encryptedValue) };
+  });
+
+  // ─── Build Router ────────────────────────────────────────────────────
+
+  return os.router({
+    getProvenance,
+    listProvenance,
+    listProviders,
+    triggerSync,
+    confirmOrphanDeletion,
+    dismissOrphan,
+    listSecrets,
+    createSecret,
+    rotateSecret,
+    deleteSecret,
+    resolveSecret,
+  });
+};
+
+export type GitOpsRouter = ReturnType<typeof createGitOpsRouter>;

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -30,15 +30,19 @@ export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }:
   // ─── Provenance ──────────────────────────────────────────────────────
 
   const getProvenance = os.getProvenance.handler(async ({ input }) => {
+    const conditions = [eq(schema.provenance.kind, input.kind)];
+
+    if (input.entityName) {
+      conditions.push(eq(schema.provenance.entityName, input.entityName));
+    }
+    if (input.entityId) {
+      conditions.push(eq(schema.provenance.entityId, input.entityId));
+    }
+
     const result = await db
       .select()
       .from(schema.provenance)
-      .where(
-        and(
-          eq(schema.provenance.kind, input.kind),
-          eq(schema.provenance.entityName, input.entityName),
-        ),
-      );
+      .where(and(...conditions));
     // eslint-disable-next-line unicorn/no-null
     return result[0] ?? null;
   });
@@ -70,6 +74,69 @@ export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }:
       lastSyncError: r.lastSyncError,
       createdAt: r.createdAt,
     }));
+  });
+
+  const createProvider = os.createProvider.handler(async ({ input }) => {
+    const id = uuidv4();
+    await db.insert(schema.providers).values({
+      id,
+      type: input.type,
+      target: input.target,
+      pathPattern: input.pathPattern,
+      baseUrl: input.baseUrl ?? null, // eslint-disable-line unicorn/no-null
+      authToken: input.authToken ? encrypt(input.authToken) : null, // eslint-disable-line unicorn/no-null
+      syncInterval: input.syncInterval ?? 300,
+      deletionPolicy: input.deletionPolicy ?? "orphan",
+    });
+    return { id };
+  });
+
+  const updateProvider = os.updateProvider.handler(async ({ input }) => {
+    const existing = await db
+      .select()
+      .from(schema.providers)
+      .where(eq(schema.providers.id, input.id));
+
+    if (!existing[0]) {
+      throw new ORPCError("NOT_FOUND", {
+        message: `Provider not found: ${input.id}`,
+      });
+    }
+
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.data.target !== undefined) updates.target = input.data.target;
+    if (input.data.pathPattern !== undefined) updates.pathPattern = input.data.pathPattern;
+    if (input.data.baseUrl !== undefined) updates.baseUrl = input.data.baseUrl;
+    if (input.data.authToken !== undefined) updates.authToken = encrypt(input.data.authToken);
+    if (input.data.syncInterval !== undefined) updates.syncInterval = input.data.syncInterval;
+    if (input.data.deletionPolicy !== undefined) updates.deletionPolicy = input.data.deletionPolicy;
+
+    await db
+      .update(schema.providers)
+      .set(updates)
+      .where(eq(schema.providers.id, input.id));
+
+    return { success: true };
+  });
+
+  const deleteProvider = os.deleteProvider.handler(async ({ input }) => {
+    const existing = await db
+      .select()
+      .from(schema.providers)
+      .where(eq(schema.providers.id, input.id));
+
+    if (!existing[0]) {
+      throw new ORPCError("NOT_FOUND", {
+        message: `Provider not found: ${input.id}`,
+      });
+    }
+
+    // Provenance entries are cascade-deleted via FK constraint
+    await db
+      .delete(schema.providers)
+      .where(eq(schema.providers.id, input.id));
+
+    return { success: true };
   });
 
   const triggerSync = os.triggerSync.handler(async ({ input }) => {
@@ -124,6 +191,7 @@ export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }:
         try {
           await kindDef.delete({
             entityName: prov.entityName,
+            entityId: prov.entityId,
             context: {
               logger: {
                 debug: () => {},
@@ -255,6 +323,9 @@ export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }:
     getProvenance,
     listProvenance,
     listProviders,
+    createProvider,
+    updateProvider,
+    deleteProvider,
     triggerSync,
     confirmOrphanDeletion,
     dismissOrphan,

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -3,6 +3,8 @@ import { autoAuthMiddleware, type RpcContext } from "@checkstack/backend-api";
 import { encrypt, decrypt } from "@checkstack/backend-api";
 import { gitopsContract } from "@checkstack/gitops-common";
 import type { SafeDatabase } from "@checkstack/backend-api";
+import type { QueueManager } from "@checkstack/queue-api";
+import { triggerSyncForProvider } from "./sync/sync-worker";
 import * as schema from "./schema";
 import { eq, and } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
@@ -19,9 +21,10 @@ const os = implement(gitopsContract)
 
 export interface GitOpsRouterDeps {
   database: SafeDatabase<typeof schema>;
+  queueManager: QueueManager;
 }
 
-export const createGitOpsRouter = ({ database: db }: GitOpsRouterDeps) => {
+export const createGitOpsRouter = ({ database: db, queueManager }: GitOpsRouterDeps) => {
   // ─── Provenance ──────────────────────────────────────────────────────
 
   const getProvenance = os.getProvenance.handler(async ({ input }) => {
@@ -58,6 +61,7 @@ export const createGitOpsRouter = ({ database: db }: GitOpsRouterDeps) => {
       type: r.type,
       target: r.target,
       pathPattern: r.pathPattern,
+      baseUrl: r.baseUrl,
       syncInterval: r.syncInterval,
       deletionPolicy: r.deletionPolicy,
       lastSyncAt: r.lastSyncAt,
@@ -66,7 +70,6 @@ export const createGitOpsRouter = ({ database: db }: GitOpsRouterDeps) => {
     }));
   });
 
-  // TODO(phase-2): Implement actual sync dispatch via queue job
   const triggerSync = os.triggerSync.handler(async ({ input }) => {
     // Verify provider exists
     const provider = await db
@@ -79,6 +82,12 @@ export const createGitOpsRouter = ({ database: db }: GitOpsRouterDeps) => {
         message: `Provider not found: ${input.providerId}`,
       });
     }
+
+    // Dispatch one-off sync job via the queue
+    await triggerSyncForProvider({
+      queueManager,
+      providerId: input.providerId,
+    });
 
     return { success: true };
   });

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -4,6 +4,7 @@ import { encrypt, decrypt } from "@checkstack/backend-api";
 import { gitopsContract } from "@checkstack/gitops-common";
 import type { SafeDatabase } from "@checkstack/backend-api";
 import type { QueueManager } from "@checkstack/queue-api";
+import type { InternalEntityKindRegistry } from "./kind-registry";
 import { triggerSyncForProvider } from "./sync/sync-worker";
 import * as schema from "./schema";
 import { eq, and } from "drizzle-orm";
@@ -22,9 +23,10 @@ const os = implement(gitopsContract)
 export interface GitOpsRouterDeps {
   database: SafeDatabase<typeof schema>;
   queueManager: QueueManager;
+  kindRegistry: InternalEntityKindRegistry;
 }
 
-export const createGitOpsRouter = ({ database: db, queueManager }: GitOpsRouterDeps) => {
+export const createGitOpsRouter = ({ database: db, queueManager, kindRegistry }: GitOpsRouterDeps) => {
   // ─── Provenance ──────────────────────────────────────────────────────
 
   const getProvenance = os.getProvenance.handler(async ({ input }) => {
@@ -112,7 +114,32 @@ export const createGitOpsRouter = ({ database: db, queueManager }: GitOpsRouterD
         });
       }
 
-      // TODO(phase-2): Call the kind's delete reconciler before removing provenance
+      // Call the kind's delete reconciler before removing provenance
+      const kindDef = kindRegistry.getKind({
+        apiVersion: prov.apiVersion,
+        kind: prov.kind,
+      });
+
+      if (kindDef?.delete) {
+        try {
+          await kindDef.delete({
+            entityName: prov.entityName,
+            context: {
+              logger: {
+                debug: () => {},
+                info: () => {},
+                warn: () => {},
+                error: () => {},
+              },
+            },
+          });
+        } catch (deleteError) {
+          throw new ORPCError("INTERNAL_SERVER_ERROR", {
+            message: `Delete reconciler failed: ${deleteError}`,
+          });
+        }
+      }
+
       await db
         .delete(schema.provenance)
         .where(eq(schema.provenance.id, input.provenanceId));

--- a/core/gitops-backend/src/schema.ts
+++ b/core/gitops-backend/src/schema.ts
@@ -1,0 +1,73 @@
+import {
+  pgTable,
+  pgEnum,
+  text,
+  timestamp,
+  integer,
+} from "drizzle-orm/pg-core";
+
+/** Enum for GitOps provider types. */
+export const providerTypeEnum = pgEnum("provider_type", ["github", "gitlab"]);
+
+/** Enum for deletion policy when descriptors disappear from git. */
+export const deletionPolicyEnum = pgEnum("deletion_policy", [
+  "orphan",
+  "auto",
+]);
+
+/** Enum for provenance sync status. */
+export const provenanceStatusEnum = pgEnum("provenance_status", [
+  "synced",
+  "error",
+  "orphaned",
+]);
+
+/** GitOps provider configurations (GitHub, GitLab, etc.) */
+export const providers = pgTable("providers", {
+  id: text("id").primaryKey(),
+  type: providerTypeEnum("type").notNull(),
+  target: text("target").notNull(), // "my-org" or "my-org/my-repo"
+  pathPattern: text("path_pattern").notNull(), // e.g., ".checkstack/**/*.yaml"
+  /** Encrypted auth token (DynamicForm secret field). */
+  authToken: text("auth_token"),
+  /** Sync interval in seconds. */
+  syncInterval: integer("sync_interval").notNull().default(300),
+  deletionPolicy: deletionPolicyEnum("deletion_policy")
+    .notNull()
+    .default("orphan"),
+  lastSyncAt: timestamp("last_sync_at"),
+  lastSyncError: text("last_sync_error"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+/** Provenance tracking for GitOps-managed entities. */
+export const provenance = pgTable("provenance", {
+  id: text("id").primaryKey(),
+  apiVersion: text("api_version").notNull(),
+  kind: text("kind").notNull(),
+  entityName: text("entity_name").notNull(),
+  providerId: text("provider_id")
+    .notNull()
+    .references(() => providers.id, { onDelete: "cascade" }),
+  repository: text("repository").notNull(),
+  filePath: text("file_path").notNull(),
+  lastSyncHash: text("last_sync_hash").notNull(),
+  status: provenanceStatusEnum("status").notNull().default("synced"),
+  errorMessage: text("error_message"),
+  lastSyncedAt: timestamp("last_synced_at").defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+/** Secret store for secretRef values in YAML descriptors. */
+export const secrets = pgTable("secrets", {
+  id: text("id").primaryKey(),
+  /** Unique name referenced by secretRef in descriptors. */
+  name: text("name").notNull().unique(),
+  /** AES-256-GCM encrypted value (format: iv:authTag:ciphertext). */
+  encryptedValue: text("encrypted_value").notNull(),
+  description: text("description"),
+  createdBy: text("created_by"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});

--- a/core/gitops-backend/src/schema.ts
+++ b/core/gitops-backend/src/schema.ts
@@ -49,6 +49,8 @@ export const provenance = pgTable("provenance", {
   apiVersion: text("api_version").notNull(),
   kind: text("kind").notNull(),
   entityName: text("entity_name").notNull(),
+  /** Plugin-specific entity ID (e.g., catalog system UUID). Set by the reconciler engine. */
+  entityId: text("entity_id").notNull(),
   providerId: text("provider_id")
     .notNull()
     .references(() => providers.id, { onDelete: "cascade" }),

--- a/core/gitops-backend/src/schema.ts
+++ b/core/gitops-backend/src/schema.ts
@@ -30,6 +30,8 @@ export const providers = pgTable("providers", {
   pathPattern: text("path_pattern").notNull(), // e.g., ".checkstack/**/*.yaml"
   /** Encrypted auth token (DynamicForm secret field). */
   authToken: text("auth_token"),
+  /** Custom API base URL for enterprise/on-prem installations (e.g., "https://github.example.com/api/v3"). */
+  baseUrl: text("base_url"),
   /** Sync interval in seconds. */
   syncInterval: integer("sync_interval").notNull().default(300),
   deletionPolicy: deletionPolicyEnum("deletion_policy")

--- a/core/gitops-backend/src/scrapers/github-scraper.test.ts
+++ b/core/gitops-backend/src/scrapers/github-scraper.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect } from "bun:test";
+import { githubScraper } from "./github-scraper";
+import type { ScraperOptions, FetchFn } from "./types";
+import type { Logger } from "@checkstack/backend-api";
+
+const mockLogger: Logger = {
+  info: () => {},
+  error: () => {},
+  warn: () => {},
+  debug: () => {},
+};
+
+/**
+ * Creates a mock fetch that returns pre-configured responses based on URL patterns.
+ */
+function createMockFetch(
+  handlers: Array<{
+    pattern: string | RegExp;
+    response: unknown;
+    status?: number;
+    headers?: Record<string, string>;
+  }>,
+): FetchFn {
+  return async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    for (const handler of handlers) {
+      const matches =
+        typeof handler.pattern === "string"
+          ? url.includes(handler.pattern)
+          : handler.pattern.test(url);
+
+      if (matches) {
+        return new Response(JSON.stringify(handler.response), {
+          status: handler.status ?? 200,
+          headers: {
+            "Content-Type": "application/json",
+            ...handler.headers,
+          },
+        });
+      }
+    }
+
+    return new Response("Not Found", { status: 404 });
+  };
+}
+
+const BASE_OPTIONS: Omit<ScraperOptions, "fetch"> = {
+  target: "my-org",
+  pathPattern: ".checkstack/**/*.yaml",
+  authToken: "ghp_test_token",
+  logger: mockLogger,
+};
+
+describe("githubScraper", () => {
+  it("discovers files from a single repo target", async () => {
+    const mockFetch = createMockFetch([
+      {
+        pattern: /repos\/my-org\/my-repo\/git\/trees/,
+        response: {
+          sha: "abc",
+          tree: [
+            { path: ".checkstack/systems.yaml", type: "blob" },
+            { path: "README.md", type: "blob" },
+            { path: "src", type: "tree" },
+          ],
+          truncated: false,
+        },
+      },
+      {
+        pattern: /repos\/my-org\/my-repo\/contents\//,
+        response: {
+          content: btoa("apiVersion: checkstack.io/v1alpha1"),
+          encoding: "base64",
+        },
+      },
+      {
+        pattern: /repos\/my-org\/my-repo$/,
+        response: { full_name: "my-org/my-repo", default_branch: "main" },
+      },
+    ]);
+
+    const files = await githubScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "my-org/my-repo",
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0].repository).toBe("my-org/my-repo");
+    expect(files[0].filePath).toBe(".checkstack/systems.yaml");
+    expect(files[0].content).toBe("apiVersion: checkstack.io/v1alpha1");
+    expect(files[0].branch).toBe("main");
+  });
+
+  it("enumerates repos from an org target", async () => {
+    const mockFetch = createMockFetch([
+      {
+        pattern: "orgs/my-org/repos",
+        response: [
+          { full_name: "my-org/repo-a", default_branch: "main" },
+          { full_name: "my-org/repo-b", default_branch: "develop" },
+        ],
+      },
+      {
+        pattern: "my-org/repo-a/git/trees",
+        response: {
+          sha: "abc",
+          tree: [{ path: ".checkstack/sys.yaml", type: "blob" }],
+          truncated: false,
+        },
+      },
+      {
+        pattern: "my-org/repo-b/git/trees",
+        response: { sha: "def", tree: [], truncated: false },
+      },
+      {
+        pattern: "repo-a/contents",
+        response: { content: btoa("yaml-content"), encoding: "base64" },
+      },
+    ]);
+
+    const files = await githubScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0].repository).toBe("my-org/repo-a");
+    expect(files[0].branch).toBe("main");
+  });
+
+  it("falls back to user endpoint when org returns 404", async () => {
+    let userEndpointCalled = false;
+
+    const mockFetch = createMockFetch([
+      {
+        pattern: "orgs/my-user/repos",
+        response: { message: "Not Found" },
+        status: 404,
+      },
+      {
+        pattern: "users/my-user/repos",
+        response: [
+          { full_name: "my-user/personal-repo", default_branch: "main" },
+        ],
+      },
+      {
+        pattern: "personal-repo/git/trees",
+        response: { sha: "abc", tree: [], truncated: false },
+      },
+    ]);
+
+    // Wrap to detect user endpoint call
+    const wrappedFetch: FetchFn = async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("users/my-user")) userEndpointCalled = true;
+      return mockFetch(input, init);
+    };
+
+    await githubScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "my-user",
+      fetch: wrappedFetch,
+    });
+
+    expect(userEndpointCalled).toBe(true);
+  });
+
+  it("filters files using minimatch pattern", async () => {
+    const mockFetch = createMockFetch([
+      {
+        pattern: /repos\/my-org\/repo\/git\/trees/,
+        response: {
+          sha: "abc",
+          tree: [
+            { path: ".checkstack/systems.yaml", type: "blob" },
+            { path: ".checkstack/deep/nested.yaml", type: "blob" },
+            { path: "other/file.yaml", type: "blob" },
+            { path: ".checkstack/readme.md", type: "blob" },
+          ],
+          truncated: false,
+        },
+      },
+      {
+        pattern: /repos\/my-org\/repo\/contents\//,
+        response: { content: btoa("content"), encoding: "base64" },
+      },
+      {
+        pattern: /repos\/my-org\/repo$/,
+        response: { full_name: "my-org/repo", default_branch: "main" },
+      },
+    ]);
+
+    const files = await githubScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "my-org/repo",
+      fetch: mockFetch,
+    });
+
+    // Should match .checkstack/**/*.yaml only
+    expect(files).toHaveLength(2);
+    expect(files[0].filePath).toBe(".checkstack/systems.yaml");
+    expect(files[1].filePath).toBe(".checkstack/deep/nested.yaml");
+  });
+
+  it("handles pagination via Link header", async () => {
+    const mockFetch: FetchFn = async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.includes("orgs/big-org/repos") && !url.includes("page=2")) {
+        return new Response(
+          JSON.stringify([
+            { full_name: "big-org/repo-1", default_branch: "main" },
+          ]),
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Link: '<https://api.github.com/orgs/big-org/repos?per_page=100&page=2>; rel="next"',
+            },
+          },
+        );
+      }
+
+      if (url.includes("page=2")) {
+        return new Response(
+          JSON.stringify([
+            { full_name: "big-org/repo-2", default_branch: "main" },
+          ]),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("git/trees")) {
+        return new Response(
+          JSON.stringify({ sha: "abc", tree: [], truncated: false }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    };
+
+    const files = await githubScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "big-org",
+      fetch: mockFetch,
+    });
+
+    // Both repos processed but no matching files
+    expect(files).toHaveLength(0);
+  });
+
+  it("continues on individual file fetch errors", async () => {
+    const mockFetch: FetchFn = async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      // Content requests
+      if (url.includes("contents/") && url.includes("bad.yaml")) {
+        return new Response("Internal Server Error", { status: 500 });
+      }
+      if (url.includes("contents/") && url.includes("good.yaml")) {
+        return new Response(
+          JSON.stringify({ content: btoa("good"), encoding: "base64" }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      // Tree request
+      if (url.includes("git/trees")) {
+        return new Response(
+          JSON.stringify({
+            sha: "abc",
+            tree: [
+              { path: ".checkstack/good.yaml", type: "blob" },
+              { path: ".checkstack/bad.yaml", type: "blob" },
+            ],
+            truncated: false,
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      // Repo metadata (must be last — matches broadly)
+      if (url.includes("repos/my-org/repo")) {
+        return new Response(
+          JSON.stringify({ full_name: "my-org/repo", default_branch: "main" }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    };
+
+    const files = await githubScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "my-org/repo",
+      fetch: mockFetch,
+    });
+
+    // Only the good file should be returned
+    expect(files).toHaveLength(1);
+    expect(files[0].filePath).toBe(".checkstack/good.yaml");
+  });
+
+  it("uses custom baseUrl for enterprise installations", async () => {
+    const enterpriseUrl = "https://github.acme.corp/api/v3";
+    const requestedUrls: string[] = [];
+
+    const mockFetch: FetchFn = async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      requestedUrls.push(url);
+
+      if (url.includes("git/trees")) {
+        return new Response(
+          JSON.stringify({
+            sha: "abc",
+            tree: [{ path: ".checkstack/sys.yaml", type: "blob" }],
+            truncated: false,
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("contents/")) {
+        return new Response(
+          JSON.stringify({ content: btoa("yaml"), encoding: "base64" }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("repos/acme/infra")) {
+        return new Response(
+          JSON.stringify({ full_name: "acme/infra", default_branch: "main" }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    };
+
+    const files = await githubScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "acme/infra",
+      baseUrl: enterpriseUrl,
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(1);
+    // All requests should use the enterprise URL, not api.github.com
+    for (const url of requestedUrls) {
+      expect(url).toStartWith(enterpriseUrl);
+    }
+  });
+});

--- a/core/gitops-backend/src/scrapers/github-scraper.ts
+++ b/core/gitops-backend/src/scrapers/github-scraper.ts
@@ -1,0 +1,263 @@
+import { minimatch } from "minimatch";
+import type { DiscoveredFile, ScraperOptions, Scraper, FetchFn } from "./types";
+
+const DEFAULT_GITHUB_API_URL = "https://api.github.com";
+
+// ─── GitHub API Types ──────────────────────────────────────────────────────
+
+interface GitHubRepo {
+  full_name: string;
+  default_branch: string;
+}
+
+interface GitHubTreeItem {
+  path: string;
+  type: "blob" | "tree";
+}
+
+interface GitHubTreeResponse {
+  sha: string;
+  tree: GitHubTreeItem[];
+  truncated: boolean;
+}
+
+interface GitHubContentResponse {
+  content: string;
+  encoding: string;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Parses the GitHub `Link` header for pagination.
+ * Returns the URL for the next page, or undefined if there is none.
+ */
+function parseNextPageUrl(linkHeader: string | null): string | undefined {
+  if (!linkHeader) return undefined;
+  const match = /<([^>]+)>;\s*rel="next"/.exec(linkHeader);
+  return match?.[1];
+}
+
+/**
+ * Makes an authenticated request to the GitHub API.
+ */
+async function githubFetch(params: {
+  url: string;
+  authToken: string;
+  fetchFn: FetchFn;
+}): Promise<Response> {
+  const { url, authToken, fetchFn } = params;
+  return fetchFn(url, {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+}
+
+// ─── Core Logic ────────────────────────────────────────────────────────────
+
+/**
+ * Enumerates repositories for an org or user target.
+ * Supports pagination via Link header.
+ */
+async function enumerateRepos(params: {
+  target: string;
+  authToken: string;
+  fetchFn: FetchFn;
+  apiUrl: string;
+}): Promise<GitHubRepo[]> {
+  const { target, authToken, fetchFn, apiUrl } = params;
+  const repos: GitHubRepo[] = [];
+
+  // Try org endpoint first, fall back to user endpoint
+  let url: string | undefined =
+    `${apiUrl}/orgs/${encodeURIComponent(target)}/repos?per_page=100`;
+
+  const orgResponse = await githubFetch({ url, authToken, fetchFn });
+
+  if (orgResponse.status === 404) {
+    // Fall back to user endpoint
+    url = `${apiUrl}/users/${encodeURIComponent(target)}/repos?per_page=100`;
+  } else if (orgResponse.ok) {
+    const data = (await orgResponse.json()) as GitHubRepo[];
+    repos.push(...data);
+    url = parseNextPageUrl(orgResponse.headers.get("Link"));
+  } else {
+    throw new Error(
+      `GitHub API error listing org repos: ${orgResponse.status} ${orgResponse.statusText}`,
+    );
+  }
+
+  // Paginate through remaining pages (or user repos if org 404'd)
+  while (url) {
+    const response = await githubFetch({ url, authToken, fetchFn });
+    if (!response.ok) {
+      throw new Error(
+        `GitHub API error listing repos: ${response.status} ${response.statusText}`,
+      );
+    }
+    const data = (await response.json()) as GitHubRepo[];
+    repos.push(...data);
+    url = parseNextPageUrl(response.headers.get("Link"));
+  }
+
+  return repos;
+}
+
+/**
+ * Gets the file tree for a repository using the Git Trees API.
+ * Returns only blob (file) paths matching the path pattern.
+ */
+async function getMatchingFiles(params: {
+  repo: GitHubRepo;
+  pathPattern: string;
+  authToken: string;
+  fetchFn: FetchFn;
+  apiUrl: string;
+}): Promise<string[]> {
+  const { repo, pathPattern, authToken, fetchFn, apiUrl } = params;
+
+  const url = `${apiUrl}/repos/${repo.full_name}/git/trees/${encodeURIComponent(repo.default_branch)}?recursive=1`;
+  const response = await githubFetch({ url, authToken, fetchFn });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API error getting tree for ${repo.full_name}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const tree = (await response.json()) as GitHubTreeResponse;
+
+  return tree.tree
+    .filter((item) => item.type === "blob")
+    .map((item) => item.path)
+    .filter((path) => minimatch(path, pathPattern));
+}
+
+/**
+ * Fetches the content of a single file from a repository.
+ */
+async function fetchFileContent(params: {
+  repoFullName: string;
+  filePath: string;
+  branch: string;
+  authToken: string;
+  fetchFn: FetchFn;
+  apiUrl: string;
+}): Promise<string> {
+  const { repoFullName, filePath, branch, authToken, fetchFn, apiUrl } = params;
+
+  const url = `${apiUrl}/repos/${repoFullName}/contents/${encodeURIComponent(filePath)}?ref=${encodeURIComponent(branch)}`;
+  const response = await githubFetch({ url, authToken, fetchFn });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API error fetching ${filePath} from ${repoFullName}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as GitHubContentResponse;
+
+  if (data.encoding === "base64") {
+    return atob(data.content.replaceAll("\n", ""));
+  }
+
+  return data.content;
+}
+
+// ─── Scraper ───────────────────────────────────────────────────────────────
+
+/**
+ * GitHub scraper implementation.
+ *
+ * Supports:
+ * - Org/user target: enumerates all repos with pagination
+ * - Single repo target: `owner/repo` format
+ * - Default branch resolution per-repo
+ * - Recursive tree walking with minimatch filtering
+ * - Custom base URL for GitHub Enterprise
+ */
+export const githubScraper: Scraper = {
+  async discoverFiles(options: ScraperOptions): Promise<DiscoveredFile[]> {
+    const {
+      target,
+      pathPattern,
+      authToken,
+      baseUrl,
+      logger,
+      fetch: fetchFn = globalThis.fetch,
+    } = options;
+
+    const apiUrl = baseUrl ?? DEFAULT_GITHUB_API_URL;
+    const isSingleRepo = target.includes("/");
+    const files: DiscoveredFile[] = [];
+
+    let repos: GitHubRepo[];
+
+    if (isSingleRepo) {
+      // Single repo mode: fetch repo metadata directly
+      const url = `${apiUrl}/repos/${target}`;
+      const response = await githubFetch({ url, authToken, fetchFn });
+      if (!response.ok) {
+        throw new Error(
+          `GitHub API error fetching repo ${target}: ${response.status} ${response.statusText}`,
+        );
+      }
+      repos = [(await response.json()) as GitHubRepo];
+    } else {
+      repos = await enumerateRepos({ target, authToken, fetchFn, apiUrl });
+    }
+
+    logger.debug(
+      `GitHub scraper: found ${repos.length} repo(s) for target "${target}"`,
+    );
+
+    for (const repo of repos) {
+      try {
+        const matchingPaths = await getMatchingFiles({
+          repo,
+          pathPattern,
+          authToken,
+          fetchFn,
+          apiUrl,
+        });
+
+        logger.debug(
+          `GitHub scraper: ${matchingPaths.length} matching file(s) in ${repo.full_name}`,
+        );
+
+        for (const filePath of matchingPaths) {
+          try {
+            const content = await fetchFileContent({
+              repoFullName: repo.full_name,
+              filePath,
+              branch: repo.default_branch,
+              authToken,
+              fetchFn,
+              apiUrl,
+            });
+
+            files.push({
+              repository: repo.full_name,
+              filePath,
+              content,
+              branch: repo.default_branch,
+            });
+          } catch (error) {
+            logger.error(
+              `GitHub scraper: failed to fetch ${filePath} from ${repo.full_name}: ${error}`,
+            );
+          }
+        }
+      } catch (error) {
+        logger.error(
+          `GitHub scraper: failed to process repo ${repo.full_name}: ${error}`,
+        );
+      }
+    }
+
+    return files;
+  },
+};

--- a/core/gitops-backend/src/scrapers/gitlab-scraper.test.ts
+++ b/core/gitops-backend/src/scrapers/gitlab-scraper.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from "bun:test";
+import { gitlabScraper } from "./gitlab-scraper";
+import type { ScraperOptions, FetchFn } from "./types";
+import type { Logger } from "@checkstack/backend-api";
+
+const mockLogger: Logger = {
+  info: () => {},
+  error: () => {},
+  warn: () => {},
+  debug: () => {},
+};
+
+const BASE_OPTIONS: Omit<ScraperOptions, "fetch"> = {
+  target: "my-group",
+  pathPattern: ".checkstack/**/*.yaml",
+  authToken: "glpat-test_token",
+  logger: mockLogger,
+};
+
+/**
+ * Creates a mock fetch for GitLab API requests.
+ * Uses if/else URL matching to handle overlapping patterns correctly.
+ */
+function createGitLabMockFetch(config: {
+  projects: Array<{
+    id: number;
+    path_with_namespace: string;
+    default_branch: string;
+    tree: Array<{ id: string; name: string; type: "blob" | "tree"; path: string }>;
+    files: Record<string, string>;
+  }>;
+  /** If true, the target is treated as a group with multiple projects. */
+  groupMode?: boolean;
+}): FetchFn {
+  return async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    // Group projects listing
+    if (url.includes("/groups/") && url.includes("/projects")) {
+      return new Response(JSON.stringify(config.projects), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Check each project
+    for (const project of config.projects) {
+      // File content (raw)
+      const rawFilePattern = `/projects/${project.id}/repository/files/`;
+      if (url.includes(rawFilePattern) && url.includes("/raw")) {
+        // Extract file path from URL
+        const pathMatch = url.match(
+          /\/files\/([^/]+)\/raw/,
+        );
+        if (pathMatch) {
+          const decodedPath = decodeURIComponent(pathMatch[1]);
+          const content = project.files[decodedPath];
+          if (content) {
+            return new Response(content, {
+              headers: { "Content-Type": "text/plain" },
+            });
+          }
+        }
+        return new Response("Not Found", { status: 404 });
+      }
+
+      // Repository tree
+      const treePattern = `/projects/${project.id}/repository/tree`;
+      if (url.includes(treePattern)) {
+        return new Response(JSON.stringify(project.tree), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      // Project metadata (single project mode)
+      const encodedPath = encodeURIComponent(project.path_with_namespace);
+      if (url.includes(`/projects/${encodedPath}`)) {
+        return new Response(JSON.stringify(project), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    return new Response("Not Found", { status: 404 });
+  };
+}
+
+describe("gitlabScraper", () => {
+  const sampleProject = {
+    id: 42,
+    path_with_namespace: "my-group/my-project",
+    default_branch: "main",
+    tree: [
+      { id: "a1", name: "systems.yaml", type: "blob" as const, path: ".checkstack/systems.yaml" },
+      { id: "a2", name: "README.md", type: "blob" as const, path: "README.md" },
+      { id: "a3", name: "src", type: "tree" as const, path: "src" },
+    ],
+    files: {
+      ".checkstack/systems.yaml": "apiVersion: checkstack.io/v1alpha1\nkind: System",
+    },
+  };
+
+  it("discovers files from a single project target", async () => {
+    const mockFetch = createGitLabMockFetch({
+      projects: [sampleProject],
+    });
+
+    const files = await gitlabScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "my-group/my-project",
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0].repository).toBe("my-group/my-project");
+    expect(files[0].filePath).toBe(".checkstack/systems.yaml");
+    expect(files[0].content).toContain("checkstack.io/v1alpha1");
+    expect(files[0].branch).toBe("main");
+  });
+
+  it("enumerates projects from a group target", async () => {
+    const mockFetch = createGitLabMockFetch({
+      projects: [
+        sampleProject,
+        {
+          id: 43,
+          path_with_namespace: "my-group/empty-project",
+          default_branch: "develop",
+          tree: [],
+          files: {},
+        },
+      ],
+      groupMode: true,
+    });
+
+    const files = await gitlabScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0].repository).toBe("my-group/my-project");
+  });
+
+  it("filters files using minimatch pattern", async () => {
+    const project = {
+      ...sampleProject,
+      tree: [
+        { id: "a1", name: "systems.yaml", type: "blob" as const, path: ".checkstack/systems.yaml" },
+        { id: "a2", name: "nested.yaml", type: "blob" as const, path: ".checkstack/deep/nested.yaml" },
+        { id: "a3", name: "file.yaml", type: "blob" as const, path: "other/file.yaml" },
+        { id: "a4", name: "readme.md", type: "blob" as const, path: ".checkstack/readme.md" },
+      ],
+      files: {
+        ".checkstack/systems.yaml": "content1",
+        ".checkstack/deep/nested.yaml": "content2",
+      },
+    };
+
+    const mockFetch = createGitLabMockFetch({ projects: [project] });
+
+    const files = await gitlabScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "my-group/my-project",
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(2);
+    expect(files[0].filePath).toBe(".checkstack/systems.yaml");
+    expect(files[1].filePath).toBe(".checkstack/deep/nested.yaml");
+  });
+
+  it("handles pagination via x-next-page header", async () => {
+    let requestCount = 0;
+
+    const mockFetch: FetchFn = async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.includes("/groups/") && url.includes("/projects")) {
+        requestCount++;
+        if (!url.includes("page=2")) {
+          return new Response(
+            JSON.stringify([
+              { id: 1, path_with_namespace: "g/p1", default_branch: "main" },
+            ]),
+            {
+              headers: {
+                "Content-Type": "application/json",
+                "x-next-page": "2",
+              },
+            },
+          );
+        }
+        return new Response(
+          JSON.stringify([
+            { id: 2, path_with_namespace: "g/p2", default_branch: "main" },
+          ]),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("/repository/tree")) {
+        return new Response(JSON.stringify([]), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    };
+
+    await gitlabScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      fetch: mockFetch,
+    });
+
+    // Should have made 2 requests for projects (page 1 + page 2)
+    expect(requestCount).toBe(2);
+  });
+
+  it("continues on individual file fetch errors", async () => {
+    const project = {
+      id: 42,
+      path_with_namespace: "my-group/my-project",
+      default_branch: "main",
+      tree: [
+        { id: "a1", name: "good.yaml", type: "blob" as const, path: ".checkstack/good.yaml" },
+        { id: "a2", name: "bad.yaml", type: "blob" as const, path: ".checkstack/bad.yaml" },
+      ],
+      files: {
+        ".checkstack/good.yaml": "good-content",
+        // bad.yaml deliberately missing from files to simulate error
+      },
+    };
+
+    const mockFetch = createGitLabMockFetch({ projects: [project] });
+
+    const files = await gitlabScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "my-group/my-project",
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0].filePath).toBe(".checkstack/good.yaml");
+  });
+
+  it("uses custom baseUrl for self-managed instances", async () => {
+    const selfHostedUrl = "https://gitlab.acme.corp/api/v4";
+    const requestedUrls: string[] = [];
+
+    const mockFetch: FetchFn = async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      requestedUrls.push(url);
+
+      if (url.includes("/repository/tree")) {
+        return new Response(
+          JSON.stringify([
+            { id: "a1", name: "sys.yaml", type: "blob", path: ".checkstack/sys.yaml" },
+          ]),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("/repository/files/") && url.includes("/raw")) {
+        return new Response("yaml-content", {
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+
+      if (url.includes("/projects/")) {
+        return new Response(
+          JSON.stringify({
+            id: 99,
+            path_with_namespace: "acme/infra",
+            default_branch: "main",
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    };
+
+    const files = await gitlabScraper.discoverFiles({
+      ...BASE_OPTIONS,
+      target: "acme/infra",
+      baseUrl: selfHostedUrl,
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(1);
+    // All requests should use the self-hosted URL, not gitlab.com
+    for (const url of requestedUrls) {
+      expect(url).toStartWith(selfHostedUrl);
+    }
+  });
+});

--- a/core/gitops-backend/src/scrapers/gitlab-scraper.ts
+++ b/core/gitops-backend/src/scrapers/gitlab-scraper.ts
@@ -1,0 +1,242 @@
+import { minimatch } from "minimatch";
+import type { DiscoveredFile, ScraperOptions, Scraper, FetchFn } from "./types";
+
+const DEFAULT_GITLAB_API_URL = "https://gitlab.com/api/v4";
+
+// ─── GitLab API Types ──────────────────────────────────────────────────────
+
+interface GitLabProject {
+  id: number;
+  path_with_namespace: string;
+  default_branch: string;
+}
+
+interface GitLabTreeItem {
+  id: string;
+  name: string;
+  type: "blob" | "tree";
+  path: string;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Makes an authenticated request to the GitLab API.
+ */
+async function gitlabFetch(params: {
+  url: string;
+  authToken: string;
+  fetchFn: FetchFn;
+}): Promise<Response> {
+  const { url, authToken, fetchFn } = params;
+  return fetchFn(url, {
+    headers: {
+      "PRIVATE-TOKEN": authToken,
+    },
+  });
+}
+
+/**
+ * Paginates through a GitLab API endpoint that uses `x-next-page` header.
+ */
+async function paginateGitLab<T>(params: {
+  initialUrl: string;
+  authToken: string;
+  fetchFn: FetchFn;
+}): Promise<T[]> {
+  const { initialUrl, authToken, fetchFn } = params;
+  const results: T[] = [];
+  let url: string | undefined = initialUrl;
+
+  while (url) {
+    const response = await gitlabFetch({ url, authToken, fetchFn });
+    if (!response.ok) {
+      throw new Error(
+        `GitLab API error: ${response.status} ${response.statusText} (${url})`,
+      );
+    }
+
+    const data = (await response.json()) as T[];
+    results.push(...data);
+
+    const nextPage = response.headers.get("x-next-page");
+    if (nextPage && nextPage.trim() !== "") {
+      // Build next page URL
+      const urlObj: URL = new URL(url);
+      urlObj.searchParams.set("page", nextPage);
+      url = urlObj.toString();
+    } else {
+      url = undefined;
+    }
+  }
+
+  return results;
+}
+
+// ─── Core Logic ────────────────────────────────────────────────────────────
+
+/**
+ * Enumerates projects for a group target (including subgroups).
+ */
+async function enumerateProjects(params: {
+  target: string;
+  authToken: string;
+  fetchFn: FetchFn;
+  apiUrl: string;
+}): Promise<GitLabProject[]> {
+  const { target, authToken, fetchFn, apiUrl } = params;
+  const encodedTarget = encodeURIComponent(target);
+  const url = `${apiUrl}/groups/${encodedTarget}/projects?include_subgroups=true&per_page=100`;
+  return paginateGitLab<GitLabProject>({ initialUrl: url, authToken, fetchFn });
+}
+
+/**
+ * Gets the file tree for a project and filters paths using minimatch.
+ */
+async function getMatchingFiles(params: {
+  project: GitLabProject;
+  pathPattern: string;
+  authToken: string;
+  fetchFn: FetchFn;
+  apiUrl: string;
+}): Promise<string[]> {
+  const { project, pathPattern, authToken, fetchFn, apiUrl } = params;
+
+  const url = `${apiUrl}/projects/${project.id}/repository/tree?recursive=true&ref=${encodeURIComponent(project.default_branch)}&per_page=100`;
+  const items = await paginateGitLab<GitLabTreeItem>({
+    initialUrl: url,
+    authToken,
+    fetchFn,
+  });
+
+  return items
+    .filter((item) => item.type === "blob")
+    .map((item) => item.path)
+    .filter((path) => minimatch(path, pathPattern));
+}
+
+/**
+ * Fetches the raw content of a file from a GitLab project.
+ */
+async function fetchFileContent(params: {
+  projectId: number;
+  filePath: string;
+  branch: string;
+  authToken: string;
+  fetchFn: FetchFn;
+  apiUrl: string;
+}): Promise<string> {
+  const { projectId, filePath, branch, authToken, fetchFn, apiUrl } = params;
+  const encodedPath = encodeURIComponent(filePath);
+  const url = `${apiUrl}/projects/${projectId}/repository/files/${encodedPath}/raw?ref=${encodeURIComponent(branch)}`;
+  const response = await gitlabFetch({ url, authToken, fetchFn });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitLab API error fetching ${filePath} from project ${projectId}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return response.text();
+}
+
+// ─── Scraper ───────────────────────────────────────────────────────────────
+
+/**
+ * GitLab scraper implementation.
+ *
+ * Supports:
+ * - Group target: enumerates all projects including subgroups with pagination
+ * - Single project target: `group/project` format
+ * - Default branch resolution per-project
+ * - Recursive tree walking with minimatch filtering
+ * - Custom base URL for self-managed GitLab instances
+ */
+export const gitlabScraper: Scraper = {
+  async discoverFiles(options: ScraperOptions): Promise<DiscoveredFile[]> {
+    const {
+      target,
+      pathPattern,
+      authToken,
+      baseUrl,
+      logger,
+      fetch: fetchFn = globalThis.fetch,
+    } = options;
+
+    const apiUrl = baseUrl ?? DEFAULT_GITLAB_API_URL;
+    const isSingleProject = target.includes("/");
+    const files: DiscoveredFile[] = [];
+
+    let projects: GitLabProject[];
+
+    if (isSingleProject) {
+      // Single project mode: fetch project metadata directly
+      const encodedTarget = encodeURIComponent(target);
+      const url = `${apiUrl}/projects/${encodedTarget}`;
+      const response = await gitlabFetch({ url, authToken, fetchFn });
+      if (!response.ok) {
+        throw new Error(
+          `GitLab API error fetching project ${target}: ${response.status} ${response.statusText}`,
+        );
+      }
+      projects = [(await response.json()) as GitLabProject];
+    } else {
+      projects = await enumerateProjects({
+        target,
+        authToken,
+        fetchFn,
+        apiUrl,
+      });
+    }
+
+    logger.debug(
+      `GitLab scraper: found ${projects.length} project(s) for target "${target}"`,
+    );
+
+    for (const project of projects) {
+      try {
+        const matchingPaths = await getMatchingFiles({
+          project,
+          pathPattern,
+          authToken,
+          fetchFn,
+          apiUrl,
+        });
+
+        logger.debug(
+          `GitLab scraper: ${matchingPaths.length} matching file(s) in ${project.path_with_namespace}`,
+        );
+
+        for (const filePath of matchingPaths) {
+          try {
+            const content = await fetchFileContent({
+              projectId: project.id,
+              filePath,
+              branch: project.default_branch,
+              authToken,
+              fetchFn,
+              apiUrl,
+            });
+
+            files.push({
+              repository: project.path_with_namespace,
+              filePath,
+              content,
+              branch: project.default_branch,
+            });
+          } catch (error) {
+            logger.error(
+              `GitLab scraper: failed to fetch ${filePath} from ${project.path_with_namespace}: ${error}`,
+            );
+          }
+        }
+      } catch (error) {
+        logger.error(
+          `GitLab scraper: failed to process project ${project.path_with_namespace}: ${error}`,
+        );
+      }
+    }
+
+    return files;
+  },
+};

--- a/core/gitops-backend/src/scrapers/types.ts
+++ b/core/gitops-backend/src/scrapers/types.ts
@@ -1,0 +1,52 @@
+import type { Logger } from "@checkstack/backend-api";
+
+/**
+ * A fetch function compatible with the standard Fetch API.
+ * We use a custom type alias instead of `typeof globalThis.fetch` because Bun's
+ * native fetch includes a non-standard `preconnect` method that breaks mock implementations.
+ */
+export type FetchFn = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * A file discovered by a scraper from a Git provider.
+ */
+export interface DiscoveredFile {
+  /** Full repository identifier (e.g., "my-org/my-repo"). */
+  repository: string;
+  /** Path to the file within the repository. */
+  filePath: string;
+  /** Raw file content (decoded from base64 if needed). */
+  content: string;
+  /** The branch the file was read from. */
+  branch: string;
+}
+
+/**
+ * Options passed to a scraper's discoverFiles method.
+ */
+export interface ScraperOptions {
+  /** Target: org/user name or "owner/repo" for single-repo mode. */
+  target: string;
+  /** Glob pattern for matching file paths (e.g., ".checkstack/**\/*.yaml"). */
+  pathPattern: string;
+  /** Decrypted auth token for the Git provider API. */
+  authToken: string;
+  /** Custom API base URL for enterprise/on-prem installations. */
+  baseUrl?: string;
+  /** Logger for diagnostic output. */
+  logger: Logger;
+  /** Optional fetch override (defaults to global fetch). Used for testing. */
+  fetch?: FetchFn;
+}
+
+/**
+ * Interface for Git provider scrapers.
+ * Each provider type (GitHub, GitLab) implements this interface.
+ */
+export interface Scraper {
+  /** Discover all YAML descriptor files matching the configured path pattern. */
+  discoverFiles(options: ScraperOptions): Promise<DiscoveredFile[]>;
+}

--- a/core/gitops-backend/src/secret-resolver.test.ts
+++ b/core/gitops-backend/src/secret-resolver.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "bun:test";
+import { resolveSecrets } from "./secret-resolver";
+
+const mockSecretStore = {
+  resolve: async (name: string): Promise<string> => {
+    const secrets: Record<string, string> = {
+      "prod-db-password": "s3cret!",
+      "api-key": "key-12345",
+    };
+    const value = secrets[name];
+    if (!value) throw new Error(`Secret not found: ${name}`);
+    return value;
+  },
+};
+
+describe("resolveSecrets", () => {
+  it("resolves a top-level secretRef", async () => {
+    const spec = { password: { secretRef: "prod-db-password" } };
+    const resolved = await resolveSecrets({
+      spec,
+      secretStore: mockSecretStore,
+    });
+    expect(resolved).toEqual({ password: "s3cret!" });
+  });
+
+  it("leaves plain strings untouched", async () => {
+    const spec = { host: "localhost", port: 5432 };
+    const resolved = await resolveSecrets({
+      spec,
+      secretStore: mockSecretStore,
+    });
+    expect(resolved).toEqual({ host: "localhost", port: 5432 });
+  });
+
+  it("resolves nested secretRefs", async () => {
+    const spec = {
+      connection: {
+        host: "db.internal",
+        password: { secretRef: "prod-db-password" },
+      },
+    };
+    const resolved = await resolveSecrets({
+      spec,
+      secretStore: mockSecretStore,
+    });
+    expect(resolved).toEqual({
+      connection: { host: "db.internal", password: "s3cret!" },
+    });
+  });
+
+  it("resolves secretRefs in arrays", async () => {
+    const spec = {
+      credentials: [
+        { name: "db", secret: { secretRef: "prod-db-password" } },
+        { name: "api", secret: { secretRef: "api-key" } },
+      ],
+    };
+    const resolved = await resolveSecrets({
+      spec,
+      secretStore: mockSecretStore,
+    });
+    expect(resolved).toEqual({
+      credentials: [
+        { name: "db", secret: "s3cret!" },
+        { name: "api", secret: "key-12345" },
+      ],
+    });
+  });
+
+  it("throws when a referenced secret is not found", async () => {
+    const spec = { password: { secretRef: "nonexistent" } };
+    await expect(
+      resolveSecrets({ spec, secretStore: mockSecretStore }),
+    ).rejects.toThrow("Secret not found: nonexistent");
+  });
+
+  it("handles null and undefined values gracefully", async () => {
+    const spec = { a: null, b: undefined, c: "value" };
+    const resolved = await resolveSecrets({
+      spec,
+      secretStore: mockSecretStore,
+    });
+    expect(resolved.a).toBeNull();
+    expect(resolved.c).toBe("value");
+  });
+});

--- a/core/gitops-backend/src/secret-resolver.ts
+++ b/core/gitops-backend/src/secret-resolver.ts
@@ -1,0 +1,54 @@
+import { isSecretRef } from "@checkstack/gitops-common";
+
+/**
+ * Interface for resolving secret names to their decrypted values.
+ */
+export interface SecretStore {
+  resolve: (name: string) => Promise<string>;
+}
+
+/**
+ * Recursively walks a parsed spec object and resolves any `{ secretRef: "name" }`
+ * values by looking them up in the secret store.
+ *
+ * After resolution, all secretRef objects are replaced with plain strings.
+ * This function is called by the reconciliation engine before invoking plugin reconcilers.
+ */
+export async function resolveSecrets(params: {
+  spec: Record<string, unknown>;
+  secretStore: SecretStore;
+}): Promise<Record<string, unknown>> {
+  const { spec, secretStore } = params;
+  return resolveValue(spec, secretStore) as Promise<Record<string, unknown>>;
+}
+
+async function resolveValue(
+  value: unknown,
+  secretStore: SecretStore,
+): Promise<unknown> {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  // Check if this value is a secretRef object
+  if (isSecretRef(value)) {
+    return secretStore.resolve(value.secretRef);
+  }
+
+  // Recurse into arrays
+  if (Array.isArray(value)) {
+    return Promise.all(value.map((item) => resolveValue(item, secretStore)));
+  }
+
+  // Recurse into plain objects
+  if (typeof value === "object") {
+    const resolved: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      resolved[key] = await resolveValue(val, secretStore);
+    }
+    return resolved;
+  }
+
+  // Primitives pass through
+  return value;
+}

--- a/core/gitops-backend/src/sync/document-parser.test.ts
+++ b/core/gitops-backend/src/sync/document-parser.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "bun:test";
+import { parseEntityDocuments, computeHash } from "./document-parser";
+import { CHECKSTACK_API_VERSION } from "@checkstack/gitops-common";
+
+const VALID_SYSTEM_YAML = `apiVersion: ${CHECKSTACK_API_VERSION}
+kind: System
+metadata:
+  name: payment-service
+  title: Payment Service
+  description: Handles payments
+spec:
+  description: A payment processing system`;
+
+const VALID_HEALTHCHECK_YAML = `apiVersion: ${CHECKSTACK_API_VERSION}
+kind: Healthcheck
+metadata:
+  name: payment-db-check
+spec:
+  strategy: postgres`;
+
+describe("parseEntityDocuments", () => {
+  it("parses a single document", () => {
+    const result = parseEntityDocuments({ content: VALID_SYSTEM_YAML });
+    expect(result.errors).toHaveLength(0);
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0].entity.kind).toBe("System");
+    expect(result.entities[0].entity.metadata.name).toBe("payment-service");
+    expect(result.entities[0].contentHash).toBeString();
+    expect(result.entities[0].contentHash).toHaveLength(64); // SHA-256 hex
+  });
+
+  it("parses multi-document YAML separated by ---", () => {
+    const content = `${VALID_SYSTEM_YAML}\n---\n${VALID_HEALTHCHECK_YAML}`;
+    const result = parseEntityDocuments({ content });
+    expect(result.errors).toHaveLength(0);
+    expect(result.entities).toHaveLength(2);
+    expect(result.entities[0].entity.kind).toBe("System");
+    expect(result.entities[1].entity.kind).toBe("Healthcheck");
+  });
+
+  it("handles leading --- in multi-doc YAML", () => {
+    const content = `---\n${VALID_SYSTEM_YAML}\n---\n${VALID_HEALTHCHECK_YAML}`;
+    const result = parseEntityDocuments({ content });
+    expect(result.errors).toHaveLength(0);
+    expect(result.entities).toHaveLength(2);
+  });
+
+  it("skips empty documents (trailing ---)", () => {
+    const content = `${VALID_SYSTEM_YAML}\n---\n`;
+    const result = parseEntityDocuments({ content });
+    expect(result.errors).toHaveLength(0);
+    expect(result.entities).toHaveLength(1);
+  });
+
+  it("collects validation errors for invalid envelope", () => {
+    const content = `kind: System
+metadata:
+  name: INVALID-UPPERCASE
+spec: {}`;
+    const result = parseEntityDocuments({ content });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].documentIndex).toBe(0);
+    expect(result.errors[0].message).toContain("Validation error");
+    expect(result.entities).toHaveLength(0);
+  });
+
+  it("parses valid docs and collects errors for invalid ones in same file", () => {
+    const content = `${VALID_SYSTEM_YAML}\n---\nkind: Bad\nmetadata:\n  name: UPPERCASE\nspec: {}`;
+    const result = parseEntityDocuments({ content });
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0].entity.kind).toBe("System");
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].documentIndex).toBe(1);
+  });
+
+  it("returns content hashes that are stable for identical content", () => {
+    const result1 = parseEntityDocuments({ content: VALID_SYSTEM_YAML });
+    const result2 = parseEntityDocuments({ content: VALID_SYSTEM_YAML });
+    expect(result1.entities[0].contentHash).toBe(
+      result2.entities[0].contentHash,
+    );
+  });
+
+  it("returns different hashes for different content", () => {
+    const modified = VALID_SYSTEM_YAML.replace(
+      "Handles payments",
+      "Handles refunds",
+    );
+    const result1 = parseEntityDocuments({ content: VALID_SYSTEM_YAML });
+    const result2 = parseEntityDocuments({ content: modified });
+    expect(result1.entities[0].contentHash).not.toBe(
+      result2.entities[0].contentHash,
+    );
+  });
+
+  it("handles completely invalid YAML gracefully", () => {
+    const content = `{{{not valid yaml at all`;
+    const result = parseEntityDocuments({ content });
+    expect(result.entities).toHaveLength(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("computeHash", () => {
+  it("produces a 64-character hex string", () => {
+    const hash = computeHash({ input: "hello world" });
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[\da-f]+$/);
+  });
+
+  it("produces deterministic output", () => {
+    expect(computeHash({ input: "test" })).toBe(
+      computeHash({ input: "test" }),
+    );
+  });
+});

--- a/core/gitops-backend/src/sync/document-parser.ts
+++ b/core/gitops-backend/src/sync/document-parser.ts
@@ -1,0 +1,124 @@
+import { parseAllDocuments } from "yaml";
+import { entityEnvelopeSchema } from "@checkstack/gitops-common";
+import { extractErrorMessage } from "@checkstack/common";
+import type { EntityEnvelope } from "@checkstack/gitops-common";
+
+/**
+ * A successfully parsed entity with its content hash for diffing.
+ */
+export interface ParsedEntity {
+  /** The validated entity envelope. */
+  entity: EntityEnvelope;
+  /** SHA-256 hex hash of the raw YAML source for this entity. */
+  contentHash: string;
+}
+
+/**
+ * An error encountered during parsing or validation.
+ */
+export interface ParseError {
+  /** 0-based document index within the YAML file. */
+  documentIndex: number;
+  /** Human-readable error message. */
+  message: string;
+}
+
+/**
+ * Result of parsing a YAML file containing one or more entity documents.
+ */
+export interface ParseResult {
+  entities: ParsedEntity[];
+  errors: ParseError[];
+}
+
+/**
+ * Parses a YAML string (potentially multi-document) into entity envelopes.
+ * Never throws — all parse/validation errors are collected in `errors`.
+ *
+ * @param content - Raw YAML content (may contain multiple docs separated by `---`)
+ * @returns Parsed entities and any errors encountered
+ */
+export function parseEntityDocuments(params: { content: string }): ParseResult {
+  const { content } = params;
+  const entities: ParsedEntity[] = [];
+  const errors: ParseError[] = [];
+
+  let docs: ReturnType<typeof parseAllDocuments>;
+  try {
+    docs = parseAllDocuments(content);
+  } catch (error) {
+    errors.push({
+      documentIndex: 0,
+      message: `Failed to parse YAML: ${extractErrorMessage(error, "Unknown error")}`,
+    });
+    return { entities, errors };
+  }
+
+  for (const [i, doc] of docs.entries()) {
+    // Check for YAML-level parse errors
+    if (doc.errors.length > 0) {
+      errors.push({
+        documentIndex: i,
+        message: `YAML parse error: ${doc.errors.map((e) => e.message).join("; ")}`,
+      });
+      continue;
+    }
+
+    const raw = doc.toJSON();
+
+    // Skip null/empty documents (e.g., trailing `---`)
+    if (raw === null || raw === undefined) {
+      continue;
+    }
+
+    // Validate against entity envelope schema
+    const result = entityEnvelopeSchema.safeParse(raw);
+    if (!result.success) {
+      const issues = result.error.issues
+        .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join("; ");
+      errors.push({
+        documentIndex: i,
+        message: `Validation error: ${issues}`,
+      });
+      continue;
+    }
+
+    // Compute content hash from the raw YAML source for this document
+    const docSource = extractDocumentSource({ content, documentIndex: i });
+    const contentHash = computeHash({ input: docSource });
+
+    entities.push({ entity: result.data, contentHash });
+  }
+
+  return { entities, errors };
+}
+
+/**
+ * Extracts the raw YAML source for a single document from a multi-doc string.
+ * Uses `---` as the separator.
+ */
+function extractDocumentSource(params: {
+  content: string;
+  documentIndex: number;
+}): string {
+  const { content, documentIndex } = params;
+  // Split on document separators, handling leading `---`
+  const parts = content.split(/^---$/m);
+
+  // If the content starts with `---`, the first part is empty
+  const nonEmptyParts = parts[0].trim() === "" ? parts.slice(1) : parts;
+
+  return (nonEmptyParts[documentIndex] ?? "").trim();
+}
+
+/**
+ * Computes a SHA-256 hex hash of a string.
+ */
+function computeHash(params: { input: string }): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(params.input);
+  return hasher.digest("hex");
+}
+
+export { computeHash };

--- a/core/gitops-backend/src/sync/reconciler-delete.test.ts
+++ b/core/gitops-backend/src/sync/reconciler-delete.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { z } from "zod";
+import { CHECKSTACK_API_VERSION } from "@checkstack/gitops-common";
+import { createEntityKindRegistry } from "../kind-registry";
+
+/**
+ * Tests that the `detectOrphans` logic in the reconciler properly invokes
+ * the kind's `delete()` reconciler before removing provenance entries.
+ *
+ * These tests verify the delete wiring in isolation by directly testing
+ * the kind registry's delete behavior, which the reconciler calls.
+ */
+
+describe("Kind delete reconciler wiring", () => {
+  it("calls the registered delete function when available", async () => {
+    const deleteHandler = mock(async () => {});
+    const registry = createEntityKindRegistry();
+
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: z.object({ description: z.string().optional() }),
+      reconcile: async () => {},
+      delete: deleteHandler,
+    });
+
+    const kindDef = registry.getKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+    });
+
+    expect(kindDef?.delete).toBeDefined();
+
+    await kindDef!.delete!({
+      entityName: "payment-service",
+      context: {
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+        },
+      },
+    });
+
+    expect(deleteHandler).toHaveBeenCalledTimes(1);
+    expect(deleteHandler).toHaveBeenCalledWith({
+      entityName: "payment-service",
+      context: expect.objectContaining({
+        logger: expect.any(Object),
+      }),
+    });
+  });
+
+  it("handles kinds with no delete handler gracefully", () => {
+    const registry = createEntityKindRegistry();
+
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "ReadOnlyKind",
+      specSchema: z.object({}),
+      reconcile: async () => {},
+      // No delete handler
+    });
+
+    const kindDef = registry.getKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "ReadOnlyKind",
+    });
+
+    expect(kindDef).toBeDefined();
+    expect(kindDef?.delete).toBeUndefined();
+  });
+
+  it("propagates errors from the delete handler", async () => {
+    const registry = createEntityKindRegistry();
+
+    registry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "FailingKind",
+      specSchema: z.object({}),
+      reconcile: async () => {},
+      delete: async () => {
+        throw new Error("DB connection failed");
+      },
+    });
+
+    const kindDef = registry.getKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "FailingKind",
+    });
+
+    expect(
+      kindDef!.delete!({
+        entityName: "broken-entity",
+        context: {
+          logger: {
+            debug: () => {},
+            info: () => {},
+            warn: () => {},
+            error: () => {},
+          },
+        },
+      }),
+    ).rejects.toThrow("DB connection failed");
+  });
+
+  it("returns undefined for unknown kind lookups (delete not called)", () => {
+    const registry = createEntityKindRegistry();
+
+    const kindDef = registry.getKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "NonExistent",
+    });
+
+    expect(kindDef).toBeUndefined();
+  });
+});

--- a/core/gitops-backend/src/sync/reconciler-delete.test.ts
+++ b/core/gitops-backend/src/sync/reconciler-delete.test.ts
@@ -13,14 +13,14 @@ import { createEntityKindRegistry } from "../kind-registry";
 
 describe("Kind delete reconciler wiring", () => {
   it("calls the registered delete function when available", async () => {
-    const deleteHandler = mock(async () => {});
+    const deleteHandler = mock(async (_params: { entityName: string; entityId?: string }) => {});
     const registry = createEntityKindRegistry();
 
     registry.registerKind({
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "System",
       specSchema: z.object({ description: z.string().optional() }),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
       delete: deleteHandler,
     });
 
@@ -33,6 +33,7 @@ describe("Kind delete reconciler wiring", () => {
 
     await kindDef!.delete!({
       entityName: "payment-service",
+      entityId: "sys-123",
       context: {
         logger: {
           debug: () => {},
@@ -46,6 +47,7 @@ describe("Kind delete reconciler wiring", () => {
     expect(deleteHandler).toHaveBeenCalledTimes(1);
     expect(deleteHandler).toHaveBeenCalledWith({
       entityName: "payment-service",
+      entityId: "sys-123",
       context: expect.objectContaining({
         logger: expect.any(Object),
       }),
@@ -59,7 +61,7 @@ describe("Kind delete reconciler wiring", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "ReadOnlyKind",
       specSchema: z.object({}),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
       // No delete handler
     });
 
@@ -79,7 +81,7 @@ describe("Kind delete reconciler wiring", () => {
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "FailingKind",
       specSchema: z.object({}),
-      reconcile: async () => {},
+      reconcile: async () => ({ entityId: "test-id" }),
       delete: async () => {
         throw new Error("DB connection failed");
       },
@@ -93,6 +95,7 @@ describe("Kind delete reconciler wiring", () => {
     expect(
       kindDef!.delete!({
         entityName: "broken-entity",
+        entityId: "broken-id",
         context: {
           logger: {
             debug: () => {},

--- a/core/gitops-backend/src/sync/reconciler-delete.test.ts
+++ b/core/gitops-backend/src/sync/reconciler-delete.test.ts
@@ -41,6 +41,7 @@ describe("Kind delete reconciler wiring", () => {
           warn: () => {},
           error: () => {},
         },
+        resolveEntityRef: async () => undefined,
       },
     });
 
@@ -103,6 +104,7 @@ describe("Kind delete reconciler wiring", () => {
             warn: () => {},
             error: () => {},
           },
+          resolveEntityRef: async () => undefined,
         },
       }),
     ).rejects.toThrow("DB connection failed");

--- a/core/gitops-backend/src/sync/reconciler.ts
+++ b/core/gitops-backend/src/sync/reconciler.ts
@@ -86,7 +86,9 @@ export async function reconcileProvider(
       fetch: fetchFn,
     });
   } catch (error) {
-    logger.error(`Reconciler: scraper failed for provider ${providerId}: ${error}`);
+    logger.error(
+      `Reconciler: scraper failed for provider ${providerId}: ${error}`,
+    );
     // Update provider with sync error
     await updateProviderSyncStatus({ db, providerId, error: String(error) });
     throw error;
@@ -187,6 +189,26 @@ async function reconcileEntity(params: {
     result,
   } = params;
 
+  // Build resolve function that queries local provenance (no RPC round-trip)
+  const resolveEntityRef = async (refParams: {
+    kind: string;
+    entityName: string;
+  }): Promise<string | undefined> => {
+    const rows = await db
+      .select({ entityId: schema.provenance.entityId })
+      .from(schema.provenance)
+      .where(
+        and(
+          eq(schema.provenance.kind, refParams.kind),
+          eq(schema.provenance.entityName, refParams.entityName),
+          eq(schema.provenance.status, "synced"),
+        ),
+      );
+    return rows[0]?.entityId;
+  };
+
+  const context = { logger, resolveEntityRef };
+
   // Look up registered kind
   const kindDef = kindRegistry.getKind({
     apiVersion: entity.apiVersion,
@@ -207,7 +229,9 @@ async function reconcileEntity(params: {
 
   const validationResult = mergedSchema.safeParse(entity.spec);
   if (!validationResult.success) {
-    throw new Error(`Spec validation failed: ${validationResult.error.message}`);
+    throw new Error(
+      `Spec validation failed: ${validationResult.error.message}`,
+    );
   }
 
   // Check provenance for diff
@@ -239,7 +263,7 @@ async function reconcileEntity(params: {
   const reconcileResult = await kindDef.reconcile({
     entity: { ...entity, spec: resolvedSpec },
     existingEntityId: existing?.entityId ?? undefined,
-    context: { logger },
+    context,
   });
 
   // Call extension reconcilers for present namespaces
@@ -256,7 +280,7 @@ async function reconcileEntity(params: {
       await ext.reconcile({
         entity: { ...entity, spec: resolvedSpec },
         extensionSpec,
-        context: { logger },
+        context,
       });
     }
   }
@@ -313,7 +337,13 @@ async function detectOrphans(params: {
             await kindDef.delete({
               entityName: prov.entityName,
               entityId: prov.entityId,
-              context: { logger },
+              context: {
+                logger,
+                resolveEntityRef: async () => {
+                  // eslint-disable-next-line unicorn/no-useless-undefined
+                  return undefined;
+                },
+              },
             });
           } catch (deleteError) {
             logger.error(
@@ -359,8 +389,16 @@ async function upsertProvenance(params: {
   status: "synced" | "error";
   errorMessage?: string;
 }): Promise<void> {
-  const { db, providerId, entity, file, contentHash, entityId, status, errorMessage } =
-    params;
+  const {
+    db,
+    providerId,
+    entity,
+    file,
+    contentHash,
+    entityId,
+    status,
+    errorMessage,
+  } = params;
   const existing = await db
     .select()
     .from(schema.provenance)

--- a/core/gitops-backend/src/sync/reconciler.ts
+++ b/core/gitops-backend/src/sync/reconciler.ts
@@ -300,7 +300,27 @@ async function detectOrphans(params: {
     const key = `${prov.kind}::${prov.entityName}`;
     if (!seenEntityKeys.has(key)) {
       if (deletionPolicy === "auto") {
-        // TODO(phase-3): Call kind's delete reconciler before removing
+        // Call the kind's delete reconciler before removing provenance
+        const kindDef = params.kindRegistry.getKind({
+          apiVersion: prov.apiVersion,
+          kind: prov.kind,
+        });
+
+        if (kindDef?.delete) {
+          try {
+            await kindDef.delete({
+              entityName: prov.entityName,
+              context: { logger },
+            });
+          } catch (deleteError) {
+            logger.error(
+              `Reconciler: delete reconciler failed for ${key}: ${deleteError}`,
+            );
+            result.errors++;
+            continue;
+          }
+        }
+
         await db
           .delete(schema.provenance)
           .where(eq(schema.provenance.id, prov.id));

--- a/core/gitops-backend/src/sync/reconciler.ts
+++ b/core/gitops-backend/src/sync/reconciler.ts
@@ -1,0 +1,393 @@
+import type { Logger, SafeDatabase } from "@checkstack/backend-api";
+import type { EntityEnvelope } from "@checkstack/gitops-common";
+import type { InternalEntityKindRegistry } from "../kind-registry";
+import type { SecretStore } from "../secret-resolver";
+import type { DiscoveredFile, Scraper, FetchFn } from "../scrapers/types";
+import { parseEntityDocuments } from "./document-parser";
+import { resolveSecrets } from "../secret-resolver";
+import * as schema from "../schema";
+import { eq, and } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+
+type Db = SafeDatabase<typeof schema>;
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+interface ReconcileProviderParams {
+  providerId: string;
+  providerType: "github" | "gitlab";
+  target: string;
+  pathPattern: string;
+  authToken: string;
+  baseUrl?: string;
+  deletionPolicy: "orphan" | "auto";
+  db: Db;
+  logger: Logger;
+  kindRegistry: InternalEntityKindRegistry;
+  secretStore: SecretStore;
+  scraper: Scraper;
+  fetchFn?: FetchFn;
+}
+
+interface ReconcileResult {
+  created: number;
+  updated: number;
+  unchanged: number;
+  orphaned: number;
+  deleted: number;
+  errors: number;
+}
+
+// ─── Main Reconciler ───────────────────────────────────────────────────────
+
+/**
+ * Runs a full reconciliation cycle for a single provider:
+ * 1. Scrape files from the Git provider
+ * 2. Parse YAML → entity envelopes
+ * 3. For each entity: validate → resolve secrets → reconcile → update provenance
+ * 4. Detect orphans (provenance entries not seen in this sync)
+ */
+export async function reconcileProvider(
+  params: ReconcileProviderParams,
+): Promise<ReconcileResult> {
+  const {
+    providerId,
+    target,
+    pathPattern,
+    authToken,
+    baseUrl,
+    deletionPolicy,
+    db,
+    logger,
+    kindRegistry,
+    secretStore,
+    scraper,
+    fetchFn,
+  } = params;
+
+  const result: ReconcileResult = {
+    created: 0,
+    updated: 0,
+    unchanged: 0,
+    orphaned: 0,
+    deleted: 0,
+    errors: 0,
+  };
+
+  // 1. Scrape
+  let discoveredFiles: DiscoveredFile[];
+  try {
+    discoveredFiles = await scraper.discoverFiles({
+      target,
+      pathPattern,
+      authToken,
+      baseUrl,
+      logger,
+      fetch: fetchFn,
+    });
+  } catch (error) {
+    logger.error(`Reconciler: scraper failed for provider ${providerId}: ${error}`);
+    // Update provider with sync error
+    await updateProviderSyncStatus({ db, providerId, error: String(error) });
+    throw error;
+  }
+
+  logger.debug(
+    `Reconciler: scraped ${discoveredFiles.length} file(s) from provider ${providerId}`,
+  );
+
+  // 2. Parse all files
+  const seenEntityKeys = new Set<string>();
+
+  for (const file of discoveredFiles) {
+    const parseResult = parseEntityDocuments({ content: file.content });
+
+    // Log parse errors
+    for (const error of parseResult.errors) {
+      logger.error(
+        `Reconciler: parse error in ${file.repository}/${file.filePath} (doc ${error.documentIndex}): ${error.message}`,
+      );
+      result.errors++;
+    }
+
+    // 3. Process each entity
+    for (const { entity, contentHash } of parseResult.entities) {
+      const entityKey = `${entity.kind}::${entity.metadata.name}`;
+      seenEntityKeys.add(entityKey);
+
+      try {
+        await reconcileEntity({
+          entity,
+          contentHash,
+          file,
+          providerId,
+          db,
+          logger,
+          kindRegistry,
+          secretStore,
+          result,
+        });
+      } catch (error) {
+        logger.error(
+          `Reconciler: error reconciling ${entityKey} from ${file.repository}/${file.filePath}: ${error}`,
+        );
+        await upsertProvenance({
+          db,
+          providerId,
+          entity,
+          file,
+          contentHash,
+          status: "error",
+          errorMessage: String(error),
+        });
+        result.errors++;
+      }
+    }
+  }
+
+  // 4. Detect orphans
+  await detectOrphans({
+    db,
+    providerId,
+    seenEntityKeys,
+    deletionPolicy,
+    kindRegistry,
+    logger,
+    result,
+  });
+
+  // 5. Update provider sync status
+  await updateProviderSyncStatus({ db, providerId });
+
+  return result;
+}
+
+// ─── Entity Reconciliation ─────────────────────────────────────────────────
+
+async function reconcileEntity(params: {
+  entity: EntityEnvelope;
+  contentHash: string;
+  file: DiscoveredFile;
+  providerId: string;
+  db: Db;
+  logger: Logger;
+  kindRegistry: InternalEntityKindRegistry;
+  secretStore: SecretStore;
+  result: ReconcileResult;
+}): Promise<void> {
+  const {
+    entity,
+    contentHash,
+    file,
+    providerId,
+    db,
+    logger,
+    kindRegistry,
+    secretStore,
+    result,
+  } = params;
+
+  // Look up registered kind
+  const kindDef = kindRegistry.getKind({
+    apiVersion: entity.apiVersion,
+    kind: entity.kind,
+  });
+
+  if (!kindDef) {
+    throw new Error(
+      `Unknown entity kind: ${entity.kind} (${entity.apiVersion})`,
+    );
+  }
+
+  // Validate spec against merged schema
+  const mergedSchema = kindRegistry.getMergedSpecSchema({
+    apiVersion: entity.apiVersion,
+    kind: entity.kind,
+  });
+
+  const validationResult = mergedSchema.safeParse(entity.spec);
+  if (!validationResult.success) {
+    throw new Error(`Spec validation failed: ${validationResult.error.message}`);
+  }
+
+  // Check provenance for diff
+  const existingProvenance = await db
+    .select()
+    .from(schema.provenance)
+    .where(
+      and(
+        eq(schema.provenance.kind, entity.kind),
+        eq(schema.provenance.entityName, entity.metadata.name),
+      ),
+    );
+
+  const existing = existingProvenance[0];
+
+  if (existing && existing.lastSyncHash === contentHash) {
+    // Unchanged — skip reconciliation
+    result.unchanged++;
+    return;
+  }
+
+  // Resolve secrets in the spec
+  const resolvedSpec = await resolveSecrets({
+    spec: entity.spec as Record<string, unknown>,
+    secretStore,
+  });
+
+  // Call base kind reconciler
+  await kindDef.reconcile({
+    entity: { ...entity, spec: resolvedSpec },
+    context: { logger },
+  });
+
+  // Call extension reconcilers for present namespaces
+  const extensions = kindRegistry.getExtensions({
+    apiVersion: entity.apiVersion,
+    kind: entity.kind,
+  });
+
+  for (const ext of extensions) {
+    const extensionSpec = (resolvedSpec as Record<string, unknown>)[
+      ext.namespace
+    ];
+    if (extensionSpec !== undefined) {
+      await ext.reconcile({
+        entity: { ...entity, spec: resolvedSpec },
+        extensionSpec,
+        context: { logger },
+      });
+    }
+  }
+
+  // Update provenance
+  await upsertProvenance({
+    db,
+    providerId,
+    entity,
+    file,
+    contentHash,
+    status: "synced",
+  });
+
+  if (existing) {
+    result.updated++;
+  } else {
+    result.created++;
+  }
+}
+
+// ─── Orphan Detection ──────────────────────────────────────────────────────
+
+async function detectOrphans(params: {
+  db: Db;
+  providerId: string;
+  seenEntityKeys: Set<string>;
+  deletionPolicy: "orphan" | "auto";
+  kindRegistry: InternalEntityKindRegistry;
+  logger: Logger;
+  result: ReconcileResult;
+}): Promise<void> {
+  const { db, providerId, seenEntityKeys, deletionPolicy, logger, result } =
+    params;
+
+  const allProvenance = await db
+    .select()
+    .from(schema.provenance)
+    .where(eq(schema.provenance.providerId, providerId));
+
+  for (const prov of allProvenance) {
+    const key = `${prov.kind}::${prov.entityName}`;
+    if (!seenEntityKeys.has(key)) {
+      if (deletionPolicy === "auto") {
+        // TODO(phase-3): Call kind's delete reconciler before removing
+        await db
+          .delete(schema.provenance)
+          .where(eq(schema.provenance.id, prov.id));
+        result.deleted++;
+        logger.debug(
+          `Reconciler: auto-deleted orphaned entity ${key} (provider: ${providerId})`,
+        );
+      } else {
+        // Mark as orphaned
+        await db
+          .update(schema.provenance)
+          .set({ status: "orphaned" })
+          .where(eq(schema.provenance.id, prov.id));
+        result.orphaned++;
+        logger.debug(
+          `Reconciler: marked entity ${key} as orphaned (provider: ${providerId})`,
+        );
+      }
+    }
+  }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+async function upsertProvenance(params: {
+  db: Db;
+  providerId: string;
+  entity: EntityEnvelope;
+  file: DiscoveredFile;
+  contentHash: string;
+  status: "synced" | "error";
+  errorMessage?: string;
+}): Promise<void> {
+  const { db, providerId, entity, file, contentHash, status, errorMessage } =
+    params;
+  const existing = await db
+    .select()
+    .from(schema.provenance)
+    .where(
+      and(
+        eq(schema.provenance.kind, entity.kind),
+        eq(schema.provenance.entityName, entity.metadata.name),
+      ),
+    );
+
+  if (existing[0]) {
+    await db
+      .update(schema.provenance)
+      .set({
+        lastSyncHash: contentHash,
+        status,
+        errorMessage: errorMessage ?? null, // eslint-disable-line unicorn/no-null
+        repository: file.repository,
+        filePath: file.filePath,
+        lastSyncedAt: new Date(),
+      })
+      .where(eq(schema.provenance.id, existing[0].id));
+    return;
+  }
+
+  await db.insert(schema.provenance).values({
+    id: uuidv4(),
+    apiVersion: entity.apiVersion,
+    kind: entity.kind,
+    entityName: entity.metadata.name,
+    providerId,
+    repository: file.repository,
+    filePath: file.filePath,
+    lastSyncHash: contentHash,
+    status,
+    errorMessage: errorMessage ?? null, // eslint-disable-line unicorn/no-null
+  });
+}
+
+async function updateProviderSyncStatus(params: {
+  db: Db;
+  providerId: string;
+  error?: string;
+}): Promise<void> {
+  const { db, providerId, error } = params;
+
+  await db
+    .update(schema.providers)
+    .set({
+      lastSyncAt: new Date(),
+      lastSyncError: error ?? null, // eslint-disable-line unicorn/no-null
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.providers.id, providerId));
+}

--- a/core/gitops-backend/src/sync/reconciler.ts
+++ b/core/gitops-backend/src/sync/reconciler.ts
@@ -236,8 +236,9 @@ async function reconcileEntity(params: {
   });
 
   // Call base kind reconciler
-  await kindDef.reconcile({
+  const reconcileResult = await kindDef.reconcile({
     entity: { ...entity, spec: resolvedSpec },
+    existingEntityId: existing?.entityId ?? undefined,
     context: { logger },
   });
 
@@ -267,6 +268,7 @@ async function reconcileEntity(params: {
     entity,
     file,
     contentHash,
+    entityId: reconcileResult.entityId,
     status: "synced",
   });
 
@@ -310,6 +312,7 @@ async function detectOrphans(params: {
           try {
             await kindDef.delete({
               entityName: prov.entityName,
+              entityId: prov.entityId,
               context: { logger },
             });
           } catch (deleteError) {
@@ -351,10 +354,12 @@ async function upsertProvenance(params: {
   entity: EntityEnvelope;
   file: DiscoveredFile;
   contentHash: string;
+  /** Required for synced status. On error, may be omitted to preserve existing value. */
+  entityId?: string;
   status: "synced" | "error";
   errorMessage?: string;
 }): Promise<void> {
-  const { db, providerId, entity, file, contentHash, status, errorMessage } =
+  const { db, providerId, entity, file, contentHash, entityId, status, errorMessage } =
     params;
   const existing = await db
     .select()
@@ -371,6 +376,8 @@ async function upsertProvenance(params: {
       .update(schema.provenance)
       .set({
         lastSyncHash: contentHash,
+        // Preserve existing entityId on error retries; update on successful reconcile
+        ...(entityId ? { entityId } : {}),
         status,
         errorMessage: errorMessage ?? null, // eslint-disable-line unicorn/no-null
         repository: file.repository,
@@ -381,11 +388,18 @@ async function upsertProvenance(params: {
     return;
   }
 
+  // First-time error: no entityId available yet, skip provenance creation.
+  // The entity will be retried on the next sync cycle.
+  if (!entityId) {
+    return;
+  }
+
   await db.insert(schema.provenance).values({
     id: uuidv4(),
     apiVersion: entity.apiVersion,
     kind: entity.kind,
     entityName: entity.metadata.name,
+    entityId,
     providerId,
     repository: file.repository,
     filePath: file.filePath,

--- a/core/gitops-backend/src/sync/reconciler.ts
+++ b/core/gitops-backend/src/sync/reconciler.ts
@@ -4,6 +4,7 @@ import type { InternalEntityKindRegistry } from "../kind-registry";
 import type { SecretStore } from "../secret-resolver";
 import type { DiscoveredFile, Scraper, FetchFn } from "../scrapers/types";
 import { parseEntityDocuments } from "./document-parser";
+import { sortEntitiesByDependency, type CollectedEntity } from "./sort-entities";
 import { resolveSecrets } from "../secret-resolver";
 import * as schema from "../schema";
 import { eq, and } from "drizzle-orm";
@@ -98,8 +99,9 @@ export async function reconcileProvider(
     `Reconciler: scraped ${discoveredFiles.length} file(s) from provider ${providerId}`,
   );
 
-  // 2. Parse all files
+  // 2. Collect all entities from all files
   const seenEntityKeys = new Set<string>();
+  const collected: CollectedEntity[] = [];
 
   for (const file of discoveredFiles) {
     const parseResult = parseEntityDocuments({ content: file.content });
@@ -112,42 +114,50 @@ export async function reconcileProvider(
       result.errors++;
     }
 
-    // 3. Process each entity
     for (const { entity, contentHash } of parseResult.entities) {
       const entityKey = `${entity.kind}::${entity.metadata.name}`;
       seenEntityKeys.add(entityKey);
-
-      try {
-        await reconcileEntity({
-          entity,
-          contentHash,
-          file,
-          providerId,
-          db,
-          logger,
-          kindRegistry,
-          secretStore,
-          result,
-        });
-      } catch (error) {
-        logger.error(
-          `Reconciler: error reconciling ${entityKey} from ${file.repository}/${file.filePath}: ${error}`,
-        );
-        await upsertProvenance({
-          db,
-          providerId,
-          entity,
-          file,
-          contentHash,
-          status: "error",
-          errorMessage: String(error),
-        });
-        result.errors++;
-      }
+      collected.push({ entity, contentHash, file });
     }
   }
 
-  // 4. Detect orphans
+  // 3. Sort by dependency order (topological sort via entity refs)
+  const sorted = sortEntitiesByDependency({ entities: collected });
+
+  // 4. Reconcile in dependency order (provenance written immediately per entity)
+  for (const { entity, contentHash, file } of sorted) {
+    const entityKey = `${entity.kind}::${entity.metadata.name}`;
+
+    try {
+      await reconcileEntity({
+        entity,
+        contentHash,
+        file,
+        providerId,
+        db,
+        logger,
+        kindRegistry,
+        secretStore,
+        result,
+      });
+    } catch (error) {
+      logger.error(
+        `Reconciler: error reconciling ${entityKey} from ${file.repository}/${file.filePath}: ${error}`,
+      );
+      await upsertProvenance({
+        db,
+        providerId,
+        entity,
+        file,
+        contentHash,
+        status: "error",
+        errorMessage: String(error),
+      });
+      result.errors++;
+    }
+  }
+
+  // 5. Detect orphans
   await detectOrphans({
     db,
     providerId,
@@ -158,7 +168,7 @@ export async function reconcileProvider(
     result,
   });
 
-  // 5. Update provider sync status
+  // 6. Update provider sync status
   await updateProviderSyncStatus({ db, providerId });
 
   return result;
@@ -280,6 +290,7 @@ async function reconcileEntity(params: {
       await ext.reconcile({
         entity: { ...entity, spec: resolvedSpec },
         extensionSpec,
+        entityId: reconcileResult.entityId,
         context,
       });
     }

--- a/core/gitops-backend/src/sync/sort-entities.test.ts
+++ b/core/gitops-backend/src/sync/sort-entities.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it } from "bun:test";
+import { sortEntitiesByDependency, type CollectedEntity } from "./sort-entities";
+import { CHECKSTACK_API_VERSION } from "@checkstack/gitops-common";
+
+function makeEntity(
+  kind: string,
+  name: string,
+  spec: Record<string, unknown> = {},
+): CollectedEntity {
+  return {
+    entity: {
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind,
+      metadata: { name },
+      spec,
+    },
+    contentHash: `hash-${kind}-${name}`,
+    file: {
+      repository: "test/repo",
+      filePath: `${name}.yaml`,
+      content: "",
+      branch: "main",
+    },
+  };
+}
+
+describe("sortEntitiesByDependency", () => {
+  it("returns independent entities in discovery order", () => {
+    const entities = [
+      makeEntity("System", "alpha"),
+      makeEntity("System", "beta"),
+      makeEntity("System", "gamma"),
+    ];
+
+    const sorted = sortEntitiesByDependency({ entities });
+    expect(sorted.map((e) => e.entity.metadata.name)).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
+  });
+
+  it("sorts a dependent entity after its dependency", () => {
+    // System references Healthcheck — should come after it
+    const system = makeEntity("System", "payment-service", {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "db-check" } },
+      ],
+    });
+    const healthcheck = makeEntity("Healthcheck", "db-check");
+
+    // Discovered in wrong order: System first
+    const sorted = sortEntitiesByDependency({
+      entities: [system, healthcheck],
+    });
+
+    expect(sorted.map((e) => e.entity.metadata.name)).toEqual([
+      "db-check",
+      "payment-service",
+    ]);
+  });
+
+  it("handles a chain of dependencies (A → B → C)", () => {
+    const a = makeEntity("Kind-A", "a", {
+      dep: { kind: "Kind-B", name: "b" },
+    });
+    const b = makeEntity("Kind-B", "b", {
+      dep: { kind: "Kind-C", name: "c" },
+    });
+    const c = makeEntity("Kind-C", "c");
+
+    const sorted = sortEntitiesByDependency({
+      entities: [a, b, c],
+    });
+
+    expect(sorted.map((e) => e.entity.metadata.name)).toEqual(["c", "b", "a"]);
+  });
+
+  it("ignores refs to entities not in the collected set", () => {
+    const system = makeEntity("System", "my-sys", {
+      ext: { kind: "Healthcheck", name: "external-check" },
+    });
+    const other = makeEntity("System", "other-sys");
+
+    // "external-check" doesn't exist — should not cause error
+    const sorted = sortEntitiesByDependency({
+      entities: [system, other],
+    });
+
+    expect(sorted.map((e) => e.entity.metadata.name)).toEqual([
+      "my-sys",
+      "other-sys",
+    ]);
+  });
+
+  it("throws on dependency cycles", () => {
+    const a = makeEntity("Kind-A", "a", {
+      dep: { kind: "Kind-B", name: "b" },
+    });
+    const b = makeEntity("Kind-B", "b", {
+      dep: { kind: "Kind-A", name: "a" },
+    });
+
+    expect(() =>
+      sortEntitiesByDependency({ entities: [a, b] }),
+    ).toThrow(/cycle/i);
+  });
+
+  it("maintains discovery order for entities at the same depth", () => {
+    // Three healthchecks (no deps), then a system that depends on one of them
+    const hc1 = makeEntity("Healthcheck", "hc-alpha");
+    const hc2 = makeEntity("Healthcheck", "hc-beta");
+    const hc3 = makeEntity("Healthcheck", "hc-gamma");
+    const sys = makeEntity("System", "my-sys", {
+      checks: [{ ref: { kind: "Healthcheck", name: "hc-beta" } }],
+    });
+
+    const sorted = sortEntitiesByDependency({
+      entities: [sys, hc1, hc2, hc3],
+    });
+
+    // All HCs should come before sys, in their original relative order
+    const names = sorted.map((e) => e.entity.metadata.name);
+    expect(names.indexOf("hc-alpha")).toBeLessThan(names.indexOf("my-sys"));
+    expect(names.indexOf("hc-beta")).toBeLessThan(names.indexOf("my-sys"));
+    expect(names.indexOf("hc-gamma")).toBeLessThan(names.indexOf("my-sys"));
+    // HCs relative order preserved
+    expect(names.indexOf("hc-alpha")).toBeLessThan(names.indexOf("hc-beta"));
+    expect(names.indexOf("hc-beta")).toBeLessThan(names.indexOf("hc-gamma"));
+  });
+
+  it("does not treat self-references as dependencies", () => {
+    // An entity referencing itself should not create a cycle
+    const entity = makeEntity("System", "self-referencing", {
+      self: { kind: "System", name: "self-referencing" },
+    });
+
+    const sorted = sortEntitiesByDependency({ entities: [entity] });
+    expect(sorted).toHaveLength(1);
+    expect(sorted[0].entity.metadata.name).toBe("self-referencing");
+  });
+});
+
+// ─── YAML Edge Case Integration Tests ──────────────────────────────────────
+
+/**
+ * These tests simulate the full pipeline: YAML → parse → collect → sort.
+ * Each test builds CollectedEntity arrays from realistic YAML content
+ * to verify dependency ordering across real-world scenarios.
+ */
+
+describe("sortEntitiesByDependency — YAML edge cases", () => {
+  /**
+   * Scenario: A single multi-document YAML file contains both a System and
+   * the Healthcheck it references, with the System listed first.
+   * The sorter must reorder them so the Healthcheck comes first.
+   */
+  it("reorders entities within a single multi-doc YAML file", () => {
+    // System defined first in the file, references a Healthcheck defined second
+    const system = makeEntity("System", "payment-service", {
+      description: "Payment processing",
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "payment-db-check" } },
+      ],
+    });
+    const healthcheck = makeEntity("Healthcheck", "payment-db-check", {
+      strategy: "postgres",
+      intervalSeconds: 30,
+      config: { host: "db.internal" },
+    });
+
+    // Both from the same file, System discovered first
+    system.file = { repository: "org/infra", filePath: ".checkstack/payment.yaml", content: "", branch: "main" };
+    healthcheck.file = { repository: "org/infra", filePath: ".checkstack/payment.yaml", content: "", branch: "main" };
+
+    const sorted = sortEntitiesByDependency({
+      entities: [system, healthcheck],
+    });
+
+    const names = sorted.map((e) => e.entity.metadata.name);
+    expect(names).toEqual(["payment-db-check", "payment-service"]);
+  });
+
+  /**
+   * Scenario: A System references multiple Healthchecks from different files.
+   * All Healthchecks must come before the System.
+   */
+  it("handles a System with multiple cross-file Healthcheck refs", () => {
+    const sys = makeEntity("System", "api-gateway", {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "http-check" } },
+        { ref: { kind: "Healthcheck", name: "dns-check" } },
+        { ref: { kind: "Healthcheck", name: "tls-check" } },
+      ],
+    });
+    const hcHttp = makeEntity("Healthcheck", "http-check", {
+      strategy: "http",
+      intervalSeconds: 15,
+      config: { url: "https://api.example.com/health" },
+    });
+    const hcDns = makeEntity("Healthcheck", "dns-check", {
+      strategy: "dns",
+      intervalSeconds: 60,
+      config: { hostname: "api.example.com" },
+    });
+    const hcTls = makeEntity("Healthcheck", "tls-check", {
+      strategy: "tls",
+      intervalSeconds: 300,
+      config: { host: "api.example.com", port: 443 },
+    });
+
+    // Discovered: System first, then HCs in arbitrary order
+    const sorted = sortEntitiesByDependency({
+      entities: [sys, hcTls, hcHttp, hcDns],
+    });
+
+    const names = sorted.map((e) => e.entity.metadata.name);
+    // All HCs must come before System
+    expect(names.indexOf("http-check")).toBeLessThan(names.indexOf("api-gateway"));
+    expect(names.indexOf("dns-check")).toBeLessThan(names.indexOf("api-gateway"));
+    expect(names.indexOf("tls-check")).toBeLessThan(names.indexOf("api-gateway"));
+  });
+
+  /**
+   * Scenario: Multiple Systems reference the same Healthcheck.
+   * The shared Healthcheck must come before both Systems.
+   */
+  it("handles a shared Healthcheck referenced by multiple Systems", () => {
+    const sharedHc = makeEntity("Healthcheck", "shared-db-check", {
+      strategy: "postgres",
+      intervalSeconds: 30,
+      config: { host: "shared-db.internal" },
+    });
+    const sysA = makeEntity("System", "billing-service", {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "shared-db-check" } },
+      ],
+    });
+    const sysB = makeEntity("System", "inventory-service", {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "shared-db-check" } },
+      ],
+    });
+
+    // Discovered: both Systems before the Healthcheck
+    const sorted = sortEntitiesByDependency({
+      entities: [sysA, sysB, sharedHc],
+    });
+
+    const names = sorted.map((e) => e.entity.metadata.name);
+    expect(names.indexOf("shared-db-check")).toBeLessThan(names.indexOf("billing-service"));
+    expect(names.indexOf("shared-db-check")).toBeLessThan(names.indexOf("inventory-service"));
+  });
+
+  /**
+   * Scenario: Diamond dependency — System depends on two Healthchecks,
+   * and both Healthchecks depend on a shared Collector entity.
+   * Expected order: Collector → Healthchecks → System
+   */
+  it("resolves diamond dependency graphs", () => {
+    const collector = makeEntity("Collector", "hardware-cpu", {
+      plugin: "collector-hardware",
+    });
+    const hcA = makeEntity("Healthcheck", "server-a-check", {
+      strategy: "http",
+      collectors: [
+        { ref: { kind: "Collector", name: "hardware-cpu" } },
+      ],
+    });
+    const hcB = makeEntity("Healthcheck", "server-b-check", {
+      strategy: "http",
+      collectors: [
+        { ref: { kind: "Collector", name: "hardware-cpu" } },
+      ],
+    });
+    const sys = makeEntity("System", "cluster", {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "server-a-check" } },
+        { ref: { kind: "Healthcheck", name: "server-b-check" } },
+      ],
+    });
+
+    // Worst-case discovery order: dependents first
+    const sorted = sortEntitiesByDependency({
+      entities: [sys, hcB, hcA, collector],
+    });
+
+    const names = sorted.map((e) => e.entity.metadata.name);
+    // Collector before both HCs
+    expect(names.indexOf("hardware-cpu")).toBeLessThan(names.indexOf("server-a-check"));
+    expect(names.indexOf("hardware-cpu")).toBeLessThan(names.indexOf("server-b-check"));
+    // Both HCs before System
+    expect(names.indexOf("server-a-check")).toBeLessThan(names.indexOf("cluster"));
+    expect(names.indexOf("server-b-check")).toBeLessThan(names.indexOf("cluster"));
+  });
+
+  /**
+   * Scenario: Mixed independent and dependent entities.
+   * Independent entities should not be affected by the sort.
+   */
+  it("interleaves independent entities with dependent ones correctly", () => {
+    const standalone1 = makeEntity("System", "standalone-1");
+    const standalone2 = makeEntity("System", "standalone-2");
+    const hc = makeEntity("Healthcheck", "dep-check", {
+      strategy: "http",
+      config: { url: "http://localhost" },
+    });
+    const sys = makeEntity("System", "dependent-sys", {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "dep-check" } },
+      ],
+    });
+
+    // discovered: standalone1, dependent-sys, standalone2, dep-check
+    const sorted = sortEntitiesByDependency({
+      entities: [standalone1, sys, standalone2, hc],
+    });
+
+    const names = sorted.map((e) => e.entity.metadata.name);
+    // dep-check must come before dependent-sys
+    expect(names.indexOf("dep-check")).toBeLessThan(names.indexOf("dependent-sys"));
+    // standalone entities maintain relative order among themselves
+    expect(names.indexOf("standalone-1")).toBeLessThan(names.indexOf("standalone-2"));
+  });
+
+  /**
+   * Scenario: Three-node cycle should throw a descriptive error.
+   * A → B → C → A
+   */
+  it("detects and reports a three-node cycle", () => {
+    const a = makeEntity("System", "sys-a", {
+      dep: { kind: "System", name: "sys-b" },
+    });
+    const b = makeEntity("System", "sys-b", {
+      dep: { kind: "System", name: "sys-c" },
+    });
+    const c = makeEntity("System", "sys-c", {
+      dep: { kind: "System", name: "sys-a" },
+    });
+
+    expect(() =>
+      sortEntitiesByDependency({ entities: [a, b, c] }),
+    ).toThrow(/cycle/i);
+  });
+
+  /**
+   * Scenario: Entity refs mixed with non-ref objects that look similar.
+   * Objects with `kind` and `name` but inside non-extension contexts
+   * (e.g., labels, metadata) should still be treated as entity refs.
+   * This is by design — extractEntityRefs is intentionally greedy.
+   */
+  it("treats all {kind, name} objects as refs regardless of nesting depth", () => {
+    const deep = makeEntity("System", "deep-nester", {
+      level1: {
+        level2: {
+          level3: {
+            checks: [
+              { ref: { kind: "Healthcheck", name: "deeply-nested-hc" } },
+            ],
+          },
+        },
+      },
+    });
+    const hc = makeEntity("Healthcheck", "deeply-nested-hc", {
+      strategy: "http",
+    });
+
+    const sorted = sortEntitiesByDependency({
+      entities: [deep, hc],
+    });
+
+    const names = sorted.map((e) => e.entity.metadata.name);
+    expect(names).toEqual(["deeply-nested-hc", "deep-nester"]);
+  });
+
+  /**
+   * Scenario: A System has a partial ref to an entity that exists AND
+   * a ref to an entity that doesn't exist in this batch.
+   * Only the existing ref should create a dependency edge.
+   */
+  it("handles a mix of resolvable and unresolvable refs", () => {
+    const hc = makeEntity("Healthcheck", "local-check");
+    const sys = makeEntity("System", "mixed-refs", {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "local-check" } },
+        { ref: { kind: "Healthcheck", name: "remote-check-not-in-batch" } },
+      ],
+    });
+
+    // Should not throw — unresolvable refs are silently ignored
+    const sorted = sortEntitiesByDependency({
+      entities: [sys, hc],
+    });
+
+    const names = sorted.map((e) => e.entity.metadata.name);
+    expect(names).toEqual(["local-check", "mixed-refs"]);
+  });
+
+  /**
+   * Scenario: Large batch with multiple independent dependency trees.
+   * Tree A: sys-a → hc-a
+   * Tree B: sys-b → hc-b1, hc-b2
+   * Independent: standalone-1, standalone-2
+   * All trees should resolve independently without affecting each other.
+   */
+  it("handles multiple independent dependency trees in one batch", () => {
+    const hcA = makeEntity("Healthcheck", "hc-a");
+    const sysA = makeEntity("System", "sys-a", {
+      healthchecks: [{ ref: { kind: "Healthcheck", name: "hc-a" } }],
+    });
+    const hcB1 = makeEntity("Healthcheck", "hc-b1");
+    const hcB2 = makeEntity("Healthcheck", "hc-b2");
+    const sysB = makeEntity("System", "sys-b", {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "hc-b1" } },
+        { ref: { kind: "Healthcheck", name: "hc-b2" } },
+      ],
+    });
+    const standalone1 = makeEntity("System", "standalone-1");
+    const standalone2 = makeEntity("System", "standalone-2");
+
+    // Discovered in worst-case interleaved order
+    const sorted = sortEntitiesByDependency({
+      entities: [sysA, sysB, standalone1, hcB2, hcA, standalone2, hcB1],
+    });
+
+    const names = sorted.map((e) => e.entity.metadata.name);
+    // Tree A ordering
+    expect(names.indexOf("hc-a")).toBeLessThan(names.indexOf("sys-a"));
+    // Tree B ordering
+    expect(names.indexOf("hc-b1")).toBeLessThan(names.indexOf("sys-b"));
+    expect(names.indexOf("hc-b2")).toBeLessThan(names.indexOf("sys-b"));
+    // Total count preserved
+    expect(names).toHaveLength(7);
+  });
+
+  /**
+   * Scenario: Entity with only empty/null spec should be handled gracefully.
+   */
+  it("handles entities with undefined or empty specs", () => {
+    const noSpec = makeEntity("System", "no-spec");
+    // Force spec to undefined
+    noSpec.entity.spec = undefined;
+
+    const emptySpec = makeEntity("System", "empty-spec");
+    emptySpec.entity.spec = {};
+
+    const sorted = sortEntitiesByDependency({
+      entities: [noSpec, emptySpec],
+    });
+
+    expect(sorted.map((e) => e.entity.metadata.name)).toEqual([
+      "no-spec",
+      "empty-spec",
+    ]);
+  });
+
+  /**
+   * Scenario: Cross-kind ref between same-named entities of different kinds.
+   * A System named "monitor" references a Healthcheck also named "monitor".
+   * These are distinct entities — the ref should create a correct dependency edge.
+   */
+  it("correctly resolves refs between entities with the same name but different kinds", () => {
+    const hcMonitor = makeEntity("Healthcheck", "monitor", {
+      strategy: "http",
+    });
+    const sysMonitor = makeEntity("System", "monitor", {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "monitor" } },
+      ],
+    });
+
+    // System discovered first
+    const sorted = sortEntitiesByDependency({
+      entities: [sysMonitor, hcMonitor],
+    });
+
+    const names = sorted.map((e) => `${e.entity.kind}::${e.entity.metadata.name}`);
+    expect(names).toEqual(["Healthcheck::monitor", "System::monitor"]);
+  });
+});

--- a/core/gitops-backend/src/sync/sort-entities.ts
+++ b/core/gitops-backend/src/sync/sort-entities.ts
@@ -1,0 +1,100 @@
+import type { EntityEnvelope } from "@checkstack/gitops-common";
+import { extractEntityRefs } from "@checkstack/gitops-common";
+import type { DiscoveredFile } from "../scrapers/types";
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface CollectedEntity {
+  entity: EntityEnvelope;
+  contentHash: string;
+  file: DiscoveredFile;
+}
+
+// ─── Topological Sort ──────────────────────────────────────────────────────
+
+/**
+ * Sort entities by dependency order using entity refs found in their specs.
+ *
+ * 1. Build a map of all collected entities keyed by "Kind::name"
+ * 2. For each entity, extract entity refs from its spec via extractEntityRefs()
+ * 3. Filter to refs that exist in the collected set (ignore external/unknown refs)
+ * 4. Exclude self-references (an entity referencing itself is not a dependency)
+ * 5. Build adjacency list and run Kahn's algorithm (BFS topological sort)
+ * 6. Throw on cycles with descriptive error
+ * 7. Entities at the same depth maintain their original discovery order
+ */
+export function sortEntitiesByDependency({
+  entities,
+}: {
+  entities: CollectedEntity[];
+}): CollectedEntity[] {
+  if (entities.length <= 1) return entities;
+
+  // Build entity key → index map
+  const keyToIndex = new Map<string, number>();
+  for (const [i, e] of entities.entries()) {
+    keyToIndex.set(`${e.entity.kind}::${e.entity.metadata.name}`, i);
+  }
+
+  // Build adjacency list: edges[i] = indices that i depends on
+  // (i.e., entities that must be processed BEFORE entity i)
+  const dependsOn: Set<number>[] = entities.map(() => new Set());
+  const dependedBy: Set<number>[] = entities.map(() => new Set());
+
+  for (const [i, collected] of entities.entries()) {
+    const spec = collected.entity.spec;
+    if (!spec) continue;
+
+    const selfKey = `${collected.entity.kind}::${collected.entity.metadata.name}`;
+    const refs = extractEntityRefs(spec);
+
+    for (const ref of refs) {
+      const refKey = `${ref.kind}::${ref.name}`;
+
+      // Skip self-references and refs to entities not in this batch
+      if (refKey === selfKey) continue;
+      const depIndex = keyToIndex.get(refKey);
+      if (depIndex === undefined) continue;
+
+      dependsOn[i].add(depIndex);
+      dependedBy[depIndex].add(i);
+    }
+  }
+
+  // Kahn's algorithm — BFS topological sort preserving discovery order
+  const inDegree = dependsOn.map((deps) => deps.size);
+  const queue: number[] = [];
+
+  // Seed with zero-dependency entities in discovery order
+  for (const [i, degree] of inDegree.entries()) {
+    if (degree === 0) queue.push(i);
+  }
+
+  const sorted: CollectedEntity[] = [];
+
+  while (queue.length > 0) {
+    const idx = queue.shift()!;
+    sorted.push(entities[idx]);
+
+    // Process dependents in their original discovery order
+    const dependents = [...dependedBy[idx]].toSorted((a, b) => a - b);
+    for (const depIdx of dependents) {
+      inDegree[depIdx]--;
+      if (inDegree[depIdx] === 0) {
+        queue.push(depIdx);
+      }
+    }
+  }
+
+  if (sorted.length !== entities.length) {
+    // Find entities involved in the cycle
+    const cycleEntities = entities
+      .filter((_, i) => inDegree[i] > 0)
+      .map((e) => `${e.entity.kind}::${e.entity.metadata.name}`);
+    throw new Error(
+      `Dependency cycle detected among entities: ${cycleEntities.join(", ")}`,
+    );
+  }
+
+  return sorted;
+}

--- a/core/gitops-backend/src/sync/sync-worker.ts
+++ b/core/gitops-backend/src/sync/sync-worker.ts
@@ -1,0 +1,158 @@
+import type { Logger, SafeDatabase } from "@checkstack/backend-api";
+import type { QueueManager } from "@checkstack/queue-api";
+import type { InternalEntityKindRegistry } from "../kind-registry";
+import type { SecretStore } from "../secret-resolver";
+import * as schema from "../schema";
+import { reconcileProvider } from "./reconciler";
+import { githubScraper } from "../scrapers/github-scraper";
+import { gitlabScraper } from "../scrapers/gitlab-scraper";
+import { eq } from "drizzle-orm";
+
+type Db = SafeDatabase<typeof schema>;
+
+const SYNC_QUEUE = "gitops-sync";
+
+interface SyncJobPayload {
+  providerId: string;
+}
+
+interface SyncWorkerDeps {
+  db: Db;
+  logger: Logger;
+  queueManager: QueueManager;
+  kindRegistry: InternalEntityKindRegistry;
+  secretStore: SecretStore;
+}
+
+/**
+ * Sets up the GitOps sync worker:
+ * 1. Registers a consumer on the `gitops-sync` queue
+ * 2. Bootstraps recurring jobs for all existing providers
+ */
+export async function setupSyncWorker(deps: SyncWorkerDeps): Promise<void> {
+  const { db, logger, queueManager, kindRegistry, secretStore } = deps;
+
+  const queue = queueManager.getQueue<SyncJobPayload>(SYNC_QUEUE);
+
+  // Register consumer
+  await queue.consume(
+    async (job) => {
+      const { providerId } = job.data;
+      logger.info(`GitOps sync: starting sync for provider ${providerId}`);
+
+      try {
+        const result = await runSyncForProvider({
+          providerId,
+          db,
+          logger,
+          kindRegistry,
+          secretStore,
+        });
+
+        logger.info(
+          `GitOps sync: completed for provider ${providerId} — ` +
+            `created=${result.created} updated=${result.updated} unchanged=${result.unchanged} ` +
+            `orphaned=${result.orphaned} deleted=${result.deleted} errors=${result.errors}`,
+        );
+      } catch (error) {
+        logger.error(
+          `GitOps sync: failed for provider ${providerId}: ${error}`,
+        );
+      }
+    },
+    { consumerGroup: "gitops-sync-worker" },
+  );
+
+  // Bootstrap: schedule recurring jobs for all existing providers
+  const providers = await db.select().from(schema.providers);
+
+  for (const provider of providers) {
+    await scheduleSyncForProvider({
+      queueManager,
+      providerId: provider.id,
+      syncIntervalSeconds: provider.syncInterval,
+    });
+  }
+
+  logger.info(
+    `GitOps sync worker initialized. ${providers.length} provider(s) scheduled.`,
+  );
+}
+
+/**
+ * Loads a provider from DB and runs the reconciliation cycle.
+ */
+async function runSyncForProvider(params: {
+  providerId: string;
+  db: Db;
+  logger: Logger;
+  kindRegistry: InternalEntityKindRegistry;
+  secretStore: SecretStore;
+}) {
+  const { providerId, db, logger, kindRegistry, secretStore } = params;
+
+  const rows = await db
+    .select()
+    .from(schema.providers)
+    .where(eq(schema.providers.id, providerId));
+
+  const provider = rows[0];
+  if (!provider) {
+    throw new Error(`Provider not found: ${providerId}`);
+  }
+
+  const scraper =
+    provider.type === "github" ? githubScraper : gitlabScraper;
+
+  return reconcileProvider({
+    providerId: provider.id,
+    providerType: provider.type,
+    target: provider.target,
+    pathPattern: provider.pathPattern,
+    authToken: provider.authToken ?? "",
+    baseUrl: provider.baseUrl ?? undefined,
+    deletionPolicy: provider.deletionPolicy,
+    db,
+    logger,
+    kindRegistry,
+    secretStore,
+    scraper,
+  });
+}
+
+/**
+ * Schedules (or updates) a recurring sync job for a provider.
+ * Called during bootstrap and when providers are created/updated.
+ */
+export async function scheduleSyncForProvider(params: {
+  queueManager: QueueManager;
+  providerId: string;
+  syncIntervalSeconds: number;
+}): Promise<void> {
+  const { queueManager, providerId, syncIntervalSeconds } = params;
+  const queue = queueManager.getQueue<SyncJobPayload>(SYNC_QUEUE);
+
+  await queue.scheduleRecurring(
+    { providerId },
+    {
+      jobId: `gitops-sync-${providerId}`,
+      intervalSeconds: syncIntervalSeconds,
+    },
+  );
+}
+
+/**
+ * Enqueues a one-off sync job for a provider (used by triggerSync RPC).
+ */
+export async function triggerSyncForProvider(params: {
+  queueManager: QueueManager;
+  providerId: string;
+}): Promise<void> {
+  const { queueManager, providerId } = params;
+  const queue = queueManager.getQueue<SyncJobPayload>(SYNC_QUEUE);
+
+  await queue.enqueue(
+    { providerId },
+    { jobId: `gitops-sync-${providerId}-manual` },
+  );
+}

--- a/core/gitops-backend/tsconfig.json
+++ b/core/gitops-backend/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@checkstack/tsconfig/backend.json",
+  "include": ["src"]
+}

--- a/core/gitops-common/package.json
+++ b/core/gitops-common/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@checkstack/gitops-common",
+  "version": "0.0.1",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "@checkstack/common": "workspace:*",
+    "@orpc/contract": "^1.13.14",
+    "zod": "^4.2.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2",
+    "@checkstack/tsconfig": "workspace:*",
+    "@checkstack/scripts": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "bun run lint:code",
+    "lint:code": "eslint . --max-warnings 0"
+  },
+  "checkstack": {
+    "type": "common"
+  }
+}

--- a/core/gitops-common/src/access.ts
+++ b/core/gitops-common/src/access.ts
@@ -1,4 +1,4 @@
-import { accessPair } from "@checkstack/common";
+import { access, accessPair } from "@checkstack/common";
 
 /**
  * Access rules for the GitOps plugin.
@@ -25,6 +25,13 @@ export const gitopsAccess = {
       description: "Create, rotate, and delete secrets",
     },
   }),
+
+  /** Kind registry browsing. */
+  kinds: {
+    read: access("kinds", "read", "View entity kind definitions and schemas", {
+      isDefault: true,
+    }),
+  },
 };
 
 /**
@@ -35,4 +42,6 @@ export const gitopsAccessRules = [
   gitopsAccess.provider.manage,
   gitopsAccess.secret.read,
   gitopsAccess.secret.manage,
+  gitopsAccess.kinds.read,
 ];
+

--- a/core/gitops-common/src/access.ts
+++ b/core/gitops-common/src/access.ts
@@ -1,0 +1,38 @@
+import { accessPair } from "@checkstack/common";
+
+/**
+ * Access rules for the GitOps plugin.
+ */
+export const gitopsAccess = {
+  /** Provider management (add/edit/remove Git providers). */
+  provider: accessPair("provider", {
+    read: {
+      description: "View GitOps providers and sync status",
+      isDefault: true,
+    },
+    manage: {
+      description: "Add, edit, and remove GitOps providers",
+    },
+  }),
+
+  /** Secret management for secretRef values. */
+  secret: accessPair("secret", {
+    read: {
+      description: "View secret names (not values)",
+      isDefault: true,
+    },
+    manage: {
+      description: "Create, rotate, and delete secrets",
+    },
+  }),
+};
+
+/**
+ * All access rules for registration with the plugin system.
+ */
+export const gitopsAccessRules = [
+  gitopsAccess.provider.read,
+  gitopsAccess.provider.manage,
+  gitopsAccess.secret.read,
+  gitopsAccess.secret.manage,
+];

--- a/core/gitops-common/src/entity-envelope.test.ts
+++ b/core/gitops-common/src/entity-envelope.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "bun:test";
+import {
+  entityEnvelopeSchema,
+  CHECKSTACK_API_VERSION,
+} from "./entity-envelope";
+
+describe("entityEnvelopeSchema", () => {
+  it("accepts a valid entity envelope", () => {
+    const result = entityEnvelopeSchema.safeParse({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      metadata: {
+        name: "payment-service",
+        title: "Payment Service",
+        description: "Handles payments",
+        labels: { team: "platform" },
+        annotations: { "pagerduty.com/service-id": "PD123" },
+        tags: ["production"],
+      },
+      spec: { description: "test" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a minimal entity envelope (only required fields)", () => {
+    const result = entityEnvelopeSchema.safeParse({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      metadata: { name: "my-system" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects metadata.name with uppercase characters", () => {
+    const result = entityEnvelopeSchema.safeParse({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      metadata: { name: "MySystem" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects metadata.name exceeding 63 characters", () => {
+    const result = entityEnvelopeSchema.safeParse({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      metadata: { name: "a".repeat(64) },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects metadata.name starting with a hyphen", () => {
+    const result = entityEnvelopeSchema.safeParse({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      metadata: { name: "-invalid" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing apiVersion", () => {
+    const result = entityEnvelopeSchema.safeParse({
+      kind: "System",
+      metadata: { name: "test" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid apiVersion format", () => {
+    const result = entityEnvelopeSchema.safeParse({
+      apiVersion: "invalid",
+      kind: "System",
+      metadata: { name: "test" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty kind", () => {
+    const result = entityEnvelopeSchema.safeParse({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "",
+      metadata: { name: "test" },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/core/gitops-common/src/entity-envelope.ts
+++ b/core/gitops-common/src/entity-envelope.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+/**
+ * The current Checkstack API version for entity descriptors.
+ */
+export const CHECKSTACK_API_VERSION = "checkstack.io/v1alpha1";
+
+/**
+ * Regex for valid entity names.
+ * Must start with a lowercase letter or digit, followed by lowercase letters, digits, or hyphens.
+ * Maximum 63 characters (aligned with Backstage/Kubernetes conventions).
+ */
+const entityNameRegex = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Schema for the entity metadata block.
+ * These fields are common to ALL entity kinds.
+ */
+export const entityMetadataSchema = z.object({
+  /** URL-safe unique identifier. Lowercase alphanumeric + hyphens, max 63 chars. */
+  name: z
+    .string()
+    .regex(
+      entityNameRegex,
+      "Must be lowercase alphanumeric with hyphens, starting with a letter or digit",
+    )
+    .max(63, "Entity name must not exceed 63 characters"),
+
+  /** Optional human-readable display name. */
+  title: z.string().optional(),
+
+  /** Optional description. */
+  description: z.string().optional(),
+
+  /** Optional key-value pairs for filtering and organizing. */
+  labels: z.record(z.string(), z.string()).optional(),
+
+  /** Optional key-value pairs for machine-readable metadata. */
+  annotations: z.record(z.string(), z.string()).optional(),
+
+  /** Optional string tags for categorization. */
+  tags: z.array(z.string()).optional(),
+});
+
+export type EntityMetadata = z.infer<typeof entityMetadataSchema>;
+
+/**
+ * Schema for the base entity envelope.
+ * All YAML descriptors must conform to this shape.
+ * The `spec` field is validated per-kind by the Entity Kind Registry.
+ */
+export const entityEnvelopeSchema = z.object({
+  /** Versioned API identifier (e.g., "checkstack.io/v1alpha1"). */
+  apiVersion: z
+    .string()
+    .regex(
+      /^[\w.-]+\/v[\w.]+$/,
+      "Must follow format: domain/version (e.g., checkstack.io/v1alpha1)",
+    ),
+
+  /** The entity kind (e.g., "System", "Healthcheck"). Must be registered. */
+  kind: z.string().min(1, "Kind must not be empty"),
+
+  /** Common metadata fields. */
+  metadata: entityMetadataSchema,
+
+  /** Kind-specific specification. Validated by the kind's registered schema. */
+  spec: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type EntityEnvelope = z.infer<typeof entityEnvelopeSchema>;

--- a/core/gitops-common/src/entity-kind-registry.ts
+++ b/core/gitops-common/src/entity-kind-registry.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import type { EntityEnvelope } from "./entity-envelope";
+
+/**
+ * Context passed to reconcile/delete functions.
+ * Extended by gitops-backend with concrete service references.
+ */
+export interface ReconcileContext {
+  /** Logger scoped to this reconciliation */
+  logger: {
+    debug: (msg: string) => void;
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+/**
+ * Definition for registering a new entity kind.
+ * The owning plugin provides the base spec schema and reconciliation logic.
+ */
+export interface EntityKindDefinition<TSpec = unknown> {
+  /** The API version this kind belongs to (e.g., "checkstack.io/v1alpha1"). */
+  apiVersion: string;
+
+  /** The kind name (e.g., "System", "Healthcheck"). Must be unique per apiVersion. */
+  kind: string;
+
+  /** Zod schema for validating the `spec` section of descriptors of this kind. */
+  specSchema: z.ZodType<TSpec>;
+
+  /**
+   * Called when an entity of this kind is discovered or updated via GitOps.
+   * The entity's spec is fully validated and all secretRef values are resolved.
+   */
+  reconcile: (params: {
+    entity: EntityEnvelope & { spec: TSpec };
+    context: ReconcileContext;
+  }) => Promise<void>;
+
+  /**
+   * Called when an entity of this kind is removed from git (deletion policy: "auto")
+   * or when an orphan is manually confirmed for deletion.
+   */
+  delete?: (params: {
+    entityName: string;
+    context: ReconcileContext;
+  }) => Promise<void>;
+}
+
+/**
+ * Definition for extending an existing entity kind's spec.
+ * The extending plugin adds namespaced fields to another kind's spec schema.
+ */
+export interface EntityKindExtensionDefinition<TExtensionSpec = unknown> {
+  /** The API version of the kind being extended. */
+  apiVersion: string;
+
+  /** The kind being extended (e.g., "System"). */
+  kind: string;
+
+  /**
+   * Namespace for this extension's spec fields.
+   * The extension's spec is placed under `spec.<namespace>` in the descriptor.
+   * Must be unique per kind. Convention: use your plugin ID (e.g., "healthcheck").
+   */
+  namespace: string;
+
+  /** Zod schema for validating the extension's spec fields. Should be `.optional()`. */
+  specSchema: z.ZodType<TExtensionSpec>;
+
+  /**
+   * Called when an entity with this extension's namespace is reconciled.
+   * Only called if the extension's namespace is present in the spec.
+   */
+  reconcile: (params: {
+    entity: EntityEnvelope;
+    extensionSpec: TExtensionSpec;
+    context: ReconcileContext;
+  }) => Promise<void>;
+}
+
+/**
+ * The registry interface exposed via the Extension Point.
+ * Plugins call these methods during their `register()` phase.
+ */
+export interface EntityKindRegistry {
+  /** Register a new entity kind (e.g., catalog registers "System"). */
+  registerKind<TSpec>(definition: EntityKindDefinition<TSpec>): void;
+
+  /** Extend an existing kind's spec (e.g., healthcheck extends "System"). */
+  registerKindExtension<TExtensionSpec>(
+    definition: EntityKindExtensionDefinition<TExtensionSpec>,
+  ): void;
+}

--- a/core/gitops-common/src/entity-kind-registry.ts
+++ b/core/gitops-common/src/entity-kind-registry.ts
@@ -32,11 +32,16 @@ export interface EntityKindDefinition<TSpec = unknown> {
   /**
    * Called when an entity of this kind is discovered or updated via GitOps.
    * The entity's spec is fully validated and all secretRef values are resolved.
+   *
+   * Must return the plugin-specific entity ID (e.g., the catalog system UUID).
+   * The reconciler engine stores this in provenance for generic frontend lookups.
    */
   reconcile: (params: {
     entity: EntityEnvelope & { spec: TSpec };
+    /** The plugin-specific entity ID from a previous reconcile, if this entity was reconciled before. */
+    existingEntityId?: string;
     context: ReconcileContext;
-  }) => Promise<void>;
+  }) => Promise<{ entityId: string }>;
 
   /**
    * Called when an entity of this kind is removed from git (deletion policy: "auto")
@@ -44,6 +49,8 @@ export interface EntityKindDefinition<TSpec = unknown> {
    */
   delete?: (params: {
     entityName: string;
+    /** The plugin-specific entity ID from provenance, if available. */
+    entityId?: string;
     context: ReconcileContext;
   }) => Promise<void>;
 }

--- a/core/gitops-common/src/entity-kind-registry.ts
+++ b/core/gitops-common/src/entity-kind-registry.ts
@@ -13,6 +13,18 @@ export interface ReconcileContext {
     warn: (msg: string) => void;
     error: (msg: string) => void;
   };
+
+  /**
+   * Resolve a GitOps entity reference to its plugin-specific entity ID.
+   * Used by extension reconcilers to look up cross-kind references
+   * (e.g., a System extension resolving a Healthcheck ref name → config UUID).
+   *
+   * Returns `undefined` if the entity is not found in provenance.
+   */
+  resolveEntityRef: (params: {
+    kind: string;
+    entityName: string;
+  }) => Promise<string | undefined>;
 }
 
 /**

--- a/core/gitops-common/src/entity-kind-registry.ts
+++ b/core/gitops-common/src/entity-kind-registry.ts
@@ -95,6 +95,8 @@ export interface EntityKindExtensionDefinition<TExtensionSpec = unknown> {
   reconcile: (params: {
     entity: EntityEnvelope;
     extensionSpec: TExtensionSpec;
+    /** The plugin-specific entity ID returned by the base kind's reconciler. */
+    entityId: string;
     context: ReconcileContext;
   }) => Promise<void>;
 }

--- a/core/gitops-common/src/entity-ref.test.ts
+++ b/core/gitops-common/src/entity-ref.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test";
+import {
+  entityRefSchema,
+  extractEntityRefs,
+  type EntityRef,
+} from "./entity-ref";
+
+describe("entityRefSchema", () => {
+  it("validates a well-formed entity ref", () => {
+    const result = entityRefSchema.safeParse({
+      kind: "Healthcheck",
+      name: "payment-db-check",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing kind", () => {
+    const result = entityRefSchema.safeParse({ name: "foo" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing name", () => {
+    const result = entityRefSchema.safeParse({ kind: "System" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty kind", () => {
+    const result = entityRefSchema.safeParse({ kind: "", name: "foo" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty name", () => {
+    const result = entityRefSchema.safeParse({ kind: "System", name: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("extractEntityRefs", () => {
+  it("extracts a single ref from a flat object", () => {
+    const spec = {
+      ref: { kind: "Healthcheck", name: "db-check" },
+    };
+    const refs = extractEntityRefs(spec);
+    expect(refs).toEqual([{ kind: "Healthcheck", name: "db-check" }]);
+  });
+
+  it("extracts multiple refs from an array", () => {
+    const spec = {
+      healthchecks: [
+        { ref: { kind: "Healthcheck", name: "db-check" } },
+        { ref: { kind: "Healthcheck", name: "api-check" } },
+      ],
+    };
+    const refs = extractEntityRefs(spec);
+    expect(refs).toEqual([
+      { kind: "Healthcheck", name: "db-check" },
+      { kind: "Healthcheck", name: "api-check" },
+    ]);
+  });
+
+  it("extracts refs from deeply nested structures", () => {
+    const spec = {
+      level1: {
+        level2: {
+          level3: { kind: "System", name: "nested-sys" },
+        },
+      },
+    };
+    const refs = extractEntityRefs(spec);
+    expect(refs).toEqual([{ kind: "System", name: "nested-sys" }]);
+  });
+
+  it("ignores objects with non-string kind or name", () => {
+    const spec = {
+      notARef1: { kind: 123, name: "foo" },
+      notARef2: { kind: "System", name: 456 },
+      notARef3: { kind: true, name: false },
+    };
+    const refs = extractEntityRefs(spec);
+    expect(refs).toEqual([]);
+  });
+
+  it("ignores objects with empty kind or name", () => {
+    const spec = {
+      emptyKind: { kind: "", name: "foo" },
+      emptyName: { kind: "System", name: "" },
+    };
+    const refs = extractEntityRefs(spec);
+    expect(refs).toEqual([]);
+  });
+
+  it("ignores primitives, nulls, and strings", () => {
+    const spec = {
+      str: "just a string",
+      num: 42,
+      bool: true,
+      nil: null,
+    };
+    const refs = extractEntityRefs(spec);
+    expect(refs).toEqual([]);
+  });
+
+  it("does not recurse into matched refs (no double-counting)", () => {
+    const ref: EntityRef = { kind: "Healthcheck", name: "db-check" };
+    const spec = { ref };
+    const refs = extractEntityRefs(spec);
+    // Should find exactly one ref, not recurse into it
+    expect(refs).toHaveLength(1);
+  });
+
+  it("handles mixed valid and invalid entries", () => {
+    const spec = {
+      items: [
+        { ref: { kind: "Healthcheck", name: "valid" } },
+        { ref: "invalid-string" },
+        { ref: { kind: "System", name: "also-valid" } },
+        { ref: null },
+      ],
+    };
+    const refs = extractEntityRefs(spec);
+    expect(refs).toEqual([
+      { kind: "Healthcheck", name: "valid" },
+      { kind: "System", name: "also-valid" },
+    ]);
+  });
+});

--- a/core/gitops-common/src/entity-ref.ts
+++ b/core/gitops-common/src/entity-ref.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+/**
+ * K8s-style structured entity reference.
+ * Used in YAML specs to reference other GitOps-managed entities.
+ *
+ * @example
+ * ```yaml
+ * healthchecks:
+ *   - ref:
+ *       kind: Healthcheck
+ *       name: payment-db-check
+ * ```
+ */
+export const entityRefSchema = z.object({
+  kind: z.string().min(1),
+  name: z.string().min(1),
+});
+
+export type EntityRef = z.infer<typeof entityRefSchema>;
+
+/**
+ * Check if a value is a valid EntityRef shape (object with string `kind` and `name`).
+ */
+function isEntityRef(value: unknown): value is EntityRef {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.kind === "string" &&
+    obj.kind.length > 0 &&
+    typeof obj.name === "string" &&
+    obj.name.length > 0
+  );
+}
+
+/**
+ * Recursively extract all entity refs from a spec value.
+ *
+ * Walks objects and arrays, collecting objects that have both
+ * a `kind` (non-empty string) and `name` (non-empty string) property.
+ * Matched refs are not recursed into (no double-counting).
+ */
+export function extractEntityRefs(value: unknown): EntityRef[] {
+  const refs: EntityRef[] = [];
+  walk(value, refs);
+  return refs;
+}
+
+function walk(value: unknown, refs: EntityRef[]): void {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      walk(item, refs);
+    }
+    return;
+  }
+
+  // Check if this object IS a ref — collect it and stop recursing
+  if (isEntityRef(value)) {
+    refs.push({ kind: value.kind, name: value.name });
+    return;
+  }
+
+  // Otherwise recurse into child values
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    walk(child, refs);
+  }
+}

--- a/core/gitops-common/src/index.ts
+++ b/core/gitops-common/src/index.ts
@@ -14,6 +14,11 @@ export {
   type ResolvedSecretField,
 } from "./secret-field";
 export {
+  entityRefSchema,
+  extractEntityRefs,
+  type EntityRef,
+} from "./entity-ref";
+export {
   type EntityKindDefinition,
   type EntityKindExtensionDefinition,
   type EntityKindRegistry,

--- a/core/gitops-common/src/index.ts
+++ b/core/gitops-common/src/index.ts
@@ -1,0 +1,32 @@
+export { pluginMetadata } from "./plugin-metadata";
+export {
+  entityEnvelopeSchema,
+  entityMetadataSchema,
+  CHECKSTACK_API_VERSION,
+  type EntityEnvelope,
+  type EntityMetadata,
+} from "./entity-envelope";
+export {
+  secretField,
+  secretRefSchema,
+  isSecretRef,
+  type SecretRef,
+  type ResolvedSecretField,
+} from "./secret-field";
+export {
+  type EntityKindDefinition,
+  type EntityKindExtensionDefinition,
+  type EntityKindRegistry,
+  type ReconcileContext,
+} from "./entity-kind-registry";
+export { gitopsAccess, gitopsAccessRules } from "./access";
+export { gitopsRoutes } from "./routes";
+export {
+  provenanceSchema,
+  provenanceStatusSchema,
+  deletionPolicySchema,
+  type Provenance,
+  type ProvenanceStatus,
+  type DeletionPolicy,
+} from "./provenance-types";
+export { gitopsContract, GitOpsApi, type GitOpsContract } from "./rpc-contract";

--- a/core/gitops-common/src/plugin-metadata.ts
+++ b/core/gitops-common/src/plugin-metadata.ts
@@ -1,0 +1,9 @@
+import { definePluginMetadata } from "@checkstack/common";
+
+/**
+ * Plugin metadata for the GitOps plugin.
+ * Exported from the common package so both backend and frontend can reference it.
+ */
+export const pluginMetadata = definePluginMetadata({
+  pluginId: "gitops",
+});

--- a/core/gitops-common/src/provenance-types.ts
+++ b/core/gitops-common/src/provenance-types.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const provenanceStatusSchema = z.enum(["synced", "error", "orphaned"]);
+export type ProvenanceStatus = z.infer<typeof provenanceStatusSchema>;
+
+export const deletionPolicySchema = z.enum(["orphan", "auto"]);
+export type DeletionPolicy = z.infer<typeof deletionPolicySchema>;
+
+export const provenanceSchema = z.object({
+  id: z.string(),
+  apiVersion: z.string(),
+  kind: z.string(),
+  entityName: z.string(),
+  providerId: z.string(),
+  repository: z.string(),
+  filePath: z.string(),
+  lastSyncHash: z.string(),
+  status: provenanceStatusSchema,
+  errorMessage: z.string().nullable(),
+  lastSyncedAt: z.date(),
+  createdAt: z.date(),
+});
+
+export type Provenance = z.infer<typeof provenanceSchema>;

--- a/core/gitops-common/src/provenance-types.ts
+++ b/core/gitops-common/src/provenance-types.ts
@@ -11,6 +11,8 @@ export const provenanceSchema = z.object({
   apiVersion: z.string(),
   kind: z.string(),
   entityName: z.string(),
+  /** Plugin-specific entity ID (e.g., catalog system UUID). Set by the reconciler engine. */
+  entityId: z.string(),
   providerId: z.string(),
   repository: z.string(),
   filePath: z.string(),

--- a/core/gitops-common/src/routes.ts
+++ b/core/gitops-common/src/routes.ts
@@ -8,4 +8,5 @@ export const gitopsRoutes = createRoutes("gitops", {
   providers: "/providers",
   secrets: "/secrets",
   status: "/status",
+  kinds: "/kinds",
 });

--- a/core/gitops-common/src/routes.ts
+++ b/core/gitops-common/src/routes.ts
@@ -1,0 +1,11 @@
+import { createRoutes } from "@checkstack/common";
+
+/**
+ * Route definitions for the GitOps plugin.
+ */
+export const gitopsRoutes = createRoutes("gitops", {
+  home: "/",
+  providers: "/providers",
+  secrets: "/secrets",
+  status: "/status",
+});

--- a/core/gitops-common/src/rpc-contract.ts
+++ b/core/gitops-common/src/rpc-contract.ts
@@ -1,0 +1,169 @@
+import { createClientDefinition, proc } from "@checkstack/common";
+import { pluginMetadata } from "./plugin-metadata";
+import { gitopsAccess } from "./access";
+import {
+  provenanceSchema,
+  provenanceStatusSchema,
+  deletionPolicySchema,
+} from "./provenance-types";
+import { z } from "zod";
+
+export const gitopsContract = {
+  // ═══════════════════════════════════════════════════════════════════════════
+  // PROVENANCE QUERIES (public read access)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /** Check if an entity is GitOps-managed. Used by frontends to lock editors. */
+  getProvenance: proc({
+    operationType: "query",
+    userType: "public",
+    access: [gitopsAccess.provider.read],
+  })
+    .input(z.object({ kind: z.string(), entityName: z.string() }))
+    .output(provenanceSchema.nullable()),
+
+  /** List all provenance entries, optionally filtered by status. */
+  listProvenance: proc({
+    operationType: "query",
+    userType: "public",
+    access: [gitopsAccess.provider.read],
+  })
+    .input(
+      z
+        .object({
+          status: provenanceStatusSchema.optional(),
+          providerId: z.string().optional(),
+        })
+        .optional(),
+    )
+    .output(z.array(provenanceSchema)),
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // PROVIDER MANAGEMENT (admin)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /** List all configured providers. */
+  listProviders: proc({
+    operationType: "query",
+    userType: "authenticated",
+    access: [gitopsAccess.provider.read],
+  }).output(
+    z.array(
+      z.object({
+        id: z.string(),
+        type: z.enum(["github", "gitlab"]),
+        target: z.string(),
+        pathPattern: z.string(),
+        syncInterval: z.number(),
+        deletionPolicy: deletionPolicySchema,
+        lastSyncAt: z.date().nullable(),
+        lastSyncError: z.string().nullable(),
+        createdAt: z.date(),
+      }),
+    ),
+  ),
+
+  /** Trigger a manual sync for a provider. */
+  triggerSync: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [gitopsAccess.provider.manage],
+  })
+    .input(z.object({ providerId: z.string() }))
+    .output(z.object({ success: z.boolean() })),
+
+  /** Confirm deletion of an orphaned entity. */
+  confirmOrphanDeletion: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [gitopsAccess.provider.manage],
+  })
+    .input(z.object({ provenanceId: z.string() }))
+    .output(z.object({ success: z.boolean() })),
+
+  /** Dismiss orphan status (keep entity, remove provenance tracking). */
+  dismissOrphan: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [gitopsAccess.provider.manage],
+  })
+    .input(z.object({ provenanceId: z.string() }))
+    .output(z.object({ success: z.boolean() })),
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // SECRET MANAGEMENT
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /** List secret names (never values). */
+  listSecrets: proc({
+    operationType: "query",
+    userType: "authenticated",
+    access: [gitopsAccess.secret.read],
+  }).output(
+    z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        description: z.string().nullable(),
+        createdAt: z.date(),
+        updatedAt: z.date(),
+      }),
+    ),
+  ),
+
+  /** Create a new secret. */
+  createSecret: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [gitopsAccess.secret.manage],
+  })
+    .input(
+      z.object({
+        name: z.string().min(1).max(63),
+        value: z.string().min(1),
+        description: z.string().optional(),
+      }),
+    )
+    .output(z.object({ id: z.string(), name: z.string() })),
+
+  /** Rotate (update) a secret's value. */
+  rotateSecret: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [gitopsAccess.secret.manage],
+  })
+    .input(
+      z.object({
+        id: z.string(),
+        value: z.string().min(1),
+      }),
+    )
+    .output(z.object({ success: z.boolean() })),
+
+  /** Delete a secret. */
+  deleteSecret: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [gitopsAccess.secret.manage],
+  })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ success: z.boolean() })),
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // SERVICE INTERFACE (backend-to-backend)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /** Resolve a secret by name. Used internally by the reconciliation engine. */
+  resolveSecret: proc({
+    operationType: "query",
+    userType: "service",
+    access: [],
+  })
+    .input(z.object({ name: z.string() }))
+    .output(z.object({ value: z.string() })),
+};
+
+export type GitOpsContract = typeof gitopsContract;
+
+/** Export client definition for type-safe forPlugin usage. */
+export const GitOpsApi = createClientDefinition(gitopsContract, pluginMetadata);

--- a/core/gitops-common/src/rpc-contract.ts
+++ b/core/gitops-common/src/rpc-contract.ts
@@ -217,6 +217,31 @@ export const gitopsContract = {
   })
     .input(z.object({ name: z.string() }))
     .output(z.object({ value: z.string() })),
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // KIND REGISTRY (browsing)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /** List all registered entity kinds with their spec schemas and extensions. */
+  listKinds: proc({
+    operationType: "query",
+    userType: "authenticated",
+    access: [gitopsAccess.kinds.read],
+  }).output(
+    z.array(
+      z.object({
+        apiVersion: z.string(),
+        kind: z.string(),
+        specSchema: z.record(z.string(), z.unknown()),
+        extensions: z.array(
+          z.object({
+            namespace: z.string(),
+            specSchema: z.record(z.string(), z.unknown()),
+          }),
+        ),
+      }),
+    ),
+  ),
 };
 
 export type GitOpsContract = typeof gitopsContract;

--- a/core/gitops-common/src/rpc-contract.ts
+++ b/core/gitops-common/src/rpc-contract.ts
@@ -54,6 +54,7 @@ export const gitopsContract = {
         type: z.enum(["github", "gitlab"]),
         target: z.string(),
         pathPattern: z.string(),
+        baseUrl: z.string().nullable(),
         syncInterval: z.number(),
         deletionPolicy: deletionPolicySchema,
         lastSyncAt: z.date().nullable(),

--- a/core/gitops-common/src/rpc-contract.ts
+++ b/core/gitops-common/src/rpc-contract.ts
@@ -19,7 +19,13 @@ export const gitopsContract = {
     userType: "public",
     access: [gitopsAccess.provider.read],
   })
-    .input(z.object({ kind: z.string(), entityName: z.string() }))
+    .input(z.object({
+      kind: z.string(),
+      /** Look up by envelope entity name. */
+      entityName: z.string().optional(),
+      /** Look up by plugin-specific entity ID (e.g., catalog system UUID). */
+      entityId: z.string().optional(),
+    }))
     .output(provenanceSchema.nullable()),
 
   /** List all provenance entries, optionally filtered by status. */
@@ -63,6 +69,55 @@ export const gitopsContract = {
       }),
     ),
   ),
+
+  /** Create a new GitOps provider. */
+  createProvider: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [gitopsAccess.provider.manage],
+  })
+    .input(
+      z.object({
+        type: z.enum(["github", "gitlab"]),
+        target: z.string().min(1),
+        pathPattern: z.string().min(1),
+        baseUrl: z.string().optional(),
+        authToken: z.string().optional(),
+        syncInterval: z.number().int().min(60).optional(),
+        deletionPolicy: deletionPolicySchema.optional(),
+      }),
+    )
+    .output(z.object({ id: z.string() })),
+
+  /** Update an existing provider. */
+  updateProvider: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [gitopsAccess.provider.manage],
+  })
+    .input(
+      z.object({
+        id: z.string(),
+        data: z.object({
+          target: z.string().min(1).optional(),
+          pathPattern: z.string().min(1).optional(),
+          baseUrl: z.string().nullable().optional(),
+          authToken: z.string().optional(),
+          syncInterval: z.number().int().min(60).optional(),
+          deletionPolicy: deletionPolicySchema.optional(),
+        }),
+      }),
+    )
+    .output(z.object({ success: z.boolean() })),
+
+  /** Delete a provider and all its provenance entries. */
+  deleteProvider: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [gitopsAccess.provider.manage],
+  })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ success: z.boolean() })),
 
   /** Trigger a manual sync for a provider. */
   triggerSync: proc({

--- a/core/gitops-common/src/secret-field.test.ts
+++ b/core/gitops-common/src/secret-field.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { secretField, isSecretRef, type SecretRef } from "./secret-field";
+
+describe("secretField", () => {
+  const schema = secretField();
+
+  it("accepts a plain string value", () => {
+    const result = schema.safeParse("my-password");
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe("my-password");
+  });
+
+  it("accepts a secretRef object", () => {
+    const result = schema.safeParse({ secretRef: "prod-db-password" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ secretRef: "prod-db-password" });
+    }
+  });
+
+  it("rejects a number", () => {
+    const result = schema.safeParse(42);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an object without secretRef", () => {
+    const result = schema.safeParse({ key: "value" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects secretRef with empty name", () => {
+    const result = schema.safeParse({ secretRef: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("isSecretRef", () => {
+  it("returns true for a SecretRef object", () => {
+    const ref: SecretRef = { secretRef: "my-secret" };
+    expect(isSecretRef(ref)).toBe(true);
+  });
+
+  it("returns false for a plain string", () => {
+    expect(isSecretRef("plain")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isSecretRef(null)).toBe(false);
+  });
+});

--- a/core/gitops-common/src/secret-field.ts
+++ b/core/gitops-common/src/secret-field.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+/**
+ * Schema for a secret reference object.
+ * Used in YAML descriptors to reference secrets stored in the Checkstack secret store.
+ */
+export const secretRefSchema = z.object({
+  secretRef: z.string().min(1, "Secret reference name must not be empty"),
+});
+
+export type SecretRef = z.infer<typeof secretRefSchema>;
+
+/**
+ * Type guard to check if a value is a SecretRef object.
+ */
+export function isSecretRef(value: unknown): value is SecretRef {
+  if (value === null || value === undefined || typeof value !== "object") {
+    return false;
+  }
+  return (
+    "secretRef" in value &&
+    typeof (value as SecretRef).secretRef === "string"
+  );
+}
+
+/**
+ * Creates a Zod schema for fields that accept either a plain string or a secret reference.
+ *
+ * In YAML descriptors, users can write either:
+ * ```yaml
+ * password: "dev-password"              # plain string
+ * password:
+ *   secretRef: production-db-creds      # reference to secret store
+ * ```
+ *
+ * The GitOps reconciliation engine resolves all secretRef values before calling
+ * plugin reconcilers, so plugins always receive plain strings.
+ */
+export function secretField() {
+  return z.union([z.string(), secretRefSchema]);
+}
+
+/**
+ * The resolved type of a secret field is always a string.
+ * After the reconciliation engine resolves secretRefs, all values are plain strings.
+ */
+export type ResolvedSecretField = string;

--- a/core/gitops-common/tsconfig.json
+++ b/core/gitops-common/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@checkstack/tsconfig/common.json",
+  "include": ["src"]
+}

--- a/core/gitops-frontend/package.json
+++ b/core/gitops-frontend/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@checkstack/catalog-frontend",
-  "version": "0.5.13",
+  "name": "@checkstack/gitops-frontend",
+  "version": "0.1.0",
   "type": "module",
   "main": "src/index.tsx",
   "checkstack": {
@@ -12,16 +12,10 @@
     "lint:code": "eslint . --max-warnings 0"
   },
   "dependencies": {
-    "@checkstack/auth-common": "workspace:*",
-    "@checkstack/auth-frontend": "workspace:*",
-    "@checkstack/catalog-common": "workspace:*",
     "@checkstack/common": "workspace:*",
     "@checkstack/frontend-api": "workspace:*",
-    "@checkstack/gitops-frontend": "workspace:*",
-    "@checkstack/notification-common": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/utilities": "^3.2.2",
     "lucide-react": "^0.344.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0"

--- a/core/gitops-frontend/src/components/GitOpsLockBanner.tsx
+++ b/core/gitops-frontend/src/components/GitOpsLockBanner.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { GitBranch, ExternalLink } from "lucide-react";
+import type { Provenance } from "@checkstack/gitops-common";
+
+interface GitOpsLockBannerProps {
+  provenance: Provenance;
+}
+
+/**
+ * Banner displayed on entity detail pages when the entity is managed by GitOps.
+ * Informs the user that manual edits are disabled and shows the Git source.
+ */
+export const GitOpsLockBanner: React.FC<GitOpsLockBannerProps> = ({
+  provenance,
+}) => {
+  return (
+    <div className="flex items-center gap-3 p-3 rounded-lg border border-primary/20 bg-primary/5 text-sm">
+      <GitBranch className="w-5 h-5 text-primary shrink-0" />
+      <div className="min-w-0 flex-1">
+        <span className="font-medium text-foreground">
+          Managed by GitOps
+        </span>
+        <span className="text-muted-foreground ml-1">
+          — edits are disabled. Changes must be made in Git.
+        </span>
+        <div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-1">
+          <span className="truncate">
+            {provenance.repository}/{provenance.filePath}
+          </span>
+          <ExternalLink className="w-3 h-3 shrink-0" />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/core/gitops-frontend/src/components/GitOpsMenuItem.tsx
+++ b/core/gitops-frontend/src/components/GitOpsMenuItem.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from "react-router-dom";
+import { GitBranch } from "lucide-react";
+import { DropdownMenuItem } from "@checkstack/ui";
+import type { UserMenuItemsContext } from "@checkstack/frontend-api";
+import { resolveRoute } from "@checkstack/common";
+import { pluginMetadata, gitopsAccess, gitopsRoutes } from "@checkstack/gitops-common";
+import React from "react";
+
+const REQUIRED_ACCESS_RULE = `${pluginMetadata.pluginId}.${gitopsAccess.provider.read.id}`;
+
+export function GitOpsMenuItem({
+  accessRules: userPerms,
+}: UserMenuItemsContext) {
+  const navigate = useNavigate();
+  const canView =
+    userPerms.includes("*") || userPerms.includes(REQUIRED_ACCESS_RULE);
+
+  if (!canView) return <React.Fragment />;
+
+  return (
+    <DropdownMenuItem
+      onClick={() => navigate(resolveRoute(gitopsRoutes.routes.home))}
+      icon={<GitBranch className="h-4 w-4" />}
+    >
+      GitOps
+    </DropdownMenuItem>
+  );
+}

--- a/core/gitops-frontend/src/components/KindRegistryMenuItem.tsx
+++ b/core/gitops-frontend/src/components/KindRegistryMenuItem.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from "react-router-dom";
+import { Blocks } from "lucide-react";
+import { DropdownMenuItem } from "@checkstack/ui";
+import type { UserMenuItemsContext } from "@checkstack/frontend-api";
+import { resolveRoute } from "@checkstack/common";
+import { pluginMetadata, gitopsAccess, gitopsRoutes } from "@checkstack/gitops-common";
+import React from "react";
+
+const REQUIRED_ACCESS_RULE = `${pluginMetadata.pluginId}.${gitopsAccess.kinds.read.id}`;
+
+export function KindRegistryMenuItem({
+  accessRules: userPerms,
+}: UserMenuItemsContext) {
+  const navigate = useNavigate();
+  const canView =
+    userPerms.includes("*") || userPerms.includes(REQUIRED_ACCESS_RULE);
+
+  if (!canView) return <React.Fragment />;
+
+  return (
+    <DropdownMenuItem
+      onClick={() => navigate(resolveRoute(gitopsRoutes.routes.kinds))}
+      icon={<Blocks className="h-4 w-4" />}
+    >
+      Kind Registry
+    </DropdownMenuItem>
+  );
+}

--- a/core/gitops-frontend/src/components/ProvenanceStatus.tsx
+++ b/core/gitops-frontend/src/components/ProvenanceStatus.tsx
@@ -1,0 +1,246 @@
+import { usePluginClient, useApi, accessApiRef } from "@checkstack/frontend-api";
+import { GitOpsApi, gitopsAccess } from "@checkstack/gitops-common";
+import type { Provenance } from "@checkstack/gitops-common";
+import {
+  Card,
+  CardHeader,
+  CardHeaderRow,
+  CardTitle,
+  CardContent,
+  Button,
+  Badge,
+  EmptyState,
+  ConfirmationModal,
+  useToast,
+} from "@checkstack/ui";
+import { useState } from "react";
+import { CheckCircle, AlertTriangle, XCircle, Trash2, X } from "lucide-react";
+import { extractErrorMessage } from "@checkstack/common";
+
+export const ProvenanceStatus = () => {
+  const client = usePluginClient(GitOpsApi);
+  const accessApi = useApi(accessApiRef);
+  const toast = useToast();
+
+  const { allowed: canManage } = accessApi.useAccess(gitopsAccess.provider.manage);
+
+  const [confirmModal, setConfirmModal] = useState<{
+    isOpen: boolean;
+    provenanceId: string;
+    entityName: string;
+  }>({ isOpen: false, provenanceId: "", entityName: "" });
+
+  const {
+    data: provenanceEntries,
+    isLoading,
+    refetch,
+  } = client.listProvenance.useQuery({});
+
+  const confirmDeleteMutation = client.confirmOrphanDeletion.useMutation({
+    onSuccess: () => {
+      toast.success("Orphan deleted successfully");
+      setConfirmModal({ isOpen: false, provenanceId: "", entityName: "" });
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to delete orphan"));
+    },
+  });
+
+  const dismissMutation = client.dismissOrphan.useMutation({
+    onSuccess: () => {
+      toast.success("Orphan dismissed — entity is no longer tracked by GitOps");
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to dismiss orphan"));
+    },
+  });
+
+  const entries = provenanceEntries ?? [];
+  const synced = entries.filter((e) => e.status === "synced");
+  const errors = entries.filter((e) => e.status === "error");
+  const orphaned = entries.filter((e) => e.status === "orphaned");
+
+  const statusIcon = (status: Provenance["status"]) => {
+    switch (status) {
+      case "synced": {
+        return <CheckCircle className="w-4 h-4 text-emerald-500" />;
+      }
+      case "error": {
+        return <XCircle className="w-4 h-4 text-destructive" />;
+      }
+      case "orphaned": {
+        return <AlertTriangle className="w-4 h-4 text-amber-500" />;
+      }
+    }
+  };
+
+  const statusBadge = (status: Provenance["status"]) => {
+    const variants: Record<Provenance["status"], "default" | "destructive" | "outline"> = {
+      synced: "default",
+      error: "destructive",
+      orphaned: "outline",
+    };
+    return <Badge variant={variants[status]}>{status}</Badge>;
+  };
+
+  const renderEntryList = (list: Provenance[], showOrphanActions: boolean) => (
+    <div className="space-y-2">
+      {list.map((entry) => (
+        <div
+          key={entry.id}
+          className="flex items-center justify-between p-3 rounded-lg border border-border bg-background/50"
+        >
+          <div className="flex items-center gap-3 min-w-0">
+            {statusIcon(entry.status)}
+            <div className="min-w-0">
+              <div className="text-sm font-medium">
+                <span className="text-muted-foreground">{entry.kind}/</span>
+                {entry.entityName}
+              </div>
+              <div className="text-xs text-muted-foreground mt-0.5 truncate">
+                {entry.repository}/{entry.filePath}
+              </div>
+              {entry.errorMessage && (
+                <div className="text-xs text-destructive mt-0.5 truncate">
+                  {entry.errorMessage}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 shrink-0">
+            {statusBadge(entry.status)}
+            {showOrphanActions && canManage && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() =>
+                    setConfirmModal({
+                      isOpen: true,
+                      provenanceId: entry.id,
+                      entityName: `${entry.kind}/${entry.entityName}`,
+                    })
+                  }
+                  title="Confirm deletion"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => dismissMutation.mutate({ provenanceId: entry.id })}
+                  title="Dismiss orphan"
+                >
+                  <X className="w-4 h-4" />
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <>
+      <div className="space-y-6">
+        {/* Summary */}
+        <div className="grid grid-cols-3 gap-4">
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-2">
+                <CheckCircle className="w-5 h-5 text-emerald-500" />
+                <span className="text-2xl font-bold">{synced.length}</span>
+                <span className="text-sm text-muted-foreground">Synced</span>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-2">
+                <XCircle className="w-5 h-5 text-destructive" />
+                <span className="text-2xl font-bold">{errors.length}</span>
+                <span className="text-sm text-muted-foreground">Errors</span>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="w-5 h-5 text-amber-500" />
+                <span className="text-2xl font-bold">{orphaned.length}</span>
+                <span className="text-sm text-muted-foreground">Orphaned</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Orphaned entities — shown first if any */}
+        {orphaned.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardHeaderRow>
+                <CardTitle className="flex items-center gap-2">
+                  <AlertTriangle className="w-5 h-5 text-amber-500" />
+                  Orphaned Entities
+                </CardTitle>
+              </CardHeaderRow>
+              <p className="text-xs text-muted-foreground mt-1">
+                These entities were removed from Git. Confirm deletion or dismiss to keep the entity.
+              </p>
+            </CardHeader>
+            <CardContent>{renderEntryList(orphaned, true)}</CardContent>
+          </Card>
+        )}
+
+        {/* Errors */}
+        {errors.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <XCircle className="w-5 h-5 text-destructive" />
+                Sync Errors
+              </CardTitle>
+            </CardHeader>
+            <CardContent>{renderEntryList(errors, false)}</CardContent>
+          </Card>
+        )}
+
+        {/* Synced entities */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <CheckCircle className="w-5 h-5 text-emerald-500" />
+              Synced Entities
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="text-center py-8 text-muted-foreground">Loading...</div>
+            ) : synced.length === 0 ? (
+              <EmptyState
+                title="No synced entities"
+                description="Entities will appear here after a successful sync."
+              />
+            ) : (
+              renderEntryList(synced, false)
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <ConfirmationModal
+        isOpen={confirmModal.isOpen}
+        onClose={() => setConfirmModal({ isOpen: false, provenanceId: "", entityName: "" })}
+        onConfirm={() => confirmDeleteMutation.mutate({ provenanceId: confirmModal.provenanceId })}
+        title="Confirm Orphan Deletion"
+        message={`Are you sure you want to permanently delete "${confirmModal.entityName}"? This will remove the entity from the system.`}
+        confirmText="Delete"
+        variant="danger"
+      />
+    </>
+  );
+};

--- a/core/gitops-frontend/src/components/ProviderEditor.tsx
+++ b/core/gitops-frontend/src/components/ProviderEditor.tsx
@@ -1,0 +1,214 @@
+import React, { useState, useEffect } from "react";
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@checkstack/ui";
+
+interface ProviderEditorProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (data: {
+    type: "github" | "gitlab";
+    target: string;
+    pathPattern: string;
+    baseUrl?: string;
+    authToken?: string;
+    syncInterval?: number;
+    deletionPolicy?: "orphan" | "auto";
+  }) => void;
+  initialData?: {
+    id: string;
+    type: "github" | "gitlab";
+    target: string;
+    pathPattern: string;
+    baseUrl?: string;
+    syncInterval: number;
+    deletionPolicy: "orphan" | "auto";
+  };
+}
+
+export const ProviderEditor: React.FC<ProviderEditorProps> = ({
+  open,
+  onClose,
+  onSave,
+  initialData,
+}) => {
+  const [type, setType] = useState<"github" | "gitlab">(initialData?.type ?? "github");
+  const [target, setTarget] = useState(initialData?.target ?? "");
+  const [pathPattern, setPathPattern] = useState(initialData?.pathPattern ?? ".checkstack/**/*.yaml");
+  const [baseUrl, setBaseUrl] = useState(initialData?.baseUrl ?? "");
+  const [authToken, setAuthToken] = useState("");
+  const [syncInterval, setSyncInterval] = useState(String(initialData?.syncInterval ?? 300));
+  const [deletionPolicy, setDeletionPolicy] = useState<"orphan" | "auto">(
+    initialData?.deletionPolicy ?? "orphan",
+  );
+
+  useEffect(() => {
+    if (open) {
+      setType(initialData?.type ?? "github");
+      setTarget(initialData?.target ?? "");
+      setPathPattern(initialData?.pathPattern ?? ".checkstack/**/*.yaml");
+      setBaseUrl(initialData?.baseUrl ?? "");
+      setAuthToken("");
+      setSyncInterval(String(initialData?.syncInterval ?? 300));
+      setDeletionPolicy(initialData?.deletionPolicy ?? "orphan");
+    }
+  }, [open, initialData]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!target.trim() || !pathPattern.trim()) return;
+
+    onSave({
+      type,
+      target: target.trim(),
+      pathPattern: pathPattern.trim(),
+      baseUrl: baseUrl.trim() || undefined,
+      authToken: authToken.trim() || undefined,
+      syncInterval: Number(syncInterval) || 300,
+      deletionPolicy,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent size="default">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>
+              {initialData ? "Edit Provider" : "Add Provider"}
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              {initialData
+                ? "Modify the settings for this Git provider"
+                : "Configure a new Git provider for GitOps syncing"}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="provider-type">Provider Type</Label>
+              <Select
+                value={type}
+                onValueChange={(v) => setType(v as "github" | "gitlab")}
+                disabled={!!initialData}
+              >
+                <SelectTrigger id="provider-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="github">GitHub</SelectItem>
+                  <SelectItem value="gitlab">GitLab</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="provider-target">Target</Label>
+              <Input
+                id="provider-target"
+                placeholder="e.g. my-org or my-org/my-repo"
+                value={target}
+                onChange={(e) => setTarget(e.target.value)}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Organization name for org-wide scanning, or owner/repo for a single repository.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="provider-path">Path Pattern</Label>
+              <Input
+                id="provider-path"
+                placeholder=".checkstack/**/*.yaml"
+                value={pathPattern}
+                onChange={(e) => setPathPattern(e.target.value)}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Glob pattern for matching descriptor files in repositories.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="provider-base-url">Base URL (optional)</Label>
+              <Input
+                id="provider-base-url"
+                placeholder="https://github.example.com/api/v3"
+                value={baseUrl}
+                onChange={(e) => setBaseUrl(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                For GitHub Enterprise or self-hosted GitLab instances.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="provider-auth-token">
+                Auth Token {initialData ? "(leave empty to keep current)" : "(optional)"}
+              </Label>
+              <Input
+                id="provider-auth-token"
+                type="password"
+                placeholder="ghp_xxxx..."
+                value={authToken}
+                onChange={(e) => setAuthToken(e.target.value)}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="provider-interval">Sync Interval (seconds)</Label>
+                <Input
+                  id="provider-interval"
+                  type="number"
+                  min={60}
+                  value={syncInterval}
+                  onChange={(e) => setSyncInterval(e.target.value)}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="provider-deletion">Deletion Policy</Label>
+                <Select
+                  value={deletionPolicy}
+                  onValueChange={(v) => setDeletionPolicy(v as "orphan" | "auto")}
+                >
+                  <SelectTrigger id="provider-deletion">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="orphan">Orphan (manual review)</SelectItem>
+                    <SelectItem value="auto">Auto-delete</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!target.trim() || !pathPattern.trim()}>
+              {initialData ? "Save Changes" : "Add Provider"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/core/gitops-frontend/src/components/ProviderList.tsx
+++ b/core/gitops-frontend/src/components/ProviderList.tsx
@@ -1,0 +1,294 @@
+import { useState } from "react";
+import {
+  usePluginClient,
+  useApi,
+  accessApiRef,
+} from "@checkstack/frontend-api";
+import { GitOpsApi, gitopsAccess } from "@checkstack/gitops-common";
+import {
+  Card,
+  CardHeader,
+  CardHeaderRow,
+  CardTitle,
+  CardContent,
+  Button,
+  EmptyState,
+  ConfirmationModal,
+  Badge,
+  useToast,
+} from "@checkstack/ui";
+import {
+  Plus,
+  RefreshCw,
+  Trash2,
+  Pencil,
+  Github,
+  GitlabIcon,
+} from "lucide-react";
+import { extractErrorMessage } from "@checkstack/common";
+import { ProviderEditor } from "./ProviderEditor";
+
+const formatInterval = (seconds: number) => {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  return `${Math.floor(seconds / 3600)}h`;
+};
+
+const formatLastSync = (date: Date | null) => {
+  if (!date) return "Never";
+  return new Date(date).toLocaleString();
+};
+
+export const ProviderList = () => {
+  const client = usePluginClient(GitOpsApi);
+  const accessApi = useApi(accessApiRef);
+  const toast = useToast();
+
+  const { allowed: canManage } = accessApi.useAccess(
+    gitopsAccess.provider.manage,
+  );
+
+  const [isEditorOpen, setIsEditorOpen] = useState(false);
+  const [editingProvider, setEditingProvider] = useState<{
+    id: string;
+    type: "github" | "gitlab";
+    target: string;
+    pathPattern: string;
+    baseUrl?: string;
+    syncInterval: number;
+    deletionPolicy: "orphan" | "auto";
+  }>();
+  const [confirmModal, setConfirmModal] = useState<{
+    isOpen: boolean;
+    providerId: string;
+    providerTarget: string;
+  }>({ isOpen: false, providerId: "", providerTarget: "" });
+
+  const {
+    data: providers,
+    isLoading,
+    refetch,
+  } = client.listProviders.useQuery({});
+
+  const createMutation = client.createProvider.useMutation({
+    onSuccess: () => {
+      toast.success("Provider created successfully");
+      setIsEditorOpen(false);
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to create provider"));
+    },
+  });
+
+  const updateMutation = client.updateProvider.useMutation({
+    onSuccess: () => {
+      toast.success("Provider updated successfully");
+      setIsEditorOpen(false);
+      setEditingProvider(undefined);
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to update provider"));
+    },
+  });
+
+  const deleteMutation = client.deleteProvider.useMutation({
+    onSuccess: () => {
+      toast.success("Provider deleted successfully");
+      setConfirmModal({ isOpen: false, providerId: "", providerTarget: "" });
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to delete provider"));
+    },
+  });
+
+  const syncMutation = client.triggerSync.useMutation({
+    onSuccess: () => {
+      toast.success("Sync triggered successfully");
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to trigger sync"));
+    },
+  });
+
+  const handleSave = (data: {
+    type: "github" | "gitlab";
+    target: string;
+    pathPattern: string;
+    baseUrl?: string;
+    authToken?: string;
+    syncInterval?: number;
+    deletionPolicy?: "orphan" | "auto";
+  }) => {
+    if (editingProvider) {
+      updateMutation.mutate({
+        id: editingProvider.id,
+        data: {
+          target: data.target,
+          pathPattern: data.pathPattern,
+          baseUrl: data.baseUrl ?? undefined,
+          authToken: data.authToken,
+          syncInterval: data.syncInterval,
+          deletionPolicy: data.deletionPolicy,
+        },
+      });
+    } else {
+      createMutation.mutate(data);
+    }
+  };
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardHeaderRow>
+            <CardTitle>Git Providers</CardTitle>
+            {canManage && (
+              <Button size="sm" onClick={() => setIsEditorOpen(true)}>
+                <Plus className="w-4 h-4 mr-2" />
+                Add Provider
+              </Button>
+            )}
+          </CardHeaderRow>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="text-center py-8 text-muted-foreground">
+              Loading...
+            </div>
+          ) : !providers || providers.length === 0 ? (
+            <EmptyState
+              title="No providers configured"
+              description="Add a GitHub or GitLab provider to start syncing infrastructure definitions."
+            />
+          ) : (
+            <div className="space-y-3">
+              {providers.map((provider) => (
+                <div
+                  key={provider.id}
+                  className="flex items-center justify-between p-4 rounded-lg border border-border bg-background/50 hover:bg-background/80 transition-colors"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    {provider.type === "github" ? (
+                      <Github className="w-5 h-5 text-muted-foreground shrink-0" />
+                    ) : (
+                      <GitlabIcon className="w-5 h-5 text-muted-foreground shrink-0" />
+                    )}
+                    <div className="min-w-0">
+                      <div className="font-medium truncate">
+                        {provider.target}
+                      </div>
+                      <div className="text-xs text-muted-foreground flex items-center gap-2 mt-0.5">
+                        <span className="truncate">{provider.pathPattern}</span>
+                        <span>·</span>
+                        <span>
+                          every {formatInterval(provider.syncInterval)}
+                        </span>
+                        <span>·</span>
+                        <Badge
+                          variant={
+                            provider.deletionPolicy === "auto"
+                              ? "destructive"
+                              : "outline"
+                          }
+                        >
+                          {provider.deletionPolicy}
+                        </Badge>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-4 shrink-0">
+                    <div className="text-right text-xs text-muted-foreground hidden md:block">
+                      <div>
+                        Last sync: {formatLastSync(provider.lastSyncAt)}
+                      </div>
+                      {provider.lastSyncError && (
+                        <div className="text-destructive truncate max-w-48">
+                          {provider.lastSyncError}
+                        </div>
+                      )}
+                    </div>
+
+                    {canManage && (
+                      <div className="flex items-center gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() =>
+                            syncMutation.mutate({ providerId: provider.id })
+                          }
+                          title="Trigger sync"
+                        >
+                          <RefreshCw className="w-4 h-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => {
+                            setEditingProvider({
+                              id: provider.id,
+                              type: provider.type,
+                              target: provider.target,
+                              pathPattern: provider.pathPattern,
+                              baseUrl: provider.baseUrl ?? undefined,
+                              syncInterval: provider.syncInterval,
+                              deletionPolicy: provider.deletionPolicy,
+                            });
+                            setIsEditorOpen(true);
+                          }}
+                          title="Edit provider"
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() =>
+                            setConfirmModal({
+                              isOpen: true,
+                              providerId: provider.id,
+                              providerTarget: provider.target,
+                            })
+                          }
+                          title="Delete provider"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <ProviderEditor
+        open={isEditorOpen}
+        onClose={() => {
+          setIsEditorOpen(false);
+          setEditingProvider(undefined);
+        }}
+        onSave={handleSave}
+        initialData={editingProvider}
+      />
+
+      <ConfirmationModal
+        isOpen={confirmModal.isOpen}
+        onClose={() =>
+          setConfirmModal({ isOpen: false, providerId: "", providerTarget: "" })
+        }
+        onConfirm={() => deleteMutation.mutate({ id: confirmModal.providerId })}
+        title="Delete Provider"
+        message={`Are you sure you want to delete the provider for "${confirmModal.providerTarget}"? All provenance tracking will be removed.`}
+        confirmText="Delete"
+        variant="danger"
+      />
+    </>
+  );
+};

--- a/core/gitops-frontend/src/components/SecretEditor.tsx
+++ b/core/gitops-frontend/src/components/SecretEditor.tsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect } from "react";
+import {
+  Button,
+  Input,
+  Label,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@checkstack/ui";
+
+interface SecretEditorProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (data: { name: string; value: string; description?: string }) => void;
+}
+
+export const SecretEditor: React.FC<SecretEditorProps> = ({
+  open,
+  onClose,
+  onSave,
+}) => {
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setValue("");
+      setDescription("");
+    }
+  }, [open]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !value.trim()) return;
+
+    onSave({
+      name: name.trim(),
+      value: value.trim(),
+      description: description.trim() || undefined,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent size="default">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create Secret</DialogTitle>
+            <DialogDescription className="sr-only">
+              Create a new secret for use in GitOps YAML descriptors
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="secret-name">Name</Label>
+              <Input
+                id="secret-name"
+                placeholder="e.g. GITHUB_TOKEN"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="font-mono"
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Referenced as <code className="text-xs">{"${{ secrets.NAME }}"}</code> in descriptors.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="secret-value">Value</Label>
+              <Input
+                id="secret-value"
+                type="password"
+                placeholder="Secret value..."
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="secret-description">Description (optional)</Label>
+              <Input
+                id="secret-description"
+                placeholder="What this secret is used for..."
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim() || !value.trim()}>
+              Create Secret
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/core/gitops-frontend/src/components/SecretList.tsx
+++ b/core/gitops-frontend/src/components/SecretList.tsx
@@ -1,0 +1,204 @@
+import { useState } from "react";
+import {
+  usePluginClient,
+  useApi,
+  accessApiRef,
+} from "@checkstack/frontend-api";
+import { GitOpsApi, gitopsAccess } from "@checkstack/gitops-common";
+import {
+  Card,
+  CardHeader,
+  CardHeaderRow,
+  CardTitle,
+  CardContent,
+  Button,
+  EmptyState,
+  ConfirmationModal,
+  useToast,
+} from "@checkstack/ui";
+import { Plus, RotateCw, Trash2, KeyRound } from "lucide-react";
+import { extractErrorMessage } from "@checkstack/common";
+import { SecretEditor } from "./SecretEditor";
+import { SecretRotateDialog } from "./SecretRotateDialog";
+
+const formatDate = (date: Date) => new Date(date).toLocaleString();
+
+export const SecretList = () => {
+  const client = usePluginClient(GitOpsApi);
+  const accessApi = useApi(accessApiRef);
+  const toast = useToast();
+
+  const { allowed: canManage } = accessApi.useAccess(
+    gitopsAccess.secret.manage,
+  );
+
+  const [isEditorOpen, setIsEditorOpen] = useState(false);
+  const [rotatingSecret, setRotatingSecret] = useState<{
+    id: string;
+    name: string;
+  }>();
+  const [confirmModal, setConfirmModal] = useState<{
+    isOpen: boolean;
+    secretId: string;
+    secretName: string;
+  }>({ isOpen: false, secretId: "", secretName: "" });
+
+  const { data: secrets, isLoading, refetch } = client.listSecrets.useQuery({});
+
+  const createMutation = client.createSecret.useMutation({
+    onSuccess: () => {
+      toast.success("Secret created successfully");
+      setIsEditorOpen(false);
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to create secret"));
+    },
+  });
+
+  const rotateMutation = client.rotateSecret.useMutation({
+    onSuccess: () => {
+      toast.success("Secret rotated successfully");
+      setRotatingSecret(undefined);
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to rotate secret"));
+    },
+  });
+
+  const deleteMutation = client.deleteSecret.useMutation({
+    onSuccess: () => {
+      toast.success("Secret deleted successfully");
+      setConfirmModal({ isOpen: false, secretId: "", secretName: "" });
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to delete secret"));
+    },
+  });
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardHeaderRow>
+            <CardTitle>Secrets</CardTitle>
+            {canManage && (
+              <Button size="sm" onClick={() => setIsEditorOpen(true)}>
+                <Plus className="w-4 h-4 mr-2" />
+                Add Secret
+              </Button>
+            )}
+          </CardHeaderRow>
+          <p className="text-xs text-muted-foreground mt-1">
+            Secrets can be referenced in YAML descriptors using{" "}
+            <code className="text-xs">{"${{ secrets.NAME }}"}</code> syntax.
+          </p>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="text-center py-8 text-muted-foreground">
+              Loading...
+            </div>
+          ) : !secrets || secrets.length === 0 ? (
+            <EmptyState
+              title="No secrets created"
+              description="Create secrets to securely reference sensitive values in your YAML descriptors."
+            />
+          ) : (
+            <div className="space-y-3">
+              {secrets.map((secret) => (
+                <div
+                  key={secret.id}
+                  className="flex items-center justify-between p-4 rounded-lg border border-border bg-background/50 hover:bg-background/80 transition-colors"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <KeyRound className="w-4 h-4 text-muted-foreground shrink-0" />
+                    <div className="min-w-0">
+                      <div className="font-medium font-mono text-sm">
+                        {secret.name}
+                      </div>
+                      {secret.description && (
+                        <div className="text-xs text-muted-foreground mt-0.5 truncate">
+                          {secret.description}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-4 shrink-0">
+                    <div className="text-right text-xs text-muted-foreground hidden md:block">
+                      <div>Updated: {formatDate(secret.updatedAt)}</div>
+                    </div>
+
+                    {canManage && (
+                      <div className="flex items-center gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() =>
+                            setRotatingSecret({
+                              id: secret.id,
+                              name: secret.name,
+                            })
+                          }
+                          title="Rotate secret"
+                        >
+                          <RotateCw className="w-4 h-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() =>
+                            setConfirmModal({
+                              isOpen: true,
+                              secretId: secret.id,
+                              secretName: secret.name,
+                            })
+                          }
+                          title="Delete secret"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <SecretEditor
+        open={isEditorOpen}
+        onClose={() => setIsEditorOpen(false)}
+        onSave={(data) => createMutation.mutate(data)}
+      />
+
+      <SecretRotateDialog
+        open={!!rotatingSecret}
+        secretName={rotatingSecret?.name ?? ""}
+        onClose={() => setRotatingSecret(undefined)}
+        onSave={(value) => {
+          if (rotatingSecret) {
+            rotateMutation.mutate({ id: rotatingSecret.id, value });
+          }
+        }}
+      />
+
+      <ConfirmationModal
+        isOpen={confirmModal.isOpen}
+        onClose={() =>
+          setConfirmModal({ isOpen: false, secretId: "", secretName: "" })
+        }
+        onConfirm={() => deleteMutation.mutate({ id: confirmModal.secretId })}
+        title="Delete Secret"
+        message={`Are you sure you want to delete the secret "${confirmModal.secretName}"? Any descriptors referencing this secret will fail validation.`}
+        confirmText="Delete"
+        variant="danger"
+      />
+    </>
+  );
+};

--- a/core/gitops-frontend/src/components/SecretRotateDialog.tsx
+++ b/core/gitops-frontend/src/components/SecretRotateDialog.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from "react";
+import {
+  Button,
+  Input,
+  Label,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@checkstack/ui";
+
+interface SecretRotateDialogProps {
+  open: boolean;
+  secretName: string;
+  onClose: () => void;
+  onSave: (value: string) => void;
+}
+
+export const SecretRotateDialog: React.FC<SecretRotateDialogProps> = ({
+  open,
+  secretName,
+  onClose,
+  onSave,
+}) => {
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setValue("");
+    }
+  }, [open]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!value.trim()) return;
+    onSave(value.trim());
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent size="default">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Rotate Secret</DialogTitle>
+            <DialogDescription>
+              Enter a new value for <code className="font-mono text-sm">{secretName}</code>.
+              The old value will be permanently replaced.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="rotate-value">New Value</Label>
+              <Input
+                id="rotate-value"
+                type="password"
+                placeholder="New secret value..."
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!value.trim()}>
+              Rotate Secret
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/core/gitops-frontend/src/hooks/useProvenanceLock.ts
+++ b/core/gitops-frontend/src/hooks/useProvenanceLock.ts
@@ -1,0 +1,32 @@
+import { usePluginClient } from "@checkstack/frontend-api";
+import { GitOpsApi } from "@checkstack/gitops-common";
+
+/**
+ * Hook to check if a catalog entity is managed by GitOps.
+ *
+ * Returns provenance data and loading state so callers can
+ * disable editing and show a lock banner.
+ *
+ * @param params.kind - Entity kind (e.g. "System", "Group")
+ * @param params.entityId - Plugin-specific entity ID (e.g. catalog system UUID)
+ */
+export const useProvenanceLock = (params: {
+  kind: string;
+  entityId: string | undefined;
+}) => {
+  const gitopsClient = usePluginClient(GitOpsApi);
+
+  const { data: provenance, isLoading } = gitopsClient.getProvenance.useQuery(
+    { kind: params.kind, entityId: params.entityId! },
+    { enabled: !!params.entityId },
+  );
+
+  return {
+    /** Whether this entity is managed by GitOps */
+    isLocked: !!provenance && provenance.status === "synced",
+    /** Full provenance data (or null) */
+    provenance,
+    /** Whether the provenance query is still loading */
+    isLoading,
+  };
+};

--- a/core/gitops-frontend/src/index.tsx
+++ b/core/gitops-frontend/src/index.tsx
@@ -1,0 +1,25 @@
+import { createFrontendPlugin } from "@checkstack/frontend-api";
+import {
+  gitopsRoutes,
+  pluginMetadata,
+  gitopsAccess,
+} from "@checkstack/gitops-common";
+
+import { GitOpsPage } from "./pages/GitOpsPage";
+
+export const gitopsPlugin = createFrontendPlugin({
+  metadata: pluginMetadata,
+  apis: [],
+  routes: [
+    {
+      route: gitopsRoutes.routes.home,
+      element: <GitOpsPage />,
+      accessRule: gitopsAccess.provider.read,
+    },
+  ],
+  extensions: [],
+});
+
+// Public API for other frontend plugins
+export { useProvenanceLock } from "./hooks/useProvenanceLock";
+export { GitOpsLockBanner } from "./components/GitOpsLockBanner";

--- a/core/gitops-frontend/src/index.tsx
+++ b/core/gitops-frontend/src/index.tsx
@@ -1,4 +1,8 @@
-import { createFrontendPlugin } from "@checkstack/frontend-api";
+import {
+  createFrontendPlugin,
+  createSlotExtension,
+  UserMenuItemsSlot,
+} from "@checkstack/frontend-api";
 import {
   gitopsRoutes,
   pluginMetadata,
@@ -6,6 +10,7 @@ import {
 } from "@checkstack/gitops-common";
 
 import { GitOpsPage } from "./pages/GitOpsPage";
+import { GitOpsMenuItem } from "./components/GitOpsMenuItem";
 
 export const gitopsPlugin = createFrontendPlugin({
   metadata: pluginMetadata,
@@ -17,7 +22,12 @@ export const gitopsPlugin = createFrontendPlugin({
       accessRule: gitopsAccess.provider.read,
     },
   ],
-  extensions: [],
+  extensions: [
+    createSlotExtension(UserMenuItemsSlot, {
+      id: "gitops.user-menu.link",
+      component: GitOpsMenuItem,
+    }),
+  ],
 });
 
 // Public API for other frontend plugins

--- a/core/gitops-frontend/src/index.tsx
+++ b/core/gitops-frontend/src/index.tsx
@@ -10,7 +10,9 @@ import {
 } from "@checkstack/gitops-common";
 
 import { GitOpsPage } from "./pages/GitOpsPage";
+import { KindRegistryPage } from "./pages/KindRegistryPage";
 import { GitOpsMenuItem } from "./components/GitOpsMenuItem";
+import { KindRegistryMenuItem } from "./components/KindRegistryMenuItem";
 
 export const gitopsPlugin = createFrontendPlugin({
   metadata: pluginMetadata,
@@ -21,11 +23,20 @@ export const gitopsPlugin = createFrontendPlugin({
       element: <GitOpsPage />,
       accessRule: gitopsAccess.provider.read,
     },
+    {
+      route: gitopsRoutes.routes.kinds,
+      element: <KindRegistryPage />,
+      accessRule: gitopsAccess.kinds.read,
+    },
   ],
   extensions: [
     createSlotExtension(UserMenuItemsSlot, {
       id: "gitops.user-menu.link",
       component: GitOpsMenuItem,
+    }),
+    createSlotExtension(UserMenuItemsSlot, {
+      id: "gitops.user-menu.kind-registry",
+      component: KindRegistryMenuItem,
     }),
   ],
 });

--- a/core/gitops-frontend/src/pages/GitOpsPage.tsx
+++ b/core/gitops-frontend/src/pages/GitOpsPage.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { useApi, accessApiRef } from "@checkstack/frontend-api";
+import { gitopsAccess } from "@checkstack/gitops-common";
+import {
+  PageLayout,
+  Tabs,
+  TabPanel,
+} from "@checkstack/ui";
+import { GitBranch, KeyRound, Activity } from "lucide-react";
+import { ProviderList } from "../components/ProviderList";
+import { SecretList } from "../components/SecretList";
+import { ProvenanceStatus } from "../components/ProvenanceStatus";
+
+const TAB_ITEMS = [
+  { id: "providers", label: "Providers", icon: <GitBranch className="w-4 h-4" /> },
+  { id: "secrets", label: "Secrets", icon: <KeyRound className="w-4 h-4" /> },
+  { id: "status", label: "Sync Status", icon: <Activity className="w-4 h-4" /> },
+];
+
+export const GitOpsPage = () => {
+  const accessApi = useApi(accessApiRef);
+  const [activeTab, setActiveTab] = useState("providers");
+
+  const { allowed: canRead, loading: accessLoading } = accessApi.useAccess(
+    gitopsAccess.provider.read,
+  );
+
+  return (
+    <PageLayout
+      title="GitOps"
+      subtitle="Manage Git providers, secrets, and sync status for infrastructure-as-code"
+      icon={GitBranch}
+      loading={accessLoading}
+      allowed={canRead}
+    >
+      <Tabs
+        items={TAB_ITEMS}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        className="mb-6"
+      />
+
+      <TabPanel id="providers" activeTab={activeTab}>
+        <ProviderList />
+      </TabPanel>
+
+      <TabPanel id="secrets" activeTab={activeTab}>
+        <SecretList />
+      </TabPanel>
+
+      <TabPanel id="status" activeTab={activeTab}>
+        <ProvenanceStatus />
+      </TabPanel>
+    </PageLayout>
+  );
+};

--- a/core/gitops-frontend/src/pages/KindRegistryPage.tsx
+++ b/core/gitops-frontend/src/pages/KindRegistryPage.tsx
@@ -1,0 +1,516 @@
+import { useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Badge,
+  PageLayout,
+} from "@checkstack/ui";
+import { ChevronDown, ChevronRight, Puzzle, Blocks } from "lucide-react";
+import { usePluginClient } from "@checkstack/frontend-api";
+import { GitOpsApi } from "@checkstack/gitops-common";
+import { extractErrorMessage } from "@checkstack/common";
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+interface JsonSchemaProperty {
+  type?: string;
+  properties?: Record<string, JsonSchemaProperty>;
+  items?: JsonSchemaProperty;
+  required?: string[];
+  description?: string;
+  enum?: string[];
+  anyOf?: JsonSchemaProperty[];
+  default?: unknown;
+}
+
+interface KindDescription {
+  apiVersion: string;
+  kind: string;
+  specSchema: JsonSchemaProperty;
+  extensions: Array<{
+    namespace: string;
+    specSchema: JsonSchemaProperty;
+  }>;
+}
+
+// ─── Schema Display ────────────────────────────────────────────────────────
+
+const TYPE_COLORS: Record<string, string> = {
+  string: "text-green-600 dark:text-green-400",
+  number: "text-amber-600 dark:text-amber-400",
+  integer: "text-amber-600 dark:text-amber-400",
+  boolean: "text-red-600 dark:text-red-400",
+  array: "text-blue-600 dark:text-blue-400",
+  object: "text-purple-600 dark:text-purple-400",
+};
+
+function SchemaPropertyDisplay({
+  schema,
+  depth = 0,
+}: {
+  schema: JsonSchemaProperty;
+  depth?: number;
+}) {
+  if (schema.enum) {
+    return (
+      <span className="text-green-600 dark:text-green-400">
+        {schema.enum.map((e) => `"${e}"`).join(" | ")}
+      </span>
+    );
+  }
+
+  if (schema.anyOf) {
+    return (
+      <span>
+        {schema.anyOf.map((s, i) => (
+          <span key={i}>
+            {i > 0 && <span className="text-muted-foreground"> | </span>}
+            <SchemaPropertyDisplay schema={s} depth={depth} />
+          </span>
+        ))}
+      </span>
+    );
+  }
+
+  if (schema.type === "object" && schema.properties) {
+    return (
+      <div className="font-mono text-sm" style={{ marginLeft: depth * 16 }}>
+        {"{"}
+        {Object.entries(schema.properties).map(([key, value]) => (
+          <div key={key} className="ml-4">
+            <span className="text-blue-600 dark:text-blue-400">{key}</span>
+            {schema.required?.includes(key) && (
+              <span className="text-red-500">*</span>
+            )}
+            : <SchemaPropertyDisplay schema={value} depth={depth + 1} />
+            {value.description && (
+              <span className="text-muted-foreground ml-2 text-xs">
+                // {value.description}
+              </span>
+            )}
+          </div>
+        ))}
+        {"}"}
+      </div>
+    );
+  }
+
+  if (schema.type === "array" && schema.items) {
+    return (
+      <span>
+        <SchemaPropertyDisplay schema={schema.items} depth={depth} />
+        {"[]"}
+      </span>
+    );
+  }
+
+  const typeStr = schema.type ?? "unknown";
+  return (
+    <span className={TYPE_COLORS[typeStr] ?? "text-gray-600"}>
+      {typeStr}
+      {schema.default !== undefined && (
+        <span className="text-muted-foreground ml-1">
+          = {JSON.stringify(schema.default)}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function SchemaBlock({
+  schema,
+  label,
+}: {
+  schema: JsonSchemaProperty;
+  label: string;
+}) {
+  const hasProperties =
+    schema.type === "object" &&
+    schema.properties &&
+    Object.keys(schema.properties).length > 0;
+
+  if (!hasProperties) {
+    return (
+      <div>
+        <h4 className="text-sm font-medium mb-2 text-muted-foreground">
+          {label}
+        </h4>
+        <div className="bg-muted rounded-md p-3 text-sm text-muted-foreground italic">
+          No properties defined
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h4 className="text-sm font-medium mb-2 text-muted-foreground">
+        {label}
+      </h4>
+      <div className="bg-muted rounded-md p-3 overflow-x-auto">
+        <SchemaPropertyDisplay schema={schema} />
+      </div>
+    </div>
+  );
+}
+
+// ─── YAML Example Generator ────────────────────────────────────────────────
+
+function generateYamlExample({ kind }: { kind: KindDescription }): string {
+  const lines = [
+    `apiVersion: ${kind.apiVersion}`,
+    `kind: ${kind.kind}`,
+    "metadata:",
+    `  name: my-${kind.kind.toLowerCase()}`,
+  ];
+
+  const baseProps = kind.specSchema.properties ?? {};
+  const hasBaseProps = Object.keys(baseProps).length > 0;
+  const hasExtensions = kind.extensions.length > 0;
+
+  if (!hasBaseProps && !hasExtensions) {
+    lines.push("spec: {}");
+    return lines.join("\n");
+  }
+
+  lines.push("spec:");
+
+  const baseRequired = new Set(kind.specSchema.required);
+  for (const [key, prop] of Object.entries(baseProps)) {
+    emitProperty({
+      lines,
+      key,
+      prop,
+      indent: 2,
+      required: baseRequired.has(key),
+    });
+  }
+
+  for (const ext of kind.extensions) {
+    emitProperty({
+      lines,
+      key: ext.namespace,
+      prop: ext.specSchema,
+      indent: 2,
+      required: false,
+    });
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Recursively emits a YAML property with proper indentation.
+ * Annotates optional and nullable fields with inline comments.
+ */
+function emitProperty({
+  lines,
+  key,
+  prop,
+  indent,
+  required,
+}: {
+  lines: string[];
+  key: string;
+  prop: JsonSchemaProperty;
+  indent: number;
+  required: boolean;
+}) {
+  const pad = " ".repeat(indent);
+  const annotation = buildAnnotation({ prop, required });
+
+  // Resolve the effective schema (unwrap nullable / anyOf wrappers)
+  const effective = resolveEffective({ prop });
+
+  if (effective.type === "object" && effective.properties) {
+    lines.push(`${pad}${key}:${annotation}`);
+    const objRequired = new Set(effective.required);
+    for (const [k, p] of Object.entries(effective.properties)) {
+      emitProperty({
+        lines,
+        key: k,
+        prop: p,
+        indent: indent + 2,
+        required: objRequired.has(k),
+      });
+    }
+  } else if (effective.type === "array") {
+    lines.push(`${pad}${key}:${annotation}`);
+    if (effective.items) {
+      emitArrayItem({ lines, itemSchema: effective.items, indent: indent + 2 });
+    } else {
+      lines.push(`${pad}  - # ...`);
+    }
+  } else {
+    lines.push(`${pad}${key}: ${scalarExample({ prop })}${annotation}`);
+  }
+}
+
+/**
+ * Emits a single array item (the `- ` prefix) with proper handling of
+ * objects, nested arrays, and scalar values.
+ */
+function emitArrayItem({
+  lines,
+  itemSchema,
+  indent,
+}: {
+  lines: string[];
+  itemSchema: JsonSchemaProperty;
+  indent: number;
+}) {
+  const pad = " ".repeat(indent);
+  const effective = resolveEffective({ prop: itemSchema });
+
+  if (effective.type === "object" && effective.properties) {
+    const itemRequired = new Set(effective.required);
+    const entries = Object.entries(effective.properties);
+    for (const [i, [k, p]] of entries.entries()) {
+      const prefix = i === 0 ? `${pad}- ` : `${pad}  `;
+      const itemAnnotation = buildAnnotation({
+        prop: p,
+        required: itemRequired.has(k),
+      });
+      const inner = resolveEffective({ prop: p });
+
+      if (inner.type === "object" && inner.properties) {
+        // Recurse into nested objects
+        lines.push(`${prefix}${k}:${itemAnnotation}`);
+        const nestedRequired = new Set(inner.required);
+        for (const [nk, np] of Object.entries(inner.properties)) {
+          emitProperty({
+            lines,
+            key: nk,
+            prop: np,
+            indent: indent + 4,
+            required: nestedRequired.has(nk),
+          });
+        }
+      } else if (inner.type === "array") {
+        lines.push(`${prefix}${k}:${itemAnnotation}`);
+        if (inner.items) {
+          emitArrayItem({ lines, itemSchema: inner.items, indent: indent + 4 });
+        } else {
+          lines.push(`${" ".repeat(indent + 4)}- # ...`);
+        }
+      } else {
+        lines.push(
+          `${prefix}${k}: ${scalarExample({ prop: p })}${itemAnnotation}`,
+        );
+      }
+    }
+  } else {
+    lines.push(`${pad}- ${scalarExample({ prop: itemSchema })}`);
+  }
+}
+
+/**
+ * Builds an inline YAML comment annotation for optional/nullable fields.
+ */
+function buildAnnotation({
+  prop,
+  required,
+}: {
+  prop: JsonSchemaProperty;
+  required: boolean;
+}): string {
+  const tags: string[] = [];
+  if (!required) tags.push("optional");
+  if (isNullable({ prop })) tags.push("nullable");
+  return tags.length > 0 ? ` # ${tags.join(", ")}` : "";
+}
+
+/**
+ * Checks if a property allows null values (via anyOf with null type).
+ */
+function isNullable({ prop }: { prop: JsonSchemaProperty }): boolean {
+  if (prop.anyOf) {
+    return prop.anyOf.some((s) => s.type === "null");
+  }
+  return false;
+}
+
+/**
+ * Resolves the effective schema by unwrapping nullable anyOf wrappers.
+ */
+function resolveEffective({
+  prop,
+}: {
+  prop: JsonSchemaProperty;
+}): JsonSchemaProperty {
+  if (prop.anyOf) {
+    const nonNull = prop.anyOf.filter((s) => s.type !== "null");
+    if (nonNull.length === 1) return nonNull[0];
+  }
+  return prop;
+}
+
+/**
+ * Returns a scalar YAML example value for a property.
+ * Objects without defined properties (z.record) get a comment annotation.
+ */
+function scalarExample({ prop }: { prop: JsonSchemaProperty }): string {
+  const effective = resolveEffective({ prop });
+  if (effective.enum) return `"${effective.enum[0]}"`;
+  if (effective.default !== undefined) return JSON.stringify(effective.default);
+  switch (effective.type) {
+    case "string": {
+      return '"..."';
+    }
+    case "number":
+    case "integer": {
+      return "0";
+    }
+    case "boolean": {
+      return "false";
+    }
+    case "array": {
+      return "[]";
+    }
+    case "object": {
+      // Object without properties = z.record() or z.unknown() — annotate
+      return "{} # key-value pairs";
+    }
+    default: {
+      return '"..."';
+    }
+  }
+}
+
+// ─── Kind Card ─────────────────────────────────────────────────────────────
+
+function KindCard({ kind }: { kind: KindDescription }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Card className="mb-3">
+      <CardHeader
+        className="cursor-pointer hover:bg-accent/50 transition-colors py-4"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="flex items-center gap-3">
+          {isOpen ? (
+            <ChevronDown className="h-4 w-4 shrink-0" />
+          ) : (
+            <ChevronRight className="h-4 w-4 shrink-0" />
+          )}
+          <Blocks className="h-5 w-5 text-blue-500 shrink-0" />
+          <CardTitle className="text-lg">{kind.kind}</CardTitle>
+          <Badge variant="secondary" className="font-mono text-xs">
+            {kind.apiVersion}
+          </Badge>
+          {kind.extensions.length > 0 && (
+            <Badge
+              variant="outline"
+              className="text-xs flex items-center gap-1"
+            >
+              <Puzzle className="h-3 w-3" />
+              {kind.extensions.length} extension
+              {kind.extensions.length > 1 ? "s" : ""}
+            </Badge>
+          )}
+        </div>
+        <CardDescription className="ml-8">
+          Entity kind with{" "}
+          {Object.keys(kind.specSchema.properties ?? {}).length} base properties
+          {kind.extensions.length > 0 &&
+            ` and ${kind.extensions.length} extension namespace${kind.extensions.length > 1 ? "s" : ""}`}
+        </CardDescription>
+      </CardHeader>
+
+      {isOpen && (
+        <CardContent className="pt-0 space-y-6">
+          {/* Base Spec Schema */}
+          <SchemaBlock schema={kind.specSchema} label="Base Spec Schema" />
+
+          {/* Extensions */}
+          {kind.extensions.length > 0 && (
+            <div className="space-y-4">
+              <h4 className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+                <Puzzle className="h-4 w-4" />
+                Extensions
+              </h4>
+              {kind.extensions.map((ext) => (
+                <div
+                  key={ext.namespace}
+                  className="border rounded-lg p-4 space-y-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className="font-mono">
+                      {ext.namespace}
+                    </Badge>
+                  </div>
+                  <div className="bg-muted rounded-md p-3 overflow-x-auto">
+                    <SchemaPropertyDisplay schema={ext.specSchema} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* YAML Example */}
+          <div>
+            <h4 className="text-sm font-medium mb-2 text-muted-foreground">
+              YAML Example
+            </h4>
+            <pre className="bg-muted rounded-md p-3 overflow-x-auto text-sm">
+              <code>{generateYamlExample({ kind })}</code>
+            </pre>
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────
+
+export function KindRegistryPage() {
+  const client = usePluginClient(GitOpsApi);
+
+  const { data: kinds, isLoading, error } = client.listKinds.useQuery({});
+
+  return (
+    <PageLayout
+      title="Entity Kind Registry"
+      subtitle="Browse registered entity kinds, their spec schemas, and extensions from all plugins"
+      icon={Blocks}
+      loading={isLoading}
+      maxWidth="full"
+    >
+      {error && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Error Loading Kind Registry</CardTitle>
+            <CardDescription>
+              {extractErrorMessage(error, "Unknown error")}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+
+      {!isLoading && !error && (!kinds || kinds.length === 0) && (
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            No entity kinds are registered. Kinds are registered by plugins
+            during startup.
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="space-y-3">
+        {(kinds ?? [])
+          .toSorted((a, b) => a.kind.localeCompare(b.kind))
+          .map((kind) => (
+            <KindCard
+              key={`${kind.apiVersion}::${kind.kind}`}
+              kind={kind as KindDescription}
+            />
+          ))}
+      </div>
+    </PageLayout>
+  );
+}

--- a/core/gitops-frontend/tsconfig.json
+++ b/core/gitops-frontend/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@checkstack/tsconfig/frontend.json",
+  "include": [
+    "src"
+  ]
+}

--- a/core/healthcheck-backend/package.json
+++ b/core/healthcheck-backend/package.json
@@ -18,6 +18,8 @@
     "@checkstack/catalog-common": "workspace:*",
     "@checkstack/command-backend": "workspace:*",
     "@checkstack/common": "workspace:*",
+    "@checkstack/gitops-backend": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
     "@checkstack/healthcheck-common": "workspace:*",
     "@checkstack/incident-common": "workspace:*",
     "@checkstack/integration-backend": "workspace:*",

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
@@ -464,12 +464,11 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
   it("creates associations from ref array", async () => {
     const ext = buildExtension();
 
-    // Setup: System and two healthchecks exist in provenance
+    // Setup: two healthchecks exist in provenance
     const contextWithRefs: ReconcileContext = {
       ...mockContext,
       resolveEntityRef: async ({ kind, entityName }) => {
         const entries: Record<string, Record<string, string>> = {
-          System: { "payment-service": "sys-123" },
           Healthcheck: {
             "db-check": "hc-1",
             "api-check": "hc-2",
@@ -487,9 +486,10 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
         spec: {},
       },
       extensionSpec: [
-        { ref: "db-check", degradedThreshold: 3, unhealthyThreshold: 5 },
-        { ref: "api-check" },
+        { ref: { kind: "Healthcheck", name: "db-check" }, degradedThreshold: 3, unhealthyThreshold: 5 },
+        { ref: { kind: "Healthcheck", name: "api-check" } },
       ],
+      entityId: "sys-123",
       context: contextWithRefs,
     });
 
@@ -535,7 +535,6 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
       ...mockContext,
       resolveEntityRef: async ({ kind, entityName }) => {
         const entries: Record<string, Record<string, string>> = {
-          System: { "my-system": "sys-123" },
           Healthcheck: { "keep-check": "hc-keep" },
         };
         return entries[kind]?.[entityName];
@@ -549,7 +548,8 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
         metadata: { name: "my-system" },
         spec: {},
       },
-      extensionSpec: [{ ref: "keep-check" }],
+      extensionSpec: [{ ref: { kind: "Healthcheck", name: "keep-check" } }],
+      entityId: "sys-123",
       context: contextWithRefs,
     });
 
@@ -563,12 +563,9 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
   it("errors on unresolvable healthcheck ref", async () => {
     const ext = buildExtension();
 
-    const contextWithSystemOnly: ReconcileContext = {
+    const contextEmpty: ReconcileContext = {
       ...mockContext,
-      resolveEntityRef: async ({ kind, entityName }) => {
-        if (kind === "System" && entityName === "my-system") return "sys-123";
-        return undefined;
-      },
+      resolveEntityRef: async () => undefined,
     };
 
     await expect(
@@ -579,8 +576,9 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
           metadata: { name: "my-system" },
           spec: {},
         },
-        extensionSpec: [{ ref: "nonexistent-check" }],
-        context: contextWithSystemOnly,
+        extensionSpec: [{ ref: { kind: "Healthcheck", name: "nonexistent-check" } }],
+        entityId: "sys-123",
+        context: contextEmpty,
       }),
     ).rejects.toThrow(/Cannot resolve Healthcheck ref "nonexistent-check"/);
   });
@@ -596,6 +594,7 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
         spec: {},
       },
       extensionSpec: [],
+      entityId: "sys-123",
       context: mockContext,
     });
 

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
@@ -204,20 +204,16 @@ describe("Healthcheck GitOps Kind: Healthcheck", () => {
     mockService = createMockService();
     mockHCRegistry = createMockHealthCheckRegistry();
     mockCollectorRegistry = createMockCollectorRegistry();
-
-    // Mock the dynamic import of HealthCheckService
-    mock.module("./service", () => ({
-      HealthCheckService: class {
-        createConfiguration = mockService.createConfiguration;
-        updateConfiguration = mockService.updateConfiguration;
-        deleteConfiguration = mockService.deleteConfiguration;
-      },
-    }));
   });
 
   function buildKind() {
     return buildHealthcheckKind({
-      getDb: () => ({}) as ReturnType<typeof createMockService>["configs"] & Record<string, unknown> as never,
+      createService: () =>
+        ({
+          createConfiguration: mockService.createConfiguration,
+          updateConfiguration: mockService.updateConfiguration,
+          deleteConfiguration: mockService.deleteConfiguration,
+        }) as never,
       getHealthCheckRegistry: () => mockHCRegistry as never,
       getCollectorRegistry: () => mockCollectorRegistry as never,
     });
@@ -443,19 +439,16 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
 
   beforeEach(() => {
     mockService = createMockService();
-
-    mock.module("./service", () => ({
-      HealthCheckService: class {
-        associateSystem = mockService.associateSystem;
-        disassociateSystem = mockService.disassociateSystem;
-        getSystemConfigurations = mockService.getSystemConfigurations;
-      },
-    }));
   });
 
   function buildExtension() {
     return buildSystemHealthcheckExtension({
-      getDb: () => ({}) as never,
+      createService: () =>
+        ({
+          associateSystem: mockService.associateSystem,
+          disassociateSystem: mockService.disassociateSystem,
+          getSystemConfigurations: mockService.getSystemConfigurations,
+        }) as never,
       getHealthCheckRegistry: () => createMockHealthCheckRegistry() as never,
       getCollectorRegistry: () => createMockCollectorRegistry() as never,
     });

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
@@ -1,0 +1,604 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { CHECKSTACK_API_VERSION } from "@checkstack/gitops-common";
+import type { ReconcileContext } from "@checkstack/gitops-common";
+import {
+  buildHealthcheckKind,
+  buildSystemHealthcheckExtension,
+} from "./healthcheck-gitops-kinds";
+import type {
+  HealthCheckConfiguration,
+  CreateHealthCheckConfiguration,
+  UpdateHealthCheckConfiguration,
+} from "@checkstack/healthcheck-common";
+import { z } from "zod";
+import { Versioned } from "@checkstack/backend-api";
+
+/**
+ * Tests for the healthcheck-backend's GitOps entity kind registrations.
+ *
+ * Exercises reconcile/delete for kind: Healthcheck and the
+ * System → healthchecks extension in isolation with mock services.
+ */
+
+// ─── Mock Healthcheck Service ──────────────────────────────────────────────
+
+interface MockConfig {
+  id: string;
+  name: string;
+  strategyId: string;
+  config: Record<string, unknown>;
+  intervalSeconds: number;
+  collectors?: unknown[];
+  paused: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface MockAssociation {
+  systemId: string;
+  configurationId: string;
+  enabled: boolean;
+}
+
+function createMockService() {
+  const configs: MockConfig[] = [];
+  const associations: MockAssociation[] = [];
+
+  return {
+    configs,
+    associations,
+    createConfiguration: mock(async (data: CreateHealthCheckConfiguration) => {
+      const config: MockConfig = {
+        id: `hc-${configs.length + 1}`,
+        name: data.name,
+        strategyId: data.strategyId,
+        config: data.config,
+        intervalSeconds: data.intervalSeconds,
+        collectors: data.collectors,
+        paused: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      configs.push(config);
+      return config as unknown as HealthCheckConfiguration;
+    }),
+    updateConfiguration: mock(
+      async (id: string, data: UpdateHealthCheckConfiguration) => {
+        const config = configs.find((c) => c.id === id);
+        if (config) {
+          Object.assign(config, data, { updatedAt: new Date() });
+        }
+        return config as unknown as HealthCheckConfiguration | undefined;
+      },
+    ),
+    deleteConfiguration: mock(async (id: string) => {
+      const idx = configs.findIndex((c) => c.id === id);
+      if (idx >= 0) configs.splice(idx, 1);
+    }),
+    associateSystem: mock(
+      async (props: {
+        systemId: string;
+        configurationId: string;
+        enabled?: boolean;
+      }) => {
+        const existing = associations.find(
+          (a) =>
+            a.systemId === props.systemId &&
+            a.configurationId === props.configurationId,
+        );
+        if (existing) {
+          existing.enabled = props.enabled ?? true;
+        } else {
+          associations.push({
+            systemId: props.systemId,
+            configurationId: props.configurationId,
+            enabled: props.enabled ?? true,
+          });
+        }
+      },
+    ),
+    disassociateSystem: mock(
+      async (systemId: string, configurationId: string) => {
+        const idx = associations.findIndex(
+          (a) =>
+            a.systemId === systemId && a.configurationId === configurationId,
+        );
+        if (idx >= 0) associations.splice(idx, 1);
+      },
+    ),
+    getSystemConfigurations: mock(async (systemId: string) => {
+      return associations
+        .filter((a) => a.systemId === systemId)
+        .map((a) => {
+          const config = configs.find((c) => c.id === a.configurationId);
+          return config as unknown as HealthCheckConfiguration;
+        })
+        .filter(Boolean);
+    }),
+  };
+}
+
+// ─── Mock Registries ───────────────────────────────────────────────────────
+
+const postgresConfigSchema = z.object({
+  host: z.string(),
+  port: z.number().optional(),
+  database: z.string(),
+  user: z.string(),
+  password: z.string(),
+});
+
+const cpuCollectorConfigSchema = z.object({
+  warningThreshold: z.number().optional(),
+});
+
+function createMockHealthCheckRegistry() {
+  const strategies = new Map<
+    string,
+    { id: string; config: Versioned<unknown> }
+  >();
+
+  // Register a test strategy
+  strategies.set("postgres", {
+    id: "postgres",
+    config: new Versioned({
+      version: 1,
+      schema: postgresConfigSchema,
+    }),
+  });
+
+  return {
+    getStrategy: (id: string) => strategies.get(id) as ReturnType<import("@checkstack/backend-api").HealthCheckRegistry["getStrategy"]>,
+    getStrategies: () =>
+      [...strategies.values()] as ReturnType<import("@checkstack/backend-api").HealthCheckRegistry["getStrategies"]>,
+    getStrategiesWithMeta: () => [],
+    register: () => {},
+  };
+}
+
+function createMockCollectorRegistry() {
+  const collectors = new Map<
+    string,
+    { qualifiedId: string; collector: { config: Versioned<unknown> } }
+  >();
+
+  collectors.set("collector-hardware.cpu", {
+    qualifiedId: "collector-hardware.cpu",
+    collector: {
+      config: new Versioned({
+        version: 1,
+        schema: cpuCollectorConfigSchema,
+      }),
+    },
+  });
+
+  return {
+    getCollector: (id: string) => collectors.get(id) as ReturnType<import("@checkstack/backend-api").CollectorRegistry["getCollector"]>,
+    getCollectors: () =>
+      [...collectors.values()] as ReturnType<import("@checkstack/backend-api").CollectorRegistry["getCollectors"]>,
+    getCollectorsForPlugin: () => [],
+    register: () => {},
+  };
+}
+
+// ─── Test Context ──────────────────────────────────────────────────────────
+
+const mockContext: ReconcileContext = {
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+  resolveEntityRef: async () => undefined,
+};
+
+// ─── Tests: kind: Healthcheck ──────────────────────────────────────────────
+
+describe("Healthcheck GitOps Kind: Healthcheck", () => {
+  let mockService: ReturnType<typeof createMockService>;
+  let mockHCRegistry: ReturnType<typeof createMockHealthCheckRegistry>;
+  let mockCollectorRegistry: ReturnType<typeof createMockCollectorRegistry>;
+
+  beforeEach(() => {
+    mockService = createMockService();
+    mockHCRegistry = createMockHealthCheckRegistry();
+    mockCollectorRegistry = createMockCollectorRegistry();
+
+    // Mock the dynamic import of HealthCheckService
+    mock.module("./service", () => ({
+      HealthCheckService: class {
+        createConfiguration = mockService.createConfiguration;
+        updateConfiguration = mockService.updateConfiguration;
+        deleteConfiguration = mockService.deleteConfiguration;
+      },
+    }));
+  });
+
+  function buildKind() {
+    return buildHealthcheckKind({
+      getDb: () => ({}) as ReturnType<typeof createMockService>["configs"] & Record<string, unknown> as never,
+      getHealthCheckRegistry: () => mockHCRegistry as never,
+      getCollectorRegistry: () => mockCollectorRegistry as never,
+    });
+  }
+
+  it("creates a new healthcheck configuration and returns entityId", async () => {
+    const kind = buildKind();
+
+    const result = await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        metadata: { name: "payment-db-check", title: "Payment DB Health" },
+        spec: {
+          strategy: "postgres",
+          intervalSeconds: 30,
+          config: {
+            host: "db.internal",
+            port: 5432,
+            database: "payments",
+            user: "monitor",
+            password: "secret",
+          },
+        },
+      },
+      context: mockContext,
+    });
+
+    expect(result.entityId).toBe("hc-1");
+    expect(mockService.createConfiguration).toHaveBeenCalledTimes(1);
+    expect(mockService.configs).toHaveLength(1);
+    expect(mockService.configs[0].name).toBe("Payment DB Health");
+    expect(mockService.configs[0].strategyId).toBe("postgres");
+  });
+
+  it("updates an existing configuration using existingEntityId", async () => {
+    const kind = buildKind();
+
+    mockService.configs.push({
+      id: "hc-existing",
+      name: "Old Name",
+      strategyId: "postgres",
+      config: {},
+      intervalSeconds: 60,
+      paused: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        metadata: { name: "payment-db-check", title: "Updated Check" },
+        spec: {
+          strategy: "postgres",
+          intervalSeconds: 15,
+          config: {
+            host: "db.new",
+            port: 5432,
+            database: "payments",
+            user: "monitor",
+            password: "new-secret",
+          },
+        },
+      },
+      existingEntityId: "hc-existing",
+      context: mockContext,
+    });
+
+    expect(result.entityId).toBe("hc-existing");
+    expect(mockService.updateConfiguration).toHaveBeenCalledTimes(1);
+    expect(mockService.createConfiguration).not.toHaveBeenCalled();
+    expect(mockService.configs[0].name).toBe("Updated Check");
+  });
+
+  it("deletes a configuration by entityId", async () => {
+    const kind = buildKind();
+
+    mockService.configs.push({
+      id: "hc-del",
+      name: "To Delete",
+      strategyId: "postgres",
+      config: {},
+      intervalSeconds: 30,
+      paused: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await kind.delete!({
+      entityName: "old-check",
+      entityId: "hc-del",
+      context: mockContext,
+    });
+
+    expect(mockService.deleteConfiguration).toHaveBeenCalledWith("hc-del");
+    expect(mockService.configs).toHaveLength(0);
+  });
+
+  it("skips delete when entityId is missing", async () => {
+    const kind = buildKind();
+
+    await kind.delete!({
+      entityName: "unknown-check",
+      context: mockContext,
+    });
+
+    expect(mockService.deleteConfiguration).not.toHaveBeenCalled();
+  });
+
+  it("throws on unknown strategy", async () => {
+    const kind = buildKind();
+
+    await expect(
+      kind.reconcile({
+        entity: {
+          apiVersion: CHECKSTACK_API_VERSION,
+          kind: "Healthcheck",
+          metadata: { name: "bad-check" },
+          spec: {
+            strategy: "nonexistent",
+            intervalSeconds: 30,
+            config: {},
+          },
+        },
+        context: mockContext,
+      }),
+    ).rejects.toThrow(/Unknown health check strategy "nonexistent"/);
+  });
+
+  it("validates config against strategy schema", async () => {
+    const kind = buildKind();
+
+    await expect(
+      kind.reconcile({
+        entity: {
+          apiVersion: CHECKSTACK_API_VERSION,
+          kind: "Healthcheck",
+          metadata: { name: "bad-config" },
+          spec: {
+            strategy: "postgres",
+            intervalSeconds: 30,
+            config: {
+              // Missing required fields: host, database, user, password
+              port: "not-a-number",
+            },
+          },
+        },
+        context: mockContext,
+      }),
+    ).rejects.toThrow(/config validation failed/);
+  });
+
+  it("validates collector configs against collector registry schemas", async () => {
+    const kind = buildKind();
+
+    await expect(
+      kind.reconcile({
+        entity: {
+          apiVersion: CHECKSTACK_API_VERSION,
+          kind: "Healthcheck",
+          metadata: { name: "bad-collector" },
+          spec: {
+            strategy: "postgres",
+            intervalSeconds: 30,
+            config: {
+              host: "db.local",
+              database: "test",
+              user: "root",
+              password: "pass",
+            },
+            collectors: [
+              {
+                collectorId: "unknown-collector",
+                config: {},
+              },
+            ],
+          },
+        },
+        context: mockContext,
+      }),
+    ).rejects.toThrow(/Unknown collector "unknown-collector"/);
+  });
+
+  it("accepts valid collector configs", async () => {
+    const kind = buildKind();
+
+    const result = await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        metadata: { name: "with-collector" },
+        spec: {
+          strategy: "postgres",
+          intervalSeconds: 30,
+          config: {
+            host: "db.local",
+            database: "test",
+            user: "root",
+            password: "pass",
+          },
+          collectors: [
+            {
+              collectorId: "collector-hardware.cpu",
+              config: { warningThreshold: 90 },
+            },
+          ],
+        },
+      },
+      context: mockContext,
+    });
+
+    expect(result.entityId).toBe("hc-1");
+    expect(mockService.createConfiguration).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Tests: System → healthchecks extension ────────────────────────────────
+
+describe("Healthcheck GitOps Kind: System Extension", () => {
+  let mockService: ReturnType<typeof createMockService>;
+
+  beforeEach(() => {
+    mockService = createMockService();
+
+    mock.module("./service", () => ({
+      HealthCheckService: class {
+        associateSystem = mockService.associateSystem;
+        disassociateSystem = mockService.disassociateSystem;
+        getSystemConfigurations = mockService.getSystemConfigurations;
+      },
+    }));
+  });
+
+  function buildExtension() {
+    return buildSystemHealthcheckExtension({
+      getDb: () => ({}) as never,
+      getHealthCheckRegistry: () => createMockHealthCheckRegistry() as never,
+      getCollectorRegistry: () => createMockCollectorRegistry() as never,
+    });
+  }
+
+  it("creates associations from ref array", async () => {
+    const ext = buildExtension();
+
+    // Setup: System and two healthchecks exist in provenance
+    const contextWithRefs: ReconcileContext = {
+      ...mockContext,
+      resolveEntityRef: async ({ kind, entityName }) => {
+        const entries: Record<string, Record<string, string>> = {
+          System: { "payment-service": "sys-123" },
+          Healthcheck: {
+            "db-check": "hc-1",
+            "api-check": "hc-2",
+          },
+        };
+        return entries[kind]?.[entityName];
+      },
+    };
+
+    await ext.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        metadata: { name: "payment-service" },
+        spec: {},
+      },
+      extensionSpec: [
+        { ref: "db-check", degradedThreshold: 3, unhealthyThreshold: 5 },
+        { ref: "api-check" },
+      ],
+      context: contextWithRefs,
+    });
+
+    expect(mockService.associateSystem).toHaveBeenCalledTimes(2);
+    expect(mockService.associations).toHaveLength(2);
+    expect(mockService.associations[0].systemId).toBe("sys-123");
+    expect(mockService.associations[0].configurationId).toBe("hc-1");
+    expect(mockService.associations[1].configurationId).toBe("hc-2");
+  });
+
+  it("removes stale associations not in spec", async () => {
+    const ext = buildExtension();
+
+    // Pre-populate: system has 2 existing associations, spec only wants 1
+    mockService.configs.push(
+      {
+        id: "hc-keep",
+        name: "Keep",
+        strategyId: "postgres",
+        config: {},
+        intervalSeconds: 30,
+        paused: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "hc-remove",
+        name: "Remove",
+        strategyId: "postgres",
+        config: {},
+        intervalSeconds: 30,
+        paused: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    );
+    mockService.associations.push(
+      { systemId: "sys-123", configurationId: "hc-keep", enabled: true },
+      { systemId: "sys-123", configurationId: "hc-remove", enabled: true },
+    );
+
+    const contextWithRefs: ReconcileContext = {
+      ...mockContext,
+      resolveEntityRef: async ({ kind, entityName }) => {
+        const entries: Record<string, Record<string, string>> = {
+          System: { "my-system": "sys-123" },
+          Healthcheck: { "keep-check": "hc-keep" },
+        };
+        return entries[kind]?.[entityName];
+      },
+    };
+
+    await ext.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        metadata: { name: "my-system" },
+        spec: {},
+      },
+      extensionSpec: [{ ref: "keep-check" }],
+      context: contextWithRefs,
+    });
+
+    expect(mockService.disassociateSystem).toHaveBeenCalledTimes(1);
+    expect(mockService.disassociateSystem).toHaveBeenCalledWith(
+      "sys-123",
+      "hc-remove",
+    );
+  });
+
+  it("errors on unresolvable healthcheck ref", async () => {
+    const ext = buildExtension();
+
+    const contextWithSystemOnly: ReconcileContext = {
+      ...mockContext,
+      resolveEntityRef: async ({ kind, entityName }) => {
+        if (kind === "System" && entityName === "my-system") return "sys-123";
+        return undefined;
+      },
+    };
+
+    await expect(
+      ext.reconcile({
+        entity: {
+          apiVersion: CHECKSTACK_API_VERSION,
+          kind: "System",
+          metadata: { name: "my-system" },
+          spec: {},
+        },
+        extensionSpec: [{ ref: "nonexistent-check" }],
+        context: contextWithSystemOnly,
+      }),
+    ).rejects.toThrow(/Cannot resolve Healthcheck ref "nonexistent-check"/);
+  });
+
+  it("skips when extensionSpec is empty", async () => {
+    const ext = buildExtension();
+
+    await ext.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "System",
+        metadata: { name: "my-system" },
+        spec: {},
+      },
+      extensionSpec: [],
+      context: mockContext,
+    });
+
+    expect(mockService.associateSystem).not.toHaveBeenCalled();
+  });
+});

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
@@ -5,7 +5,7 @@ import type {
   EntityKindRegistry,
   ReconcileContext,
 } from "@checkstack/gitops-common";
-import { CHECKSTACK_API_VERSION, secretField } from "@checkstack/gitops-common";
+import { CHECKSTACK_API_VERSION, secretField, entityRefSchema } from "@checkstack/gitops-common";
 import type {
   HealthCheckRegistry,
   CollectorRegistry,
@@ -67,7 +67,7 @@ type HealthcheckSpec = z.infer<typeof healthcheckSpecSchema>;
 const systemHealthcheckExtensionSchema = z
   .array(
     z.object({
-      ref: z.string().min(1),
+      ref: entityRefSchema,
       degradedThreshold: z.number().int().min(1).optional(),
       unhealthyThreshold: z.number().int().min(1).optional(),
       satelliteIds: z.array(z.string()).optional(),
@@ -229,10 +229,12 @@ export function buildSystemHealthcheckExtension(
     reconcile: async ({
       entity,
       extensionSpec,
+      entityId,
       context,
     }: {
       entity: { metadata: { name: string } };
       extensionSpec: SystemHealthcheckExtension;
+      entityId: string;
       context: ReconcileContext;
     }) => {
       if (!extensionSpec || extensionSpec.length === 0) return;
@@ -243,30 +245,21 @@ export function buildSystemHealthcheckExtension(
       const { HealthCheckService: HCService } = await import("./service");
       const service = new HCService(db, healthCheckRegistry, collectorRegistry);
 
-      // Resolve the system's entityId from provenance
-      const systemEntityId = await context.resolveEntityRef({
-        kind: "System",
-        entityName: entity.metadata.name,
-      });
-
-      if (!systemEntityId) {
-        throw new Error(
-          `Cannot resolve System "${entity.metadata.name}" — ensure the System kind is reconciled before its extensions`,
-        );
-      }
+      // entityId is injected directly from the base reconciler — no provenance lookup needed
+      const systemEntityId = entityId;
 
       // Resolve each healthcheck ref → configurationId
       const desiredConfigIds = new Set<string>();
 
       for (const entry of extensionSpec) {
         const configId = await context.resolveEntityRef({
-          kind: "Healthcheck",
-          entityName: entry.ref,
+          kind: entry.ref.kind,
+          entityName: entry.ref.name,
         });
 
         if (!configId) {
           throw new Error(
-            `Cannot resolve Healthcheck ref "${entry.ref}" — ensure the Healthcheck entity exists`,
+            `Cannot resolve ${entry.ref.kind} ref "${entry.ref.name}" — ensure the entity exists`,
           );
         }
 
@@ -297,7 +290,7 @@ export function buildSystemHealthcheckExtension(
         });
 
         context.logger.info(
-          `GitOps: associated Healthcheck "${entry.ref}" (${configId}) with System "${entity.metadata.name}"`,
+          `GitOps: associated ${entry.ref.kind} "${entry.ref.name}" (${configId}) with System "${entity.metadata.name}"`,
         );
       }
 

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
@@ -9,13 +9,9 @@ import { CHECKSTACK_API_VERSION, secretField, entityRefSchema } from "@checkstac
 import type {
   HealthCheckRegistry,
   CollectorRegistry,
-  SafeDatabase,
 } from "@checkstack/backend-api";
-import type * as schema from "./schema";
+import { HealthCheckService } from "./service";
 
-// ─── Types ─────────────────────────────────────────────────────────────────
-
-type Db = SafeDatabase<typeof schema>;
 
 /**
  * Lazy accessor functions — populated during init(), consumed during reconcile.
@@ -23,7 +19,7 @@ type Db = SafeDatabase<typeof schema>;
  * point init() has completed.
  */
 interface HealthcheckGitOpsKindsDeps {
-  getDb: () => Db;
+  createService: () => HealthCheckService;
   getHealthCheckRegistry: () => HealthCheckRegistry;
   getCollectorRegistry: () => CollectorRegistry;
 }
@@ -105,14 +101,11 @@ export function buildHealthcheckKind(
       existingEntityId?: string;
       context: ReconcileContext;
     }) => {
-      const db = deps.getDb();
-      const healthCheckRegistry = deps.getHealthCheckRegistry();
-      const collectorRegistry = deps.getCollectorRegistry();
-      const { HealthCheckService: HCService } = await import("./service");
-      const service = new HCService(db, healthCheckRegistry, collectorRegistry);
+      const service = deps.createService();
       const spec = entity.spec;
 
       // Validate strategy exists in registry
+      const healthCheckRegistry = deps.getHealthCheckRegistry();
       const strategy = healthCheckRegistry.getStrategy(spec.strategy);
       if (!strategy) {
         throw new Error(
@@ -132,13 +125,14 @@ export function buildHealthcheckKind(
       // Validate collector configs against their registry schemas
       if (spec.collectors) {
         for (const collector of spec.collectors) {
-          const registered = collectorRegistry.getCollector(
+          const collectorReg = deps.getCollectorRegistry();
+          const registered = collectorReg.getCollector(
             collector.collectorId,
           );
           if (!registered) {
             throw new Error(
               `Unknown collector "${collector.collectorId}". ` +
-                `Available: ${collectorRegistry.getCollectors().map((c) => c.qualifiedId).join(", ")}`,
+                `Available: ${collectorReg.getCollectors().map((c) => c.qualifiedId).join(", ")}`,
             );
           }
           const collectorConfigValidation =
@@ -200,11 +194,7 @@ export function buildHealthcheckKind(
       context: ReconcileContext;
     }) => {
       if (!entityId) return;
-      const db = deps.getDb();
-      const healthCheckRegistry = deps.getHealthCheckRegistry();
-      const collectorRegistry = deps.getCollectorRegistry();
-      const { HealthCheckService: HCService } = await import("./service");
-      const service = new HCService(db, healthCheckRegistry, collectorRegistry);
+      const service = deps.createService();
       await service.deleteConfiguration(entityId);
       context.logger.info(`GitOps: deleted Healthcheck (id: ${entityId})`);
     },
@@ -239,11 +229,7 @@ export function buildSystemHealthcheckExtension(
     }) => {
       if (!extensionSpec || extensionSpec.length === 0) return;
 
-      const db = deps.getDb();
-      const healthCheckRegistry = deps.getHealthCheckRegistry();
-      const collectorRegistry = deps.getCollectorRegistry();
-      const { HealthCheckService: HCService } = await import("./service");
-      const service = new HCService(db, healthCheckRegistry, collectorRegistry);
+      const service = deps.createService();
 
       // entityId is injected directly from the base reconciler — no provenance lookup needed
       const systemEntityId = entityId;

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
@@ -1,0 +1,333 @@
+import { z } from "zod";
+import type {
+  EntityKindDefinition,
+  EntityKindExtensionDefinition,
+  EntityKindRegistry,
+  ReconcileContext,
+} from "@checkstack/gitops-common";
+import { CHECKSTACK_API_VERSION, secretField } from "@checkstack/gitops-common";
+import type {
+  HealthCheckRegistry,
+  CollectorRegistry,
+  SafeDatabase,
+} from "@checkstack/backend-api";
+import type * as schema from "./schema";
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+type Db = SafeDatabase<typeof schema>;
+
+/**
+ * Lazy accessor functions — populated during init(), consumed during reconcile.
+ * Safe because reconcile only runs during sync (afterPluginsReady), by which
+ * point init() has completed.
+ */
+interface HealthcheckGitOpsKindsDeps {
+  getDb: () => Db;
+  getHealthCheckRegistry: () => HealthCheckRegistry;
+  getCollectorRegistry: () => CollectorRegistry;
+}
+
+// ─── Healthcheck Spec Schema ───────────────────────────────────────────────
+
+/**
+ * GitOps spec schema for kind: Healthcheck.
+ *
+ * Strategy `config` fields use `secretField()` for sensitive values
+ * (passwords, tokens) that are resolved by the reconciliation engine.
+ */
+const healthcheckSpecSchema = z.object({
+  strategy: z.string().min(1),
+  intervalSeconds: z.number().int().min(1),
+  config: z.record(z.string(), z.union([z.unknown(), secretField()])),
+  collectors: z
+    .array(
+      z.object({
+        collectorId: z.string().min(1),
+        config: z.record(z.string(), z.unknown()),
+        assertions: z
+          .array(
+            z.object({
+              field: z.string(),
+              jsonPath: z.string().optional(),
+              operator: z.string(),
+              value: z.unknown().optional(),
+            }),
+          )
+          .optional(),
+      }),
+    )
+    .optional(),
+});
+
+type HealthcheckSpec = z.infer<typeof healthcheckSpecSchema>;
+
+// ─── System Extension Schema ───────────────────────────────────────────────
+
+const systemHealthcheckExtensionSchema = z
+  .array(
+    z.object({
+      ref: z.string().min(1),
+      degradedThreshold: z.number().int().min(1).optional(),
+      unhealthyThreshold: z.number().int().min(1).optional(),
+      satelliteIds: z.array(z.string()).optional(),
+      includeLocal: z.boolean().optional(),
+    }),
+  )
+  .optional();
+
+type SystemHealthcheckExtension = z.infer<
+  typeof systemHealthcheckExtensionSchema
+>;
+
+// ─── Kind Builder Functions ────────────────────────────────────────────────
+
+/**
+ * Build the ``kind: Healthcheck`` definition.
+ *
+ * Exported for isolated unit testing — the register() phase calls this
+ * and passes the result to `kindRegistry.registerKind()`.
+ */
+export function buildHealthcheckKind(
+  deps: HealthcheckGitOpsKindsDeps,
+): EntityKindDefinition<HealthcheckSpec> {
+  return {
+    apiVersion: CHECKSTACK_API_VERSION,
+    kind: "Healthcheck",
+    specSchema: healthcheckSpecSchema,
+
+    reconcile: async ({
+      entity,
+      existingEntityId,
+      context,
+    }: {
+      entity: { metadata: { name: string; title?: string; description?: string }; spec: HealthcheckSpec };
+      existingEntityId?: string;
+      context: ReconcileContext;
+    }) => {
+      const db = deps.getDb();
+      const healthCheckRegistry = deps.getHealthCheckRegistry();
+      const collectorRegistry = deps.getCollectorRegistry();
+      const { HealthCheckService: HCService } = await import("./service");
+      const service = new HCService(db, healthCheckRegistry, collectorRegistry);
+      const spec = entity.spec;
+
+      // Validate strategy exists in registry
+      const strategy = healthCheckRegistry.getStrategy(spec.strategy);
+      if (!strategy) {
+        throw new Error(
+          `Unknown health check strategy "${spec.strategy}". ` +
+            `Available: ${healthCheckRegistry.getStrategies().map((s) => s.id).join(", ")}`,
+        );
+      }
+
+      // Validate config against strategy's Zod schema
+      const configValidation = strategy.config.schema.safeParse(spec.config);
+      if (!configValidation.success) {
+        throw new Error(
+          `Strategy "${spec.strategy}" config validation failed: ${configValidation.error.message}`,
+        );
+      }
+
+      // Validate collector configs against their registry schemas
+      if (spec.collectors) {
+        for (const collector of spec.collectors) {
+          const registered = collectorRegistry.getCollector(
+            collector.collectorId,
+          );
+          if (!registered) {
+            throw new Error(
+              `Unknown collector "${collector.collectorId}". ` +
+                `Available: ${collectorRegistry.getCollectors().map((c) => c.qualifiedId).join(", ")}`,
+            );
+          }
+          const collectorConfigValidation =
+            registered.collector.config.schema.safeParse(collector.config);
+          if (!collectorConfigValidation.success) {
+            throw new Error(
+              `Collector "${collector.collectorId}" config validation failed: ${collectorConfigValidation.error.message}`,
+            );
+          }
+        }
+      }
+
+      // Create or update configuration
+      const displayName = entity.metadata.title ?? entity.metadata.name;
+
+      if (existingEntityId) {
+        await service.updateConfiguration(existingEntityId, {
+          name: displayName,
+          strategyId: spec.strategy,
+          config: spec.config,
+          intervalSeconds: spec.intervalSeconds,
+          collectors: spec.collectors?.map((c) => ({
+            id: c.collectorId,
+            collectorId: c.collectorId,
+            config: c.config,
+            assertions: c.assertions,
+          })),
+        });
+        context.logger.info(
+          `GitOps: updated Healthcheck "${displayName}" (id: ${existingEntityId})`,
+        );
+        return { entityId: existingEntityId };
+      }
+
+      const config = await service.createConfiguration({
+        name: displayName,
+        strategyId: spec.strategy,
+        config: spec.config,
+        intervalSeconds: spec.intervalSeconds,
+        collectors: spec.collectors?.map((c) => ({
+          id: c.collectorId,
+          collectorId: c.collectorId,
+          config: c.config,
+          assertions: c.assertions,
+        })),
+      });
+      context.logger.info(
+        `GitOps: created Healthcheck "${displayName}" (id: ${config.id})`,
+      );
+      return { entityId: config.id };
+    },
+
+    delete: async ({
+      entityId,
+      context,
+    }: {
+      entityName: string;
+      entityId?: string;
+      context: ReconcileContext;
+    }) => {
+      if (!entityId) return;
+      const db = deps.getDb();
+      const healthCheckRegistry = deps.getHealthCheckRegistry();
+      const collectorRegistry = deps.getCollectorRegistry();
+      const { HealthCheckService: HCService } = await import("./service");
+      const service = new HCService(db, healthCheckRegistry, collectorRegistry);
+      await service.deleteConfiguration(entityId);
+      context.logger.info(`GitOps: deleted Healthcheck (id: ${entityId})`);
+    },
+  };
+}
+
+/**
+ * Build the System → healthchecks extension definition.
+ *
+ * Resolves health check entity references to configuration IDs via
+ * `context.resolveEntityRef`, then manages system ↔ health check associations.
+ */
+export function buildSystemHealthcheckExtension(
+  deps: HealthcheckGitOpsKindsDeps,
+): EntityKindExtensionDefinition<SystemHealthcheckExtension> {
+  return {
+    apiVersion: CHECKSTACK_API_VERSION,
+    kind: "System",
+    namespace: "healthchecks",
+    specSchema: systemHealthcheckExtensionSchema,
+
+    reconcile: async ({
+      entity,
+      extensionSpec,
+      context,
+    }: {
+      entity: { metadata: { name: string } };
+      extensionSpec: SystemHealthcheckExtension;
+      context: ReconcileContext;
+    }) => {
+      if (!extensionSpec || extensionSpec.length === 0) return;
+
+      const db = deps.getDb();
+      const healthCheckRegistry = deps.getHealthCheckRegistry();
+      const collectorRegistry = deps.getCollectorRegistry();
+      const { HealthCheckService: HCService } = await import("./service");
+      const service = new HCService(db, healthCheckRegistry, collectorRegistry);
+
+      // Resolve the system's entityId from provenance
+      const systemEntityId = await context.resolveEntityRef({
+        kind: "System",
+        entityName: entity.metadata.name,
+      });
+
+      if (!systemEntityId) {
+        throw new Error(
+          `Cannot resolve System "${entity.metadata.name}" — ensure the System kind is reconciled before its extensions`,
+        );
+      }
+
+      // Resolve each healthcheck ref → configurationId
+      const desiredConfigIds = new Set<string>();
+
+      for (const entry of extensionSpec) {
+        const configId = await context.resolveEntityRef({
+          kind: "Healthcheck",
+          entityName: entry.ref,
+        });
+
+        if (!configId) {
+          throw new Error(
+            `Cannot resolve Healthcheck ref "${entry.ref}" — ensure the Healthcheck entity exists`,
+          );
+        }
+
+        desiredConfigIds.add(configId);
+
+        // Build state thresholds from the shorthand
+        const stateThresholds =
+          entry.degradedThreshold || entry.unhealthyThreshold
+            ? ({
+                mode: "consecutive" as const,
+                healthy: { minSuccessCount: 1 },
+                degraded: {
+                  minFailureCount: entry.degradedThreshold ?? 2,
+                },
+                unhealthy: {
+                  minFailureCount: entry.unhealthyThreshold ?? 5,
+                },
+              })
+            : undefined;
+
+        await service.associateSystem({
+          systemId: systemEntityId,
+          configurationId: configId,
+          enabled: true,
+          stateThresholds,
+          satelliteIds: entry.satelliteIds,
+          includeLocal: entry.includeLocal,
+        });
+
+        context.logger.info(
+          `GitOps: associated Healthcheck "${entry.ref}" (${configId}) with System "${entity.metadata.name}"`,
+        );
+      }
+
+      // Remove stale associations not in the spec
+      const currentAssociations =
+        await service.getSystemConfigurations(systemEntityId);
+      for (const existing of currentAssociations) {
+        if (!desiredConfigIds.has(existing.id)) {
+          await service.disassociateSystem(systemEntityId, existing.id);
+          context.logger.info(
+            `GitOps: removed stale association ${existing.id} from System "${entity.metadata.name}"`,
+          );
+        }
+      }
+    },
+  };
+}
+
+// ─── Registration Entry Point ──────────────────────────────────────────────
+
+/**
+ * Register all healthcheck-related GitOps entity kinds and extensions.
+ * Called from healthcheck-backend's `register()` phase.
+ */
+export function registerHealthcheckGitOpsKinds({
+  kindRegistry,
+  ...deps
+}: HealthcheckGitOpsKindsDeps & {
+  kindRegistry: EntityKindRegistry;
+}): void {
+  kindRegistry.registerKind(buildHealthcheckKind(deps));
+  kindRegistry.registerKindExtension(buildSystemHealthcheckExtension(deps));
+}

--- a/core/healthcheck-backend/src/index.ts
+++ b/core/healthcheck-backend/src/index.ts
@@ -102,9 +102,17 @@ export default createBackendPlugin({
     const kindRegistry = env.getExtensionPoint(entityKindExtensionPoint);
     registerHealthcheckGitOpsKinds({
       kindRegistry,
-      getDb: () => {
+      createService: () => {
         if (!gitopsDb) throw new Error("Healthcheck database not initialized");
-        return gitopsDb;
+        if (!gitopsHealthCheckRegistry)
+          throw new Error("HealthCheckRegistry not initialized");
+        if (!gitopsCollectorRegistry)
+          throw new Error("CollectorRegistry not initialized");
+        return new HealthCheckService(
+          gitopsDb,
+          gitopsHealthCheckRegistry,
+          gitopsCollectorRegistry,
+        );
       },
       getHealthCheckRegistry: () => {
         if (!gitopsHealthCheckRegistry)

--- a/core/healthcheck-backend/src/index.ts
+++ b/core/healthcheck-backend/src/index.ts
@@ -16,11 +16,15 @@ import {
   coreServices,
   type EmitHookFn,
   type SafeDatabase,
+  type HealthCheckRegistry,
+  type CollectorRegistry,
 } from "@checkstack/backend-api";
 import { integrationEventExtensionPoint } from "@checkstack/integration-backend";
+import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
 import { z } from "zod";
 import { createHealthCheckRouter } from "./router";
 import { HealthCheckService } from "./service";
+import { registerHealthcheckGitOpsKinds } from "./healthcheck-gitops-kinds";
 import { catalogHooks } from "@checkstack/catalog-backend";
 import { satelliteHooks } from "@checkstack/satellite-backend";
 import { CatalogApi } from "@checkstack/catalog-common";
@@ -89,6 +93,31 @@ export default createBackendPlugin({
       pluginMetadata,
     );
 
+    // ─── GitOps Entity Kind Registration ───────────────────────────────
+    // Mutable refs — populated during init(), consumed by reconcile closures.
+    let gitopsDb: SafeDatabase<typeof schema> | undefined;
+    let gitopsHealthCheckRegistry: HealthCheckRegistry | undefined;
+    let gitopsCollectorRegistry: CollectorRegistry | undefined;
+
+    const kindRegistry = env.getExtensionPoint(entityKindExtensionPoint);
+    registerHealthcheckGitOpsKinds({
+      kindRegistry,
+      getDb: () => {
+        if (!gitopsDb) throw new Error("Healthcheck database not initialized");
+        return gitopsDb;
+      },
+      getHealthCheckRegistry: () => {
+        if (!gitopsHealthCheckRegistry)
+          throw new Error("HealthCheckRegistry not initialized");
+        return gitopsHealthCheckRegistry;
+      },
+      getCollectorRegistry: () => {
+        if (!gitopsCollectorRegistry)
+          throw new Error("CollectorRegistry not initialized");
+        return gitopsCollectorRegistry;
+      },
+    });
+
     env.registerInit({
       schema,
       deps: {
@@ -112,6 +141,11 @@ export default createBackendPlugin({
         signalService,
       }) => {
         logger.debug("🏥 Initializing Health Check Backend...");
+
+        // Populate mutable refs for GitOps reconcile closures
+        gitopsDb = database;
+        gitopsHealthCheckRegistry = healthCheckRegistry;
+        gitopsCollectorRegistry = collectorRegistry;
 
         // Create catalog client for notification delegation
         const catalogClient = rpcClient.forPlugin(CatalogApi);

--- a/core/healthcheck-frontend/package.json
+++ b/core/healthcheck-frontend/package.json
@@ -17,6 +17,7 @@
     "@checkstack/common": "workspace:*",
     "@checkstack/dashboard-frontend": "workspace:*",
     "@checkstack/frontend-api": "workspace:*",
+    "@checkstack/gitops-frontend": "workspace:*",
     "@checkstack/healthcheck-common": "workspace:*",
     "@checkstack/signal-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",

--- a/core/healthcheck-frontend/src/pages/HealthCheckIDEPage.tsx
+++ b/core/healthcheck-frontend/src/pages/HealthCheckIDEPage.tsx
@@ -15,6 +15,8 @@ import { resolveRoute, extractErrorMessage} from "@checkstack/common";
 import { useCollectors } from "../hooks/useCollectors";
 import { EditorTree, type TreeNodeId } from "../components/editor/EditorTree";
 import { EditorPanel } from "../components/editor/EditorPanel";
+import { useProvenanceLock, GitOpsLockBanner } from "@checkstack/gitops-frontend";
+
 
 // =============================================================================
 // TYPES
@@ -38,9 +40,14 @@ const HealthCheckIDEPageContent = () => {
   const toast = useToast();
   const healthCheckClient = usePluginClient(HealthCheckApi);
 
-  // "new" is a sentinel value used by the create flow
   const isEditMode = !!configId && configId !== "new";
   const strategyIdFromUrl = searchParams.get("strategy") ?? undefined;
+
+  // --- GitOps Provenance Lock ---
+  const { isLocked, provenance } = useProvenanceLock({
+    kind: "Healthcheck",
+    entityId: isEditMode ? configId : undefined,
+  });
 
   // --- Data Fetching ---
 
@@ -320,13 +327,18 @@ const HealthCheckIDEPageContent = () => {
       actions={
         <Button
           onClick={handleSave}
-          disabled={!isValid || isSaving}
+      disabled={!isValid || isSaving || isLocked}
         >
           <Save className="mr-2 h-4 w-4" />
           {isSaving ? "Saving..." : "Save"}
         </Button>
       }
     >
+      {isLocked && provenance && (
+        <div className="mb-4">
+          <GitOpsLockBanner provenance={provenance} />
+        </div>
+      )}
       <IDELayout
         tree={
           <EditorTree

--- a/docs/backend/gitops-entity-kinds.md
+++ b/docs/backend/gitops-entity-kinds.md
@@ -1,0 +1,441 @@
+---
+title: GitOps Entity Kinds
+parent: Backend
+---
+
+# GitOps Entity Kinds
+
+This guide explains how plugin developers register entity kinds and kind extensions for the GitOps reconciliation system.
+
+## Overview
+
+The GitOps system lets teams define Checkstack resources (systems, health checks, etc.) as YAML files in Git repositories. Each resource is described by an **entity kind** that defines:
+
+- A **spec schema** (Zod) for validating the YAML descriptor
+- A **reconcile** function that creates or updates the resource
+- An optional **delete** function for cleanup
+
+Plugins can also **extend** existing kinds by adding namespaced spec fields (e.g., the healthcheck plugin extends `System` with health check assignments).
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     YAML Descriptor                         │
+│                                                             │
+│  apiVersion: checkstack.io/v1alpha1                         │
+│  kind: System                                               │
+│  metadata:                                                  │
+│    name: payment-api                                        │
+│  spec:                                                      │
+│    description: Payment processing API                      │
+│    healthcheck:               ← extension namespace         │
+│      - ref:                                                 │
+│          kind: Healthcheck                                  │
+│          name: payment-db-check                             │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+          ┌──────────────┼──────────────┐
+          ▼              ▼              ▼
+   ┌────────────┐ ┌────────────┐ ┌────────────┐
+   │  Validate  │ │   Sort     │ │ Reconcile  │
+   │  envelope  │ │  by deps   │ │  in order  │
+   │  + spec    │ │ (topo)     │ │            │
+   └────────────┘ └────────────┘ └────────────┘
+```
+
+## Descriptor Format
+
+All YAML descriptors follow the Kubernetes-inspired envelope format:
+
+```yaml
+apiVersion: checkstack.io/v1alpha1    # Required. Must match a registered kind.
+kind: System                           # Required. The entity kind name.
+metadata:                              # Required. Common fields.
+  name: my-system                      # Required. URL-safe identifier (lowercase, hyphens).
+  title: My System                     # Optional. Human-readable display name.
+  description: A brief description     # Optional.
+  labels:                              # Optional. Key-value pairs for filtering.
+    team: platform
+  tags:                                # Optional. String tags.
+    - production
+spec:                                  # Kind-specific configuration.
+  # ... fields defined by the kind's specSchema
+```
+
+## Registering a Kind
+
+Register kinds during your plugin's `register()` phase via the `entityKindExtensionPoint`:
+
+```typescript
+// my-plugin-backend/src/index.ts
+import { createBackendPlugin } from "@checkstack/backend-api";
+import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
+import { CHECKSTACK_API_VERSION } from "@checkstack/gitops-common";
+import { z } from "zod";
+
+export default createBackendPlugin({
+  metadata: pluginMetadata,
+
+  register(env) {
+    const kindRegistry = env.getExtensionPoint(entityKindExtensionPoint);
+
+    kindRegistry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "System",
+      specSchema: z.object({
+        // Define the fields that appear under `spec:` in the YAML
+      }),
+
+      reconcile: async ({ entity, existingEntityId, context }) => {
+        // Create or update the resource in your plugin's database.
+        // `entity.spec` is fully validated and typed.
+        // `existingEntityId` is set when updating an existing resource.
+        //
+        // Must return { entityId: string } — the plugin-specific ID.
+        const id = existingEntityId ?? await createResource(entity);
+        return { entityId: id };
+      },
+
+      delete: async ({ entityName, entityId, context }) => {
+        // Optional. Called when the entity is removed from Git.
+        if (entityId) await deleteResource(entityId);
+      },
+    });
+  },
+});
+```
+
+### `EntityKindDefinition<TSpec>` Interface
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `apiVersion` | `string` | API version (e.g., `"checkstack.io/v1alpha1"`) |
+| `kind` | `string` | Unique kind name (e.g., `"System"`, `"Healthcheck"`) |
+| `specSchema` | `z.ZodType<TSpec>` | Zod schema for the `spec` section |
+| `reconcile` | `(params) => Promise<{ entityId }>` | Create/update handler |
+| `delete` | `(params) => Promise<void>` | Optional cleanup handler |
+
+### Reconcile Parameters
+
+```typescript
+reconcile: async ({
+  entity,            // Full envelope (metadata + validated spec)
+  existingEntityId,  // Set on updates (from previous reconcile)
+  context,           // Logger + resolveEntityRef helper
+}) => { ... }
+```
+
+### Delete Parameters
+
+```typescript
+delete: async ({
+  entityName,  // The metadata.name from the removed descriptor
+  entityId,    // Plugin-specific ID from provenance (if available)
+  context,     // Logger + resolveEntityRef helper
+}) => { ... }
+```
+
+## Registering a Kind Extension
+
+Extensions let a plugin add namespaced fields to another plugin's kind. For example, the healthcheck plugin extends `System` to allow health check assignments:
+
+```typescript
+// healthcheck-backend/src/index.ts
+kindRegistry.registerKindExtension({
+  apiVersion: CHECKSTACK_API_VERSION,
+  kind: "System",
+  namespace: "healthcheck",   // Fields appear under spec.healthcheck
+
+  specSchema: z.array(
+    z.object({
+      ref: entityRefSchema,                             // { kind, name }
+      degradedThreshold: z.number().int().min(1).optional(),
+      unhealthyThreshold: z.number().int().min(1).optional(),
+    }),
+  ).optional(),
+
+  reconcile: async ({ entity, extensionSpec, entityId, context }) => {
+    // `entityId` is the System's plugin-specific ID (from the base reconciler).
+    // `extensionSpec` is the validated data from spec.healthcheck.
+    for (const entry of extensionSpec) {
+      const configId = await context.resolveEntityRef({
+        kind: entry.ref.kind,
+        entityName: entry.ref.name,
+      });
+      if (configId) {
+        await assignHealthcheck({ systemId: entityId, configId });
+      }
+    }
+  },
+});
+```
+
+### `EntityKindExtensionDefinition<TExtensionSpec>` Interface
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `apiVersion` | `string` | API version of the kind being extended |
+| `kind` | `string` | The kind being extended (e.g., `"System"`) |
+| `namespace` | `string` | Unique namespace under `spec` (convention: your plugin ID) |
+| `specSchema` | `z.ZodType<TExtensionSpec>` | Zod schema for the extension fields (should be `.optional()`) |
+| `reconcile` | `(params) => Promise<void>` | Called with the base kind's `entityId` |
+
+### Extension Registration Order
+
+Extensions can be registered **before** the base kind is registered. The registry stores them and merges them once the base kind is registered. This removes cross-plugin load-order dependencies.
+
+## Entity References
+
+Use Kubernetes-style structured references to create dependencies between entities:
+
+```yaml
+# A System that references a Healthcheck
+apiVersion: checkstack.io/v1alpha1
+kind: System
+metadata:
+  name: payment-api
+spec:
+  healthcheck:
+    - ref:
+        kind: Healthcheck        # The kind of the referenced entity
+        name: payment-db-check   # The metadata.name of the referenced entity
+```
+
+The `entityRefSchema` from `@checkstack/gitops-common` validates these references:
+
+```typescript
+import { entityRefSchema } from "@checkstack/gitops-common";
+
+// Use in your spec schema
+const mySchema = z.object({
+  ref: entityRefSchema,  // { kind: string, name: string }
+});
+```
+
+### Automatic Dependency Resolution
+
+The reconciliation engine automatically detects entity refs in specs using `extractEntityRefs()`. This walks the entire spec tree and collects all objects matching `{ kind, name }`. These are used to build a dependency graph and reconcile entities in topological order (dependencies first).
+
+**You don't need to do anything special** — just use the `entityRefSchema` in your spec and the engine handles the rest.
+
+## Reconciliation Lifecycle
+
+The GitOps sync engine follows a strict **Collect → Sort → Reconcile** lifecycle:
+
+```
+  Git Repository
+       │
+       ▼
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   Collect    │ ──▶ │    Sort      │ ──▶ │  Reconcile   │
+│              │     │              │     │              │
+│ Discover all │     │ Topological  │     │ Process each │
+│ YAML files,  │     │ sort using   │     │ entity in    │
+│ parse and    │     │ entity refs  │     │ dependency   │
+│ validate     │     │ (Kahn's alg) │     │ order        │
+└──────────────┘     └──────────────┘     └──────────────┘
+```
+
+1. **Collect**: All YAML files matching the provider's path pattern are discovered, parsed, and validated against registered spec schemas.
+
+2. **Sort**: Entities are topologically sorted based on their entity refs. If entity A references entity B, B is reconciled first. Cycles are detected and rejected with descriptive error messages.
+
+3. **Reconcile**: Each entity is reconciled in dependency order:
+   - The base kind's `reconcile()` is called first, returning an `entityId`.
+   - Then each extension's `reconcile()` is called with that `entityId`.
+   - Provenance records are created/updated to track the mapping.
+
+### Provenance
+
+Every reconciled entity gets a provenance record linking:
+- The Git source (provider, file path, commit)
+- The entity kind and name
+- The plugin-specific entity ID
+
+This enables:
+- **Locking**: Resources managed by GitOps are locked from manual editing in the UI.
+- **Orphan detection**: When a YAML file is removed, the orphaned provenance record enables cleanup (automatic or manual, based on the provider's deletion policy).
+
+### Secret References
+
+Use `secretField()` for sensitive values that should be resolved from the GitOps secret store:
+
+```yaml
+spec:
+  config:
+    password:
+      secretRef: my-database-password   # Resolved at reconcile time
+```
+
+```typescript
+import { secretField } from "@checkstack/gitops-common";
+
+const specSchema = z.object({
+  config: z.object({
+    password: z.union([z.string(), secretField()]),
+  }),
+});
+```
+
+## ReconcileContext
+
+Both kind and extension reconcilers receive a `ReconcileContext`:
+
+```typescript
+interface ReconcileContext {
+  /** Scoped logger */
+  logger: {
+    debug: (msg: string) => void;
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+
+  /**
+   * Resolve a GitOps entity name to its plugin-specific ID.
+   * Used by extensions to look up cross-kind references.
+   */
+  resolveEntityRef: (params: {
+    kind: string;
+    entityName: string;
+  }) => Promise<string | undefined>;
+}
+```
+
+## Kind Registry Browser
+
+The **Kind Registry** page (accessible from the user menu) provides a live view of all registered kinds, their base spec schemas, extensions, and auto-generated YAML examples. This is useful for:
+
+- Discovering what entity kinds are available
+- Understanding the full spec schema (base + extensions)
+- Copying YAML examples as a starting point
+
+Access is controlled by the `gitops.kinds.read` access rule (granted to all authenticated users by default).
+
+## Example: Full Kind + Extension Registration
+
+Here is a complete real-world example showing how the catalog and healthcheck plugins cooperate:
+
+**Catalog plugin** registers `kind: System`:
+
+```typescript
+// catalog-backend/src/index.ts
+kindRegistry.registerKind({
+  apiVersion: CHECKSTACK_API_VERSION,
+  kind: "System",
+  specSchema: z.object({}),
+
+  reconcile: async ({ entity, existingEntityId, context }) => {
+    const displayName = entity.metadata.title ?? entity.metadata.name;
+    if (existingEntityId) {
+      await entityService.updateSystem(existingEntityId, { name: displayName });
+      return { entityId: existingEntityId };
+    }
+    const system = await entityService.createSystem({ name: displayName });
+    return { entityId: system.id };
+  },
+
+  delete: async ({ entityId }) => {
+    if (entityId) await entityService.deleteSystem(entityId);
+  },
+});
+```
+
+**Healthcheck plugin** extends `System` and registers `kind: Healthcheck`:
+
+```typescript
+// healthcheck-backend/src/healthcheck-gitops-kinds.ts
+kindRegistry.registerKind({
+  apiVersion: CHECKSTACK_API_VERSION,
+  kind: "Healthcheck",
+  specSchema: z.object({
+    strategy: z.string().min(1),
+    intervalSeconds: z.number().int().min(1),
+    config: z.record(z.string(), z.union([z.unknown(), secretField()])),
+  }),
+  reconcile: async ({ entity, existingEntityId }) => {
+    // Create or update health check config
+    return { entityId: configId };
+  },
+});
+
+kindRegistry.registerKindExtension({
+  apiVersion: CHECKSTACK_API_VERSION,
+  kind: "System",
+  namespace: "healthcheck",
+  specSchema: z.array(
+    z.object({
+      ref: entityRefSchema,
+      degradedThreshold: z.number().int().min(1).optional(),
+      unhealthyThreshold: z.number().int().min(1).optional(),
+    }),
+  ).optional(),
+  reconcile: async ({ extensionSpec, entityId, context }) => {
+    // Assign health checks to the system
+    for (const entry of extensionSpec) {
+      const configId = await context.resolveEntityRef({
+        kind: entry.ref.kind,
+        entityName: entry.ref.name,
+      });
+      if (configId) {
+        await assignToSystem({ systemId: entityId, configId });
+      }
+    }
+  },
+});
+```
+
+**Resulting YAML**:
+
+```yaml
+apiVersion: checkstack.io/v1alpha1
+kind: System
+metadata:
+  name: payment-api
+  title: Payment API
+spec:
+  healthcheck:
+    - ref:
+        kind: Healthcheck
+        name: payment-db-check
+      degradedThreshold: 2
+      unhealthyThreshold: 5
+---
+apiVersion: checkstack.io/v1alpha1
+kind: Healthcheck
+metadata:
+  name: payment-db-check
+spec:
+  strategy: postgres
+  intervalSeconds: 60
+  config:
+    host: db.internal
+    port: 5432
+    database: payments
+    user: monitor
+    password:
+      secretRef: payment-db-password
+```
+
+## Troubleshooting
+
+### Kind Not Appearing in Registry
+
+1. Verify your plugin is loaded (check Admin → Plugins)
+2. Ensure `entityKindExtensionPoint` is imported from `@checkstack/gitops-backend`
+3. Check that `registerKind()` is called in the `register()` phase (not `init()`)
+
+### Extension Not Merging
+
+1. Verify the `apiVersion` and `kind` match the base kind exactly
+2. Check that the `namespace` is unique (no other extension uses the same namespace for the same kind)
+3. Extension schemas should be `.optional()` so descriptors without the extension still validate
+
+### Reconcile Not Called
+
+1. Verify the provider's path pattern matches your YAML file location
+2. Check the Sync Status tab for error messages
+3. Ensure the `apiVersion` and `kind` in your YAML match a registered kind
+
+### Dependency Cycle Detected
+
+The reconciler rejects circular entity references. Check the error message for the cycle path and restructure your descriptors to break the cycle.

--- a/docs/plans/2026-04-19-gitops-entity-system-design.md
+++ b/docs/plans/2026-04-19-gitops-entity-system-design.md
@@ -1,0 +1,353 @@
+# GitOps Entity System Design
+
+## Overview
+
+This document defines the architecture for Checkstack's GitOps integration — a system that allows users to manage platform entities (systems, groups, healthchecks, etc.) declaratively via YAML descriptors stored in Git repositories.
+
+The design is inspired by Backstage's Software Catalog but adapted to Checkstack's existing plugin architecture. Rather than replacing the catalog, the GitOps system provides a **generic Entity Kind Registry** that plugins register with. The catalog becomes a consumer of the entity system alongside other plugins.
+
+## Core Concepts
+
+### Entity Envelope
+
+All YAML descriptors share a common envelope schema. The `spec` section is kind-specific and validated per registered kind.
+
+```yaml
+apiVersion: checkstack.io/v1alpha1    # versioned API, required
+kind: System                          # registered kind, required
+metadata:
+  name: payment-service               # url-safe, [a-z0-9][a-z0-9-]*, max 63 chars, required
+  title: Payment Service              # optional human-readable display name
+  description: Handles payments       # optional
+  labels:                             # optional, key-value for filtering
+    team: platform
+    tier: critical
+  annotations:                        # optional, key-value for machine-readable data
+    pagerduty.com/service-id: PD12345
+  tags:                               # optional, string array for categorization
+    - production
+    - payments
+spec:
+  # Kind-specific fields, owned by the registering plugin
+  # + namespaced extension fields from other plugins
+```
+
+**Key constraints:**
+- `metadata.name` is the unique identifier per kind: `[a-z0-9][a-z0-9-]*`, max 63 characters
+- `metadata.title` is a separate human-readable display name (spaces/casing allowed)
+- `metadata.namespace` is intentionally omitted — can be added later if multi-tenancy is needed
+- Multi-document YAML files are supported (multiple entities separated by `---`)
+
+### Entity Kind Registry
+
+Plugins register entity kinds via an **Extension Point** during the `register()` phase. This mirrors how healthcheck strategies and integration events are registered.
+
+```typescript
+// gitops-common — Extension point definition
+export const entityKindExtensionPoint = createExtensionPoint<EntityKindRegistry>(
+  "gitops.entity-kind-registry"
+);
+
+export interface EntityKindRegistry {
+  /** Register a new entity kind (e.g., catalog registers "System") */
+  registerKind(def: EntityKindDefinition): void;
+
+  /** Extend an existing kind's spec (e.g., healthcheck extends "System") */
+  registerKindExtension(def: EntityKindExtensionDefinition): void;
+}
+```
+
+### Kind Registration (Owning Plugin)
+
+The plugin that owns a kind defines its base spec schema and reconciliation logic:
+
+```typescript
+// catalog-backend register():
+const registry = env.getExtensionPoint(entityKindExtensionPoint);
+registry.registerKind({
+  apiVersion: "checkstack.io/v1alpha1",
+  kind: "System",
+  specSchema: z.object({
+    description: z.string().optional(),
+  }),
+  reconcile: async ({ entity, context }) => {
+    // Create or update via local DB
+    // entity.spec is fully resolved (secrets replaced)
+  },
+  delete: async ({ entityName, context }) => {
+    // Remove the entity from local DB
+  },
+});
+```
+
+### Kind Extension (Cross-Plugin)
+
+Plugins can extend another plugin's kind by adding namespaced spec fields:
+
+```typescript
+// healthcheck-backend register():
+registry.registerKindExtension({
+  apiVersion: "checkstack.io/v1alpha1",
+  kind: "System",
+  namespace: "healthchecks",       // → spec.healthchecks.*
+  specSchema: z.array(z.object({
+    ref: z.string(),               // reference to a Healthcheck entity
+    degradedThreshold: z.number().optional(),
+    unhealthyThreshold: z.number().optional(),
+  })).optional(),
+  reconcile: async ({ entity, extensionSpec, context }) => {
+    // extensionSpec = the validated healthchecks slice only
+    // Resolve refs and create system↔healthcheck associations
+  },
+});
+```
+
+At init time, the GitOps engine merges all extensions into the base spec schema per kind. Validation uses the merged schema, but each reconciler only receives its own slice.
+
+### Entity References
+
+Entities reference each other by name. Healthchecks are their own entity kind and reference systems:
+
+```yaml
+apiVersion: checkstack.io/v1alpha1
+kind: Healthcheck
+metadata:
+  name: payment-db-check
+spec:
+  strategy: postgres
+  system: payment-service          # references a System entity by name
+  connection:
+    host: db.internal
+    password:
+      secretRef: prod-db-pass
+---
+apiVersion: checkstack.io/v1alpha1
+kind: System
+metadata:
+  name: payment-service
+spec:
+  description: Handles payments
+  healthchecks:                       # extension from healthcheck plugin
+    - ref: payment-db-check           # reference to Healthcheck entity
+      degradedThreshold: 3
+      unhealthyThreshold: 5
+```
+
+## Secret Management
+
+### Secret Store (`secret-backend`)
+
+A simple encrypted key-value store for secrets referenced in YAML descriptors via `secretRef`. Secrets are AES-256-GCM encrypted at rest, with the encryption key provided via environment variable.
+
+```typescript
+// secret-backend schema
+export const secrets = pgTable("secrets", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull().unique(),
+  encryptedValue: text("encrypted_value").notNull(),
+  iv: text("iv").notNull(),
+  description: text("description"),
+  createdBy: text("created_by"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+```
+
+### `secretField()` Utility
+
+A Zod utility for plugin authors to mark fields as secret-resolvable:
+
+```typescript
+// gitops-common
+export function secretField() {
+  return z.union([
+    z.string(),
+    z.object({ secretRef: z.string() }),
+  ]);
+}
+```
+
+In YAML descriptors:
+```yaml
+password: "dev-password"           # plain string (dev/testing)
+password:
+  secretRef: production-db-creds   # reference to secret store
+```
+
+### Automatic Secret Resolution
+
+The GitOps reconciliation engine resolves all `secretRef` values **before** calling a plugin's reconciler. Plugin authors never handle secret resolution manually:
+
+```typescript
+registry.registerKind({
+  kind: "Healthcheck",
+  specSchema: z.object({
+    connection: z.object({
+      host: z.string(),
+      password: secretField(),  // accepts string or { secretRef: "..." }
+    }),
+  }),
+  reconcile: async ({ entity }) => {
+    // entity.spec.connection.password is ALWAYS a plain string here
+    // secretRef was automatically resolved by the engine
+  },
+});
+```
+
+### Provider Auth vs. Descriptor Secrets
+
+| Secret type | Storage mechanism |
+|---|---|
+| Provider auth tokens (GitHub/GitLab API) | DynamicForm secret fields (encrypted at rest, like notification strategies) |
+| Values referenced via `secretRef` in descriptors | Secret store (`secret-backend`) |
+
+Provider configuration uses DynamicForm's built-in secret field support, consistent with how auth strategies and notification strategies already work.
+
+## GitOps Providers & Discovery
+
+### Provider Configuration
+
+GitOps providers are configured via the admin UI using DynamicForm and stored in the gitops-backend's database:
+
+- **Type**: GitHub / GitLab
+- **Target**: `"my-org"` (org-wide) or `"my-org/my-repo"` (single repo)
+- **Path Pattern**: `.checkstack/**/*.yaml` (glob via `minimatch`)
+- **Auth**: DynamicForm secret field for API token
+- **Sync Interval**: Configurable (e.g., 5m, 15m, 1h)
+- **Deletion Policy**: `"orphan"` (default) or `"auto"`
+
+### Scraper Strategies
+
+Each provider type has a scraper implementation:
+
+**GitHub scraper:**
+1. Enumerate repos: `/orgs/{target}/repos` with pagination (fallback to `/users/{target}/repos`)
+2. Resolve default branch from repo metadata (no hardcoded `main`)
+3. Walk file tree via Git Trees API, filter with `minimatch`
+4. Fetch matching file contents
+
+**GitLab scraper:**
+1. Enumerate projects: `/api/v4/groups/{target}/projects?include_subgroups=true` with pagination
+2. Resolve default branch from project metadata
+3. Walk recursive tree API, filter with `minimatch`
+4. Fetch matching file contents
+
+### Sync Loop
+
+Runs as a recurring queue job (using the existing `queueManager`):
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Sync Cycle (per provider, on configured interval)  │
+├─────────────────────────────────────────────────────┤
+│ 1. Scrape: Discover YAML files from git provider    │
+│ 2. Parse: YAML → entity envelopes (multi-doc aware) │
+│ 3. Validate: envelope + merged kind spec schema     │
+│ 4. Resolve: secretField() values from secret store  │
+│ 5. Diff: Compare against provenance table           │
+│    • New entity → call kind reconciler (create)     │
+│    • Changed entity → call kind reconciler (update) │
+│    • Missing entity → orphan or delete (per policy) │
+│ 6. Update provenance table with sync state          │
+└─────────────────────────────────────────────────────┘
+```
+
+**Diffing** uses a content hash of the raw YAML per entity. If the hash matches the provenance table's `lastSyncHash`, reconciliation is skipped.
+
+**Error handling**: If a single descriptor fails validation or reconciliation, it's logged with the error and marked as failed in the provenance table. The sync continues for remaining entities.
+
+## Provenance Tracking
+
+### Centralized Provenance Table
+
+The GitOps backend maintains a provenance mapping table in its own database schema:
+
+```typescript
+export const provenance = pgTable("provenance", {
+  id: text("id").primaryKey(),
+  apiVersion: text("api_version").notNull(),
+  kind: text("kind").notNull(),
+  entityName: text("entity_name").notNull(),
+  providerId: text("provider_id").notNull().references(() => providers.id),
+  repository: text("repository").notNull(),
+  filePath: text("file_path").notNull(),
+  lastSyncHash: text("last_sync_hash").notNull(),
+  status: text("status").notNull(),  // "synced" | "error" | "orphaned"
+  errorMessage: text("error_message"),
+  lastSyncedAt: timestamp("last_synced_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+// Unique constraint on (kind, entityName) — one provenance per entity
+```
+
+### Provenance Locking
+
+Entity editor pages query `gitopsClient.getProvenance({ kind, name })`. If the entity is GitOps-managed, the editor shows a read-only banner:
+
+> *"This entity is managed by GitOps (repo: org/repo, file: .checkstack/systems.yaml). Edit the source file to make changes."*
+
+No schema changes needed in consuming plugins — provenance is fully centralized.
+
+### Deletion Policy
+
+Configurable per provider:
+
+- **`orphan`** (default): Missing entities are marked as "orphaned" in the provenance table. Admins confirm deletion via the GitOps dashboard.
+- **`auto`**: Missing entities are immediately deleted by calling the kind's `delete` reconciler.
+
+## Frontend
+
+### GitOps Settings Page (Admin)
+
+- **Providers tab**: Add/edit/remove GitOps providers using DynamicForm (type, target, path pattern, sync interval, deletion policy, auth token)
+- **Secrets tab**: Manage named secrets for `secretRef` usage in descriptors (create, view names, rotate values — values never displayed after creation)
+
+### GitOps Dashboard
+
+- Per-provider sync status (last sync time, next sync, error count)
+- Entity list with status badges: ✅ synced, ⚠️ error (with message), 👻 orphaned
+- Orphan management: confirm deletion or dismiss orphan status
+
+### Provenance Integration
+
+Entity detail pages across the platform (catalog system detail, healthcheck config, etc.) show a read-only banner for GitOps-managed entities, preventing manual edits that would be overwritten on the next sync.
+
+## Package Structure
+
+```
+core/
+├── gitops-common/       # Entity envelope schema, secretField(), extension point type,
+│                        # RPC contract, access rules, provenance types
+├── gitops-backend/      # Kind registry, reconciliation engine, provider scrapers,
+│                        # provenance table, sync worker, secret resolution
+├── gitops-frontend/     # Provider management UI, sync dashboard, orphan management
+├── secret-common/       # Secret store RPC contract, types
+├── secret-backend/      # Encrypted KV store, secret management API
+└── secret-database-backend/  # (existing empty shell — evaluate if needed)
+```
+
+## Implementation Phases
+
+### Phase 1: Foundation (no UI, no scrapers)
+1. `gitops-common` — Entity envelope schema, `secretField()` utility, extension point type, RPC contract, access rules
+2. `secret-backend` + `secret-common` — Secret store (encrypted KV), RPC contract for resolving secrets
+3. `gitops-backend` — Kind registry implementation, reconciliation engine (with secret resolution), provenance table, provider DB schema
+
+### Phase 2: Providers & Sync
+4. GitHub scraper (org discovery, default branch, file tree walking, `minimatch`)
+5. GitLab scraper (group projects, recursive tree)
+6. Sync worker (recurring queue job, diff engine, error tracking)
+
+### Phase 3: First Consumers
+7. `catalog-backend` registers `kind: System` and `kind: Group`
+8. End-to-end test: YAML descriptor → scraped → validated → reconciled into catalog
+
+### Phase 4: Frontend
+9. `gitops-frontend` — Provider management, sync dashboard, orphan management
+10. Provenance locking in catalog-frontend (read-only banner for GitOps-managed entities)
+
+### Phase 5: Ecosystem
+11. `healthcheck-backend` registers `kind: Healthcheck` + extends `kind: System`
+12. Other plugins follow the pattern
+
+Each phase is independently shippable and testable.

--- a/docs/plans/2026-04-21-kind-registry-sub-schemas.md
+++ b/docs/plans/2026-04-21-kind-registry-sub-schemas.md
@@ -1,0 +1,70 @@
+# Kind Registry: Conditional Sub-Schema Documentation
+
+**Date**: 2026-04-21
+**Status**: Open
+**Related**: Kind Registry Browser (`gitops-frontend/src/pages/KindRegistryPage.tsx`)
+
+## Problem
+
+The Kind Registry page shows the structural YAML format for each entity kind, but generic/dynamic fields like `config` (`z.record()`) render as `{} # key-value pairs` — the actual available fields depend on runtime choices (e.g., which health check strategy is selected).
+
+### Specific Example: Healthcheck Kind
+
+The `Healthcheck` kind has:
+- `strategy`: a string like `"postgres"`, `"http"`, `"jenkins"`, etc.
+- `config`: a `z.record()` whose actual fields **depend on the chosen strategy**
+- `collectors`: an optional array where valid collector IDs and their configs **also depend on the strategy**
+
+The Kind Registry cannot currently show "when strategy=postgres, config expects `{ host, port, database, user, password }`" because:
+1. Per-strategy config schemas live in `HealthCheckRegistry`, not in the entity kind registry
+2. Per-collector config schemas live in `CollectorRegistry`
+3. The relationship is **conditional** — not a flat list of alternatives
+
+### Generalized Problem
+
+This applies to **both** kinds and extensions. Any registered schema (kind or extension) may have dynamic fields whose concrete variants are managed by a separate domain-specific registry.
+
+## Design Considerations
+
+### Option A: `subSchemas` on Kind/Extension Definitions
+
+Add an optional `subSchemas` field to both `EntityKindDefinition` and `EntityKindExtensionDefinition`:
+
+```typescript
+subSchemas?: Array<{
+  label: string;
+  description?: string;
+  schema: z.ZodType;
+}>;
+```
+
+**Pros**: Simple, self-documenting, no cross-registry introspection needed.
+**Cons**: Cannot express conditional relationships (e.g., "these collectors are only valid for this strategy"). Results in a flat list that may confuse users.
+
+### Option B: Conditional Sub-Schema Trees
+
+A more structured approach where sub-schemas declare their conditions:
+
+```typescript
+subSchemas?: Array<{
+  label: string;
+  description?: string;
+  schema: z.ZodType;
+  appliesWhen?: { field: string; value: string }; // e.g., { field: "strategy", value: "postgres" }
+  children?: SubSchema[]; // nested conditional schemas (e.g., collectors)
+}>;
+```
+
+**Pros**: Accurately models the conditional relationship.
+**Cons**: Complex to implement, risks over-engineering, may not generalize to other kinds.
+
+### Option C: Link to Domain-Specific Documentation
+
+Instead of embedding all sub-schemas in the Kind Registry, add a `documentationUrl` or `relatedPages` field that links to the existing domain-specific documentation (e.g., the health check strategy listing page).
+
+**Pros**: Zero duplication, leverages existing UIs.
+**Cons**: Fragmented documentation experience.
+
+## Recommendation
+
+Start with **Option A** as it covers the majority of use cases. If conditional relationships prove important in practice, evolve to **Option B** later. The current Kind Registry is already useful for understanding the structural YAML format and discovering available kinds/extensions.

--- a/plugins/healthcheck-jenkins-backend/src/collectors/job-status.test.ts
+++ b/plugins/healthcheck-jenkins-backend/src/collectors/job-status.test.ts
@@ -70,7 +70,8 @@ describe("JobStatusCollector", () => {
       pluginId: "healthcheck-jenkins",
     });
 
-    expect(result.error).toBe("Last build: FAILURE");
+    // Failed builds are reported in result metrics, not as collector errors
+    expect(result.error).toBeUndefined();
     expect(result.result.lastBuildResult).toBe("FAILURE");
   });
 

--- a/plugins/healthcheck-jenkins-backend/src/collectors/node-health.test.ts
+++ b/plugins/healthcheck-jenkins-backend/src/collectors/node-health.test.ts
@@ -107,7 +107,9 @@ describe("NodeHealthCollector", () => {
 
     expect(result.result.offlineNodes).toBe(1);
     expect(result.result.nodeOffline).toBe(true);
-    expect(result.error).toContain("Connection lost");
+    expect(result.result.nodeOfflineReason).toBe("Connection lost");
+    // Offline status is reported in result metrics, not as an error
+    expect(result.error).toBeUndefined();
   });
 
   it("should aggregate correctly", () => {

--- a/plugins/healthcheck-jenkins-backend/src/collectors/queue-info.test.ts
+++ b/plugins/healthcheck-jenkins-backend/src/collectors/queue-info.test.ts
@@ -56,8 +56,8 @@ describe("QueueInfoCollector", () => {
     expect(result.result.buildableCount).toBe(2);
     expect(result.result.stuckCount).toBe(1);
     expect(result.result.oldestWaitingMs).toBeGreaterThanOrEqual(30000);
-    // Error should be set because stuck > 0
-    expect(result.error).toContain("stuck");
+    // Non-critical status (stuck items) is reported in result metrics, not as an error
+    expect(result.error).toBeUndefined();
   });
 
   it("should report no error for empty queue", async () => {


### PR DESCRIPTION
## Summary

Introduces a complete GitOps subsystem that enables declarative, Git-driven management of Checkstack resources. Teams can define systems, health checks, and other entities as YAML files in Git repositories, which are automatically discovered, validated, and reconciled by the platform.

## Phases Delivered

### Phase 1: Foundation
- New packages: `gitops-backend`, `gitops-common`, `gitops-frontend`
- Entity envelope schema with Kubernetes-inspired `apiVersion/kind/metadata/spec` structure
- Pluggable entity kind registry via `entityKindExtensionPoint`

### Phase 2: Sync Engine
- GitHub and GitLab scrapers with organizational/wildcard repository discovery
- Automatic default branch resolution per repository
- Configurable path pattern matching via `minimatch`
- Enterprise/on-premise support via optional `baseUrl` for GitHub/GitLab API endpoints

### Phase 3: Provenance & Reconciliation
- Generalized provenance architecture tracking Git source → entity mapping
- Full reconciliation lifecycle: Collect → Sort → Reconcile
- Entity reference detection and topological dependency sorting (Kahn's algorithm)
- Cycle detection with descriptive error messages
- Secret reference resolution (`secretRef`) for sensitive config values

### Phase 4: Kind Registration
- `System` and `Group` kinds registered by the catalog plugin
- `Healthcheck` kind with strategy-aware config validation
- `System` extension by the healthcheck plugin (health check assignments)
- Delete reconciler for orphan cleanup

### Phase 5: Provenance Locking
- Resources managed by GitOps are locked from manual editing in the UI
- Frontend plugin with provider management, secret store, and sync status tabs

### Phase 6: Kind Registry Browser
- Standalone Kind Registry page with JSON Schema visualization
- Recursive YAML example generator with optional/nullable annotations
- `gitopsAccess.kinds.read` access rule (independent from data permissions)
- Developer documentation in `docs/backend/gitops-entity-kinds.md`

## Access Rules
- `gitopsAccess.providers.*` — provider CRUD operations
- `gitopsAccess.secrets.*` — secret store management
- `gitopsAccess.kinds.read` — Kind Registry browsing (all authenticated users)

## Documentation
- `docs/backend/gitops-entity-kinds.md` — developer guide for kind/extension registration
- `docs/plans/2026-04-19-gitops-entity-system-design.md` — original design document
- `docs/plans/2026-04-21-kind-registry-sub-schemas.md` — follow-up: conditional sub-schema documentation

## Verification
- ✅ `bun run typecheck` — 105/105 packages
- ✅ `bun run lint` — clean
- ✅ `bun test core/gitops-backend/` — 63 tests, 138 assertions
