### PR TITLE
Fix vendor build conflicting with Vite publicDir — favicon not served in production

### DIFF
--- a/.changeset/fix-vendor-public-conflict.md
+++ b/.changeset/fix-vendor-public-conflict.md
@@ -1,0 +1,10 @@
+---
+"@checkstack/frontend": patch
+---
+
+Fix vendor build output conflicting with Vite's publicDir
+
+The vendor build was outputting to `public/vendor/` which is inside Vite's `publicDir` (`public/`). This caused Vite to skip copying public directory contents (including `favicon.svg`) to the `dist/` folder during production builds, resulting in missing static assets in the Docker container.
+
+- Move vendor build output from `public/vendor/` to `dist/vendor/`
+- Set `emptyOutDir: false` on the main build to preserve the pre-built vendor bundles

--- a/core/frontend/vite.config.ts
+++ b/core/frontend/vite.config.ts
@@ -50,6 +50,9 @@ export default defineConfig(() => {
       target: "esnext",
       // Generate sourcemaps for production debugging
       sourcemap: true,
+      // Don't wipe dist/ — the vendor build (build:vendor) writes to dist/vendor/
+      // before this build runs, and we need to preserve those files
+      emptyOutDir: false,
     },
     resolve: {
       // Force all monorepo packages to use the same React copy at build time.

--- a/core/frontend/vite.config.vendor.ts
+++ b/core/frontend/vite.config.vendor.ts
@@ -9,8 +9,10 @@ import path from "node:path";
  * We point directly to node_modules - no custom entry files needed.
  */
 export default defineConfig({
+  // Don't copy public/ contents — the main build handles that
+  publicDir: false,
   build: {
-    outDir: "public/vendor",
+    outDir: "dist/vendor",
     emptyOutDir: true,
     lib: {
       formats: ["es"],


### PR DESCRIPTION
## Problem

The favicon fails to load in the production Docker container with:

> `This page contains the following error: error on line 1 at column 1: Start tag expected, '<' not found`

### Root cause

The vendor build (`vite.config.vendor.ts`) outputs to `public/vendor/`, which is **inside** Vite's `publicDir` (`public/`). This triggers the warning:

> `(!) The public directory feature may not work correctly. outDir public/vendor and publicDir public are not separate folders.`

When Vite detects this conflict, it **skips copying `public/` contents to `dist/`**, meaning `favicon.svg` never makes it into the production bundle. The backend then serves `index.html` as fallback (with the correct SVG MIME type from `Bun.file().type`), causing the XML parse error.

## Fix

| File | Change |
|------|--------|
| `vite.config.vendor.ts` | Move `outDir` from `public/vendor` → `dist/vendor` |
| `vite.config.vendor.ts` | Set `publicDir: false` (vendor build shouldn't copy public assets) |
| `vite.config.ts` | Set `emptyOutDir: false` so the main build preserves `dist/vendor/` |

### Build order

1. `build:vendor` → writes vendor bundles to `dist/vendor/`
2. `vite build` → writes app bundle to `dist/assets/`, copies `public/favicon.svg` → `dist/favicon.svg`, preserves `dist/vendor/`

### Verified

- ✅ Clean build produces correct `dist/` structure
- ✅ `favicon.svg` present in `dist/` root with correct MIME type
- ✅ No stray files in `dist/vendor/`
- ✅ No publicDir/outDir conflict warning
- ✅ Lint passes
- ✅ Dev server unaffected (`public/vendor/` still served by Vite dev)