### PR TITLE
feat: Schema-driven secret resolution with warnings and name validation

### DIFF
--- a/.changeset/secret-template-syntax.md
+++ b/.changeset/secret-template-syntax.md
@@ -1,0 +1,32 @@
+---
+"@checkstack/gitops-common": minor
+"@checkstack/gitops-backend": minor
+"@checkstack/gitops-frontend": minor
+"@checkstack/healthcheck-backend": patch
+"@checkstack/catalog-backend": patch
+---
+
+### Schema-driven secret resolution, rotation invalidation, and security hardening
+
+**Breaking**: Replaced `{ secretRef: "..." }` object syntax with `${{ secrets.NAME }}` template interpolation. The `secretField()`, `secretRefSchema`, `isSecretRef`, `SecretRef`, and `ResolvedSecretField` exports have been removed from `@checkstack/gitops-common`.
+
+**Breaking**: `ReconcileContext.resolveSecretsBySchema()` now returns `{ resolved: T; warnings: string[] }` instead of `T` directly. Plugins must destructure the result. Warnings contain messages for `${{ secrets.NAME }}` templates found in non-secret fields (fields without `x-secret` annotation).
+
+**New features**:
+- Secrets can be referenced in **any string field** using `${{ secrets.NAME }}` syntax
+- Inline interpolation is supported: `"postgres://user:${{ secrets.DB_PASS }}@host/db"`
+- Resolution is **schema-driven** — reuses the existing `configString({ "x-secret": true })` pattern from DynamicForm
+- Secret rotation now automatically invalidates affected entities, triggering re-reconciliation on the next sync cycle
+- New `getSecretUsage` RPC endpoint to look up which entities reference a given secret
+- Secrets UI now shows an expandable usage panel per secret showing referencing entities
+- Reconciliation warnings: templates in non-secret fields are detected and surfaced in the provenance UI
+- New `secretNameSchema` and `SECRET_NAME_REGEX` exports for validating secret names
+
+**Security**:
+- Secret names are validated at creation: must start with a letter, contain only `[a-zA-Z0-9_-]`, max 63 chars
+- Secrets are validated to exist at sync time but **not pre-resolved** into the spec
+- Templates in `metadata` fields are **rejected** to prevent secret leaks via display fields
+- Only fields with `x-secret` schema annotations get resolved — no escape hatch
+- Templates in non-secret fields emit warnings (stored in provenance, visible in UI) instead of silently passing
+
+**Migration**: Update YAML descriptors to use `${{ secrets.NAME }}` instead of `secretRef: name`. Remove `secretField()` imports from plugin schemas — use `configString({ "x-secret": true })` to annotate secret fields. Destructure `const { resolved } = await context.resolveSecretsBySchema({ value, schema })` (return type changed from `T` to `{ resolved: T; warnings: string[] }`).

