### PR TITLE
fix: sync lifecycle management for GitOps providers

### DIFF
--- a/.changeset/fix-gitops-sync-lifecycle.md
+++ b/.changeset/fix-gitops-sync-lifecycle.md
@@ -1,0 +1,10 @@
+---
+"@checkstack/gitops-backend": patch
+---
+
+### GitOps: Fix sync lifecycle management
+
+- Schedule recurring sync job immediately when creating a provider (previously required server restart)
+- Reschedule recurring job when provider's sync interval is updated
+- Cancel recurring job when provider is deleted
+- Fix manual sync trigger being silently dropped due to job ID deduplication

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -5,7 +5,7 @@ import { gitopsContract } from "@checkstack/gitops-common";
 import type { SafeDatabase } from "@checkstack/backend-api";
 import type { QueueManager } from "@checkstack/queue-api";
 import type { InternalEntityKindRegistry } from "./kind-registry";
-import { triggerSyncForProvider } from "./sync/sync-worker";
+import { triggerSyncForProvider, scheduleSyncForProvider, cancelSyncForProvider } from "./sync/sync-worker";
 import * as schema from "./schema";
 import { eq, and } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
@@ -82,6 +82,7 @@ export const createGitOpsRouter = ({
 
   const createProvider = os.createProvider.handler(async ({ input }) => {
     const id = uuidv4();
+    const syncInterval = input.syncInterval ?? 300;
     await db.insert(schema.providers).values({
       id,
       type: input.type,
@@ -89,9 +90,17 @@ export const createGitOpsRouter = ({
       pathPattern: input.pathPattern,
       baseUrl: input.baseUrl ?? null, // eslint-disable-line unicorn/no-null
       authToken: input.authToken ? encrypt(input.authToken) : null, // eslint-disable-line unicorn/no-null
-      syncInterval: input.syncInterval ?? 300,
+      syncInterval,
       deletionPolicy: input.deletionPolicy ?? "orphan",
     });
+
+    // Schedule recurring sync for the new provider
+    await scheduleSyncForProvider({
+      queueManager,
+      providerId: id,
+      syncIntervalSeconds: syncInterval,
+    });
+
     return { id };
   });
 
@@ -127,6 +136,15 @@ export const createGitOpsRouter = ({
       .set(updates)
       .where(eq(schema.providers.id, input.id));
 
+    // If syncInterval changed, reschedule the recurring job
+    if (input.data.syncInterval !== undefined) {
+      await scheduleSyncForProvider({
+        queueManager,
+        providerId: input.id,
+        syncIntervalSeconds: input.data.syncInterval,
+      });
+    }
+
     return { success: true };
   });
 
@@ -144,6 +162,12 @@ export const createGitOpsRouter = ({
 
     // Provenance entries are cascade-deleted via FK constraint
     await db.delete(schema.providers).where(eq(schema.providers.id, input.id));
+
+    // Cancel the recurring sync job
+    await cancelSyncForProvider({
+      queueManager,
+      providerId: input.id,
+    });
 
     return { success: true };
   });

--- a/core/gitops-backend/src/sync/sync-worker.ts
+++ b/core/gitops-backend/src/sync/sync-worker.ts
@@ -165,8 +165,18 @@ export async function triggerSyncForProvider(params: {
   const { queueManager, providerId } = params;
   const queue = queueManager.getQueue<SyncJobPayload>(SYNC_QUEUE);
 
-  await queue.enqueue(
-    { providerId },
-    { jobId: `gitops-sync-${providerId}-manual` },
-  );
+  await queue.enqueue({ providerId });
+}
+
+/**
+ * Cancels the recurring sync job for a provider (used when deleting a provider).
+ */
+export async function cancelSyncForProvider(params: {
+  queueManager: QueueManager;
+  providerId: string;
+}): Promise<void> {
+  const { queueManager, providerId } = params;
+  const queue = queueManager.getQueue<SyncJobPayload>(SYNC_QUEUE);
+
+  await queue.cancelRecurring(`gitops-sync-${providerId}`);
 }


### PR DESCRIPTION
## Problem

When creating a new GitOps provider, no recurring sync job was scheduled. Syncs would only run after a server restart (when the bootstrap loop picks up existing providers from the DB). Additionally, manual sync triggers were silently dropped by the queue due to job ID deduplication.

## Changes

### Sync scheduling on CRUD operations
- **Create**: Schedule a recurring sync job immediately after inserting the provider
- **Update**: Reschedule the recurring job when `syncInterval` changes
- **Delete**: Cancel the recurring job when a provider is deleted

### Fix manual sync deduplication
- Removed the fixed `jobId` from manual sync triggers — the memory queue silently drops duplicate jobs with the same ID, which meant only the first manual trigger ever ran

### New utility
- Added `cancelSyncForProvider` for clean teardown of recurring jobs

## Files Changed
- `core/gitops-backend/src/router.ts` — wire up sync lifecycle in create/update/delete handlers
- `core/gitops-backend/src/sync/sync-worker.ts` — add `cancelSyncForProvider`, remove fixed jobId from manual trigger