### PR TITLE
feat(gitops): enforce backend provenance locks

### DIFF
--- a/.changeset/gitops-backend-locks.md
+++ b/.changeset/gitops-backend-locks.md
@@ -1,0 +1,8 @@
+---
+"@checkstack/healthcheck-backend": minor
+"@checkstack/catalog-backend": minor
+"@checkstack/healthcheck-frontend": minor
+"@checkstack/catalog-frontend": minor
+---
+
+Enforce GitOps provenance lock on backend API endpoints to prevent manual configuration drift for synchronized resources.

--- a/README.md
+++ b/README.md
@@ -372,6 +372,20 @@ API keys are managed via **Settings → External Applications** with full RBAC p
 
 ---
 
+### GitOps Integration
+> *Manage your infrastructure as code with automated synchronization*
+
+Connect Checkstack directly to your source control repositories and manage your Systems, Groups, and Dependencies via YAML specifications.
+
+- **Provider Support** - Native integrations with GitHub and GitLab, including self-hosted enterprise instances
+- **Automated Discovery** - Dynamically discover definitions across individual repositories, whole organizations, or wildcard patterns
+- **Resource Provenance** - Resources synchronized via GitOps are automatically locked from manual editing in the UI to prevent configuration drift
+- **Reconciliation Engine** - Robust lifecycle management that creates, updates, and removes resources as your code changes
+- **Background Synchronization** - Automatic recurring sync jobs keep your Checkstack catalog perfectly aligned with your source of truth
+- **Secret Management** - Securely inject runtime credentials with strict naming standards and validation
+
+---
+
 ### Flexible Authentication & Access Control
 > *Secure access with enterprise-grade granularity*
 

--- a/core/catalog-backend/src/index.ts
+++ b/core/catalog-backend/src/index.ts
@@ -18,7 +18,7 @@ import { resolveRoute, type InferClient, extractErrorMessage} from "@checkstack/
 import { registerSearchProvider } from "@checkstack/command-backend";
 import { EntityService } from "./services/entity-service";
 import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
-import { CHECKSTACK_API_VERSION, entityRefSchema } from "@checkstack/gitops-common";
+import { CHECKSTACK_API_VERSION, entityRefSchema, GitOpsApi } from "@checkstack/gitops-common";
 import { z } from "zod";
 
 // Database schema is still needed for types in creating the router
