### PR TITLE
feat: GitOps Entity Kind Registry Assertion Documentation

### DIFF
--- a/.changeset/gitops-spec-schema-docs.md
+++ b/.changeset/gitops-spec-schema-docs.md
@@ -1,0 +1,8 @@
+---
+"@checkstack/gitops-common": minor
+"@checkstack/gitops-backend": minor
+"@checkstack/gitops-frontend": minor
+"@checkstack/healthcheck-backend": minor
+---
+
+Added `registerSpecSchemaDocumentation` to EntityKindRegistry to allow plugins to provide detailed JSON Schemas for specific configurations. The frontend now displays these registered schemas as dropdown alternatives, improving the developer experience when authoring GitOps configurations.

--- a/core/gitops-backend/src/index.ts
+++ b/core/gitops-backend/src/index.ts
@@ -72,6 +72,9 @@ export default createBackendPlugin({
       ) {
         kindRegistry.registerKindExtension(definition);
       },
+      registerSpecSchemaDocumentation(params) {
+        kindRegistry.registerSpecSchemaDocumentation(params);
+      },
     });
 
     env.registerInit({

--- a/core/gitops-backend/src/kind-registry.test.ts
+++ b/core/gitops-backend/src/kind-registry.test.ts
@@ -207,6 +207,7 @@ describe("EntityKindRegistry", () => {
       const sys = described[0];
       expect(sys.apiVersion).toBe(CHECKSTACK_API_VERSION);
       expect(sys.kind).toBe("System");
+      expect(sys.metadataSchema).toBeDefined();
       expect(sys.specSchema).toBeDefined();
       expect(sys.extensions).toHaveLength(0);
 

--- a/core/gitops-backend/src/kind-registry.test.ts
+++ b/core/gitops-backend/src/kind-registry.test.ts
@@ -259,4 +259,99 @@ describe("EntityKindRegistry", () => {
       expect(described).toHaveLength(0);
     });
   });
+
+  describe("registerSpecSchemaDocumentation", () => {
+    it("allows registering documentation for different field paths and multiple entries per path", () => {
+      const registry = createEntityKindRegistry();
+
+      registry.registerKind({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        specSchema: z.object({ config: z.unknown(), collectors: z.array(z.unknown()) }),
+        reconcile: async () => ({ entityId: "test-id" }),
+      });
+
+      // Register two strategies for the 'config' field
+      registry.registerSpecSchemaDocumentation({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        fieldPath: "config",
+        variantId: "http-strat",
+        label: "HTTP Strategy",
+        description: "Configure HTTP health check",
+        schema: z.object({ url: z.string() }),
+      });
+
+      registry.registerSpecSchemaDocumentation({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        fieldPath: "config",
+        variantId: "dns-strat",
+        label: "DNS Strategy",
+        schema: z.object({ hostname: z.string() }), // no description
+      });
+
+      // Register a collector for 'collectors[].config'
+      registry.registerSpecSchemaDocumentation({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        fieldPath: "collectors[].config",
+        label: "Ping Collector",
+        description: "Ping something",
+        schema: z.object({ count: z.number() }),
+        conditions: [{
+          fieldPath: "config",
+          variantIds: ["http-strat", "dns-strat"],
+        }],
+      });
+
+      const described = registry.describeKinds();
+      expect(described).toHaveLength(1);
+      
+      const docs = described[0].specSchemaDocumentation;
+      expect(docs).toHaveLength(3);
+
+      const configDocs = docs.filter(d => d.fieldPath === "config");
+      expect(configDocs).toHaveLength(2);
+      expect(configDocs[0].label).toBe("HTTP Strategy");
+      expect(configDocs[0].variantId).toBe("http-strat");
+      expect(configDocs[0].description).toBe("Configure HTTP health check");
+      expect(configDocs[1].label).toBe("DNS Strategy");
+      expect(configDocs[1].variantId).toBe("dns-strat");
+      expect(configDocs[1].description).toBeUndefined();
+
+      const collectorDocs = docs.filter(d => d.fieldPath === "collectors[].config");
+      expect(collectorDocs).toHaveLength(1);
+      expect(collectorDocs[0].label).toBe("Ping Collector");
+      expect(collectorDocs[0].conditions).toBeDefined();
+      expect(collectorDocs[0].conditions?.[0].variantIds).toEqual(["http-strat", "dns-strat"]);
+    });
+
+    it("allows registering docs before the kind itself is registered", () => {
+      const registry = createEntityKindRegistry();
+
+      registry.registerSpecSchemaDocumentation({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        fieldPath: "config",
+        label: "HTTP Strategy",
+        schema: z.object({ url: z.string() }),
+      });
+
+      // Base kind is missing, so describeKinds should skip it
+      expect(registry.describeKinds()).toHaveLength(0);
+
+      registry.registerKind({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        specSchema: z.object({ config: z.unknown() }),
+        reconcile: async () => ({ entityId: "test-id" }),
+      });
+
+      // Now it should be included
+      const described = registry.describeKinds();
+      expect(described).toHaveLength(1);
+      expect(described[0].specSchemaDocumentation).toHaveLength(1);
+    });
+  });
 });

