### PR TITLE
fix: GitOps auth token handling, SLO achievement criteria & milestone enrichment

### DIFF
--- a/.changeset/fix-gitops-auth-slo-achievements.md
+++ b/.changeset/fix-gitops-auth-slo-achievements.md
@@ -1,0 +1,25 @@
+---
+"@checkstack/gitops-backend": patch
+"@checkstack/gitops-common": patch
+"@checkstack/gitops-frontend": patch
+"@checkstack/slo-backend": patch
+"@checkstack/slo-frontend": patch
+---
+
+### GitOps: Fix authentication token handling
+
+- Made `authToken` optional in `ReconcileProviderParams` and `ScraperOptions` to support unauthenticated access to public repositories
+- GitHub and GitLab scrapers now conditionally set authentication headers only when a token is provided
+- Sync worker now decrypts the encrypted `authToken` from the database before passing it to scrapers, fixing authentication failures caused by sending encrypted values in HTTP headers
+
+### SLO: Fix premature Nines Club achievement unlock
+
+- The "Nines Club" achievement now requires both ≥99.99% availability **and** a 365-day compliance streak, preventing immediate unlock on newly created SLOs with 100% default availability
+
+### SLO: Align frontend achievement descriptions with backend criteria
+
+- Fixed mismatched descriptions for Iron Uptime (7-day, not 30), Diamond Uptime (30-day, not 90), Clean Sheet (rolling window, not quarter), Full Coverage (3+ SLOs, not all systems in group), and Nines Club (99.99%)
+
+### SLO: Enrich milestones with system names
+
+- The `getRecentMilestones` endpoint now resolves human-readable system names via the Catalog API instead of returning raw system IDs

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "core/about-frontend": {
       "name": "@checkstack/about-frontend",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@checkstack/about-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -94,7 +94,7 @@
     },
     "core/announcement-frontend": {
       "name": "@checkstack/announcement-frontend",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -128,7 +128,7 @@
     },
     "core/api-docs-frontend": {
       "name": "@checkstack/api-docs-frontend",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.5.24",
+      "version": "0.5.25",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -269,7 +269,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "0.2.24",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -314,7 +314,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.5.14",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -371,7 +371,7 @@
     },
     "core/command-frontend": {
       "name": "@checkstack/command-frontend",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "dependencies": {
         "@checkstack/command-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -404,7 +404,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -433,7 +433,7 @@
     },
     "core/dependency-backend": {
       "name": "@checkstack/dependency-backend",
-      "version": "0.2.4",
+      "version": "0.2.6",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -476,7 +476,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -507,7 +507,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -568,7 +568,7 @@
     },
     "core/gitops-backend": {
       "name": "@checkstack/gitops-backend",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -594,7 +594,7 @@
     },
     "core/gitops-common": {
       "name": "@checkstack/gitops-common",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -608,7 +608,7 @@
     },
     "core/gitops-frontend": {
       "name": "@checkstack/gitops-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -627,7 +627,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "0.13.1",
+      "version": "0.14.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -677,7 +677,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.13.6",
+      "version": "0.14.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -708,7 +708,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "0.4.14",
+      "version": "0.4.16",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -751,7 +751,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -813,7 +813,7 @@
     },
     "core/integration-frontend": {
       "name": "@checkstack/integration-frontend",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -876,7 +876,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -939,7 +939,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1006,7 +1006,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1029,7 +1029,7 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.53.0",
+      "version": "0.55.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
@@ -1048,7 +1048,7 @@
     },
     "core/satellite-backend": {
       "name": "@checkstack/satellite-backend",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1088,7 +1088,7 @@
     },
     "core/satellite-frontend": {
       "name": "@checkstack/satellite-frontend",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1170,7 +1170,7 @@
     },
     "core/slo-backend": {
       "name": "@checkstack/slo-backend",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -1216,7 +1216,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1312,7 +1312,7 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1338,7 +1338,7 @@
     },
     "core/ui": {
       "name": "@checkstack/ui",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -112,8 +112,11 @@ export const createGitOpsRouter = ({
     if (input.data.pathPattern !== undefined)
       updates.pathPattern = input.data.pathPattern;
     if (input.data.baseUrl !== undefined) updates.baseUrl = input.data.baseUrl;
-    if (input.data.authToken !== undefined)
-      updates.authToken = encrypt(input.data.authToken);
+    if (input.data.authToken !== undefined) {
+      // null = explicitly clear token, string = encrypt and store
+      // eslint-disable-next-line unicorn/no-null
+      updates.authToken = input.data.authToken ? encrypt(input.data.authToken) : null;
+    }
     if (input.data.syncInterval !== undefined)
       updates.syncInterval = input.data.syncInterval;
     if (input.data.deletionPolicy !== undefined)

--- a/core/gitops-backend/src/scrapers/github-scraper.test.ts
+++ b/core/gitops-backend/src/scrapers/github-scraper.test.ts
@@ -352,4 +352,55 @@ describe("githubScraper", () => {
       expect(url).toStartWith(enterpriseUrl);
     }
   });
+  it("works without auth token and does not send Authorization header", async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+
+    const mockFetch: FetchFn = async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const headers = init?.headers as Record<string, string> | undefined;
+      if (headers) {
+        capturedHeaders.push(headers);
+      }
+
+      if (url.includes("git/trees")) {
+        return new Response(
+          JSON.stringify({
+            sha: "abc",
+            tree: [{ path: ".checkstack/sys.yaml", type: "blob" }],
+            truncated: false,
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("contents/")) {
+        return new Response(
+          JSON.stringify({ content: btoa("yaml"), encoding: "base64" }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("repos/public-org/repo")) {
+        return new Response(
+          JSON.stringify({ full_name: "public-org/repo", default_branch: "main" }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    };
+
+    const files = await githubScraper.discoverFiles({
+      target: "public-org/repo",
+      pathPattern: ".checkstack/**/*.yaml",
+      logger: mockLogger,
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(1);
+    // Verify no Authorization header was sent
+    for (const headers of capturedHeaders) {
+      expect(headers.Authorization).toBeUndefined();
+    }
+  });
 });

--- a/core/gitops-backend/src/scrapers/github-scraper.ts
+++ b/core/gitops-backend/src/scrapers/github-scraper.ts
@@ -43,17 +43,18 @@ function parseNextPageUrl(linkHeader: string | null): string | undefined {
  */
 async function githubFetch(params: {
   url: string;
-  authToken: string;
+  authToken?: string;
   fetchFn: FetchFn;
 }): Promise<Response> {
   const { url, authToken, fetchFn } = params;
-  return fetchFn(url, {
-    headers: {
-      Authorization: `Bearer ${authToken}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  });
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (authToken) {
+    headers.Authorization = `Bearer ${authToken}`;
+  }
+  return fetchFn(url, { headers });
 }
 
 // ─── Core Logic ────────────────────────────────────────────────────────────
@@ -64,7 +65,7 @@ async function githubFetch(params: {
  */
 async function enumerateRepos(params: {
   target: string;
-  authToken: string;
+  authToken?: string;
   fetchFn: FetchFn;
   apiUrl: string;
 }): Promise<GitHubRepo[]> {
@@ -113,7 +114,7 @@ async function enumerateRepos(params: {
 async function getMatchingFiles(params: {
   repo: GitHubRepo;
   pathPattern: string;
-  authToken: string;
+  authToken?: string;
   fetchFn: FetchFn;
   apiUrl: string;
 }): Promise<string[]> {
@@ -143,7 +144,7 @@ async function fetchFileContent(params: {
   repoFullName: string;
   filePath: string;
   branch: string;
-  authToken: string;
+  authToken?: string;
   fetchFn: FetchFn;
   apiUrl: string;
 }): Promise<string> {

--- a/core/gitops-backend/src/scrapers/gitlab-scraper.test.ts
+++ b/core/gitops-backend/src/scrapers/gitlab-scraper.test.ts
@@ -293,4 +293,56 @@ describe("gitlabScraper", () => {
       expect(url).toStartWith(selfHostedUrl);
     }
   });
+  it("works without auth token and does not send PRIVATE-TOKEN header", async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+
+    const mockFetch: FetchFn = async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const headers = init?.headers as Record<string, string> | undefined;
+      if (headers) {
+        capturedHeaders.push(headers);
+      }
+
+      if (url.includes("/repository/tree")) {
+        return new Response(
+          JSON.stringify([
+            { id: "a1", name: "sys.yaml", type: "blob", path: ".checkstack/sys.yaml" },
+          ]),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("/repository/files/") && url.includes("/raw")) {
+        return new Response("yaml-content", {
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+
+      if (url.includes("/projects/")) {
+        return new Response(
+          JSON.stringify({
+            id: 99,
+            path_with_namespace: "public/repo",
+            default_branch: "main",
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    };
+
+    const files = await gitlabScraper.discoverFiles({
+      target: "public/repo",
+      pathPattern: ".checkstack/**/*.yaml",
+      logger: mockLogger,
+      fetch: mockFetch,
+    });
+
+    expect(files).toHaveLength(1);
+    // Verify no PRIVATE-TOKEN header was sent
+    for (const headers of capturedHeaders) {
+      expect(headers["PRIVATE-TOKEN"]).toBeUndefined();
+    }
+  });
 });

--- a/core/gitops-backend/src/scrapers/gitlab-scraper.ts
+++ b/core/gitops-backend/src/scrapers/gitlab-scraper.ts
@@ -25,15 +25,15 @@ interface GitLabTreeItem {
  */
 async function gitlabFetch(params: {
   url: string;
-  authToken: string;
+  authToken?: string;
   fetchFn: FetchFn;
 }): Promise<Response> {
   const { url, authToken, fetchFn } = params;
-  return fetchFn(url, {
-    headers: {
-      "PRIVATE-TOKEN": authToken,
-    },
-  });
+  const headers: Record<string, string> = {};
+  if (authToken) {
+    headers["PRIVATE-TOKEN"] = authToken;
+  }
+  return fetchFn(url, { headers });
 }
 
 /**
@@ -41,7 +41,7 @@ async function gitlabFetch(params: {
  */
 async function paginateGitLab<T>(params: {
   initialUrl: string;
-  authToken: string;
+  authToken?: string;
   fetchFn: FetchFn;
 }): Promise<T[]> {
   const { initialUrl, authToken, fetchFn } = params;
@@ -80,7 +80,7 @@ async function paginateGitLab<T>(params: {
  */
 async function enumerateProjects(params: {
   target: string;
-  authToken: string;
+  authToken?: string;
   fetchFn: FetchFn;
   apiUrl: string;
 }): Promise<GitLabProject[]> {
@@ -96,7 +96,7 @@ async function enumerateProjects(params: {
 async function getMatchingFiles(params: {
   project: GitLabProject;
   pathPattern: string;
-  authToken: string;
+  authToken?: string;
   fetchFn: FetchFn;
   apiUrl: string;
 }): Promise<string[]> {
@@ -122,7 +122,7 @@ async function fetchFileContent(params: {
   projectId: number;
   filePath: string;
   branch: string;
-  authToken: string;
+  authToken?: string;
   fetchFn: FetchFn;
   apiUrl: string;
 }): Promise<string> {

--- a/core/gitops-backend/src/scrapers/types.ts
+++ b/core/gitops-backend/src/scrapers/types.ts
@@ -32,8 +32,8 @@ export interface ScraperOptions {
   target: string;
   /** Glob pattern for matching file paths (e.g., ".checkstack/**\/*.yaml"). */
   pathPattern: string;
-  /** Decrypted auth token for the Git provider API. */
-  authToken: string;
+  /** Decrypted auth token for the Git provider API. Optional for public repos. */
+  authToken?: string;
   /** Custom API base URL for enterprise/on-prem installations. */
   baseUrl?: string;
   /** Logger for diagnostic output. */

--- a/core/gitops-backend/src/sync/reconciler.ts
+++ b/core/gitops-backend/src/sync/reconciler.ts
@@ -19,7 +19,7 @@ interface ReconcileProviderParams {
   providerType: "github" | "gitlab";
   target: string;
   pathPattern: string;
-  authToken: string;
+  authToken?: string;
   baseUrl?: string;
   deletionPolicy: "orphan" | "auto";
   db: Db;

--- a/core/gitops-backend/src/sync/sync-worker.ts
+++ b/core/gitops-backend/src/sync/sync-worker.ts
@@ -1,4 +1,5 @@
 import type { Logger, SafeDatabase } from "@checkstack/backend-api";
+import { decrypt } from "@checkstack/backend-api";
 import type { QueueManager } from "@checkstack/queue-api";
 import type { InternalEntityKindRegistry } from "../kind-registry";
 import type { SecretStore } from "../secret-resolver";
@@ -104,12 +105,25 @@ async function runSyncForProvider(params: {
   const scraper =
     provider.type === "github" ? githubScraper : gitlabScraper;
 
+  // Decrypt authToken from database (stored encrypted via DynamicForm secret field)
+  let authToken: string | undefined;
+  if (provider.authToken) {
+    try {
+      authToken = decrypt(provider.authToken);
+    } catch (error) {
+      logger.error(
+        `GitOps sync: failed to decrypt authToken for provider ${providerId}: ${error}`,
+      );
+      throw new Error(`Failed to decrypt auth token for provider ${providerId}`);
+    }
+  }
+
   return reconcileProvider({
     providerId: provider.id,
     providerType: provider.type,
     target: provider.target,
     pathPattern: provider.pathPattern,
-    authToken: provider.authToken ?? "",
+    authToken,
     baseUrl: provider.baseUrl ?? undefined,
     deletionPolicy: provider.deletionPolicy,
     db,

--- a/core/gitops-common/src/rpc-contract.ts
+++ b/core/gitops-common/src/rpc-contract.ts
@@ -102,7 +102,7 @@ export const gitopsContract = {
           target: z.string().min(1).optional(),
           pathPattern: z.string().min(1).optional(),
           baseUrl: z.string().nullable().optional(),
-          authToken: z.string().optional(),
+          authToken: z.string().nullable().optional(),
           syncInterval: z.number().int().min(60).optional(),
           deletionPolicy: deletionPolicySchema.optional(),
         }),

--- a/core/gitops-frontend/src/components/ProviderEditor.tsx
+++ b/core/gitops-frontend/src/components/ProviderEditor.tsx
@@ -24,7 +24,7 @@ interface ProviderEditorProps {
     target: string;
     pathPattern: string;
     baseUrl?: string;
-    authToken?: string;
+    authToken?: string | null;
     syncInterval?: number;
     deletionPolicy?: "orphan" | "auto";
   }) => void;
@@ -50,6 +50,7 @@ export const ProviderEditor: React.FC<ProviderEditorProps> = ({
   const [pathPattern, setPathPattern] = useState(initialData?.pathPattern ?? ".checkstack/**/*.yaml");
   const [baseUrl, setBaseUrl] = useState(initialData?.baseUrl ?? "");
   const [authToken, setAuthToken] = useState("");
+  const [clearToken, setClearToken] = useState(false);
   const [syncInterval, setSyncInterval] = useState(String(initialData?.syncInterval ?? 300));
   const [deletionPolicy, setDeletionPolicy] = useState<"orphan" | "auto">(
     initialData?.deletionPolicy ?? "orphan",
@@ -62,6 +63,7 @@ export const ProviderEditor: React.FC<ProviderEditorProps> = ({
       setPathPattern(initialData?.pathPattern ?? ".checkstack/**/*.yaml");
       setBaseUrl(initialData?.baseUrl ?? "");
       setAuthToken("");
+      setClearToken(false);
       setSyncInterval(String(initialData?.syncInterval ?? 300));
       setDeletionPolicy(initialData?.deletionPolicy ?? "orphan");
     }
@@ -71,12 +73,24 @@ export const ProviderEditor: React.FC<ProviderEditorProps> = ({
     e.preventDefault();
     if (!target.trim() || !pathPattern.trim()) return;
 
+    // Determine authToken value:
+    // - clearToken=true → null (explicitly remove)
+    // - non-empty string → new token
+    // - empty string → undefined (keep current)
+    let authTokenValue: string | null | undefined;
+    if (clearToken) {
+      // eslint-disable-next-line unicorn/no-null
+      authTokenValue = null;
+    } else if (authToken.trim()) {
+      authTokenValue = authToken.trim();
+    }
+
     onSave({
       type,
       target: target.trim(),
       pathPattern: pathPattern.trim(),
       baseUrl: baseUrl.trim() || undefined,
-      authToken: authToken.trim() || undefined,
+      authToken: authTokenValue,
       syncInterval: Number(syncInterval) || 300,
       deletionPolicy,
     });
@@ -160,13 +174,45 @@ export const ProviderEditor: React.FC<ProviderEditorProps> = ({
               <Label htmlFor="provider-auth-token">
                 Auth Token {initialData ? "(leave empty to keep current)" : "(optional)"}
               </Label>
-              <Input
-                id="provider-auth-token"
-                type="password"
-                placeholder="ghp_xxxx..."
-                value={authToken}
-                onChange={(e) => setAuthToken(e.target.value)}
-              />
+              {clearToken ? (
+                <div className="flex items-center gap-2 p-2 rounded-md border border-border bg-muted/50">
+                  <span className="text-sm text-muted-foreground flex-1">
+                    Token will be removed on save
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setClearToken(false)}
+                  >
+                    Undo
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex gap-2">
+                  <Input
+                    id="provider-auth-token"
+                    type="password"
+                    placeholder="ghp_xxxx..."
+                    value={authToken}
+                    onChange={(e) => setAuthToken(e.target.value)}
+                    className="flex-1"
+                  />
+                  {initialData && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        setAuthToken("");
+                        setClearToken(true);
+                      }}
+                    >
+                      Remove
+                    </Button>
+                  )}
+                </div>
+              )}
             </div>
 
             <div className="grid grid-cols-2 gap-4">

--- a/core/gitops-frontend/src/components/ProviderList.tsx
+++ b/core/gitops-frontend/src/components/ProviderList.tsx
@@ -119,7 +119,7 @@ export const ProviderList = () => {
     target: string;
     pathPattern: string;
     baseUrl?: string;
-    authToken?: string;
+    authToken?: string | null;
     syncInterval?: number;
     deletionPolicy?: "orphan" | "auto";
   }) => {
@@ -136,7 +136,11 @@ export const ProviderList = () => {
         },
       });
     } else {
-      createMutation.mutate(data);
+      // On create, authToken is always string|undefined (Remove button not shown)
+      createMutation.mutate({
+        ...data,
+        authToken: data.authToken ?? undefined,
+      });
     }
   };
 

--- a/core/slo-backend/src/achievement-evaluator.test.ts
+++ b/core/slo-backend/src/achievement-evaluator.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "bun:test";
+import {
+  ACHIEVEMENT_DEFINITIONS,
+  type AchievementContext,
+} from "./achievement-evaluator";
+
+/**
+ * Creates a base context with sensible defaults for testing.
+ * All achievements should be OFF with these defaults.
+ */
+function baseContext(
+  overrides?: Partial<AchievementContext>,
+): AchievementContext {
+  return {
+    objectiveCount: 0,
+    streakDays: 0,
+    bestAvailability: undefined,
+    budgetRemainingPercent: undefined,
+    hasZeroDowntime: false,
+    hasUpstreamOnlyDowntime: false,
+    fastestRecoverySeconds: undefined,
+    ...overrides,
+  };
+}
+
+function findDefinition(type: string) {
+  const def = ACHIEVEMENT_DEFINITIONS.find((d) => d.type === type);
+  if (!def) throw new Error(`Achievement definition not found: ${type}`);
+  return def;
+}
+
+describe("achievement definitions", () => {
+  describe("nines_club", () => {
+    const ninesClub = findDefinition("nines_club");
+
+    it("requires both 99.99% availability AND 365-day streak", () => {
+      const ctx = baseContext({
+        bestAvailability: 99.995,
+        streakDays: 365,
+      });
+      expect(ninesClub.evaluate(ctx)).toBe(true);
+    });
+
+    it("does NOT unlock with high availability but insufficient streak", () => {
+      const ctx = baseContext({
+        bestAvailability: 99.999,
+        streakDays: 30,
+      });
+      expect(ninesClub.evaluate(ctx)).toBe(false);
+    });
+
+    it("does NOT unlock with 365-day streak but low availability", () => {
+      const ctx = baseContext({
+        bestAvailability: 99.98,
+        streakDays: 400,
+      });
+      expect(ninesClub.evaluate(ctx)).toBe(false);
+    });
+
+    it("does NOT unlock with undefined availability even with long streak", () => {
+      const ctx = baseContext({
+        bestAvailability: undefined,
+        streakDays: 500,
+      });
+      expect(ninesClub.evaluate(ctx)).toBe(false);
+    });
+
+    it("does NOT unlock on a freshly created SLO (zero streak, 100% availability)", () => {
+      const ctx = baseContext({
+        bestAvailability: 100.0,
+        streakDays: 0,
+      });
+      expect(ninesClub.evaluate(ctx)).toBe(false);
+    });
+  });
+
+  describe("iron_uptime", () => {
+    const ironUptime = findDefinition("iron_uptime");
+
+    it("unlocks at 7-day streak", () => {
+      expect(ironUptime.evaluate(baseContext({ streakDays: 7 }))).toBe(true);
+    });
+
+    it("does NOT unlock below 7 days", () => {
+      expect(ironUptime.evaluate(baseContext({ streakDays: 6 }))).toBe(false);
+    });
+  });
+
+  describe("diamond_uptime", () => {
+    const diamondUptime = findDefinition("diamond_uptime");
+
+    it("unlocks at 30-day streak", () => {
+      expect(diamondUptime.evaluate(baseContext({ streakDays: 30 }))).toBe(
+        true,
+      );
+    });
+
+    it("does NOT unlock below 30 days", () => {
+      expect(diamondUptime.evaluate(baseContext({ streakDays: 29 }))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("first_steps", () => {
+    const firstSteps = findDefinition("first_steps");
+
+    it("unlocks with 1 objective", () => {
+      expect(firstSteps.evaluate(baseContext({ objectiveCount: 1 }))).toBe(
+        true,
+      );
+    });
+
+    it("does NOT unlock with 0 objectives", () => {
+      expect(firstSteps.evaluate(baseContext({ objectiveCount: 0 }))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("full_coverage", () => {
+    const fullCoverage = findDefinition("full_coverage");
+
+    it("unlocks with 3 or more objectives", () => {
+      expect(fullCoverage.evaluate(baseContext({ objectiveCount: 3 }))).toBe(
+        true,
+      );
+      expect(fullCoverage.evaluate(baseContext({ objectiveCount: 5 }))).toBe(
+        true,
+      );
+    });
+
+    it("does NOT unlock with fewer than 3 objectives", () => {
+      expect(fullCoverage.evaluate(baseContext({ objectiveCount: 2 }))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("budget_miser", () => {
+    const budgetMiser = findDefinition("budget_miser");
+
+    it("unlocks when 90% or more budget remaining", () => {
+      expect(
+        budgetMiser.evaluate(baseContext({ budgetRemainingPercent: 90 })),
+      ).toBe(true);
+      expect(
+        budgetMiser.evaluate(baseContext({ budgetRemainingPercent: 99 })),
+      ).toBe(true);
+    });
+
+    it("does NOT unlock below 90% remaining", () => {
+      expect(
+        budgetMiser.evaluate(baseContext({ budgetRemainingPercent: 89.9 })),
+      ).toBe(false);
+    });
+
+    it("does NOT unlock with undefined budget", () => {
+      expect(
+        budgetMiser.evaluate(baseContext({ budgetRemainingPercent: undefined })),
+      ).toBe(false);
+    });
+  });
+
+  describe("clean_sheet", () => {
+    const cleanSheet = findDefinition("clean_sheet");
+
+    it("unlocks with zero downtime", () => {
+      expect(cleanSheet.evaluate(baseContext({ hasZeroDowntime: true }))).toBe(
+        true,
+      );
+    });
+
+    it("does NOT unlock when downtime has occurred", () => {
+      expect(cleanSheet.evaluate(baseContext({ hasZeroDowntime: false }))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("cascade_breaker", () => {
+    const cascadeBreaker = findDefinition("cascade_breaker");
+
+    it("unlocks when all downtime is upstream-attributed", () => {
+      expect(
+        cascadeBreaker.evaluate(
+          baseContext({ hasUpstreamOnlyDowntime: true }),
+        ),
+      ).toBe(true);
+    });
+
+    it("does NOT unlock without upstream-only downtime", () => {
+      expect(
+        cascadeBreaker.evaluate(
+          baseContext({ hasUpstreamOnlyDowntime: false }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("rapid_recovery", () => {
+    const rapidRecovery = findDefinition("rapid_recovery");
+
+    it("unlocks with 5-minute or under recovery", () => {
+      expect(
+        rapidRecovery.evaluate(baseContext({ fastestRecoverySeconds: 300 })),
+      ).toBe(true);
+      expect(
+        rapidRecovery.evaluate(baseContext({ fastestRecoverySeconds: 60 })),
+      ).toBe(true);
+    });
+
+    it("does NOT unlock over 5 minutes", () => {
+      expect(
+        rapidRecovery.evaluate(baseContext({ fastestRecoverySeconds: 301 })),
+      ).toBe(false);
+    });
+  });
+});

--- a/core/slo-backend/src/achievement-evaluator.ts
+++ b/core/slo-backend/src/achievement-evaluator.ts
@@ -34,9 +34,9 @@ const ACHIEVEMENT_DEFINITIONS: Array<{
   },
   {
     type: "nines_club",
-    description: "Achieved 99.9% or higher availability in a rolling window",
-    evaluate: ({ bestAvailability }) =>
-      bestAvailability !== undefined && bestAvailability >= 99.9,
+    description: "Maintained 99.99% or higher availability for 365 days",
+    evaluate: ({ bestAvailability, streakDays }) =>
+      bestAvailability !== undefined && bestAvailability >= 99.99 && streakDays >= 365,
   },
   {
     type: "budget_miser",
@@ -199,3 +199,7 @@ export function getAchievementDefinitions() {
     description: d.description,
   }));
 }
+
+// Export for testing
+export { ACHIEVEMENT_DEFINITIONS };
+export type { AchievementContext };

--- a/core/slo-backend/src/index.ts
+++ b/core/slo-backend/src/index.ts
@@ -177,7 +177,7 @@ export default createBackendPlugin({
         rpcClient: coreServices.rpcClient,
         queueManager: coreServices.queueManager,
       },
-      init: async ({ logger, database, rpc, signalService }) => {
+      init: async ({ logger, database, rpc, signalService, rpcClient }) => {
         logger.debug("🔧 Initializing SLO Backend...");
 
         const service = new SloService(database as SafeDatabase<typeof schema>);
@@ -190,7 +190,7 @@ export default createBackendPlugin({
         // Store for afterPluginsReady
         sharedEngine = engine;
 
-        const router = createRouter({ service, engine, signalService });
+        const router = createRouter({ service, engine, signalService, rpcClient });
         rpc.registerRouter(router, sloContract);
 
         // Register command palette entries

--- a/core/slo-backend/src/router.ts
+++ b/core/slo-backend/src/router.ts
@@ -6,8 +6,10 @@ import {
 import {
   autoAuthMiddleware,
   type RpcContext,
+  type RpcClient,
 } from "@checkstack/backend-api";
 import type { SignalService } from "@checkstack/signal-common";
+import { CatalogApi } from "@checkstack/catalog-common";
 import type { SloService } from "./service";
 import type { SloEngine } from "./slo-engine";
 
@@ -15,10 +17,12 @@ export function createRouter({
   service,
   engine,
   signalService,
+  rpcClient,
 }: {
   service: SloService;
   engine: SloEngine;
   signalService: SignalService;
+  rpcClient: RpcClient;
 }) {
   const os = implement(sloContract)
     .$context<RpcContext>()
@@ -180,9 +184,30 @@ export function createRouter({
       const achievements = await service.getRecentMilestones({
         limit: input.limit ?? 20,
       });
+
+      // Collect unique system IDs for batch lookup
+      const uniqueSystemIds = [...new Set(achievements.map((a) => a.systemId))];
+      const systemNameMap = new Map<string, string>();
+
+      // Resolve system names via catalog RPC
+      const catalogClient = rpcClient.forPlugin(CatalogApi);
+      await Promise.all(
+        uniqueSystemIds.map(async (systemId) => {
+          try {
+            const system = await catalogClient.getSystem({ systemId });
+            if (system?.name) {
+              systemNameMap.set(systemId, system.name);
+            }
+          } catch {
+            // Silently skip — system may have been deleted
+          }
+        }),
+      );
+
       return {
         milestones: achievements.map((a) => ({
           systemId: a.systemId,
+          systemName: systemNameMap.get(a.systemId),
           achievement: a.achievement,
           unlockedAt: a.unlockedAt,
         })),

--- a/core/slo-frontend/src/components/AchievementBadge.tsx
+++ b/core/slo-frontend/src/components/AchievementBadge.tsx
@@ -19,12 +19,12 @@ const ACHIEVEMENT_META: Record<
   iron_uptime: {
     label: "Iron Uptime",
     emoji: "🛡️",
-    description: "30-day compliance streak",
+    description: "7-day compliance streak",
   },
   diamond_uptime: {
     label: "Diamond Uptime",
     emoji: "💎",
-    description: "90-day compliance streak",
+    description: "30-day compliance streak",
   },
   budget_miser: {
     label: "Budget Miser",
@@ -34,12 +34,12 @@ const ACHIEVEMENT_META: Record<
   clean_sheet: {
     label: "Clean Sheet",
     emoji: "✨",
-    description: "Zero breaches in a quarter",
+    description: "Zero downtime in the rolling window",
   },
   nines_club: {
     label: "Nines Club",
     emoji: "🏆",
-    description: "99.99% over 365 days",
+    description: "99.99% availability over 365 days",
   },
   cascade_breaker: {
     label: "Cascade Breaker",
@@ -49,7 +49,7 @@ const ACHIEVEMENT_META: Record<
   full_coverage: {
     label: "Full Coverage",
     emoji: "🔒",
-    description: "All systems in group have SLOs",
+    description: "3+ SLOs configured on a system",
   },
   rapid_recovery: {
     label: "Rapid Recovery",


### PR DESCRIPTION
## Summary

Fixes several bugs across the GitOps and SLO subsystems.

### GitOps: Auth Token Handling
- Made `authToken` optional in `ReconcileProviderParams` and `ScraperOptions` to support unauthenticated access to public repositories
- GitHub and GitLab scrapers now conditionally set authentication headers only when a token is provided
- Sync worker now decrypts the encrypted `authToken` from the database before passing it to scrapers, fixing authentication failures caused by sending encrypted values in HTTP headers
- Added "Remove Token" button in the provider editor so users can clear credentials to switch to public repo access
- Updated `updateProvider` contract to accept `null` for `authToken` (explicit clear vs. `undefined` = keep current)

### SLO: Fix Premature Nines Club Achievement
- The "Nines Club" achievement now requires both ≥99.99% availability **and** a 365-day compliance streak
- Previously unlocked immediately on freshly created SLOs (100% default availability)

### SLO: Frontend Description Alignment
- Fixed mismatched achievement descriptions: Iron Uptime (7-day, not 30), Diamond Uptime (30-day, not 90), Clean Sheet (rolling window, not quarter), Full Coverage (3+ SLOs, not all systems in group), Nines Club (99.99%)

### SLO: Milestone System Names
- `getRecentMilestones` now resolves human-readable system names via Catalog API instead of returning raw system IDs

## Testing
- 22 new achievement evaluator tests covering all 9 achievement types
- 2 new scraper tests verifying unauthenticated access (no auth headers sent)
- All 41 affected tests pass
- 105/105 packages typecheck clean
- Lint clean