--- a/bun.lock
+++ b/bun.lock
@@ -269,7 +269,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -314,7 +314,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -404,7 +404,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.3.33",
+      "version": "0.3.34",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -433,7 +433,7 @@
     },
     "core/dependency-backend": {
       "name": "@checkstack/dependency-backend",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -476,7 +476,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -507,7 +507,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -568,7 +568,7 @@
     },
     "core/gitops-backend": {
       "name": "@checkstack/gitops-backend",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -594,7 +594,7 @@
     },
     "core/gitops-common": {
       "name": "@checkstack/gitops-common",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -608,7 +608,7 @@
     },
     "core/gitops-frontend": {
       "name": "@checkstack/gitops-frontend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -627,7 +627,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "0.14.1",
+      "version": "0.14.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -677,7 +677,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -708,7 +708,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "0.4.16",
+      "version": "0.4.18",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -751,7 +751,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -876,7 +876,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.4.27",
+      "version": "0.4.28",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -1029,7 +1029,7 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.55.0",
+      "version": "0.57.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
@@ -1048,7 +1048,7 @@
     },
     "core/satellite-backend": {
       "name": "@checkstack/satellite-backend",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1170,7 +1170,7 @@
     },
     "core/slo-backend": {
       "name": "@checkstack/slo-backend",
-      "version": "0.2.4",
+      "version": "0.2.6",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -1216,7 +1216,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -3860,17 +3860,23 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@checkstack/backend-api/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@checkstack/command-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
     "@checkstack/command-frontend/react-router-dom": ["react-router-dom@7.14.1", "", { "dependencies": { "react-router": "7.14.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA=="],
 
     "@checkstack/common/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
+    "@checkstack/frontend-api/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@checkstack/queue-backend/@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
     "@checkstack/queue-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
     "@checkstack/queue-frontend/react-router-dom": ["react-router-dom@7.14.1", "", { "dependencies": { "react-router": "7.14.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA=="],
+
+    "@checkstack/test-utils-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@checkstack/ui/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
@@ -4028,9 +4034,15 @@
 
     "xml-crypto/xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
 
+    "@checkstack/backend-api/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@checkstack/command-frontend/react-router-dom/react-router": ["react-router@7.14.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="],
 
+    "@checkstack/frontend-api/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@checkstack/queue-frontend/react-router-dom/react-router": ["react-router@7.14.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="],
+
+    "@checkstack/test-utils-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@checkstack/ui/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 

--- a/core/catalog-backend/src/catalog-gitops-kinds.test.ts
+++ b/core/catalog-backend/src/catalog-gitops-kinds.test.ts
@@ -103,6 +103,8 @@ const mockContext: ReconcileContext = {
     error: () => {},
   },
   resolveEntityRef: async () => undefined,
+  resolveSecretsBySchema: async <T>(params: { value: T }): Promise<{ resolved: T; warnings: string[] }> =>
+    ({ resolved: params.value, warnings: [] }),
 };
 
 // ─── Tests ─────────────────────────────────────────────────────────────────

--- a/core/gitops-backend/drizzle/0001_wandering_leech.sql
+++ b/core/gitops-backend/drizzle/0001_wandering_leech.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provenance" ADD COLUMN "secret_refs" text[] DEFAULT '{}';

--- a/core/gitops-backend/drizzle/0002_far_lady_vermin.sql
+++ b/core/gitops-backend/drizzle/0002_far_lady_vermin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provenance" ADD COLUMN "warnings" text[] DEFAULT '{}';

--- a/core/gitops-backend/drizzle/meta/0001_snapshot.json
+++ b/core/gitops-backend/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,317 @@
+{
+  "id": "c1ccd846-04bb-4799-b93b-26ae781e01d3",
+  "prevId": "01bbd45b-d962-4e98-b25d-53310f487822",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.provenance": {
+      "name": "provenance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_hash": {
+          "name": "last_sync_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_refs": {
+          "name": "secret_refs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "provenance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provenance_provider_id_providers_id_fk": {
+          "name": "provenance_provider_id_providers_id_fk",
+          "tableFrom": "provenance",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_token": {
+          "name": "auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "deletion_policy": {
+          "name": "deletion_policy",
+          "type": "deletion_policy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'orphan'"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.deletion_policy": {
+      "name": "deletion_policy",
+      "schema": "public",
+      "values": [
+        "orphan",
+        "auto"
+      ]
+    },
+    "public.provenance_status": {
+      "name": "provenance_status",
+      "schema": "public",
+      "values": [
+        "synced",
+        "error",
+        "orphaned"
+      ]
+    },
+    "public.provider_type": {
+      "name": "provider_type",
+      "schema": "public",
+      "values": [
+        "github",
+        "gitlab"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/core/gitops-backend/drizzle/meta/0002_snapshot.json
+++ b/core/gitops-backend/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,324 @@
+{
+  "id": "7b64a31e-1aec-46e5-bf15-013bef1a5e9c",
+  "prevId": "c1ccd846-04bb-4799-b93b-26ae781e01d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.provenance": {
+      "name": "provenance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_hash": {
+          "name": "last_sync_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_refs": {
+          "name": "secret_refs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "provenance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provenance_provider_id_providers_id_fk": {
+          "name": "provenance_provider_id_providers_id_fk",
+          "tableFrom": "provenance",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_token": {
+          "name": "auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "deletion_policy": {
+          "name": "deletion_policy",
+          "type": "deletion_policy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'orphan'"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.deletion_policy": {
+      "name": "deletion_policy",
+      "schema": "public",
+      "values": [
+        "orphan",
+        "auto"
+      ]
+    },
+    "public.provenance_status": {
+      "name": "provenance_status",
+      "schema": "public",
+      "values": [
+        "synced",
+        "error",
+        "orphaned"
+      ]
+    },
+    "public.provider_type": {
+      "name": "provider_type",
+      "schema": "public",
+      "values": [
+        "github",
+        "gitlab"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/core/gitops-backend/drizzle/meta/_journal.json
+++ b/core/gitops-backend/drizzle/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1776797758378,
       "tag": "0000_tense_stryfe",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776929187262,
+      "tag": "0001_wandering_leech",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776931984135,
+      "tag": "0002_far_lady_vermin",
+      "breakpoints": true
     }
   ]
 }

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -1,4 +1,5 @@
 import { implement, ORPCError } from "@orpc/server";
+import { z } from "zod";
 import { autoAuthMiddleware, type RpcContext } from "@checkstack/backend-api";
 import { encrypt, decrypt } from "@checkstack/backend-api";
 import { gitopsContract } from "@checkstack/gitops-common";
@@ -7,7 +8,7 @@ import type { QueueManager } from "@checkstack/queue-api";
 import type { InternalEntityKindRegistry } from "./kind-registry";
 import { triggerSyncForProvider, scheduleSyncForProvider, cancelSyncForProvider } from "./sync/sync-worker";
 import * as schema from "./schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 
 /**
@@ -47,12 +48,15 @@ export const createGitOpsRouter = ({
       .select()
       .from(schema.provenance)
       .where(and(...conditions));
+    const row = result[0];
     // eslint-disable-next-line unicorn/no-null
-    return result[0] ?? null;
+    return row ? { ...row, warnings: row.warnings ?? [] } : null;
   });
 
   const listProvenance = os.listProvenance.handler(async ({ input }) => {
-    const rows = await db.select().from(schema.provenance);
+    const rawRows = await db.select().from(schema.provenance);
+    // Normalize: ensure warnings is always a string[] (Drizzle may return null for pre-migration rows)
+    const rows = rawRows.map((row) => ({ ...row, warnings: row.warnings ?? [] }));
     if (!input) return rows;
 
     return rows.filter((row) => {
@@ -236,6 +240,8 @@ export const createGitOpsRouter = ({
                 // eslint-disable-next-line unicorn/no-useless-undefined
                 return undefined;
               },
+              resolveSecretsBySchema: async <T>(params: { value: T; schema: z.ZodTypeAny }): Promise<{ resolved: T; warnings: string[] }> =>
+                ({ resolved: params.value, warnings: [] }),
             },
           });
         } catch (deleteError) {
@@ -327,6 +333,16 @@ export const createGitOpsRouter = ({
       .set({ encryptedValue, updatedAt: new Date() })
       .where(eq(schema.secrets.id, input.id));
 
+    // Invalidate provenance for all entities referencing this secret
+    // so the next sync cycle re-reconciles them with the updated value
+    const secretName = existing[0].name;
+    await db
+      .update(schema.provenance)
+      .set({ lastSyncHash: "" })
+      .where(
+        sql`${secretName} = ANY(${schema.provenance.secretRefs})`,
+      );
+
     return { success: true };
   });
 
@@ -352,6 +368,22 @@ export const createGitOpsRouter = ({
     return { value: decrypt(secret.encryptedValue) };
   });
 
+  const getSecretUsage = os.getSecretUsage.handler(async ({ input }) => {
+    const rows = await db
+      .select({
+        kind: schema.provenance.kind,
+        entityName: schema.provenance.entityName,
+        repository: schema.provenance.repository,
+        filePath: schema.provenance.filePath,
+      })
+      .from(schema.provenance)
+      .where(
+        sql`${input.secretName} = ANY(${schema.provenance.secretRefs})`,
+      );
+
+    return rows;
+  });
+
   // ─── Kind Registry ────────────────────────────────────────────────────
 
   const listKinds = os.listKinds.handler(async () => {
@@ -375,6 +407,7 @@ export const createGitOpsRouter = ({
     rotateSecret,
     deleteSecret,
     resolveSecret,
+    getSecretUsage,
     listKinds,
   });
 };

--- a/core/gitops-backend/src/schema.ts
+++ b/core/gitops-backend/src/schema.ts
@@ -57,16 +57,20 @@ export const provenance = pgTable("provenance", {
   repository: text("repository").notNull(),
   filePath: text("file_path").notNull(),
   lastSyncHash: text("last_sync_hash").notNull(),
+  /** Secret names referenced via ${{ secrets.NAME }} in this entity's spec. */
+  secretRefs: text("secret_refs").array().default([]),
   status: provenanceStatusEnum("status").notNull().default("synced"),
   errorMessage: text("error_message"),
+  /** Warnings about unresolved secret templates in non-secret fields. */
+  warnings: text("warnings").array().default([]),
   lastSyncedAt: timestamp("last_synced_at").defaultNow().notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
-/** Secret store for secretRef values in YAML descriptors. */
+/** Secret store for ${{ secrets.NAME }} template values in YAML descriptors. */
 export const secrets = pgTable("secrets", {
   id: text("id").primaryKey(),
-  /** Unique name referenced by secretRef in descriptors. */
+  /** Unique name referenced via ${{ secrets.NAME }} in descriptors. */
   name: text("name").notNull().unique(),
   /** AES-256-GCM encrypted value (format: iv:authTag:ciphertext). */
   encryptedValue: text("encrypted_value").notNull(),

--- a/core/gitops-backend/src/secret-resolver.test.ts
+++ b/core/gitops-backend/src/secret-resolver.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect } from "bun:test";
-import { resolveSecrets } from "./secret-resolver";
+import { z } from "zod";
+import { configString } from "@checkstack/backend-api";
+import { resolveSecretsBySchema } from "./secret-resolver";
 
 const mockSecretStore = {
   resolve: async (name: string): Promise<string> => {
     const secrets: Record<string, string> = {
-      "prod-db-password": "s3cret!",
-      "api-key": "key-12345",
+      DB_PASS: "s3cret!",
+      API_KEY: "key-12345",
+      DB_USER: "admin",
+      DB_HOST: "db.production.internal",
     };
     const value = secrets[name];
     if (!value) throw new Error(`Secret not found: ${name}`);
@@ -13,52 +17,110 @@ const mockSecretStore = {
   },
 };
 
-describe("resolveSecrets", () => {
-  it("resolves a top-level secretRef", async () => {
-    const spec = { password: { secretRef: "prod-db-password" } };
-    const resolved = await resolveSecrets({
-      spec,
+describe("resolveSecretsBySchema", () => {
+  it("resolves a field marked with x-secret", async () => {
+    const schema = z.object({
+      host: z.string(),
+      password: configString({ "x-secret": true }),
+    });
+
+    const { resolved, warnings } = await resolveSecretsBySchema({
+      value: { host: "localhost", password: "${{ secrets.DB_PASS }}" },
+      schema,
       secretStore: mockSecretStore,
     });
-    expect(resolved).toEqual({ password: "s3cret!" });
+
+    expect(resolved).toEqual({ host: "localhost", password: "s3cret!" });
+    expect(warnings).toEqual([]);
   });
 
-  it("leaves plain strings untouched", async () => {
-    const spec = { host: "localhost", port: 5432 };
-    const resolved = await resolveSecrets({
-      spec,
-      secretStore: mockSecretStore,
+  it("leaves non-secret fields untouched and emits warnings", async () => {
+    const schema = z.object({
+      description: z.string(),
+      password: configString({ "x-secret": true }),
     });
-    expect(resolved).toEqual({ host: "localhost", port: 5432 });
-  });
 
-  it("resolves nested secretRefs", async () => {
-    const spec = {
-      connection: {
-        host: "db.internal",
-        password: { secretRef: "prod-db-password" },
+    const { resolved, warnings } = await resolveSecretsBySchema({
+      value: {
+        description: "Contains ${{ secrets.DB_PASS }} but should NOT be resolved",
+        password: "${{ secrets.DB_PASS }}",
       },
-    };
-    const resolved = await resolveSecrets({
-      spec,
+      schema,
       secretStore: mockSecretStore,
     });
+
+    expect(resolved).toEqual({
+      description: "Contains ${{ secrets.DB_PASS }} but should NOT be resolved",
+      password: "s3cret!",
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("description");
+    expect(warnings[0]).toContain("not marked as a secret field");
+  });
+
+  it("resolves inline interpolation in secret fields", async () => {
+    const schema = z.object({
+      connectionString: configString({ "x-secret": true }),
+    });
+
+    const { resolved } = await resolveSecretsBySchema({
+      value: {
+        connectionString:
+          "postgres://${{ secrets.DB_USER }}:${{ secrets.DB_PASS }}@${{ secrets.DB_HOST }}/mydb",
+      },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    expect(resolved).toEqual({
+      connectionString:
+        "postgres://admin:s3cret!@db.production.internal/mydb",
+    });
+  });
+
+  it("resolves secrets in nested objects", async () => {
+    const schema = z.object({
+      connection: z.object({
+        host: z.string(),
+        password: configString({ "x-secret": true }),
+      }),
+    });
+
+    const { resolved, warnings } = await resolveSecretsBySchema({
+      value: {
+        connection: { host: "db.internal", password: "${{ secrets.DB_PASS }}" },
+      },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
     expect(resolved).toEqual({
       connection: { host: "db.internal", password: "s3cret!" },
     });
+    expect(warnings).toEqual([]);
   });
 
-  it("resolves secretRefs in arrays", async () => {
-    const spec = {
-      credentials: [
-        { name: "db", secret: { secretRef: "prod-db-password" } },
-        { name: "api", secret: { secretRef: "api-key" } },
-      ],
-    };
-    const resolved = await resolveSecrets({
-      spec,
+  it("resolves secrets in arrays of objects", async () => {
+    const schema = z.object({
+      credentials: z.array(
+        z.object({
+          name: z.string(),
+          secret: configString({ "x-secret": true }),
+        }),
+      ),
+    });
+
+    const { resolved } = await resolveSecretsBySchema({
+      value: {
+        credentials: [
+          { name: "db", secret: "${{ secrets.DB_PASS }}" },
+          { name: "api", secret: "${{ secrets.API_KEY }}" },
+        ],
+      },
+      schema,
       secretStore: mockSecretStore,
     });
+
     expect(resolved).toEqual({
       credentials: [
         { name: "db", secret: "s3cret!" },
@@ -67,20 +129,197 @@ describe("resolveSecrets", () => {
     });
   });
 
-  it("throws when a referenced secret is not found", async () => {
-    const spec = { password: { secretRef: "nonexistent" } };
-    await expect(
-      resolveSecrets({ spec, secretStore: mockSecretStore }),
-    ).rejects.toThrow("Secret not found: nonexistent");
+  it("handles optional secret fields", async () => {
+    const schema = z.object({
+      password: configString({ "x-secret": true }).optional(),
+    });
+
+    const { resolved } = await resolveSecretsBySchema({
+      value: { password: "${{ secrets.DB_PASS }}" },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    expect(resolved).toEqual({ password: "s3cret!" });
+  });
+
+  it("handles default-wrapped secret fields", async () => {
+    const schema = z.object({
+      password: configString({ "x-secret": true }).default("fallback"),
+    });
+
+    const { resolved } = await resolveSecretsBySchema({
+      value: { password: "${{ secrets.DB_PASS }}" },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    expect(resolved).toEqual({ password: "s3cret!" });
+  });
+
+  it("returns non-secret objects unchanged", async () => {
+    const schema = z.object({
+      host: z.string(),
+      port: z.number(),
+    });
+
+    const { resolved, warnings } = await resolveSecretsBySchema({
+      value: { host: "localhost", port: 5432 },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    expect(resolved).toEqual({ host: "localhost", port: 5432 });
+    expect(warnings).toEqual([]);
   });
 
   it("handles null and undefined values gracefully", async () => {
-    const spec = { a: null, b: undefined, c: "value" };
-    const resolved = await resolveSecrets({
-      spec,
+    const schema = z.object({
+      password: configString({ "x-secret": true }).optional(),
+    });
+
+    const { resolved } = await resolveSecretsBySchema({
+      value: { password: undefined },
+      schema,
       secretStore: mockSecretStore,
     });
-    expect(resolved.a).toBeNull();
-    expect(resolved.c).toBe("value");
+
+    expect(resolved).toEqual({ password: undefined });
+  });
+
+  it("throws when a referenced secret is not found", async () => {
+    const schema = z.object({
+      password: configString({ "x-secret": true }),
+    });
+
+    await expect(
+      resolveSecretsBySchema({
+        value: { password: "${{ secrets.NONEXISTENT }}" },
+        schema,
+        secretStore: mockSecretStore,
+      }),
+    ).rejects.toThrow("Secret not found: NONEXISTENT");
+  });
+
+  it("resolves templates with extra whitespace", async () => {
+    const schema = z.object({
+      password: configString({ "x-secret": true }),
+    });
+
+    const { resolved } = await resolveSecretsBySchema({
+      value: { password: "${{  secrets.DB_PASS  }}" },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    expect(resolved).toEqual({ password: "s3cret!" });
+  });
+
+  it("preserves fields not in the schema (extra keys in value)", async () => {
+    const schema = z.object({
+      password: configString({ "x-secret": true }),
+    });
+
+    const { resolved } = await resolveSecretsBySchema({
+      value: {
+        password: "${{ secrets.DB_PASS }}",
+        extraField: "should remain",
+      },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    expect(resolved).toEqual({
+      password: "s3cret!",
+      extraField: "should remain",
+    });
+  });
+
+  it("does not resolve secret templates in secret fields when no template is present", async () => {
+    const schema = z.object({
+      password: configString({ "x-secret": true }),
+    });
+
+    const { resolved } = await resolveSecretsBySchema({
+      value: { password: "plain-password" },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    expect(resolved).toEqual({ password: "plain-password" });
+  });
+
+  // ─── Warning tests ──────────────────────────────────────────────────────
+
+  it("warns for template in nested non-secret field with correct path", async () => {
+    const schema = z.object({
+      connection: z.object({
+        host: z.string(),
+        password: configString({ "x-secret": true }),
+      }),
+    });
+
+    const { resolved, warnings } = await resolveSecretsBySchema({
+      value: {
+        connection: {
+          host: "${{ secrets.DB_HOST }}",
+          password: "${{ secrets.DB_PASS }}",
+        },
+      },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    // Password resolved, host left as-is
+    expect(resolved).toEqual({
+      connection: {
+        host: "${{ secrets.DB_HOST }}",
+        password: "s3cret!",
+      },
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("connection.host");
+  });
+
+  it("warns for template in array element non-secret field with index", async () => {
+    const schema = z.object({
+      items: z.array(
+        z.object({
+          label: z.string(),
+          secret: configString({ "x-secret": true }),
+        }),
+      ),
+    });
+
+    const { warnings } = await resolveSecretsBySchema({
+      value: {
+        items: [
+          { label: "${{ secrets.DB_PASS }}", secret: "${{ secrets.DB_PASS }}" },
+        ],
+      },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("items[0].label");
+  });
+
+  it("emits no warnings when all templates are in secret fields", async () => {
+    const schema = z.object({
+      password: configString({ "x-secret": true }),
+      apiKey: configString({ "x-secret": true }),
+    });
+
+    const { warnings } = await resolveSecretsBySchema({
+      value: {
+        password: "${{ secrets.DB_PASS }}",
+        apiKey: "${{ secrets.API_KEY }}",
+      },
+      schema,
+      secretStore: mockSecretStore,
+    });
+
+    expect(warnings).toEqual([]);
   });
 });

--- a/core/gitops-backend/src/secret-resolver.ts
+++ b/core/gitops-backend/src/secret-resolver.ts
@@ -1,4 +1,6 @@
-import { isSecretRef } from "@checkstack/gitops-common";
+import { z } from "zod";
+import { SECRET_TEMPLATE_REGEX } from "@checkstack/gitops-common";
+import { isSecretSchema } from "@checkstack/backend-api";
 
 /**
  * Interface for resolving secret names to their decrypted values.
@@ -8,47 +10,212 @@ export interface SecretStore {
 }
 
 /**
- * Recursively walks a parsed spec object and resolves any `{ secretRef: "name" }`
- * values by looking them up in the secret store.
- *
- * After resolution, all secretRef objects are replaced with plain strings.
- * This function is called by the reconciliation engine before invoking plugin reconcilers.
+ * Result of schema-driven secret resolution.
  */
-export async function resolveSecrets(params: {
-  spec: Record<string, unknown>;
-  secretStore: SecretStore;
-}): Promise<Record<string, unknown>> {
-  const { spec, secretStore } = params;
-  return resolveValue(spec, secretStore) as Promise<Record<string, unknown>>;
+export interface SecretResolutionResult<T> {
+  /** The value with x-secret fields resolved. */
+  resolved: T;
+  /**
+   * Warnings for `${{ secrets.NAME }}` templates found in non-secret fields.
+   * These templates will NOT be resolved — the field must be annotated with
+   * `configString({ "x-secret": true })` for resolution to occur.
+   */
+  warnings: string[];
 }
 
-async function resolveValue(
-  value: unknown,
-  secretStore: SecretStore,
-): Promise<unknown> {
+/**
+ * Schema-driven secret resolver.
+ *
+ * Walks a Zod schema to find fields annotated with `configString({ "x-secret": true })`,
+ * then resolves `${{ secrets.NAME }}` templates **only** in those fields.
+ * Non-secret fields are returned as-is, preventing accidental leaks into display fields.
+ *
+ * Templates found in non-secret fields are reported as warnings — the value
+ * is still returned unmodified, but the caller can surface these to the user.
+ *
+ * Supports both full-value templates and inline interpolation:
+ * - `"${{ secrets.DB_PASS }}"` → `"actual-password"`
+ * - `"postgres://user:${{ secrets.PASS }}@host/db"` → `"postgres://user:actual-password@host/db"`
+ */
+export async function resolveSecretsBySchema(params: {
+  value: unknown;
+  schema: z.ZodTypeAny;
+  secretStore: SecretStore;
+}): Promise<SecretResolutionResult<unknown>> {
+  const { value, schema, secretStore } = params;
+  const warnings: string[] = [];
+  const resolved = await walkAndResolve({ value, schema, secretStore, warnings, path: "" });
+  return { resolved, warnings };
+}
+
+// ─── Recursive Walker ──────────────────────────────────────────────────────
+
+async function walkAndResolve(params: {
+  value: unknown;
+  schema: z.ZodTypeAny;
+  secretStore: SecretStore;
+  warnings: string[];
+  path: string;
+}): Promise<unknown> {
+  const { value, secretStore, warnings, path } = params;
+  const schema = unwrapZod(params.schema);
+
   if (value === null || value === undefined) {
     return value;
   }
 
-  // Check if this value is a secretRef object
-  if (isSecretRef(value)) {
-    return secretStore.resolve(value.secretRef);
-  }
-
-  // Recurse into arrays
-  if (Array.isArray(value)) {
-    return Promise.all(value.map((item) => resolveValue(item, secretStore)));
-  }
-
-  // Recurse into plain objects
-  if (typeof value === "object") {
-    const resolved: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(value)) {
-      resolved[key] = await resolveValue(val, secretStore);
+  // Leaf node: if this schema is marked x-secret, resolve templates in the string
+  if (isSecretSchema(schema)) {
+    if (typeof value === "string") {
+      return resolveTemplateString({ value, secretStore });
     }
-    return resolved;
+    return value;
   }
 
-  // Primitives pass through
+  // Non-secret string leaf: check for unresolved templates and warn
+  if (typeof value === "string" && containsSecretTemplate(value)) {
+    const fieldPath = path || "(root)";
+    warnings.push(
+      `Field "${fieldPath}" contains a secret template but is not marked as a secret field. ` +
+        `Add configString({ "x-secret": true }) to the schema for this field to enable resolution.`,
+    );
+    return value;
+  }
+
+  // Object: recurse into each property using the schema's shape
+  if (schema instanceof z.ZodObject && typeof value === "object" && !Array.isArray(value)) {
+    const shape = schema.shape as Record<string, z.ZodTypeAny>;
+    const result: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+
+    for (const [key, fieldSchema] of Object.entries(shape)) {
+      if (key in result) {
+        result[key] = await walkAndResolve({
+          value: result[key],
+          schema: fieldSchema,
+          secretStore,
+          warnings,
+          path: path ? `${path}.${key}` : key,
+        });
+      }
+    }
+
+    return result;
+  }
+
+  // Array: recurse into each element using the element schema
+  if (schema instanceof z.ZodArray && Array.isArray(value)) {
+    const elementSchema = schema.element as z.ZodTypeAny;
+    return Promise.all(
+      value.map((item, index) =>
+        walkAndResolve({
+          value: item,
+          schema: elementSchema,
+          secretStore,
+          warnings,
+          path: `${path}[${index}]`,
+        }),
+      ),
+    );
+  }
+
+  // Discriminated union: find the matching variant and recurse
+  if (schema instanceof z.ZodDiscriminatedUnion && typeof value === "object" && value !== null) {
+    const discriminator = (schema.def as { discriminator: string }).discriminator;
+    const discriminatorValue = (value as Record<string, unknown>)[discriminator];
+    const options = schema.options as z.ZodObject<z.ZodRawShape>[];
+    const matchedVariant = options.find((option) => {
+      const discField = option.shape[discriminator];
+      if (discField instanceof z.ZodLiteral) {
+        return discField.value === discriminatorValue;
+      }
+      return false;
+    });
+
+    if (matchedVariant) {
+      return walkAndResolve({ value, schema: matchedVariant, secretStore, warnings, path });
+    }
+  }
+
+  // Union (oneOf/anyOf without discriminator): try each variant
+  if (schema instanceof z.ZodUnion && typeof value === "object" && value !== null) {
+    const options = schema.options as z.ZodTypeAny[];
+    for (const option of options) {
+      const parsed = option.safeParse(value);
+      if (parsed.success) {
+        return walkAndResolve({ value, schema: option, secretStore, warnings, path });
+      }
+    }
+  }
+
+  // No schema match — return value unchanged
   return value;
+}
+
+/**
+ * Quick check whether a string contains any `${{ secrets.NAME }}` pattern.
+ */
+function containsSecretTemplate(value: string): boolean {
+  SECRET_TEMPLATE_REGEX.lastIndex = 0;
+  return SECRET_TEMPLATE_REGEX.test(value);
+}
+
+// ─── Zod Unwrapping ────────────────────────────────────────────────────────
+
+/**
+ * Unwraps Optional, Default, and Nullable wrappers to get the inner schema.
+ */
+function unwrapZod(schema: z.ZodTypeAny): z.ZodTypeAny {
+  let unwrapped = schema;
+
+  if (unwrapped instanceof z.ZodOptional) {
+    unwrapped = unwrapped.unwrap() as z.ZodTypeAny;
+  }
+
+  if (unwrapped instanceof z.ZodDefault) {
+    unwrapped = unwrapped.def.innerType as z.ZodTypeAny;
+  }
+
+  if (unwrapped instanceof z.ZodNullable) {
+    unwrapped = unwrapped.unwrap() as z.ZodTypeAny;
+  }
+
+  return unwrapped;
+}
+
+// ─── Template Resolution ───────────────────────────────────────────────────
+
+/**
+ * Resolves all `${{ secrets.NAME }}` patterns in a string.
+ * Each unique secret name is resolved once (cached per call) to avoid duplicate lookups.
+ */
+async function resolveTemplateString(params: {
+  value: string;
+  secretStore: SecretStore;
+}): Promise<string> {
+  const { value, secretStore } = params;
+
+  // Collect all secret names first
+  const secretNames = new Set<string>();
+  SECRET_TEMPLATE_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SECRET_TEMPLATE_REGEX.exec(value)) !== null) {
+    secretNames.add(match[1]);
+  }
+
+  // No templates found — return as-is
+  if (secretNames.size === 0) {
+    return value;
+  }
+
+  // Resolve all unique secret names
+  const resolvedValues = new Map<string, string>();
+  for (const name of secretNames) {
+    resolvedValues.set(name, await secretStore.resolve(name));
+  }
+
+  // Replace all template expressions with resolved values
+  SECRET_TEMPLATE_REGEX.lastIndex = 0;
+  return value.replaceAll(SECRET_TEMPLATE_REGEX, (_fullMatch, secretName: string) => {
+    return resolvedValues.get(secretName)!;
+  });
 }

--- a/core/gitops-backend/src/sync/reconciler-delete.test.ts
+++ b/core/gitops-backend/src/sync/reconciler-delete.test.ts
@@ -42,6 +42,8 @@ describe("Kind delete reconciler wiring", () => {
           error: () => {},
         },
         resolveEntityRef: async () => undefined,
+        resolveSecretsBySchema: async <T>(params: { value: T }): Promise<{ resolved: T; warnings: string[] }> =>
+          ({ resolved: params.value, warnings: [] }),
       },
     });
 
@@ -105,6 +107,8 @@ describe("Kind delete reconciler wiring", () => {
             error: () => {},
           },
           resolveEntityRef: async () => undefined,
+          resolveSecretsBySchema: async <T>(params: { value: T }): Promise<{ resolved: T; warnings: string[] }> =>
+            ({ resolved: params.value, warnings: [] }),
         },
       }),
     ).rejects.toThrow("DB connection failed");

--- a/core/gitops-backend/src/sync/reconciler.ts
+++ b/core/gitops-backend/src/sync/reconciler.ts
@@ -1,11 +1,13 @@
 import type { Logger, SafeDatabase } from "@checkstack/backend-api";
 import type { EntityEnvelope } from "@checkstack/gitops-common";
+import { collectSecretNames } from "@checkstack/gitops-common";
+import { z } from "zod";
 import type { InternalEntityKindRegistry } from "../kind-registry";
 import type { SecretStore } from "../secret-resolver";
 import type { DiscoveredFile, Scraper, FetchFn } from "../scrapers/types";
 import { parseEntityDocuments } from "./document-parser";
 import { sortEntitiesByDependency, type CollectedEntity } from "./sort-entities";
-import { resolveSecrets } from "../secret-resolver";
+import { resolveSecretsBySchema } from "../secret-resolver";
 import * as schema from "../schema";
 import { eq, and } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
@@ -117,7 +119,8 @@ export async function reconcileProvider(
     for (const { entity, contentHash } of parseResult.entities) {
       const entityKey = `${entity.kind}::${entity.metadata.name}`;
       seenEntityKeys.add(entityKey);
-      collected.push({ entity, contentHash, file });
+      const secretRefs = collectSecretNames({ value: entity.spec });
+      collected.push({ entity, contentHash, file, secretRefs });
     }
   }
 
@@ -125,13 +128,14 @@ export async function reconcileProvider(
   const sorted = sortEntitiesByDependency({ entities: collected });
 
   // 4. Reconcile in dependency order (provenance written immediately per entity)
-  for (const { entity, contentHash, file } of sorted) {
+  for (const { entity, contentHash, file, secretRefs } of sorted) {
     const entityKey = `${entity.kind}::${entity.metadata.name}`;
 
     try {
       await reconcileEntity({
         entity,
         contentHash,
+        secretRefs: secretRefs ?? [],
         file,
         providerId,
         db,
@@ -150,6 +154,7 @@ export async function reconcileProvider(
         entity,
         file,
         contentHash,
+        secretRefs: secretRefs ?? [],
         status: "error",
         errorMessage: String(error),
       });
@@ -179,6 +184,7 @@ export async function reconcileProvider(
 async function reconcileEntity(params: {
   entity: EntityEnvelope;
   contentHash: string;
+  secretRefs: string[];
   file: DiscoveredFile;
   providerId: string;
   db: Db;
@@ -190,6 +196,7 @@ async function reconcileEntity(params: {
   const {
     entity,
     contentHash,
+    secretRefs,
     file,
     providerId,
     db,
@@ -217,7 +224,25 @@ async function reconcileEntity(params: {
     return rows[0]?.entityId;
   };
 
-  const context = { logger, resolveEntityRef };
+  // Accumulates warnings from all resolveSecretsBySchema calls during this reconciliation
+  const reconcileWarnings: string[] = [];
+
+  const context = {
+    logger,
+    resolveEntityRef,
+    resolveSecretsBySchema: async <T>(params: {
+      value: T;
+      schema: z.ZodTypeAny;
+    }): Promise<{ resolved: T; warnings: string[] }> => {
+      const result = await resolveSecretsBySchema({
+        value: params.value as unknown,
+        schema: params.schema,
+        secretStore,
+      });
+      reconcileWarnings.push(...result.warnings);
+      return { resolved: result.resolved as T, warnings: result.warnings };
+    },
+  };
 
   // Look up registered kind
   const kindDef = kindRegistry.getKind({
@@ -244,6 +269,22 @@ async function reconcileEntity(params: {
     );
   }
 
+  // Reject secret templates in metadata (display fields must never contain secrets)
+  const metadataSecrets = collectSecretNames({ value: entity.metadata });
+  if (metadataSecrets.length > 0) {
+    throw new Error(
+      `Secret templates are not allowed in metadata fields (found: ${metadataSecrets.join(", ")}). ` +
+        `Secrets can only be referenced in the spec section.`,
+    );
+  }
+
+  // Validate all referenced secrets exist before reconciliation.
+  // This catches typos / missing secrets early even though resolution is deferred
+  // to when the plugin explicitly calls context.resolveSecretsBySchema().
+  for (const name of secretRefs) {
+    await secretStore.resolve(name);
+  }
+
   // Check provenance for diff
   const existingProvenance = await db
     .select()
@@ -263,15 +304,10 @@ async function reconcileEntity(params: {
     return;
   }
 
-  // Resolve secrets in the spec
-  const resolvedSpec = await resolveSecrets({
-    spec: entity.spec as Record<string, unknown>,
-    secretStore,
-  });
-
-  // Call base kind reconciler
+  // Call base kind reconciler with raw spec (secrets NOT pre-resolved).
+  // Plugins use context.resolveSecretsBySchema() to resolve specific fields.
   const reconcileResult = await kindDef.reconcile({
-    entity: { ...entity, spec: resolvedSpec },
+    entity: entity as typeof entity & { spec: Record<string, unknown> },
     existingEntityId: existing?.entityId ?? undefined,
     context,
   });
@@ -283,12 +319,12 @@ async function reconcileEntity(params: {
   });
 
   for (const ext of extensions) {
-    const extensionSpec = (resolvedSpec as Record<string, unknown>)[
+    const extensionSpec = (entity.spec as Record<string, unknown>)[
       ext.namespace
     ];
     if (extensionSpec !== undefined) {
       await ext.reconcile({
-        entity: { ...entity, spec: resolvedSpec },
+        entity,
         extensionSpec,
         entityId: reconcileResult.entityId,
         context,
@@ -303,8 +339,10 @@ async function reconcileEntity(params: {
     entity,
     file,
     contentHash,
+    secretRefs,
     entityId: reconcileResult.entityId,
     status: "synced",
+    warnings: reconcileWarnings,
   });
 
   if (existing) {
@@ -354,6 +392,8 @@ async function detectOrphans(params: {
                   // eslint-disable-next-line unicorn/no-useless-undefined
                   return undefined;
                 },
+                resolveSecretsBySchema: async <T>(params: { value: T; schema: z.ZodTypeAny }): Promise<{ resolved: T; warnings: string[] }> =>
+                  ({ resolved: params.value, warnings: [] }),
               },
             });
           } catch (deleteError) {
@@ -395,10 +435,13 @@ async function upsertProvenance(params: {
   entity: EntityEnvelope;
   file: DiscoveredFile;
   contentHash: string;
+  secretRefs: string[];
   /** Required for synced status. On error, may be omitted to preserve existing value. */
   entityId?: string;
   status: "synced" | "error";
   errorMessage?: string;
+  /** Warnings about unresolved secret templates in non-secret fields. */
+  warnings?: string[];
 }): Promise<void> {
   const {
     db,
@@ -406,9 +449,11 @@ async function upsertProvenance(params: {
     entity,
     file,
     contentHash,
+    secretRefs,
     entityId,
     status,
     errorMessage,
+    warnings,
   } = params;
   const existing = await db
     .select()
@@ -425,10 +470,12 @@ async function upsertProvenance(params: {
       .update(schema.provenance)
       .set({
         lastSyncHash: contentHash,
+        secretRefs,
         // Preserve existing entityId on error retries; update on successful reconcile
         ...(entityId ? { entityId } : {}),
         status,
         errorMessage: errorMessage ?? null, // eslint-disable-line unicorn/no-null
+        warnings: warnings ?? [],
         repository: file.repository,
         filePath: file.filePath,
         lastSyncedAt: new Date(),
@@ -453,8 +500,10 @@ async function upsertProvenance(params: {
     repository: file.repository,
     filePath: file.filePath,
     lastSyncHash: contentHash,
+    secretRefs,
     status,
     errorMessage: errorMessage ?? null, // eslint-disable-line unicorn/no-null
+    warnings: warnings ?? [],
   });
 }
 

--- a/core/gitops-backend/src/sync/sort-entities.ts
+++ b/core/gitops-backend/src/sync/sort-entities.ts
@@ -8,6 +8,8 @@ export interface CollectedEntity {
   entity: EntityEnvelope;
   contentHash: string;
   file: DiscoveredFile;
+  /** Secret names referenced via ${{ secrets.NAME }} in this entity's spec. */
+  secretRefs?: string[];
 }
 
 // ─── Topological Sort ──────────────────────────────────────────────────────

--- a/core/gitops-common/src/access.ts
+++ b/core/gitops-common/src/access.ts
@@ -15,7 +15,7 @@ export const gitopsAccess = {
     },
   }),
 
-  /** Secret management for secretRef values. */
+  /** Secret management for ${{ secrets.NAME }} template values. */
   secret: accessPair("secret", {
     read: {
       description: "View secret names (not values)",

--- a/core/gitops-common/src/entity-kind-registry.ts
+++ b/core/gitops-common/src/entity-kind-registry.ts
@@ -25,6 +25,32 @@ export interface ReconcileContext {
     kind: string;
     entityName: string;
   }) => Promise<string | undefined>;
+  /**
+   * Schema-driven secret resolution.
+   *
+   * Walks the provided Zod schema to find fields annotated with
+   * `configString({ "x-secret": true })`, then resolves `${{ secrets.NAME }}`
+   * templates **only** in those fields. Non-secret fields are returned as-is.
+   *
+   * Returns warnings for any templates found in non-secret fields — these
+   * templates will NOT be resolved and should be surfaced to the user.
+   *
+   * Use the plugin's actual typed schema (e.g., the strategy config schema)
+   * rather than the generic GitOps spec schema — the typed schema carries the
+   * `x-secret` annotations.
+   *
+   * @example
+   * ```typescript
+   * const { resolved, warnings } = await context.resolveSecretsBySchema({
+   *   value: entity.spec.config,
+   *   schema: strategy.config.schema,
+   * });
+   * ```
+   */
+  resolveSecretsBySchema: <T>(params: {
+    value: T;
+    schema: z.ZodTypeAny;
+  }) => Promise<{ resolved: T; warnings: string[] }>;
 }
 
 /**
@@ -43,7 +69,7 @@ export interface EntityKindDefinition<TSpec = unknown> {
 
   /**
    * Called when an entity of this kind is discovered or updated via GitOps.
-   * The entity's spec is fully validated and all secretRef values are resolved.
+   * The entity's spec is fully validated and all `${{ secrets.NAME }}` templates are resolved.
    *
    * Must return the plugin-specific entity ID (e.g., the catalog system UUID).
    * The reconciler engine stores this in provenance for generic frontend lookups.

--- a/core/gitops-common/src/index.ts
+++ b/core/gitops-common/src/index.ts
@@ -7,11 +7,11 @@ export {
   type EntityMetadata,
 } from "./entity-envelope";
 export {
-  secretField,
-  secretRefSchema,
-  isSecretRef,
-  type SecretRef,
-  type ResolvedSecretField,
+  SECRET_NAME_REGEX,
+  SECRET_TEMPLATE_REGEX,
+  secretNameSchema,
+  secretTemplateSchema,
+  collectSecretNames,
 } from "./secret-field";
 export {
   entityRefSchema,

--- a/core/gitops-common/src/provenance-types.ts
+++ b/core/gitops-common/src/provenance-types.ts
@@ -19,6 +19,8 @@ export const provenanceSchema = z.object({
   lastSyncHash: z.string(),
   status: provenanceStatusSchema,
   errorMessage: z.string().nullable(),
+  /** Warnings about unresolved secret templates in non-secret fields. */
+  warnings: z.array(z.string()),
   lastSyncedAt: z.date(),
   createdAt: z.date(),
 });

--- a/core/gitops-common/src/rpc-contract.ts
+++ b/core/gitops-common/src/rpc-contract.ts
@@ -6,6 +6,7 @@ import {
   provenanceStatusSchema,
   deletionPolicySchema,
 } from "./provenance-types";
+import { secretNameSchema } from "./secret-field";
 import { z } from "zod";
 
 export const gitopsContract = {
@@ -175,7 +176,7 @@ export const gitopsContract = {
   })
     .input(
       z.object({
-        name: z.string().min(1).max(63),
+        name: secretNameSchema,
         value: z.string().min(1),
         description: z.string().optional(),
       }),
@@ -217,6 +218,24 @@ export const gitopsContract = {
   })
     .input(z.object({ name: z.string() }))
     .output(z.object({ value: z.string() })),
+
+  /** Look up which entities reference a given secret. */
+  getSecretUsage: proc({
+    operationType: "query",
+    userType: "authenticated",
+    access: [gitopsAccess.secret.read],
+  })
+    .input(z.object({ secretName: z.string() }))
+    .output(
+      z.array(
+        z.object({
+          kind: z.string(),
+          entityName: z.string(),
+          repository: z.string(),
+          filePath: z.string(),
+        }),
+      ),
+    ),
 
   // ═══════════════════════════════════════════════════════════════════════════
   // KIND REGISTRY (browsing)

--- a/core/gitops-common/src/secret-field.test.ts
+++ b/core/gitops-common/src/secret-field.test.ts
@@ -1,50 +1,168 @@
 import { describe, it, expect } from "bun:test";
-import { secretField, isSecretRef, type SecretRef } from "./secret-field";
+import {
+  SECRET_TEMPLATE_REGEX,
+  secretNameSchema,
+  collectSecretNames,
+  secretTemplateSchema,
+} from "./secret-field";
 
-describe("secretField", () => {
-  const schema = secretField();
-
-  it("accepts a plain string value", () => {
-    const result = schema.safeParse("my-password");
-    expect(result.success).toBe(true);
-    if (result.success) expect(result.data).toBe("my-password");
+describe("SECRET_TEMPLATE_REGEX", () => {
+  it("matches a simple secret template", () => {
+    SECRET_TEMPLATE_REGEX.lastIndex = 0;
+    const match = SECRET_TEMPLATE_REGEX.exec("${{ secrets.DB_PASS }}");
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("DB_PASS");
   });
 
-  it("accepts a secretRef object", () => {
-    const result = schema.safeParse({ secretRef: "prod-db-password" });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toEqual({ secretRef: "prod-db-password" });
+  it("matches templates with extra whitespace", () => {
+    SECRET_TEMPLATE_REGEX.lastIndex = 0;
+    const match = SECRET_TEMPLATE_REGEX.exec("${{  secrets.MY_KEY  }}");
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("MY_KEY");
+  });
+
+  it("matches hyphenated secret names", () => {
+    SECRET_TEMPLATE_REGEX.lastIndex = 0;
+    const match = SECRET_TEMPLATE_REGEX.exec("${{ secrets.prod-db-pass }}");
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("prod-db-pass");
+  });
+
+  it("matches multiple templates in one string", () => {
+    const str =
+      "postgres://${{ secrets.DB_USER }}:${{ secrets.DB_PASS }}@host/db";
+    const matches: string[] = [];
+    SECRET_TEMPLATE_REGEX.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = SECRET_TEMPLATE_REGEX.exec(str)) !== null) {
+      matches.push(match[1]);
     }
+    expect(matches).toEqual(["DB_USER", "DB_PASS"]);
   });
 
-  it("rejects a number", () => {
-    const result = schema.safeParse(42);
-    expect(result.success).toBe(false);
+  it("does not match plain strings", () => {
+    SECRET_TEMPLATE_REGEX.lastIndex = 0;
+    expect(SECRET_TEMPLATE_REGEX.exec("just a string")).toBeNull();
   });
 
-  it("rejects an object without secretRef", () => {
-    const result = schema.safeParse({ key: "value" });
-    expect(result.success).toBe(false);
+  it("does not match malformed templates", () => {
+    SECRET_TEMPLATE_REGEX.lastIndex = 0;
+    expect(SECRET_TEMPLATE_REGEX.exec("${ secrets.WRONG }")).toBeNull();
+    SECRET_TEMPLATE_REGEX.lastIndex = 0;
+    expect(SECRET_TEMPLATE_REGEX.exec("${{ notSecrets.WRONG }}")).toBeNull();
+  });
+});
+
+describe("secretTemplateSchema", () => {
+  it("accepts a valid template string", () => {
+    const result = secretTemplateSchema.safeParse("${{ secrets.MY_SECRET }}");
+    expect(result.success).toBe(true);
   });
 
-  it("rejects secretRef with empty name", () => {
-    const result = schema.safeParse({ secretRef: "" });
+  it("rejects a plain string without template", () => {
+    const result = secretTemplateSchema.safeParse("just-a-string");
     expect(result.success).toBe(false);
   });
 });
 
-describe("isSecretRef", () => {
-  it("returns true for a SecretRef object", () => {
-    const ref: SecretRef = { secretRef: "my-secret" };
-    expect(isSecretRef(ref)).toBe(true);
+describe("collectSecretNames", () => {
+  it("extracts a single secret from a top-level string", () => {
+    const result = collectSecretNames({
+      value: { password: "${{ secrets.DB_PASS }}" },
+    });
+    expect(result).toEqual(["DB_PASS"]);
   });
 
-  it("returns false for a plain string", () => {
-    expect(isSecretRef("plain")).toBe(false);
+  it("returns empty array when no secrets are referenced", () => {
+    const result = collectSecretNames({
+      value: { host: "localhost", port: 5432 },
+    });
+    expect(result).toEqual([]);
   });
 
-  it("returns false for null", () => {
-    expect(isSecretRef(null)).toBe(false);
+  it("extracts secrets from nested objects", () => {
+    const result = collectSecretNames({
+      value: {
+        connection: {
+          host: "db.internal",
+          password: "${{ secrets.NESTED_PASS }}",
+        },
+      },
+    });
+    expect(result).toEqual(["NESTED_PASS"]);
+  });
+
+  it("extracts secrets from arrays", () => {
+    const result = collectSecretNames({
+      value: {
+        credentials: [
+          { name: "db", secret: "${{ secrets.DB_PASS }}" },
+          { name: "api", secret: "${{ secrets.API_KEY }}" },
+        ],
+      },
+    });
+    expect(result).toEqual(["DB_PASS", "API_KEY"]);
+  });
+
+  it("extracts multiple secrets from a single interpolated string", () => {
+    const result = collectSecretNames({
+      value: {
+        url: "postgres://${{ secrets.DB_USER }}:${{ secrets.DB_PASS }}@host/db",
+      },
+    });
+    expect(result).toEqual(["DB_USER", "DB_PASS"]);
+  });
+
+  it("deduplicates secret names", () => {
+    const result = collectSecretNames({
+      value: {
+        primary: "${{ secrets.SHARED }}",
+        secondary: "${{ secrets.SHARED }}",
+      },
+    });
+    expect(result).toEqual(["SHARED"]);
+  });
+
+  it("handles null and undefined values gracefully", () => {
+    const result = collectSecretNames({
+      value: { a: null, b: undefined, c: "${{ secrets.VALID }}" },
+    });
+    expect(result).toEqual(["VALID"]);
+  });
+
+  it("ignores non-string primitives", () => {
+    const result = collectSecretNames({
+      value: { num: 42, bool: true, str: "${{ secrets.ONLY_THIS }}" },
+    });
+    expect(result).toEqual(["ONLY_THIS"]);
+  });
+});
+
+describe("secretNameSchema", () => {
+  it.each(["DB_PASS", "my-secret", "ApiKey123", "a", "prod_db_pass_v2"])("accepts valid name: %s", (name) => {
+    expect(secretNameSchema.safeParse(name).success).toBe(true);
+  });
+
+  it.each([
+    "has space",
+    "has\ttab",
+    "123starts-with-digit",
+    "has.dot",
+    "no@special",
+    "no/slashes",
+    "${{ secrets.NOPE }}",
+    "",
+  ])("rejects invalid name: %s", (name) => {
+    expect(secretNameSchema.safeParse(name).success).toBe(false);
+  });
+
+  it("rejects names exceeding 63 characters", () => {
+    const longName = "A".repeat(64);
+    expect(secretNameSchema.safeParse(longName).success).toBe(false);
+  });
+
+  it("accepts names at the 63-character limit", () => {
+    const maxName = "A".repeat(63);
+    expect(secretNameSchema.safeParse(maxName).success).toBe(true);
   });
 });

--- a/core/gitops-common/src/secret-field.ts
+++ b/core/gitops-common/src/secret-field.ts
@@ -1,47 +1,82 @@
 import { z } from "zod";
 
 /**
- * Schema for a secret reference object.
- * Used in YAML descriptors to reference secrets stored in the Checkstack secret store.
+ * Valid characters for a secret name: letters, digits, underscores, and hyphens.
+ * This must stay in sync with the capture group in {@link SECRET_TEMPLATE_REGEX}.
  */
-export const secretRefSchema = z.object({
-  secretRef: z.string().min(1, "Secret reference name must not be empty"),
-});
-
-export type SecretRef = z.infer<typeof secretRefSchema>;
+export const SECRET_NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
 
 /**
- * Type guard to check if a value is a SecretRef object.
+ * Zod schema for validating secret names at creation time.
+ * Ensures the name can be referenced via `${{ secrets.NAME }}`.
  */
-export function isSecretRef(value: unknown): value is SecretRef {
-  if (value === null || value === undefined || typeof value !== "object") {
-    return false;
-  }
-  return (
-    "secretRef" in value &&
-    typeof (value as SecretRef).secretRef === "string"
+export const secretNameSchema = z
+  .string()
+  .min(1)
+  .max(63)
+  .regex(
+    SECRET_NAME_REGEX,
+    "Secret names must start with a letter and contain only letters, digits, underscores, or hyphens",
   );
-}
 
 /**
- * Creates a Zod schema for fields that accept either a plain string or a secret reference.
+ * Regex matching ${{ secrets.NAME }} template expressions in strings.
+ * Captures the secret name in group 1.
+ * Supports multiple occurrences within a single string value.
  *
- * In YAML descriptors, users can write either:
- * ```yaml
- * password: "dev-password"              # plain string
- * password:
- *   secretRef: production-db-creds      # reference to secret store
- * ```
- *
- * The GitOps reconciliation engine resolves all secretRef values before calling
- * plugin reconcilers, so plugins always receive plain strings.
+ * @example
+ * "${{ secrets.DB_PASS }}" → captures "DB_PASS"
+ * "postgres://u:${{ secrets.PASS }}@${{ secrets.HOST }}/db" → captures "PASS", "HOST"
  */
-export function secretField() {
-  return z.union([z.string(), secretRefSchema]);
-}
+export const SECRET_TEMPLATE_REGEX =
+  /\$\{\{\s*secrets\.([a-zA-Z0-9_-]+)\s*\}\}/g;
 
 /**
- * The resolved type of a secret field is always a string.
- * After the reconciliation engine resolves secretRefs, all values are plain strings.
+ * Zod schema for validating secret template strings.
+ * Matches strings containing at least one ${{ secrets.NAME }} pattern.
  */
-export type ResolvedSecretField = string;
+export const secretTemplateSchema = z.string().regex(
+  /\$\{\{\s*secrets\.[a-zA-Z0-9_-]+\s*\}\}/,
+  "Must contain a ${{ secrets.NAME }} reference",
+);
+
+/**
+ * Recursively walks a value and collects all unique secret names
+ * referenced via ${{ secrets.NAME }} patterns in string values.
+ *
+ * @returns Deduplicated array of secret names found in the value tree
+ */
+export function collectSecretNames(params: { value: unknown }): string[] {
+  const names = new Set<string>();
+  collectFromValue(params.value, names);
+  return [...names];
+}
+
+function collectFromValue(value: unknown, names: Set<string>): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+
+  if (typeof value === "string") {
+    // Reset regex lastIndex for safe reuse (global flag)
+    SECRET_TEMPLATE_REGEX.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = SECRET_TEMPLATE_REGEX.exec(value)) !== null) {
+      names.add(match[1]);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectFromValue(item, names);
+    }
+    return;
+  }
+
+  if (typeof value === "object") {
+    for (const val of Object.values(value)) {
+      collectFromValue(val, names);
+    }
+  }
+}

--- a/core/gitops-frontend/src/components/ProvenanceStatus.tsx
+++ b/core/gitops-frontend/src/components/ProvenanceStatus.tsx
@@ -61,6 +61,9 @@ export const ProvenanceStatus = () => {
   const synced = entries.filter((e) => e.status === "synced");
   const errors = entries.filter((e) => e.status === "error");
   const orphaned = entries.filter((e) => e.status === "orphaned");
+  const withWarnings = entries.filter(
+    (e) => e.warnings.length > 0 && e.status === "synced",
+  );
 
   const statusIcon = (status: Provenance["status"]) => {
     switch (status) {
@@ -107,6 +110,19 @@ export const ProvenanceStatus = () => {
                   {entry.errorMessage}
                 </div>
               )}
+              {entry.warnings.length > 0 && (
+                <div className="mt-1 space-y-0.5">
+                  {entry.warnings.map((warning, index) => (
+                    <div
+                      key={index}
+                      className="text-xs text-amber-500 flex items-start gap-1"
+                    >
+                      <AlertTriangle className="w-3 h-3 shrink-0 mt-0.5" />
+                      <span className="truncate">{warning}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
 
@@ -148,7 +164,7 @@ export const ProvenanceStatus = () => {
     <>
       <div className="space-y-6">
         {/* Summary */}
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-4 gap-4">
           <Card>
             <CardContent className="pt-6">
               <div className="flex items-center gap-2">
@@ -176,6 +192,15 @@ export const ProvenanceStatus = () => {
               </div>
             </CardContent>
           </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="w-5 h-5 text-amber-500" />
+                <span className="text-2xl font-bold">{withWarnings.length}</span>
+                <span className="text-sm text-muted-foreground">Warnings</span>
+              </div>
+            </CardContent>
+          </Card>
         </div>
 
         {/* Orphaned entities — shown first if any */}
@@ -193,6 +218,22 @@ export const ProvenanceStatus = () => {
               </p>
             </CardHeader>
             <CardContent>{renderEntryList(orphaned, true)}</CardContent>
+          </Card>
+        )}
+
+        {/* Warnings */}
+        {withWarnings.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <AlertTriangle className="w-5 h-5 text-amber-500" />
+                Sync Warnings
+              </CardTitle>
+              <p className="text-xs text-muted-foreground mt-1">
+                These entities contain secret templates in non-secret fields. The templates will not be resolved.
+              </p>
+            </CardHeader>
+            <CardContent>{renderEntryList(withWarnings, false)}</CardContent>
           </Card>
         )}
 

--- a/core/gitops-frontend/src/components/SecretEditor.tsx
+++ b/core/gitops-frontend/src/components/SecretEditor.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@checkstack/ui";
+import { SECRET_NAME_REGEX } from "@checkstack/gitops-common";
 
 interface SecretEditorProps {
   open: boolean;
@@ -34,9 +35,18 @@ export const SecretEditor: React.FC<SecretEditorProps> = ({
     }
   }, [open]);
 
+  const nameError =
+    name.length > 0 && !SECRET_NAME_REGEX.test(name)
+      ? "Must start with a letter and contain only letters, digits, underscores, or hyphens"
+      : name.length > 63
+        ? "Must be 63 characters or fewer"
+        : undefined;
+
+  const canSubmit = name.trim().length > 0 && !nameError && value.trim().length > 0;
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim() || !value.trim()) return;
+    if (!canSubmit) return;
 
     onSave({
       name: name.trim(),
@@ -64,12 +74,16 @@ export const SecretEditor: React.FC<SecretEditorProps> = ({
                 placeholder="e.g. GITHUB_TOKEN"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="font-mono"
+                className={`font-mono ${nameError ? "border-destructive" : ""}`}
                 required
               />
-              <p className="text-xs text-muted-foreground">
-                Referenced as <code className="text-xs">{"${{ secrets.NAME }}"}</code> in descriptors.
-              </p>
+              {nameError ? (
+                <p className="text-xs text-destructive">{nameError}</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Referenced as <code className="text-xs">{"${{ secrets.NAME }}"}</code> in descriptors.
+                </p>
+              )}
             </div>
 
             <div className="space-y-2">
@@ -99,7 +113,7 @@ export const SecretEditor: React.FC<SecretEditorProps> = ({
             <Button type="button" variant="outline" onClick={onClose}>
               Cancel
             </Button>
-            <Button type="submit" disabled={!name.trim() || !value.trim()}>
+            <Button type="submit" disabled={!canSubmit}>
               Create Secret
             </Button>
           </DialogFooter>
@@ -108,3 +122,4 @@ export const SecretEditor: React.FC<SecretEditorProps> = ({
     </Dialog>
   );
 };
+

--- a/core/gitops-frontend/src/components/SecretList.tsx
+++ b/core/gitops-frontend/src/components/SecretList.tsx
@@ -15,13 +15,55 @@ import {
   EmptyState,
   ConfirmationModal,
   useToast,
+  Badge,
 } from "@checkstack/ui";
-import { Plus, RotateCw, Trash2, KeyRound } from "lucide-react";
+import { Plus, RotateCw, Trash2, KeyRound, ChevronDown, ChevronRight } from "lucide-react";
 import { extractErrorMessage } from "@checkstack/common";
 import { SecretEditor } from "./SecretEditor";
 import { SecretRotateDialog } from "./SecretRotateDialog";
 
 const formatDate = (date: Date) => new Date(date).toLocaleString();
+
+/** Expandable usage panel for a single secret. */
+const SecretUsagePanel = ({ secretName }: { secretName: string }) => {
+  const client = usePluginClient(GitOpsApi);
+  const { data: usage, isLoading } = client.getSecretUsage.useQuery({
+    secretName,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="text-xs text-muted-foreground py-2 px-4">Loading…</div>
+    );
+  }
+
+  if (!usage || usage.length === 0) {
+    return (
+      <div className="text-xs text-muted-foreground py-2 px-4">
+        Not referenced by any entities.
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 pb-3 space-y-1">
+      {usage.map((entry) => (
+        <div
+          key={`${entry.kind}::${entry.entityName}`}
+          className="flex items-center gap-2 text-xs text-muted-foreground"
+        >
+          <Badge variant="outline" className="text-[10px] font-mono px-1.5 py-0">
+            {entry.kind}
+          </Badge>
+          <span className="font-medium text-foreground">{entry.entityName}</span>
+          <span className="hidden sm:inline truncate">
+            {entry.repository}/{entry.filePath}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
 
 export const SecretList = () => {
   const client = usePluginClient(GitOpsApi);
@@ -42,6 +84,9 @@ export const SecretList = () => {
     secretId: string;
     secretName: string;
   }>({ isOpen: false, secretId: "", secretName: "" });
+  const [expandedSecrets, setExpandedSecrets] = useState<Set<string>>(
+    new Set(),
+  );
 
   const { data: secrets, isLoading, refetch } = client.listSecrets.useQuery({});
 
@@ -78,6 +123,18 @@ export const SecretList = () => {
     },
   });
 
+  const toggleExpanded = (secretId: string) => {
+    setExpandedSecrets((prev) => {
+      const next = new Set(prev);
+      if (next.has(secretId)) {
+        next.delete(secretId);
+      } else {
+        next.add(secretId);
+      }
+      return next;
+    });
+  };
+
   return (
     <>
       <Card>
@@ -108,64 +165,83 @@ export const SecretList = () => {
             />
           ) : (
             <div className="space-y-3">
-              {secrets.map((secret) => (
-                <div
-                  key={secret.id}
-                  className="flex items-center justify-between p-4 rounded-lg border border-border bg-background/50 hover:bg-background/80 transition-colors"
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <KeyRound className="w-4 h-4 text-muted-foreground shrink-0" />
-                    <div className="min-w-0">
-                      <div className="font-medium font-mono text-sm">
-                        {secret.name}
-                      </div>
-                      {secret.description && (
-                        <div className="text-xs text-muted-foreground mt-0.5 truncate">
-                          {secret.description}
+              {secrets.map((secret) => {
+                const isExpanded = expandedSecrets.has(secret.id);
+                return (
+                  <div
+                    key={secret.id}
+                    className="rounded-lg border border-border bg-background/50 hover:bg-background/80 transition-colors"
+                  >
+                    <div className="flex items-center justify-between p-4">
+                      <button
+                        type="button"
+                        className="flex items-center gap-3 min-w-0 cursor-pointer bg-transparent border-none p-0 text-left"
+                        onClick={() => toggleExpanded(secret.id)}
+                        title={isExpanded ? "Hide usage" : "Show usage"}
+                      >
+                        {isExpanded ? (
+                          <ChevronDown className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                        ) : (
+                          <ChevronRight className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                        )}
+                        <KeyRound className="w-4 h-4 text-muted-foreground shrink-0" />
+                        <div className="min-w-0">
+                          <div className="font-medium font-mono text-sm">
+                            {secret.name}
+                          </div>
+                          {secret.description && (
+                            <div className="text-xs text-muted-foreground mt-0.5 truncate">
+                              {secret.description}
+                            </div>
+                          )}
                         </div>
-                      )}
-                    </div>
-                  </div>
+                      </button>
 
-                  <div className="flex items-center gap-4 shrink-0">
-                    <div className="text-right text-xs text-muted-foreground hidden md:block">
-                      <div>Updated: {formatDate(secret.updatedAt)}</div>
-                    </div>
+                      <div className="flex items-center gap-4 shrink-0">
+                        <div className="text-right text-xs text-muted-foreground hidden md:block">
+                          <div>Updated: {formatDate(secret.updatedAt)}</div>
+                        </div>
 
-                    {canManage && (
-                      <div className="flex items-center gap-1">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() =>
-                            setRotatingSecret({
-                              id: secret.id,
-                              name: secret.name,
-                            })
-                          }
-                          title="Rotate secret"
-                        >
-                          <RotateCw className="w-4 h-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() =>
-                            setConfirmModal({
-                              isOpen: true,
-                              secretId: secret.id,
-                              secretName: secret.name,
-                            })
-                          }
-                          title="Delete secret"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
+                        {canManage && (
+                          <div className="flex items-center gap-1">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() =>
+                                setRotatingSecret({
+                                  id: secret.id,
+                                  name: secret.name,
+                                })
+                              }
+                              title="Rotate secret"
+                            >
+                              <RotateCw className="w-4 h-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() =>
+                                setConfirmModal({
+                                  isOpen: true,
+                                  secretId: secret.id,
+                                  secretName: secret.name,
+                                })
+                              }
+                              title="Delete secret"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </Button>
+                          </div>
+                        )}
                       </div>
+                    </div>
+
+                    {isExpanded && (
+                      <SecretUsagePanel secretName={secret.name} />
                     )}
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </CardContent>

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
@@ -191,6 +191,8 @@ const mockContext: ReconcileContext = {
     error: () => {},
   },
   resolveEntityRef: async () => undefined,
+  resolveSecretsBySchema: async <T>(params: { value: T }): Promise<{ resolved: T; warnings: string[] }> =>
+    ({ resolved: params.value, warnings: [] }),
 };
 
 // ─── Tests: kind: Healthcheck ──────────────────────────────────────────────
@@ -592,5 +594,113 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
     });
 
     expect(mockService.associateSystem).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Tests: Secret template resolution in healthcheck configs ──────────────
+
+describe("Healthcheck GitOps: Secret template resolution", () => {
+  it("collectSecretNames extracts secrets from healthcheck config", async () => {
+    const { collectSecretNames } = await import("@checkstack/gitops-common");
+
+    const spec = {
+      strategy: "postgres",
+      intervalSeconds: 30,
+      config: {
+        host: "db.internal",
+        port: 5432,
+        database: "payments",
+        user: "monitor",
+        password: "${{ secrets.DB_PASS }}",
+      },
+    };
+
+    const names = collectSecretNames({ value: spec });
+    expect(names).toEqual(["DB_PASS"]);
+  });
+
+  it("collectSecretNames extracts multiple secrets from config", async () => {
+    const { collectSecretNames } = await import("@checkstack/gitops-common");
+
+    const spec = {
+      strategy: "postgres",
+      intervalSeconds: 30,
+      config: {
+        host: "db.internal",
+        user: "${{ secrets.DB_USER }}",
+        password: "${{ secrets.DB_PASS }}",
+      },
+    };
+
+    const names = collectSecretNames({ value: spec });
+    expect(names).toContain("DB_USER");
+    expect(names).toContain("DB_PASS");
+    expect(names).toHaveLength(2);
+  });
+
+  it("collectSecretNames handles inline interpolation in config values", async () => {
+    const { collectSecretNames } = await import("@checkstack/gitops-common");
+
+    const spec = {
+      strategy: "postgres",
+      intervalSeconds: 30,
+      config: {
+        connectionString:
+          "postgres://${{ secrets.DB_USER }}:${{ secrets.DB_PASS }}@host/db",
+      },
+    };
+
+    const names = collectSecretNames({ value: spec });
+    expect(names).toContain("DB_USER");
+    expect(names).toContain("DB_PASS");
+  });
+
+  it("SECRET_TEMPLATE_REGEX correctly identifies templates in healthcheck config values", async () => {
+    const { SECRET_TEMPLATE_REGEX } = await import("@checkstack/gitops-common");
+
+    const configValues = [
+      { input: "${{ secrets.DB_PASS }}", expectedSecrets: ["DB_PASS"] },
+      { input: "db-${{ secrets.ENV }}.internal", expectedSecrets: ["ENV"] },
+      {
+        input:
+          "postgres://${{ secrets.DB_USER }}:${{ secrets.DB_PASS }}@host/db",
+        expectedSecrets: ["DB_USER", "DB_PASS"],
+      },
+      { input: "plain-value", expectedSecrets: [] },
+    ];
+
+    for (const { input, expectedSecrets } of configValues) {
+      const found: string[] = [];
+      SECRET_TEMPLATE_REGEX.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = SECRET_TEMPLATE_REGEX.exec(input)) !== null) {
+        found.push(match[1]);
+      }
+      expect(found).toEqual(expectedSecrets);
+    }
+  });
+
+  it("template replacement produces expected resolved config", () => {
+    // Simulates what the reconciler does: replace ${{ secrets.X }} with values
+    const secrets: Record<string, string> = {
+      DB_PASS: "production-password-123",
+      ENV: "production",
+    };
+
+    const rawConfig: Record<string, string> = {
+      host: "db-${{ secrets.ENV }}.internal",
+      password: "${{ secrets.DB_PASS }}",
+    };
+
+    const resolvedConfig: Record<string, string> = {};
+    for (const [key, value] of Object.entries(rawConfig)) {
+      resolvedConfig[key] = value.replaceAll(
+        /\$\{\{\s*secrets\.([a-zA-Z0-9_-]+)\s*\}\}/g,
+        (_match, secretName: string) => secrets[secretName] ?? _match,
+      );
+    }
+
+    expect(resolvedConfig.host).toBe("db-production.internal");
+    expect(resolvedConfig.password).toBe("production-password-123");
   });
 });

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
@@ -5,7 +5,7 @@ import type {
   EntityKindRegistry,
   ReconcileContext,
 } from "@checkstack/gitops-common";
-import { CHECKSTACK_API_VERSION, secretField, entityRefSchema } from "@checkstack/gitops-common";
+import { CHECKSTACK_API_VERSION, entityRefSchema } from "@checkstack/gitops-common";
 import type {
   HealthCheckRegistry,
   CollectorRegistry,
@@ -29,13 +29,13 @@ interface HealthcheckGitOpsKindsDeps {
 /**
  * GitOps spec schema for kind: Healthcheck.
  *
- * Strategy `config` fields use `secretField()` for sensitive values
- * (passwords, tokens) that are resolved by the reconciliation engine.
+ * Strategy `config` values may contain `${{ secrets.NAME }}` templates
+ * which are automatically resolved by the reconciliation engine.
  */
 const healthcheckSpecSchema = z.object({
   strategy: z.string().min(1),
   intervalSeconds: z.number().int().min(1),
-  config: z.record(z.string(), z.union([z.unknown(), secretField()])),
+  config: z.record(z.string(), z.unknown()),
   collectors: z
     .array(
       z.object({
@@ -104,7 +104,7 @@ export function buildHealthcheckKind(
       const service = deps.createService();
       const spec = entity.spec;
 
-      // Validate strategy exists in registry
+      // Look up strategy first — we need its typed schema for secret resolution
       const healthCheckRegistry = deps.getHealthCheckRegistry();
       const strategy = healthCheckRegistry.getStrategy(spec.strategy);
       if (!strategy) {
@@ -114,36 +114,52 @@ export function buildHealthcheckKind(
         );
       }
 
-      // Validate config against strategy's Zod schema
-      const configValidation = strategy.config.schema.safeParse(spec.config);
+      // Resolve secrets using the strategy's typed schema.
+      // Only fields marked with configString({ "x-secret": true }) get resolved.
+      const { resolved: resolvedConfig } = await context.resolveSecretsBySchema({
+        value: spec.config,
+        schema: strategy.config.schema,
+      });
+
+      // Validate resolved config against strategy's Zod schema
+      const configValidation = strategy.config.schema.safeParse(resolvedConfig);
       if (!configValidation.success) {
         throw new Error(
           `Strategy "${spec.strategy}" config validation failed: ${configValidation.error.message}`,
         );
       }
 
-      // Validate collector configs against their registry schemas
-      if (spec.collectors) {
-        for (const collector of spec.collectors) {
-          const collectorReg = deps.getCollectorRegistry();
-          const registered = collectorReg.getCollector(
-            collector.collectorId,
-          );
-          if (!registered) {
-            throw new Error(
-              `Unknown collector "${collector.collectorId}". ` +
-                `Available: ${collectorReg.getCollectors().map((c) => c.qualifiedId).join(", ")}`,
-            );
-          }
-          const collectorConfigValidation =
-            registered.collector.config.schema.safeParse(collector.config);
-          if (!collectorConfigValidation.success) {
-            throw new Error(
-              `Collector "${collector.collectorId}" config validation failed: ${collectorConfigValidation.error.message}`,
-            );
-          }
-        }
-      }
+      // Resolve and validate collector configs using their registry schemas
+      const resolvedCollectors = spec.collectors
+        ? await Promise.all(
+            spec.collectors.map(async (c) => {
+              const collectorReg = deps.getCollectorRegistry();
+              const registered = collectorReg.getCollector(c.collectorId);
+              if (!registered) {
+                throw new Error(
+                  `Unknown collector "${c.collectorId}". ` +
+                    `Available: ${collectorReg.getCollectors().map((col) => col.qualifiedId).join(", ")}`,
+                );
+              }
+
+              // Resolve secrets using the collector's typed schema
+              const { resolved: resolvedCollectorConfig } = await context.resolveSecretsBySchema({
+                value: c.config,
+                schema: registered.collector.config.schema,
+              });
+
+              const collectorConfigValidation =
+                registered.collector.config.schema.safeParse(resolvedCollectorConfig);
+              if (!collectorConfigValidation.success) {
+                throw new Error(
+                  `Collector "${c.collectorId}" config validation failed: ${collectorConfigValidation.error.message}`,
+                );
+              }
+
+              return { ...c, config: resolvedCollectorConfig };
+            }),
+          )
+        : undefined;
 
       // Create or update configuration
       const displayName = entity.metadata.title ?? entity.metadata.name;
@@ -152,9 +168,9 @@ export function buildHealthcheckKind(
         await service.updateConfiguration(existingEntityId, {
           name: displayName,
           strategyId: spec.strategy,
-          config: spec.config,
+          config: resolvedConfig,
           intervalSeconds: spec.intervalSeconds,
-          collectors: spec.collectors?.map((c) => ({
+          collectors: resolvedCollectors?.map((c) => ({
             id: c.collectorId,
             collectorId: c.collectorId,
             config: c.config,
@@ -170,9 +186,9 @@ export function buildHealthcheckKind(
       const config = await service.createConfiguration({
         name: displayName,
         strategyId: spec.strategy,
-        config: spec.config,
+        config: resolvedConfig,
         intervalSeconds: spec.intervalSeconds,
-        collectors: spec.collectors?.map((c) => ({
+        collectors: resolvedCollectors?.map((c) => ({
           id: c.collectorId,
           collectorId: c.collectorId,
           config: c.config,

--- a/docs/backend/gitops-entity-kinds.md
+++ b/docs/backend/gitops-entity-kinds.md
@@ -257,24 +257,38 @@ This enables:
 
 ### Secret References
 
-Use `secretField()` for sensitive values that should be resolved from the GitOps secret store:
+Use `${{ secrets.NAME }}` template syntax for sensitive values that should be resolved from the GitOps secret store:
 
 ```yaml
 spec:
   config:
-    password:
-      secretRef: my-database-password   # Resolved at reconcile time
+    password: "${{ secrets.my-database-password }}"
+    # Also supports inline interpolation:
+    connectionString: "postgres://user:${{ secrets.DB_PASS }}@host/db"
 ```
+
+Secret resolution is **schema-driven** — only fields marked with `configString({ "x-secret": true })` are resolved. This is the same annotation pattern used by DynamicForm for the admin UI:
 
 ```typescript
-import { secretField } from "@checkstack/gitops-common";
+import { configString } from "@checkstack/backend-api";
 
-const specSchema = z.object({
-  config: z.object({
-    password: z.union([z.string(), secretField()]),
-  }),
+const postgresConfigSchema = z.object({
+  host: configString({}).describe("Hostname"),
+  password: configString({ "x-secret": true }).describe("Database password"),
 });
 ```
+
+#### Security Model
+
+Secrets are **not pre-resolved** in the spec. Instead:
+
+1. **Validation**: All referenced secrets are validated to exist at sync time. Missing secrets cause the entity to error immediately.
+2. **Metadata guard**: Templates in `metadata` fields (`name`, `title`, `description`) are **rejected** to prevent secrets from leaking into display fields.
+3. **Schema-driven resolution**: The plugin reconciler calls `context.resolveSecretsBySchema()` with the **typed schema** (e.g., the strategy config schema). Only fields annotated with `x-secret` are resolved — everything else is returned as-is.
+
+This prevents a malicious actor from exfiltrating secrets via display fields or non-secret config fields.
+
+> **Secret rotation**: When a secret is rotated via the admin UI, all entities referencing that secret are automatically flagged for re-reconciliation on the next sync cycle.
 
 ## ReconcileContext
 
@@ -298,6 +312,33 @@ interface ReconcileContext {
     kind: string;
     entityName: string;
   }) => Promise<string | undefined>;
+
+  /**
+   * Schema-driven secret resolution. Walks the provided Zod schema,
+   * finds fields annotated with configString({ "x-secret": true }),
+   * and resolves ${{ secrets.NAME }} templates only in those fields.
+   */
+  resolveSecretsBySchema: <T>(params: {
+    value: T;
+    schema: z.ZodTypeAny;
+  }) => Promise<T>;
+}
+```
+
+**Usage in a reconciler:**
+
+```typescript
+reconcile: async ({ entity, context }) => {
+  // Look up the strategy to get its typed schema (with x-secret annotations)
+  const strategy = registry.getStrategy(entity.spec.strategy);
+
+  // Resolve secrets using the strategy's schema — only x-secret fields are resolved
+  const resolvedConfig = await context.resolveSecretsBySchema({
+    value: entity.spec.config,
+    schema: strategy.config.schema,
+  });
+
+  await createConfiguration({ config: resolvedConfig });
 }
 ```
 
@@ -350,10 +391,17 @@ kindRegistry.registerKind({
   specSchema: z.object({
     strategy: z.string().min(1),
     intervalSeconds: z.number().int().min(1),
-    config: z.record(z.string(), z.union([z.unknown(), secretField()])),
+    config: z.record(z.string(), z.unknown()),
   }),
-  reconcile: async ({ entity, existingEntityId }) => {
-    // Create or update health check config
+  reconcile: async ({ entity, existingEntityId, context }) => {
+    // Look up strategy — its typed schema carries x-secret annotations
+    const strategy = registry.getStrategy(entity.spec.strategy);
+
+    // Resolve secrets using the strategy's schema
+    const resolvedConfig = await context.resolveSecretsBySchema({
+      value: entity.spec.config,
+      schema: strategy.config.schema,
+    });
     return { entityId: configId };
   },
 });
@@ -412,8 +460,7 @@ spec:
     port: 5432
     database: payments
     user: monitor
-    password:
-      secretRef: payment-db-password
+    password: "${{ secrets.payment-db-password }}"
 ```
 
 ## Troubleshooting

--- a/docs/plans/2026-04-19-gitops-entity-system-design.md
+++ b/docs/plans/2026-04-19-gitops-entity-system-design.md
@@ -118,8 +118,7 @@ spec:
   system: payment-service          # references a System entity by name
   connection:
     host: db.internal
-    password:
-      secretRef: prod-db-pass
+    password: "${{ secrets.prod-db-pass }}"
 ---
 apiVersion: checkstack.io/v1alpha1
 kind: System
@@ -137,7 +136,7 @@ spec:
 
 ### Secret Store (`secret-backend`)
 
-A simple encrypted key-value store for secrets referenced in YAML descriptors via `secretRef`. Secrets are AES-256-GCM encrypted at rest, with the encryption key provided via environment variable.
+A simple encrypted key-value store for secrets referenced in YAML descriptors via `${{ secrets.NAME }}` template syntax. Secrets are AES-256-GCM encrypted at rest, with the encryption key provided via environment variable.
 
 ```typescript
 // secret-backend schema
@@ -153,53 +152,53 @@ export const secrets = pgTable("secrets", {
 });
 ```
 
-### `secretField()` Utility
+### `${{ secrets.NAME }}` Template Syntax
 
-A Zod utility for plugin authors to mark fields as secret-resolvable:
+Secrets can be referenced in any string field using template expressions:
 
-```typescript
-// gitops-common
-export function secretField() {
-  return z.union([
-    z.string(),
-    z.object({ secretRef: z.string() }),
-  ]);
-}
-```
-
-In YAML descriptors:
 ```yaml
-password: "dev-password"           # plain string (dev/testing)
-password:
-  secretRef: production-db-creds   # reference to secret store
+password: "dev-password"                           # plain string (dev/testing)
+password: "${{ secrets.production-db-creds }}"     # resolved from secret store
+connectionString: "postgres://user:${{ secrets.DB_PASS }}@host/db"  # inline interpolation
 ```
 
 ### Automatic Secret Resolution
 
-The GitOps reconciliation engine resolves all `secretRef` values **before** calling a plugin's reconciler. Plugin authors never handle secret resolution manually:
+The GitOps reconciliation engine resolves all `${{ secrets.NAME }}` templates **before** calling a plugin's reconciler. Plugin authors never handle secret resolution manually — just use `z.string()` or `z.unknown()`:
 
 ```typescript
 registry.registerKind({
   kind: "Healthcheck",
   specSchema: z.object({
-    connection: z.object({
-      host: z.string(),
-      password: secretField(),  // accepts string or { secretRef: "..." }
-    }),
+    strategy: z.string(),
+    config: z.record(z.string(), z.unknown()), // generic record
   }),
-  reconcile: async ({ entity }) => {
-    // entity.spec.connection.password is ALWAYS a plain string here
-    // secretRef was automatically resolved by the engine
+  reconcile: async ({ entity, context }) => {
+    // The generic specSchema doesn't carry x-secret annotations, but the
+    // strategy's typed schema does (e.g., password: configString({ "x-secret": true })).
+    const strategy = registry.getStrategy(entity.spec.strategy);
+    const resolvedConfig = await context.resolveSecretsBySchema({
+      value: entity.spec.config,
+      schema: strategy.config.schema, // typed schema with x-secret annotations
+    });
+    // resolvedConfig.password is now the actual secret value;
+    // non-secret fields are returned as-is
   },
 });
 ```
+
+> **Security**: Resolution is **schema-driven** — only fields annotated with `configString({ "x-secret": true })` are resolved. Templates in `metadata` fields are **rejected** at sync time. Secrets are never pre-resolved into the spec, preventing leaks through display fields like `description`.
+
+### Secret Rotation & Invalidation
+
+When a secret is rotated via the admin UI, all provenance entries referencing that secret are invalidated (their `lastSyncHash` is cleared). The next sync cycle will re-reconcile these entities with the new secret value. Referenced secret names are tracked as a Postgres `text[]` array on the provenance table.
 
 ### Provider Auth vs. Descriptor Secrets
 
 | Secret type | Storage mechanism |
 |---|---|
 | Provider auth tokens (GitHub/GitLab API) | DynamicForm secret fields (encrypted at rest, like notification strategies) |
-| Values referenced via `secretRef` in descriptors | Secret store (`secret-backend`) |
+| Values referenced via `${{ secrets.NAME }}` in descriptors | Secret store (`secret-backend`) |
 
 Provider configuration uses DynamicForm's built-in secret field support, consistent with how auth strategies and notification strategies already work.
 
@@ -237,19 +236,19 @@ Each provider type has a scraper implementation:
 Runs as a recurring queue job (using the existing `queueManager`):
 
 ```
-┌─────────────────────────────────────────────────────┐
-│  Sync Cycle (per provider, on configured interval)  │
-├─────────────────────────────────────────────────────┤
-│ 1. Scrape: Discover YAML files from git provider    │
-│ 2. Parse: YAML → entity envelopes (multi-doc aware) │
-│ 3. Validate: envelope + merged kind spec schema     │
-│ 4. Resolve: secretField() values from secret store  │
-│ 5. Diff: Compare against provenance table           │
-│    • New entity → call kind reconciler (create)     │
-│    • Changed entity → call kind reconciler (update) │
-│    • Missing entity → orphan or delete (per policy) │
-│ 6. Update provenance table with sync state          │
-└─────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│  Sync Cycle (per provider, on configured interval)   │
+├──────────────────────────────────────────────────────┤
+│ 1. Scrape: Discover YAML files from git provider     │
+│ 2. Parse: YAML → entity envelopes (multi-doc aware)  │
+│ 3. Validate: envelope + merged kind spec schema      │
+│ 4. Resolve: ${{ secrets.NAME }} templates from store │
+│ 5. Diff: Compare against provenance table            │
+│    • New entity → call kind reconciler (create)      │
+│    • Changed entity → call kind reconciler (update)  │
+│    • Missing entity → orphan or delete (per policy)  │
+│ 6. Update provenance table with sync state           │
+└──────────────────────────────────────────────────────┘
 ```
 
 **Diffing** uses a content hash of the raw YAML per entity. If the hash matches the provenance table's `lastSyncHash`, reconciliation is skipped.
@@ -300,7 +299,7 @@ Configurable per provider:
 ### GitOps Settings Page (Admin)
 
 - **Providers tab**: Add/edit/remove GitOps providers using DynamicForm (type, target, path pattern, sync interval, deletion policy, auth token)
-- **Secrets tab**: Manage named secrets for `secretRef` usage in descriptors (create, view names, rotate values — values never displayed after creation)
+- **Secrets tab**: Manage named secrets for `${{ secrets.NAME }}` usage in descriptors (create, view names, rotate values — values never displayed after creation, usage lookup shows referencing entities)
 
 ### GitOps Dashboard
 
@@ -316,8 +315,9 @@ Entity detail pages across the platform (catalog system detail, healthcheck conf
 
 ```
 core/
-├── gitops-common/       # Entity envelope schema, secretField(), extension point type,
-│                        # RPC contract, access rules, provenance types
+├── gitops-common/       # Entity envelope schema, secret template utilities,
+│                        # extension point type, RPC contract, access rules,
+│                        # provenance types
 ├── gitops-backend/      # Kind registry, reconciliation engine, provider scrapers,
 │                        # provenance table, sync worker, secret resolution
 ├── gitops-frontend/     # Provider management UI, sync dashboard, orphan management
@@ -329,7 +329,7 @@ core/
 ## Implementation Phases
 
 ### Phase 1: Foundation (no UI, no scrapers)
-1. `gitops-common` — Entity envelope schema, `secretField()` utility, extension point type, RPC contract, access rules
+1. `gitops-common` — Entity envelope schema, `${{ secrets.NAME }}` template utilities, extension point type, RPC contract, access rules
 2. `secret-backend` + `secret-common` — Secret store (encrypted KV), RPC contract for resolving secrets
 3. `gitops-backend` — Kind registry implementation, reconciliation engine (with secret resolution), provenance table, provider DB schema
 


### PR DESCRIPTION
## Summary

Replace the manual `resolveSecretTemplates` escape hatch with a **schema-driven** `resolveSecretsBySchema` that uses existing `configString({ "x-secret": true })` annotations from the DynamicForm pattern. Only fields explicitly marked as secret in the Zod schema get resolved — preventing accidental leaks into display or non-sensitive config fields.

## Breaking Changes

- Removed `secretField()`, `secretRefSchema`, `isSecretRef`, `SecretRef`, `ResolvedSecretField` from `@checkstack/gitops-common`
- `resolveSecretsBySchema` now returns `{ resolved: T; warnings: string[] }` instead of `T` directly
- `ReconcileContext` interface updated across all plugins

## New Features

- **\${{ secrets.NAME }} template syntax** with inline interpolation
- **Schema-driven resolution** via `x-secret` annotations — reuses the DynamicForm pattern
- **Secret rotation invalidation** — affected entities are re-reconciled on next sync
- **`getSecretUsage` RPC endpoint** + expandable usage panel in secrets UI
- **Reconciliation warnings** — templates found in non-secret fields are detected, stored in provenance, and surfaced in the UI
- **Secret name validation** — `secretNameSchema` / `SECRET_NAME_REGEX` enforced at creation (must start with letter, `[a-zA-Z0-9_-]`, max 63 chars)
- **Client-side validation** in SecretEditor with inline field errors

## Security

- Metadata guard rejects templates in display fields
- Only `x-secret` annotated fields get resolved — no escape hatch
- Non-secret field templates emit warnings instead of silently passing
- Secret names validated at both client and server

## Migration

```diff
- const resolved = await context.resolveSecretTemplates({ value });
+ const { resolved } = await context.resolveSecretsBySchema({ value, schema });
```

See changeset for full migration guide.

## Verification

- 262 tests pass, 0 fail
- Lint clean
- 105/105 packages typecheck

## Database Migration

Adds `secret_refs text[]` and `warnings text[]` columns to the `provenance` table. Existing rows get empty arrays, populated on next sync cycle.