--- a/core/gitops-backend/src/kind-registry.ts
+++ b/core/gitops-backend/src/kind-registry.ts
@@ -4,12 +4,14 @@ import type {
   EntityKindDefinition,
   EntityKindExtensionDefinition,
   EntityKindRegistry,
+  SpecSchemaDocumentation,
 } from "@checkstack/gitops-common";
 
 /** Internal storage for a registered kind with its extensions. */
 interface RegisteredKind {
   definition: EntityKindDefinition<unknown> | undefined;
   extensions: Map<string, EntityKindExtensionDefinition<unknown>>;
+  specSchemaDocumentation: SpecSchemaDocumentation[];
 }
 
 /** Composite key for looking up kinds by apiVersion + kind. */
@@ -51,6 +53,17 @@ export function createEntityKindRegistry() {
         namespace: string;
         specSchema: Record<string, unknown>;
       }>;
+      specSchemaDocumentation: Array<{
+        fieldPath: string;
+        variantId?: string;
+        label: string;
+        description?: string;
+        specSchema: Record<string, unknown>;
+        conditions?: Array<{
+          fieldPath: string;
+          variantIds: string[];
+        }>;
+      }>;
     }>;
   } = {
     registerKind<TSpec>(definition: EntityKindDefinition<TSpec>) {
@@ -70,6 +83,7 @@ export function createEntityKindRegistry() {
         kinds.set(key, {
           definition: definition as EntityKindDefinition<unknown>,
           extensions: new Map(),
+          specSchemaDocumentation: [],
         });
       }
     },
@@ -91,6 +105,7 @@ export function createEntityKindRegistry() {
               definition as EntityKindExtensionDefinition<unknown>,
             ],
           ]),
+          specSchemaDocumentation: [],
         });
         return;
       }
@@ -105,6 +120,30 @@ export function createEntityKindRegistry() {
         definition.namespace,
         definition as EntityKindExtensionDefinition<unknown>,
       );
+    },
+
+    registerSpecSchemaDocumentation(params) {
+      const key = kindKey(params);
+      let registered = kinds.get(key);
+
+      if (!registered) {
+        // Allow registering docs before the kind itself
+        registered = {
+          definition: undefined,
+          extensions: new Map(),
+          specSchemaDocumentation: [],
+        };
+        kinds.set(key, registered);
+      }
+
+      registered.specSchemaDocumentation.push({
+        fieldPath: params.fieldPath,
+        variantId: params.variantId,
+        label: params.label,
+        description: params.description,
+        schema: params.schema,
+        conditions: params.conditions,
+      });
     },
 
     getKind(params) {
@@ -154,6 +193,17 @@ export function createEntityKindRegistry() {
           namespace: string;
           specSchema: Record<string, unknown>;
         }>;
+        specSchemaDocumentation: Array<{
+          fieldPath: string;
+          variantId?: string;
+          label: string;
+          description?: string;
+          specSchema: Record<string, unknown>;
+          conditions?: Array<{
+            fieldPath: string;
+            variantIds: string[];
+          }>;
+        }>;
       }> = [];
 
       for (const registered of kinds.values()) {
@@ -171,11 +221,23 @@ export function createEntityKindRegistry() {
           }),
         );
 
+        const specSchemaDocumentation = registered.specSchemaDocumentation.map(
+          (doc) => ({
+            fieldPath: doc.fieldPath,
+            variantId: doc.variantId,
+            label: doc.label,
+            description: doc.description,
+            specSchema: toJsonSchema(doc.schema),
+            conditions: doc.conditions,
+          }),
+        );
+
         result.push({
           apiVersion: def.apiVersion,
           kind: def.kind,
           specSchema: baseSchema,
           extensions,
+          specSchemaDocumentation,
         });
       }
 

--- a/core/gitops-backend/src/kind-registry.ts
+++ b/core/gitops-backend/src/kind-registry.ts
@@ -6,6 +6,7 @@ import type {
   EntityKindRegistry,
   SpecSchemaDocumentation,
 } from "@checkstack/gitops-common";