@@ -193,12 +193,14 @@ export default createBackendPlugin({
         // Get notification client for group management and sending notifications
         const notificationClient = rpcClient.forPlugin(NotificationApi);
         const authClient = rpcClient.forPlugin(AuthApi);
+        const gitOpsClient = rpcClient.forPlugin(GitOpsApi);
 
         // Register oRPC router with notification client and auth client
         const catalogRouter = createCatalogRouter({
           database: typedDb,
           notificationClient,
           authClient,
+          gitOpsClient,
           pluginId: pluginMetadata.pluginId,
         });
         rpc.registerRouter(catalogRouter, catalogContract);

--- a/core/catalog-backend/src/router.test.ts
+++ b/core/catalog-backend/src/router.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, mock } from "bun:test";
+import { createCatalogRouter } from "./router";
+import { createMockRpcContext } from "@checkstack/backend-api";
+import { call } from "@orpc/server";
+
+describe("Catalog Router - GitOps Provenance Enforcement", () => {
+  const mockUser = {
+    type: "user" as const,
+    id: "test-user",
+    accessRules: ["*"],
+    roles: ["admin"],
+  };
+
+  const mockDb = {
+    select: mock(() => ({
+      from: mock(() => ({
+        where: mock(() => Promise.resolve([])),
+      })),
+    })),
+  } as unknown;
+
+  const mockNotificationClient = {
+    createGroup: mock(() => Promise.resolve()),
+    deleteGroup: mock(() => Promise.resolve()),
+    notifyGroups: mock(() => Promise.resolve({ notifiedCount: 0 })),
+  };
+
+  const mockAuthClient = {
+    getUserById: mock(() => Promise.resolve(null)),
+  };
+
+  const mockGitOpsClient = {
+    getProvenance: mock<any>(() => Promise.resolve(null)),
+  };
+
+  const router = createCatalogRouter({
+    database: mockDb as never,
+    notificationClient: mockNotificationClient as never,
+    authClient: mockAuthClient as never,
+    gitOpsClient: mockGitOpsClient as never,
+    pluginId: "test-catalog",
+  });
+
+  it("allows deleteSystem when GitOps lock is not present", async () => {
+    mockGitOpsClient.getProvenance.mockResolvedValueOnce(null);
+    const context = createMockRpcContext({ user: mockUser, emitHook: mock(() => Promise.resolve()) });
+
+    try {
+      await call(router.deleteSystem, "sys-1", { context });
+    } catch (e: any) {
+      expect(e.code).not.toBe("FORBIDDEN");
+    }
+
+    expect(mockGitOpsClient.getProvenance).toHaveBeenCalledWith({
+      kind: "System",
+      entityId: "sys-1",
+    });
+  });
+
+  it("throws FORBIDDEN when deleting a GitOps locked system", async () => {
+    mockGitOpsClient.getProvenance.mockResolvedValueOnce({
+      id: "prov-1", kind: "System", entityId: "sys-1",
+      providerId: "prov", entityName: "sys1", status: "synced",
+      lastSyncedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+      repository: "", filePath: "", fileSha: ""
+    });
+    const context = createMockRpcContext({ user: mockUser });
+
+    let error;
+    try {
+      await call(router.deleteSystem, "sys-1", { context });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect((error as any).code).toBe("FORBIDDEN");
+    expect((error as any).message).toContain("managed by GitOps");
+  });
+
+  it("throws FORBIDDEN when updating a GitOps locked group", async () => {
+    mockGitOpsClient.getProvenance.mockResolvedValueOnce({
+      id: "prov-1", kind: "Group", entityId: "grp-1",
+      providerId: "prov", entityName: "grp1", status: "synced",
+      lastSyncedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+      repository: "", filePath: "", fileSha: ""
+    });
+    const context = createMockRpcContext({ user: mockUser });
+
+    let error;
+    try {
+      await call(router.updateGroup, { id: "grp-1", data: { name: "New Name" } }, { context });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect((error as any).code).toBe("FORBIDDEN");
+  });
+
+  it("throws FORBIDDEN when adding a locked system to a group", async () => {
+    mockGitOpsClient.getProvenance.mockResolvedValueOnce({
+      id: "prov-1", kind: "System", entityId: "sys-1",
+      providerId: "prov", entityName: "sys1", status: "synced",
+      lastSyncedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+      repository: "", filePath: "", fileSha: ""
+    }); 
+    
+    const context = createMockRpcContext({ user: mockUser });
+
+    let error;
+    try {
+      await call(router.addSystemToGroup, { systemId: "sys-1", groupId: "grp-1" }, { context });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect((error as any).code).toBe("FORBIDDEN");
+  });
+
+  it("allows adding an unlocked system to a group, even if the group is locked", async () => {
+    mockGitOpsClient.getProvenance.mockResolvedValueOnce(null);
+    
+    const context = createMockRpcContext({ user: mockUser });
+
+    try {
+      await call(router.addSystemToGroup, { systemId: "sys-1", groupId: "grp-1" }, { context });
+    } catch (e: any) {
+      expect(e.code).not.toBe("FORBIDDEN");
+    }
+  });
+});

--- a/core/catalog-backend/src/router.ts
+++ b/core/catalog-backend/src/router.ts
@@ -12,6 +12,7 @@ import { AuthApi } from "@checkstack/auth-common";
 import type { InferClient } from "@checkstack/common";
 import { catalogHooks } from "./hooks";
 import { eq } from "drizzle-orm";
+import { GitOpsApi } from "@checkstack/gitops-common";
 
 /**
  * Creates the catalog router using contract-based implementation.
@@ -27,6 +28,7 @@ export interface CatalogRouterDeps {
   database: SafeDatabase<typeof schema>;
   notificationClient: InferClient<typeof NotificationApi>;
   authClient: InferClient<typeof AuthApi>;
+  gitOpsClient: InferClient<typeof GitOpsApi>;
   pluginId: string;
 }
 
@@ -34,9 +36,22 @@ export const createCatalogRouter = ({
   database,
   notificationClient,
   authClient,
+  gitOpsClient,
   pluginId,
 }: CatalogRouterDeps) => {
   const entityService = new EntityService(database);
+
+  const enforceNotGitOpsLocked = async (kind: string, entityId: string) => {
+    const provenance = await gitOpsClient.getProvenance({
+      kind,
+      entityId,
+    });
+    if (provenance) {
+      throw new ORPCError("FORBIDDEN", {
+        message: `${kind} is managed by GitOps and cannot be modified manually.`,
+      });
+    }
+  };
 
   // Helper to create notification group for an entity
   const createNotificationGroup = async (
@@ -136,6 +151,7 @@ export const createCatalogRouter = ({
   });
 
   const updateSystem = os.updateSystem.handler(async ({ input }) => {
+    await enforceNotGitOpsLocked("System", input.id);
     // Convert null to undefined and filter out fields
     const cleanData: Partial<{
       name: string;
@@ -160,6 +176,7 @@ export const createCatalogRouter = ({
   });
 
   const deleteSystem = os.deleteSystem.handler(async ({ input, context }) => {
+    await enforceNotGitOpsLocked("System", input);
     await entityService.deleteSystem(input);
 
     // Delete the notification group for this system
@@ -189,6 +206,7 @@ export const createCatalogRouter = ({
   });
 
   const updateGroup = os.updateGroup.handler(async ({ input }) => {
+    await enforceNotGitOpsLocked("Group", input.id);
     // Convert null to undefined for optional fields
     const cleanData = {
       ...input.data,
@@ -214,6 +232,7 @@ export const createCatalogRouter = ({
   });
 
   const deleteGroup = os.deleteGroup.handler(async ({ input, context }) => {
+    await enforceNotGitOpsLocked("Group", input);
     await entityService.deleteGroup(input);
 
     // Delete the notification group for this catalog group
@@ -226,12 +245,20 @@ export const createCatalogRouter = ({
   });
 
   const addSystemToGroup = os.addSystemToGroup.handler(async ({ input }) => {
+    // Note: We only enforce the lock on the System, not the Group.
+    // This is because system-group associations are reconciled as a kindExtension
+    // of the System kind. The Group reconciler does not touch associations.
+    // Thus, it is perfectly safe (and intended) to manually add an unlocked System 
+    // to a GitOps-managed Group.
+    await enforceNotGitOpsLocked("System", input.systemId);
     await entityService.addSystemToGroup(input);
     return { success: true };
   });
 
   const removeSystemFromGroup = os.removeSystemFromGroup.handler(
     async ({ input }) => {
+      // See addSystemToGroup for why we only check the System provenance lock.
+      await enforceNotGitOpsLocked("System", input.systemId);
       await entityService.removeSystemFromGroup(input);
       return { success: true };
     },
@@ -286,6 +313,7 @@ export const createCatalogRouter = ({
   });
 
   const addSystemContact = os.addSystemContact.handler(async ({ input }) => {
+    await enforceNotGitOpsLocked("System", input.systemId);
     // Validate input based on type
     if (input.type === "user" && !input.userId) {
       throw new ORPCError("BAD_REQUEST", {
@@ -333,6 +361,10 @@ export const createCatalogRouter = ({
 
   const removeSystemContact = os.removeSystemContact.handler(
     async ({ input }) => {
+      const contacts = await database.select().from(schema.systemContacts).where(eq(schema.systemContacts.id, input));
+      if (contacts[0]) {
+        await enforceNotGitOpsLocked("System", contacts[0].systemId);
+      }
       await entityService.removeContact(input);
       return { success: true };
     },

--- a/core/catalog-frontend/src/components/DraggableSystem.tsx
+++ b/core/catalog-frontend/src/components/DraggableSystem.tsx
@@ -111,9 +111,9 @@ export const DraggableSystem = ({
               variant="ghost"
               size="sm"
               className="h-7 w-7 p-0"
-              title={`Add ${system.name} to a group`}
+              title={isLocked ? "Managed by GitOps" : `Add ${system.name} to a group`}
               onClick={() => setIsPickerOpen((v) => !v)}
-              disabled={availableGroups.length === 0}
+              disabled={availableGroups.length === 0 || isLocked}
               aria-expanded={isPickerOpen}
               aria-haspopup="listbox"
               aria-label={`Add ${system.name} to group`}

--- a/core/healthcheck-backend/src/index.ts
+++ b/core/healthcheck-backend/src/index.ts
@@ -30,6 +30,7 @@ import { satelliteHooks } from "@checkstack/satellite-backend";
 import { CatalogApi } from "@checkstack/catalog-common";
 import { MaintenanceApi } from "@checkstack/maintenance-common";
 import { IncidentApi } from "@checkstack/incident-common";
+import { GitOpsApi } from "@checkstack/gitops-common";
 import { healthCheckHooks } from "./hooks";
 import { registerSearchProvider } from "@checkstack/command-backend";
 import { resolveRoute } from "@checkstack/common";
@@ -164,6 +165,9 @@ export default createBackendPlugin({
         // Create incident client for notification suppression checks
         const incidentClient = rpcClient.forPlugin(IncidentApi);
 
+        // Create gitops client for provenance lock checks
+        const gitOpsClient = rpcClient.forPlugin(GitOpsApi);
+
         // Setup queue-based health check worker
         await setupHealthCheckWorker({
           db: database,
@@ -189,6 +193,7 @@ export default createBackendPlugin({
           database: database as SafeDatabase<typeof schema>,
           registry: healthCheckRegistry,
           collectorRegistry,
+          gitOpsClient,
           getEmitHook: () => storedEmitHook,
         });
         rpc.registerRouter(healthCheckRouter, healthCheckContract);

--- a/core/healthcheck-backend/src/router.test.ts
+++ b/core/healthcheck-backend/src/router.test.ts
@@ -50,10 +50,15 @@ describe("HealthCheck Router", () => {
     getCollectorsForPlugin: mock(() => []),
   };
 
+  const mockGitOpsClient = {
+    getProvenance: mock<any>(() => Promise.resolve(null)),
+  };
+
   const router = createHealthCheckRouter({
     database: mockDb as never,
     registry: mockRegistry,
     collectorRegistry: mockCollectorRegistry as never,
+    gitOpsClient: mockGitOpsClient as never,
     getEmitHook: () => undefined,
   });
 
@@ -168,5 +173,64 @@ describe("HealthCheck Router", () => {
       { context },
     );
     expect(result).toHaveLength(0);
+  });
+
+  describe("GitOps Provenance Enforcement", () => {
+    it("allows deleteConfiguration when GitOps lock is not present", async () => {
+      mockGitOpsClient.getProvenance.mockResolvedValueOnce(null);
+      const context = createMockRpcContext({ user: mockUser });
+      
+      try {
+        await call(router.deleteConfiguration, "config-1", { context });
+      } catch (e: any) {
+        // If it throws anything other than FORBIDDEN, it passed the lock check
+        expect(e.code).not.toBe("FORBIDDEN");
+      }
+      
+      expect(mockGitOpsClient.getProvenance).toHaveBeenCalledWith({
+        kind: "Healthcheck",
+        entityId: "config-1"
+      });
+    });
+
+    it("throws FORBIDDEN when deleting a GitOps locked configuration", async () => {
+      mockGitOpsClient.getProvenance.mockResolvedValueOnce({ 
+        id: "prov-1", kind: "Healthcheck", entityId: "config-1", 
+        providerId: "prov", entityName: "c1", status: "synced", 
+        lastSyncedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+        repository: "", filePath: "", fileSha: ""
+      });
+      const context = createMockRpcContext({ user: mockUser });
+      
+      let error;
+      try {
+        await call(router.deleteConfiguration, "config-1", { context });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect((error as any).code).toBe("FORBIDDEN");
+      expect((error as any).message).toContain("managed by GitOps");
+    });
+    
+    it("throws FORBIDDEN when associating a system that is GitOps locked", async () => {
+      mockGitOpsClient.getProvenance.mockResolvedValueOnce({ 
+        id: "prov-1", kind: "System", entityId: "sys-1", 
+        providerId: "prov", entityName: "s1", status: "synced", 
+        lastSyncedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+        repository: "", filePath: "", fileSha: ""
+      });
+      const context = createMockRpcContext({ user: mockUser });
+      
+      let error;
+      try {
+        await call(router.associateSystem, { systemId: "sys-1", body: { configurationId: "12345678-1234-4234-8234-123456789012", enabled: true, satelliteIds: [], includeLocal: false } }, { context });
+      } catch (e: any) {
+        error = e;
+        if (e.code !== "FORBIDDEN") console.log(e.issues || e.message);
+      }
+      expect(error).toBeDefined();
+      expect((error as any).code).toBe("FORBIDDEN");
+    });
   });
 });

--- a/core/healthcheck-backend/src/router.ts
+++ b/core/healthcheck-backend/src/router.ts
@@ -13,6 +13,8 @@ import { HealthCheckService } from "./service";
 import { healthCheckHooks } from "./hooks";
 import * as schema from "./schema";
 import { toJsonSchemaWithChartMeta } from "./schema-utils";
+import type { InferClient } from "@checkstack/common";
+import { GitOpsApi } from "@checkstack/gitops-common";
 
 /**
  * Creates the healthcheck router using contract-based implementation.
@@ -24,6 +26,7 @@ export const createHealthCheckRouter = (opts: {
   database: SafeDatabase<typeof schema>;
   registry: HealthCheckRegistry;
   collectorRegistry: CollectorRegistry;
+  gitOpsClient: InferClient<typeof GitOpsApi>;
   getEmitHook: () => ((hook: { id: string }, payload: Record<string, unknown>) => Promise<void>) | undefined;
 }) => {
   const { database, registry, collectorRegistry, getEmitHook } = opts;
@@ -34,6 +37,18 @@ export const createHealthCheckRouter = (opts: {
   const os = implement(healthCheckContract)
     .$context<RpcContext>()
     .use(autoAuthMiddleware);
+
+  const enforceNotGitOpsLocked = async (kind: string, entityId: string) => {
+    const provenance = await opts.gitOpsClient.getProvenance({
+      kind,
+      entityId,
+    });
+    if (provenance) {
+      throw new ORPCError("FORBIDDEN", {
+        message: `${kind} is managed by GitOps and cannot be modified manually.`,
+      });
+    }
+  };
 
   return os.router({
     getStrategies: os.getStrategies.handler(async ({ context }) => {
@@ -101,6 +116,7 @@ export const createHealthCheckRouter = (opts: {
     }),
 
     updateConfiguration: os.updateConfiguration.handler(async ({ input }) => {
+      await enforceNotGitOpsLocked("Healthcheck", input.id);
       const config = await service.updateConfiguration(input.id, input.body);
       if (!config) {
         throw new ORPCError("NOT_FOUND", {
@@ -111,14 +127,17 @@ export const createHealthCheckRouter = (opts: {
     }),
 
     deleteConfiguration: os.deleteConfiguration.handler(async ({ input }) => {
+      await enforceNotGitOpsLocked("Healthcheck", input);
       await service.deleteConfiguration(input);
     }),
 
     pauseConfiguration: os.pauseConfiguration.handler(async ({ input }) => {
+      await enforceNotGitOpsLocked("Healthcheck", input);
       await service.pauseConfiguration(input);
     }),
 
     resumeConfiguration: os.resumeConfiguration.handler(async ({ input }) => {
+      await enforceNotGitOpsLocked("Healthcheck", input);
       await service.resumeConfiguration(input);
     }),
 
@@ -135,6 +154,7 @@ export const createHealthCheckRouter = (opts: {
     ),
 
     associateSystem: os.associateSystem.handler(async ({ input, context }) => {
+      await enforceNotGitOpsLocked("System", input.systemId);
       await service.associateSystem({
         systemId: input.systemId,
         configurationId: input.body.configurationId,
@@ -173,6 +193,7 @@ export const createHealthCheckRouter = (opts: {
     }),
 
     disassociateSystem: os.disassociateSystem.handler(async ({ input }) => {
+      await enforceNotGitOpsLocked("System", input.systemId);
       await service.disassociateSystem(input.systemId, input.configId);
 
       // Notify subscribers that assignments changed
@@ -191,6 +212,7 @@ export const createHealthCheckRouter = (opts: {
 
     updateRetentionConfig: os.updateRetentionConfig.handler(
       async ({ input }) => {
+        await enforceNotGitOpsLocked("System", input.systemId);
         await service.updateRetentionConfig(
           input.systemId,
           input.configurationId,

--- a/core/healthcheck-frontend/src/components/HealthCheckList.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckList.tsx
@@ -14,6 +14,7 @@ import {
   Badge,
 } from "@checkstack/ui";
 import { Trash2, Edit, Pause, Play } from "lucide-react";
+import { useProvenanceLock } from "@checkstack/gitops-frontend";
 
 interface HealthCheckListProps {
   configurations: HealthCheckConfiguration[];
@@ -59,68 +60,112 @@ export const HealthCheckList: React.FC<HealthCheckListProps> = ({
             </TableRow>
           ) : (
             configurations.map((config) => (
-              <TableRow
+              <HealthCheckRow
                 key={config.id}
-                className={config.paused ? "opacity-60" : ""}
-              >
-                <TableCell className="font-medium">{config.name}</TableCell>
-                <TableCell>{getStrategyName(config.strategyId)}</TableCell>
-                <TableCell>{config.intervalSeconds}</TableCell>
-                <TableCell>
-                  {config.paused ? (
-                    <Badge variant="secondary">Paused</Badge>
-                  ) : (
-                    <Badge variant="default">Active</Badge>
-                  )}
-                </TableCell>
-                <TableCell className="text-right">
-                  <div className="flex justify-end gap-2">
-                    {canManage &&
-                      onPause &&
-                      onResume &&
-                      (config.paused ? (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => onResume(config.id)}
-                          title="Resume health check"
-                        >
-                          <Play className="h-4 w-4" />
-                        </Button>
-                      ) : (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => onPause(config.id)}
-                          title="Pause health check"
-                        >
-                          <Pause className="h-4 w-4" />
-                        </Button>
-                      ))}
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => onEdit(config)}
-                    >
-                      <Edit className="h-4 w-4" />
-                    </Button>
-                    {canManage && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-destructive hover:text-destructive"
-                        onClick={() => onDelete(config.id)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    )}
-                  </div>
-                </TableCell>
-              </TableRow>
+                config={config}
+                strategyName={getStrategyName(config.strategyId)}
+                onEdit={onEdit}
+                onDelete={onDelete}
+                onPause={onPause}
+                onResume={onResume}
+                canManage={canManage}
+              />
             ))
           )}
         </TableBody>
       </Table>
     </div>
+  );
+};
+
+interface HealthCheckRowProps {
+  config: HealthCheckConfiguration;
+  strategyName: string;
+  onEdit: (config: HealthCheckConfiguration) => void;
+  onDelete: (id: string) => void;
+  onPause?: (id: string) => void;
+  onResume?: (id: string) => void;
+  canManage: boolean;
+}
+
+const HealthCheckRow: React.FC<HealthCheckRowProps> = ({
+  config,
+  strategyName,
+  onEdit,
+  onDelete,
+  onPause,
+  onResume,
+  canManage,
+}) => {
+  const { isLocked } = useProvenanceLock({
+    kind: "Healthcheck",
+    entityId: config.id,
+  });
+
+  return (
+    <TableRow className={config.paused ? "opacity-60" : ""}>
+      <TableCell className="font-medium">{config.name}</TableCell>
+      <TableCell>{strategyName}</TableCell>
+      <TableCell>{config.intervalSeconds}</TableCell>
+      <TableCell>
+        {config.paused ? (
+          <Badge variant="secondary">Paused</Badge>
+        ) : (
+          <Badge variant="default">Active</Badge>
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        <div className="flex justify-end gap-2">
+          {canManage &&
+            onPause &&
+            onResume &&
+            (config.paused ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onResume(config.id)}
+                title={isLocked ? "Managed by GitOps" : "Resume health check"}
+                disabled={isLocked}
+              >
+                <Play className="h-4 w-4" />
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onPause(config.id)}
+                title={isLocked ? "Managed by GitOps" : "Pause health check"}
+                disabled={isLocked}
+              >
+                <Pause className="h-4 w-4" />
+              </Button>
+            ))}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onEdit(config)}
+            title={
+              isLocked
+                ? "View configuration (Managed by GitOps)"
+                : "Edit configuration"
+            }
+          >
+            <Edit className="h-4 w-4" />
+          </Button>
+          {canManage && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-destructive hover:text-destructive"
+              onClick={() => onDelete(config.id)}
+              disabled={isLocked}
+              title={isLocked ? "Managed by GitOps" : "Delete configuration"}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
   );
 };

--- a/core/healthcheck-frontend/src/components/assignments/AssignmentTree.tsx
+++ b/core/healthcheck-frontend/src/components/assignments/AssignmentTree.tsx
@@ -25,6 +25,7 @@ interface AssignmentTreeProps {
   selectedNode: AssignmentNodeId | undefined;
   onSelectNode: (nodeId: AssignmentNodeId) => void;
   onToggleAssignment: (configId: string, assigned: boolean) => void;
+  isLocked?: boolean;
 }
 
 // =============================================================================
@@ -37,6 +38,7 @@ export const AssignmentTree: React.FC<AssignmentTreeProps> = ({
   selectedNode,
   onSelectNode,
   onToggleAssignment,
+  isLocked,
 }) => {
   return (
     <div className="py-2">
@@ -99,7 +101,7 @@ export const AssignmentTree: React.FC<AssignmentTreeProps> = ({
       ))}
 
       {/* Available (unassigned) health checks */}
-      {available.length > 0 && (
+      {!isLocked && available.length > 0 && (
         <>
           <IDETreeSection label="Available" />
           {available.map((config) => (

--- a/core/healthcheck-frontend/src/components/assignments/ExecutionPanel.tsx
+++ b/core/healthcheck-frontend/src/components/assignments/ExecutionPanel.tsx
@@ -16,6 +16,7 @@ interface ExecutionPanelProps {
   onToggleLocal: () => void;
   onToggleSatellite: (satelliteId: string) => void;
   saving: boolean;
+  isLocked?: boolean;
 }
 
 /**
@@ -29,6 +30,7 @@ export const ExecutionPanel: React.FC<ExecutionPanelProps> = ({
   onToggleLocal,
   onToggleSatellite,
   saving,
+  isLocked,
 }) => {
   const hasSatellites = satelliteIds.length > 0;
   const willRunAnywhere = includeLocal || hasSatellites;
@@ -49,7 +51,7 @@ export const ExecutionPanel: React.FC<ExecutionPanelProps> = ({
           <Checkbox
             checked={includeLocal}
             onCheckedChange={onToggleLocal}
-            disabled={saving || (!hasSatellites && includeLocal)}
+            disabled={saving || isLocked || (!hasSatellites && includeLocal)}
           />
           <div>
             <Label className="text-sm font-medium">Run Locally</Label>
@@ -87,7 +89,7 @@ export const ExecutionPanel: React.FC<ExecutionPanelProps> = ({
                   <Checkbox
                     checked={isChecked}
                     onCheckedChange={() => onToggleSatellite(sat.id)}
-                    disabled={saving}
+                    disabled={saving || isLocked}
                   />
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">

--- a/core/healthcheck-frontend/src/components/assignments/GeneralPanel.tsx
+++ b/core/healthcheck-frontend/src/components/assignments/GeneralPanel.tsx
@@ -13,6 +13,7 @@ interface GeneralPanelProps {
   onToggleEnabled: () => void;
   onUnassign: () => void;
   saving: boolean;
+  isLocked?: boolean;
 }
 
 /**
@@ -26,6 +27,7 @@ export const GeneralPanel: React.FC<GeneralPanelProps> = ({
   onToggleEnabled,
   onUnassign,
   saving,
+  isLocked,
 }) => {
   const editUrl = resolveRoute(healthcheckRoutes.routes.edit, {
     configId: configurationId,
@@ -46,7 +48,7 @@ export const GeneralPanel: React.FC<GeneralPanelProps> = ({
           <Checkbox
             checked={enabled}
             onCheckedChange={onToggleEnabled}
-            disabled={saving}
+            disabled={saving || isLocked}
           />
           <div>
             <Label className="text-sm font-medium">Enabled</Label>
@@ -85,7 +87,8 @@ export const GeneralPanel: React.FC<GeneralPanelProps> = ({
           variant="ghost"
           size="sm"
           onClick={onUnassign}
-          disabled={saving}
+          disabled={saving || isLocked}
+          title={isLocked ? "Managed by GitOps" : undefined}
           className="text-destructive hover:text-destructive hover:bg-destructive/10"
         >
           <Trash2 className="h-3.5 w-3.5 mr-1.5" />

--- a/core/healthcheck-frontend/src/components/assignments/RetentionPanel.tsx
+++ b/core/healthcheck-frontend/src/components/assignments/RetentionPanel.tsx
@@ -14,6 +14,7 @@ interface RetentionPanelProps {
   onSave: () => void;
   onReset: () => void;
   saving: boolean;
+  isLocked?: boolean;
 }
 
 /**
@@ -25,6 +26,7 @@ export const RetentionPanel: React.FC<RetentionPanelProps> = ({
   onSave,
   onReset,
   saving,
+  isLocked,
 }) => {
   if (!data) {
     return (
@@ -68,6 +70,7 @@ export const RetentionPanel: React.FC<RetentionPanelProps> = ({
         min={1}
         max={30}
         onChange={(v) => onFieldChange("rawRetentionDays", v)}
+        disabled={saving || isLocked}
       />
 
       {/* Hourly Aggregates */}
@@ -78,6 +81,7 @@ export const RetentionPanel: React.FC<RetentionPanelProps> = ({
         min={7}
         max={365}
         onChange={(v) => onFieldChange("hourlyRetentionDays", v)}
+        disabled={saving || isLocked}
       />
 
       {/* Daily Aggregates */}
@@ -88,6 +92,7 @@ export const RetentionPanel: React.FC<RetentionPanelProps> = ({
         min={30}
         max={1095}
         onChange={(v) => onFieldChange("dailyRetentionDays", v)}
+        disabled={saving || isLocked}
       />
 
       {/* Actions */}
@@ -96,14 +101,14 @@ export const RetentionPanel: React.FC<RetentionPanelProps> = ({
           variant="ghost"
           size="sm"
           onClick={onReset}
-          disabled={saving || !data.isCustom}
+          disabled={saving || isLocked || !data.isCustom}
         >
           Reset to Defaults
         </Button>
         <Button
           size="sm"
           onClick={onSave}
-          disabled={saving || !isValidHierarchy}
+          disabled={saving || isLocked || !isValidHierarchy}
         >
           {saving ? "Saving..." : "Save Retention"}
         </Button>
@@ -123,6 +128,7 @@ function RetentionTier({
   min,
   max,
   onChange,
+  disabled,
 }: {
   label: string;
   description: string;
@@ -130,6 +136,7 @@ function RetentionTier({
   min: number;
   max: number;
   onChange: (value: number) => void;
+  disabled?: boolean;
 }) {
   return (
     <div className="p-3 rounded-lg border bg-muted/30">
@@ -145,6 +152,7 @@ function RetentionTier({
             max={max}
             value={value}
             onChange={(e) => onChange(Number(e.target.value))}
+            disabled={disabled}
             className="h-8 w-20 text-center"
           />
           <span className="text-sm text-muted-foreground w-10">days</span>

--- a/core/healthcheck-frontend/src/components/assignments/ThresholdsPanel.tsx
+++ b/core/healthcheck-frontend/src/components/assignments/ThresholdsPanel.tsx
@@ -18,6 +18,7 @@ interface ThresholdsPanelProps {
   onChange: (thresholds: StateThresholds) => void;
   onSave: () => void;
   saving: boolean;
+  isLocked?: boolean;
 }
 
 /**
@@ -29,6 +30,7 @@ export const ThresholdsPanel: React.FC<ThresholdsPanelProps> = ({
   onChange,
   onSave,
   saving,
+  isLocked,
 }) => {
   return (
     <div className="p-6 space-y-4">
@@ -64,6 +66,7 @@ export const ThresholdsPanel: React.FC<ThresholdsPanelProps> = ({
               });
             }
           }}
+          disabled={saving || isLocked}
         >
           <SelectTrigger className="w-full">
             <SelectValue />
@@ -96,6 +99,7 @@ export const ThresholdsPanel: React.FC<ThresholdsPanelProps> = ({
             onChange={(v) =>
               onChange({ ...thresholds, healthy: { minSuccessCount: v } })
             }
+            disabled={saving || isLocked}
           />
           <ThresholdCard
             status="warning"
@@ -106,6 +110,7 @@ export const ThresholdsPanel: React.FC<ThresholdsPanelProps> = ({
             onChange={(v) =>
               onChange({ ...thresholds, degraded: { minFailureCount: v } })
             }
+            disabled={saving || isLocked}
           />
           <ThresholdCard
             status="destructive"
@@ -116,6 +121,7 @@ export const ThresholdsPanel: React.FC<ThresholdsPanelProps> = ({
             onChange={(v) =>
               onChange({ ...thresholds, unhealthy: { minFailureCount: v } })
             }
+            disabled={saving || isLocked}
           />
         </div>
       ) : (
@@ -139,6 +145,7 @@ export const ThresholdsPanel: React.FC<ThresholdsPanelProps> = ({
                       windowSize: Number.parseInt(e.target.value) || 10,
                     })
                   }
+                  disabled={saving || isLocked}
                   className="h-8 w-16 text-center"
                 />
                 <span className="text-xs text-muted-foreground">runs</span>
@@ -156,6 +163,7 @@ export const ThresholdsPanel: React.FC<ThresholdsPanelProps> = ({
             onChange={(v) =>
               onChange({ ...thresholds, degraded: { minFailureCount: v } })
             }
+            disabled={saving || isLocked}
           />
           <ThresholdCard
             status="destructive"
@@ -167,13 +175,14 @@ export const ThresholdsPanel: React.FC<ThresholdsPanelProps> = ({
             onChange={(v) =>
               onChange({ ...thresholds, unhealthy: { minFailureCount: v } })
             }
+            disabled={saving || isLocked}
           />
         </div>
       )}
 
       {/* Save Button */}
       <div className="flex justify-end pt-2 border-t">
-        <Button size="sm" onClick={onSave} disabled={saving}>
+        <Button size="sm" onClick={onSave} disabled={saving || isLocked}>
           {saving ? "Saving..." : "Save Thresholds"}
         </Button>
       </div>
@@ -214,6 +223,7 @@ function ThresholdCard({
   prefix,
   suffix,
   onChange,
+  disabled,
 }: {
   status: keyof typeof STATUS_STYLES;
   label: string;
@@ -222,6 +232,7 @@ function ThresholdCard({
   prefix?: string;
   suffix: string;
   onChange: (value: number) => void;
+  disabled?: boolean;
 }) {
   const styles = STATUS_STYLES[status];
   return (
@@ -241,6 +252,7 @@ function ThresholdCard({
             min={1}
             value={value}
             onChange={(e) => onChange(Number.parseInt(e.target.value) || 1)}
+            disabled={disabled}
             className="h-8 w-16 text-center"
           />
           <span className="text-xs text-muted-foreground w-20">{suffix}</span>

--- a/core/healthcheck-frontend/src/pages/AssignmentIDEPage.tsx
+++ b/core/healthcheck-frontend/src/pages/AssignmentIDEPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "../components/assignments/AssignmentTree";
 import { GeneralPanel } from "../components/assignments/GeneralPanel";
 import { ThresholdsPanel } from "../components/assignments/ThresholdsPanel";
+import { useProvenanceLock, GitOpsLockBanner } from "@checkstack/gitops-frontend";
 import {
   RetentionPanel,
   type RetentionData,
@@ -60,6 +61,11 @@ const AssignmentIDEPageContent = () => {
       { systemId: systemId ?? "" },
       { enabled: !!systemId },
     );
+
+  const { isLocked, provenance } = useProvenanceLock({
+    kind: "System",
+    entityId: systemId,
+  });
 
   const { data: satellitesData } = satelliteClient.listSatellites.useQuery({});
 
@@ -390,6 +396,7 @@ const AssignmentIDEPageContent = () => {
             onToggleEnabled={() => handleToggleEnabled(configId, assoc.enabled)}
             onUnassign={() => handleToggleAssignment(configId, true)}
             saving={saving}
+            isLocked={isLocked}
           />
         );
       }
@@ -404,6 +411,7 @@ const AssignmentIDEPageContent = () => {
             onChange={(t) => handleThresholdChange(configId, t)}
             onSave={() => handleSaveThresholds(configId)}
             saving={saving}
+            isLocked={isLocked}
           />
         );
       }
@@ -417,6 +425,7 @@ const AssignmentIDEPageContent = () => {
             onSave={() => handleSaveRetention(configId)}
             onReset={() => handleResetRetention(configId)}
             saving={saving}
+            isLocked={isLocked}
           />
         );
       }
@@ -431,6 +440,7 @@ const AssignmentIDEPageContent = () => {
               handleToggleSatellite(configId, satId)
             }
             saving={saving}
+            isLocked={isLocked}
           />
         );
       }
@@ -458,6 +468,11 @@ const AssignmentIDEPageContent = () => {
         </BackLink>
       }
     >
+      {isLocked && provenance && (
+        <div className="mb-4">
+          <GitOpsLockBanner provenance={provenance} />
+        </div>
+      )}
       <IDELayout
         tree={
           <AssignmentTree
@@ -466,6 +481,7 @@ const AssignmentIDEPageContent = () => {
             selectedNode={selectedNode}
             onSelectNode={setSelectedNode}
             onToggleAssignment={handleToggleAssignment}
+            isLocked={isLocked}
           />
         }
         panel={renderPanel()}


### PR DESCRIPTION
This PR enforces GitOps provenance locking at the API layer. Systems and configurations managed by GitOps cannot be mutated manually via the API/UI. The internal GitOps sync bypasses the RPC layer, enabling seamless reconciliation while protecting against manual configuration drift.