+import { entityMetadataSchema } from "@checkstack/gitops-common";
 
 /** Internal storage for a registered kind with its extensions. */
 interface RegisteredKind {
@@ -48,6 +49,7 @@ export function createEntityKindRegistry() {
     describeKinds: () => Array<{
       apiVersion: string;
       kind: string;
+      metadataSchema: Record<string, unknown>;
       specSchema: Record<string, unknown>;
       extensions: Array<{
         namespace: string;
@@ -188,6 +190,7 @@ export function createEntityKindRegistry() {
       const result: Array<{
         apiVersion: string;
         kind: string;
+        metadataSchema: Record<string, unknown>;
         specSchema: Record<string, unknown>;
         extensions: Array<{
           namespace: string;
@@ -210,9 +213,7 @@ export function createEntityKindRegistry() {
         if (!registered.definition) continue;
 
         const def = registered.definition;
-        const baseSchema = toJsonSchema(
-          def.specSchema as z.ZodTypeAny,
-        );
+        const baseSchema = toJsonSchema(def.specSchema as z.ZodTypeAny);
 
         const extensions = [...registered.extensions.entries()].map(
           ([namespace, ext]) => ({
@@ -235,6 +236,7 @@ export function createEntityKindRegistry() {
         result.push({
           apiVersion: def.apiVersion,
           kind: def.kind,
+          metadataSchema: toJsonSchema(entityMetadataSchema),
           specSchema: baseSchema,
           extensions,
           specSchemaDocumentation,

--- a/core/gitops-common/src/entity-kind-registry.ts
+++ b/core/gitops-common/src/entity-kind-registry.ts
@@ -128,6 +128,33 @@ export interface EntityKindExtensionDefinition<TExtensionSpec = unknown> {
 }
 
 /**
+ * Definition for documenting a specific field variant within a kind's spec.
+ */
+export interface SpecSchemaDocumentation {
+  /** Which field this documentation applies to (e.g., "config", "collectors[].config") */
+  fieldPath: string;
+  /** 
+   * Optional unique identifier for this variant.
+   * Useful when other variants depend on this one being selected.
+   */
+  variantId?: string;
+  /** Human-readable label shown in the dropdown (e.g., "HTTP Strategy") */
+  label: string;
+  /** Optional markdown description shown alongside the schema */
+  description?: string;
+  /** The Zod schema for this variant */
+  schema: z.ZodTypeAny;
+  /** 
+   * If specified, this variant will only be shown if the selected variant 
+   * in the target fieldPath matches one of the provided variantIds.
+   */
+  conditions?: Array<{
+    fieldPath: string;
+    variantIds: string[];
+  }>;
+}
+
+/**
  * The registry interface exposed via the Extension Point.
  * Plugins call these methods during their `register()` phase.
  */
@@ -138,5 +165,13 @@ export interface EntityKindRegistry {
   /** Extend an existing kind's spec (e.g., healthcheck extends "System"). */
   registerKindExtension<TExtensionSpec>(
     definition: EntityKindExtensionDefinition<TExtensionSpec>,
+  ): void;
+
+  /** Register documentation for a specific field variant within a kind's spec. */
+  registerSpecSchemaDocumentation(
+    params: {
+      apiVersion: string;
+      kind: string;
+    } & SpecSchemaDocumentation,
   ): void;
 }

--- a/core/gitops-common/src/index.ts
+++ b/core/gitops-common/src/index.ts
@@ -23,6 +23,7 @@ export {
   type EntityKindExtensionDefinition,
   type EntityKindRegistry,
   type ReconcileContext,
+  type SpecSchemaDocumentation,
 } from "./entity-kind-registry";
 export { gitopsAccess, gitopsAccessRules } from "./access";
 export { gitopsRoutes } from "./routes";

--- a/core/gitops-common/src/rpc-contract.ts
+++ b/core/gitops-common/src/rpc-contract.ts
@@ -258,6 +258,19 @@ export const gitopsContract = {
             specSchema: z.record(z.string(), z.unknown()),
           }),
         ),
+        specSchemaDocumentation: z.array(
+          z.object({
+            fieldPath: z.string(),
+            variantId: z.string().optional(),
+            label: z.string(),
+            description: z.string().optional(),
+            specSchema: z.record(z.string(), z.unknown()),
+            conditions: z.array(z.object({
+              fieldPath: z.string(),
+              variantIds: z.array(z.string()),
+            })).optional(),
+          }),
+        ),
       }),
     ),
   ),

--- a/core/gitops-common/src/rpc-contract.ts
+++ b/core/gitops-common/src/rpc-contract.ts
@@ -251,6 +251,7 @@ export const gitopsContract = {
       z.object({
         apiVersion: z.string(),
         kind: z.string(),
+        metadataSchema: z.record(z.string(), z.unknown()),
         specSchema: z.record(z.string(), z.unknown()),
         extensions: z.array(
           z.object({

--- a/core/gitops-frontend/src/pages/KindRegistryPage.tsx
+++ b/core/gitops-frontend/src/pages/KindRegistryPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import {
   Card,
   CardContent,
@@ -7,8 +7,19 @@ import {
   CardTitle,
   Badge,
   PageLayout,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@checkstack/ui";
-import { ChevronDown, ChevronRight, Puzzle, Blocks } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Puzzle,
+  Blocks,
+  BookOpen,
+} from "lucide-react";
 import { usePluginClient } from "@checkstack/frontend-api";
 import { GitOpsApi } from "@checkstack/gitops-common";
 import { extractErrorMessage } from "@checkstack/common";
@@ -33,6 +44,17 @@ interface KindDescription {
   extensions: Array<{
     namespace: string;
     specSchema: JsonSchemaProperty;
+  }>;
+  specSchemaDocumentation?: Array<{
+    fieldPath: string;
+    variantId?: string;
+    label: string;
+    description?: string;
+    specSchema: JsonSchemaProperty;
+    conditions?: Array<{
+      fieldPath: string;
+      variantIds: string[];
+    }>;
   }>;
 }
 
@@ -380,6 +402,144 @@ function scalarExample({ prop }: { prop: JsonSchemaProperty }): string {
   }
 }
 
+// ─── Spec Schema Documentation ─────────────────────────────────────────────
+
+function SpecSchemaDocumentationSection({
+  docs,
+}: {
+  docs: NonNullable<KindDescription["specSchemaDocumentation"]>;
+}) {
+  const [selections, setSelections] = useState<Record<string, string>>({});
+
+  const handleSelect = useCallback((fieldPath: string, variantId: string) => {
+    setSelections((prev) => {
+      if (prev[fieldPath] === variantId) return prev;
+      return { ...prev, [fieldPath]: variantId };
+    });
+  }, []);
+
+  const groupedDocs: Record<string, typeof docs> = {};
+  for (const doc of docs) {
+    if (!groupedDocs[doc.fieldPath]) {
+      groupedDocs[doc.fieldPath] = [];
+    }
+    groupedDocs[doc.fieldPath].push(doc);
+  }
+
+  return (
+    <div className="space-y-6">
+      <h4 className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+        <BookOpen className="h-4 w-4" />
+        Additional Schemas
+      </h4>
+
+      {Object.entries(groupedDocs).map(([fieldPath, fieldDocs]) => {
+        return (
+          <SpecSchemaDocumentationField
+            key={fieldPath}
+            fieldPath={fieldPath}
+            docs={fieldDocs.toSorted((a, b) => a.label.localeCompare(b.label))}
+            selections={selections}
+            onSelect={handleSelect}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function SpecSchemaDocumentationField({
+  fieldPath,
+  docs,
+  selections,
+  onSelect,
+}: {
+  fieldPath: string;
+  docs: NonNullable<KindDescription["specSchemaDocumentation"]>;
+  selections: Record<string, string>;
+  onSelect: (fieldPath: string, variantId: string) => void;
+}) {
+  const availableDocs = useMemo(() => {
+    return docs.filter((doc) => {
+      if (!doc.conditions || doc.conditions.length === 0) return true;
+      return doc.conditions.every((cond) => {
+        const selectedForField = selections[cond.fieldPath];
+        if (!selectedForField) return false;
+        return cond.variantIds.includes(selectedForField);
+      });
+    });
+  }, [docs, selections]);
+
+  const currentSelection = selections[fieldPath] || "";
+  const isValidSelection =
+    currentSelection !== "" &&
+    availableDocs.some((d) => (d.variantId || d.label) === currentSelection);
+
+  useEffect(() => {
+    if (currentSelection !== "" && !isValidSelection) {
+      onSelect(fieldPath, "");
+    }
+  }, [currentSelection, isValidSelection, onSelect, fieldPath]);
+
+  if (availableDocs.length === 0) {
+    return <></>;
+  }
+
+  const selectedDoc = availableDocs.find(
+    (d) => (d.variantId || d.label) === currentSelection,
+  );
+
+  return (
+    <div className="border rounded-lg p-4 space-y-4">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary" className="font-mono">
+            {fieldPath}
+          </Badge>
+          <span className="text-sm text-muted-foreground">
+            {availableDocs.length} variant{availableDocs.length > 1 ? "s" : ""}
+          </span>
+        </div>
+
+        <div className="w-full sm:w-64">
+          <Select
+            value={isValidSelection ? currentSelection : ""}
+            onValueChange={(val) => onSelect(fieldPath, val)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select a schema variant..." />
+            </SelectTrigger>
+            <SelectContent>
+              {availableDocs.map((doc, i) => (
+                <SelectItem key={i} value={doc.variantId || doc.label}>
+                  {doc.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {selectedDoc ? (
+        <div className="space-y-3 animate-in fade-in slide-in-from-top-2 duration-200">
+          {selectedDoc.description && (
+            <div className="text-sm text-muted-foreground italic">
+              {selectedDoc.description}
+            </div>
+          )}
+          <div className="bg-muted rounded-md p-3 overflow-x-auto">
+            <SchemaPropertyDisplay schema={selectedDoc.specSchema} />
+          </div>
+        </div>
+      ) : (
+        <div className="text-sm text-muted-foreground italic bg-muted/50 rounded-md p-4 text-center">
+          Select a variant from the dropdown above to view its schema.
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Kind Card ─────────────────────────────────────────────────────────────
 
 function KindCard({ kind }: { kind: KindDescription }) {
@@ -450,6 +610,14 @@ function KindCard({ kind }: { kind: KindDescription }) {
               ))}
             </div>
           )}
+
+          {/* Spec Schema Documentation */}
+          {kind.specSchemaDocumentation &&
+            kind.specSchemaDocumentation.length > 0 && (
+              <SpecSchemaDocumentationSection
+                docs={kind.specSchemaDocumentation}
+              />
+            )}
 
           {/* YAML Example */}
           <div>

--- a/core/gitops-frontend/src/pages/KindRegistryPage.tsx
+++ b/core/gitops-frontend/src/pages/KindRegistryPage.tsx
@@ -13,6 +13,8 @@ import {
   SelectTrigger,
   SelectValue,
   CodeEditor,
+  Markdown,
+  MarkdownBlock,
 } from "@checkstack/ui";
 import {
   ChevronDown,
@@ -111,8 +113,11 @@ function SchemaPropertyDisplay({
             )}
             : <SchemaPropertyDisplay schema={value} depth={depth + 1} />
             {value.description && (
-              <span className="text-muted-foreground ml-2 text-xs">
-                // {value.description}
+              <span className="text-muted-foreground ml-2 text-xs inline-flex items-center gap-1">
+                //{" "}
+                <Markdown size="sm" className="inline">
+                  {value.description}
+                </Markdown>
               </span>
             )}
           </div>
@@ -544,8 +549,8 @@ function SpecSchemaDocumentationField({
       {selectedDoc ? (
         <div className="space-y-3 animate-in fade-in slide-in-from-top-2 duration-200">
           {selectedDoc.description && (
-            <div className="text-sm text-muted-foreground italic">
-              {selectedDoc.description}
+            <div className="text-sm text-muted-foreground">
+              <MarkdownBlock>{selectedDoc.description}</MarkdownBlock>
             </div>
           )}
           <div className="bg-muted rounded-md p-3 overflow-x-auto">

--- a/core/gitops-frontend/src/pages/KindRegistryPage.tsx
+++ b/core/gitops-frontend/src/pages/KindRegistryPage.tsx
@@ -12,6 +12,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  CodeEditor,
 } from "@checkstack/ui";
 import {
   ChevronDown,
@@ -40,6 +41,7 @@ interface JsonSchemaProperty {
 interface KindDescription {
   apiVersion: string;
   kind: string;
+  metadataSchema: JsonSchemaProperty;
   specSchema: JsonSchemaProperty;
   extensions: Array<{
     namespace: string;
@@ -182,12 +184,31 @@ function SchemaBlock({
 // ─── YAML Example Generator ────────────────────────────────────────────────
 
 function generateYamlExample({ kind }: { kind: KindDescription }): string {
-  const lines = [
-    `apiVersion: ${kind.apiVersion}`,
-    `kind: ${kind.kind}`,
-    "metadata:",
-    `  name: my-${kind.kind.toLowerCase()}`,
-  ];
+  const lines = [`apiVersion: ${kind.apiVersion}`, `kind: ${kind.kind}`];
+
+  if (kind.metadataSchema) {
+    lines.push("metadata:");
+    const metadataProps = kind.metadataSchema.properties ?? {};
+    const metadataRequired = new Set(kind.metadataSchema.required);
+
+    for (const [key, prop] of Object.entries(metadataProps)) {
+      // Provide a nice default for name instead of generic "..."
+      const customProp =
+        key === "name"
+          ? { ...prop, default: `my-${kind.kind.toLowerCase()}` }
+          : prop;
+
+      emitProperty({
+        lines,
+        key,
+        prop: customProp,
+        indent: 2,
+        required: metadataRequired.has(key),
+      });
+    }
+  } else {
+    lines.push("metadata:", `  name: my-${kind.kind.toLowerCase()}`);
+  }
 
   const baseProps = kind.specSchema.properties ?? {};
   const hasBaseProps = Object.keys(baseProps).length > 0;
@@ -544,6 +565,7 @@ function SpecSchemaDocumentationField({
 
 function KindCard({ kind }: { kind: KindDescription }) {
   const [isOpen, setIsOpen] = useState(false);
+  const yamlExample = useMemo(() => generateYamlExample({ kind }), [kind]);
 
   return (
     <Card className="mb-3">
@@ -583,6 +605,12 @@ function KindCard({ kind }: { kind: KindDescription }) {
 
       {isOpen && (
         <CardContent className="pt-0 space-y-6">
+          {/* Entity Envelope Fields */}
+          <SchemaBlock
+            schema={kind.metadataSchema}
+            label="Entity Envelope Fields"
+          />
+
           {/* Base Spec Schema */}
           <SchemaBlock schema={kind.specSchema} label="Base Spec Schema" />
 
@@ -624,9 +652,15 @@ function KindCard({ kind }: { kind: KindDescription }) {
             <h4 className="text-sm font-medium mb-2 text-muted-foreground">
               YAML Example
             </h4>
-            <pre className="bg-muted rounded-md p-3 overflow-x-auto text-sm">
-              <code>{generateYamlExample({ kind })}</code>
-            </pre>
+            <div className="rounded-md overflow-hidden border border-input">
+              <CodeEditor
+                value={yamlExample}
+                language="yaml"
+                readOnly
+                onChange={() => {}}
+                minHeight={`${Math.max(100, yamlExample.split("\n").length * 20 + 20)}px`}
+              />
+            </div>
           </div>
         </CardContent>
       )}

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
@@ -5,13 +5,15 @@ import type {
   EntityKindRegistry,
   ReconcileContext,
 } from "@checkstack/gitops-common";
-import { CHECKSTACK_API_VERSION, entityRefSchema } from "@checkstack/gitops-common";
+import {
+  CHECKSTACK_API_VERSION,
+  entityRefSchema,
+} from "@checkstack/gitops-common";
 import type {
   HealthCheckRegistry,
   CollectorRegistry,
 } from "@checkstack/backend-api";
 import { HealthCheckService } from "./service";
-
 
 /**
  * Lazy accessor functions — populated during init(), consumed during reconcile.
@@ -97,7 +99,10 @@ export function buildHealthcheckKind(
       existingEntityId,
       context,
     }: {
-      entity: { metadata: { name: string; title?: string; description?: string }; spec: HealthcheckSpec };
+      entity: {
+        metadata: { name: string; title?: string; description?: string };
+        spec: HealthcheckSpec;
+      };
       existingEntityId?: string;
       context: ReconcileContext;
     }) => {
@@ -110,16 +115,21 @@ export function buildHealthcheckKind(
       if (!strategy) {
         throw new Error(
           `Unknown health check strategy "${spec.strategy}". ` +
-            `Available: ${healthCheckRegistry.getStrategies().map((s) => s.id).join(", ")}`,
+            `Available: ${healthCheckRegistry
+              .getStrategies()
+              .map((s) => s.id)
+              .join(", ")}`,
         );
       }
 
       // Resolve secrets using the strategy's typed schema.
       // Only fields marked with configString({ "x-secret": true }) get resolved.
-      const { resolved: resolvedConfig } = await context.resolveSecretsBySchema({
-        value: spec.config,
-        schema: strategy.config.schema,
-      });
+      const { resolved: resolvedConfig } = await context.resolveSecretsBySchema(
+        {
+          value: spec.config,
+          schema: strategy.config.schema,
+        },
+      );
 
       // Validate resolved config against strategy's Zod schema
       const configValidation = strategy.config.schema.safeParse(resolvedConfig);
@@ -138,18 +148,24 @@ export function buildHealthcheckKind(
               if (!registered) {
                 throw new Error(
                   `Unknown collector "${c.collectorId}". ` +
-                    `Available: ${collectorReg.getCollectors().map((col) => col.qualifiedId).join(", ")}`,
+                    `Available: ${collectorReg
+                      .getCollectors()
+                      .map((col) => col.qualifiedId)
+                      .join(", ")}`,
                 );
               }
 
               // Resolve secrets using the collector's typed schema
-              const { resolved: resolvedCollectorConfig } = await context.resolveSecretsBySchema({
-                value: c.config,
-                schema: registered.collector.config.schema,
-              });
+              const { resolved: resolvedCollectorConfig } =
+                await context.resolveSecretsBySchema({
+                  value: c.config,
+                  schema: registered.collector.config.schema,
+                });
 
               const collectorConfigValidation =
-                registered.collector.config.schema.safeParse(resolvedCollectorConfig);
+                registered.collector.config.schema.safeParse(
+                  resolvedCollectorConfig,
+                );
               if (!collectorConfigValidation.success) {
                 throw new Error(
                   `Collector "${c.collectorId}" config validation failed: ${collectorConfigValidation.error.message}`,
@@ -270,7 +286,7 @@ export function buildSystemHealthcheckExtension(
         // Build state thresholds from the shorthand
         const stateThresholds =
           entry.degradedThreshold || entry.unhealthyThreshold
-            ? ({
+            ? {
                 mode: "consecutive" as const,
                 healthy: { minSuccessCount: 1 },
                 degraded: {
@@ -279,7 +295,7 @@ export function buildSystemHealthcheckExtension(
                 unhealthy: {
                   minFailureCount: entry.unhealthyThreshold ?? 5,
                 },
-              })
+              }
             : undefined;
 
         await service.associateSystem({
@@ -325,4 +341,51 @@ export function registerHealthcheckGitOpsKinds({
 }): void {
   kindRegistry.registerKind(buildHealthcheckKind(deps));
   kindRegistry.registerKindExtension(buildSystemHealthcheckExtension(deps));
+}
+
+/**
+ * Register spec schema documentation for the Healthcheck kind.
+ * Called from healthcheck-backend's `afterPluginsReady` phase once registries are populated.
+ */
+export function registerHealthcheckGitOpsDocumentation({
+  kindRegistry,
+  healthCheckRegistry,
+  collectorRegistry,
+}: {
+  kindRegistry: EntityKindRegistry;
+  healthCheckRegistry: HealthCheckRegistry;
+  collectorRegistry: CollectorRegistry;
+}): void {
+  // 1. Register documentation for strategy configs (fieldPath: "config")
+  for (const registered of healthCheckRegistry.getStrategiesWithMeta()) {
+    kindRegistry.registerSpecSchemaDocumentation({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "Healthcheck",
+      fieldPath: "config",
+      variantId: registered.ownerPluginId,
+      label: registered.strategy.displayName,
+      description: registered.strategy.description,
+      schema: registered.strategy.config.schema,
+    });
+  }
+
+  // 2. Register documentation for collector configs (fieldPath: "collectors[].config")
+  for (const registered of collectorRegistry.getCollectors()) {
+    kindRegistry.registerSpecSchemaDocumentation({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "Healthcheck",
+      fieldPath: "collectors[].config",
+      label: registered.collector.displayName,
+      description: registered.collector.description,
+      schema: registered.collector.config.schema,
+      conditions: [
+        {
+          fieldPath: "config",
+          variantIds: registered.collector.supportedPlugins.map(
+            (p) => p.pluginId,
+          ),
+        },
+      ],
+    });
+  }
 }

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
@@ -14,6 +14,14 @@ import type {
   CollectorRegistry,
 } from "@checkstack/backend-api";
 import { HealthCheckService } from "./service";
+import {
+  DynamicOperators,
+  numericField,
+  stringField,
+  booleanField,
+  arrayField,
+  enumField,
+} from "@checkstack/backend-api";
 
 /**
  * Lazy accessor functions — populated during init(), consumed during reconcile.
@@ -364,7 +372,7 @@ export function registerHealthcheckGitOpsDocumentation({
       fieldPath: "config",
       variantId: registered.ownerPluginId,
       label: registered.strategy.displayName,
-      description: registered.strategy.description,
+      description: `ID: ${registered.ownerPluginId}\n\n${registered.strategy.description}`,
       schema: registered.strategy.config.schema,
     });
   }
@@ -375,8 +383,9 @@ export function registerHealthcheckGitOpsDocumentation({
       apiVersion: CHECKSTACK_API_VERSION,
       kind: "Healthcheck",
       fieldPath: "collectors[].config",
+      variantId: registered.qualifiedId,
       label: registered.collector.displayName,
-      description: registered.collector.description,
+      description: `ID: ${registered.qualifiedId}\n\n${registered.collector.description}`,
       schema: registered.collector.config.schema,
       conditions: [
         {
@@ -387,5 +396,92 @@ export function registerHealthcheckGitOpsDocumentation({
         },
       ],
     });
+
+    // 3. Register documentation for collector assertions (fieldPath: "collectors[].assertions")
+    const unwrapped = unwrapZodType(registered.collector.result.schema);
+    
+    if (unwrapped instanceof z.ZodObject) {
+      const shape = unwrapped.shape;
+      
+      for (const [key, prop] of Object.entries(shape)) {
+        const propUnwrapped = unwrapZodType(prop as z.ZodTypeAny);
+
+        let fieldSchema: z.ZodTypeAny;
+
+        if (propUnwrapped instanceof z.ZodNumber) {
+          fieldSchema = numericField(key);
+        } else if (propUnwrapped instanceof z.ZodString) {
+          fieldSchema = stringField(key);
+        } else if (propUnwrapped instanceof z.ZodBoolean) {
+          fieldSchema = booleanField(key);
+        } else if (propUnwrapped instanceof z.ZodArray) {
+          fieldSchema = arrayField(key);
+        } else if (propUnwrapped instanceof z.ZodEnum) {
+          const enumValues = propUnwrapped.options;
+          const stringValues = enumValues.filter((v: unknown) => typeof v === "string") as string[];
+          fieldSchema = stringValues.length > 0 ? enumField(key, stringValues) : stringField(key);
+        } else {
+          fieldSchema = stringField(key);
+        }
+
+        kindRegistry.registerSpecSchemaDocumentation({
+          apiVersion: CHECKSTACK_API_VERSION,
+          kind: "Healthcheck",
+          fieldPath: "collectors[].assertions",
+          variantId: `${registered.qualifiedId}.assert.${key}`,
+          label: `Assert: ${key}`,
+          description: `Assertion documentation for the '${key}' field of ${registered.collector.displayName}.`,
+          schema: z.array(fieldSchema).describe(`Assertions array`),
+          conditions: [
+            {
+              fieldPath: "collectors[].config",
+              variantIds: [registered.qualifiedId],
+            },
+          ],
+        });
+      }
+    } else {
+      // Fallback if result schema is not an object
+      kindRegistry.registerSpecSchemaDocumentation({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        fieldPath: "collectors[].assertions",
+        variantId: `${registered.qualifiedId}.assert.generic`,
+        label: `${registered.collector.displayName} Assertions`,
+        description: `Define assertions against the result of this collector.`,
+        schema: z.array(
+          z.object({
+            field: z.string(),
+            operator: DynamicOperators,
+            value: z.unknown().optional(),
+          })
+        ).describe(`Assertions array`),
+        conditions: [
+          {
+            fieldPath: "collectors[].config",
+            variantIds: [registered.qualifiedId],
+          },
+        ],
+      });
+    }
   }
 }
+
+function unwrapZodType(type: z.ZodTypeAny): z.ZodTypeAny {
+  let current = type;
+  while (current) {
+    if (current instanceof z.ZodOptional || current instanceof z.ZodNullable) {
+      current = current.unwrap() as z.ZodTypeAny;
+    } else if (current instanceof z.ZodDefault) {
+      current = current._def.innerType as z.ZodTypeAny;
+    } else if ("innerType" in current && typeof current.innerType === "function") {
+      // Handles ZodEffects/ZodBranded generically without relying on removed types
+      current = current.innerType() as z.ZodTypeAny;
+    } else {
+      break;
+    }
+  }
+  return current;
+}
+
+

--- a/core/healthcheck-backend/src/index.ts
+++ b/core/healthcheck-backend/src/index.ts
@@ -24,7 +24,7 @@ import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
 import { z } from "zod";
 import { createHealthCheckRouter } from "./router";
 import { HealthCheckService } from "./service";
-import { registerHealthcheckGitOpsKinds } from "./healthcheck-gitops-kinds";
+import { registerHealthcheckGitOpsKinds, registerHealthcheckGitOpsDocumentation } from "./healthcheck-gitops-kinds";
 import { catalogHooks } from "@checkstack/catalog-backend";
 import { satelliteHooks } from "@checkstack/satellite-backend";
 import { CatalogApi } from "@checkstack/catalog-common";
@@ -237,6 +237,13 @@ export default createBackendPlugin({
           db: database,
           queueManager,
           logger,
+        });
+
+        // Register GitOps documentation now that registries are populated
+        registerHealthcheckGitOpsDocumentation({
+          kindRegistry,
+          healthCheckRegistry,
+          collectorRegistry,
         });
 
         // Subscribe to catalog system deletion to clean up associations


### PR DESCRIPTION
Implements dynamic, dependency-aware documentation system for the GitOps Entity Kind Registry. It automatically derives assertion schemas from collector result definitions and uses Zod instanceof checks to create documentation variants per field. Includes changeset.