### PR TITLE
Fix static file Content-Length header stripped by Hono middleware

### DIFF
--- a/.changeset/fix-static-content-length.md
+++ b/.changeset/fix-static-content-length.md
@@ -1,0 +1,7 @@
+---
+"@checkstack/backend": patch
+---
+
+Fix static file Content-Length header stripped by Hono middleware
+
+Hono's CORS middleware wraps raw `Response` objects and strips Bun's auto-generated headers. Switched to using `c.body()` + `c.header()` so Content-Type and Content-Length survive the middleware pipeline. Extracted a shared `serveFile` helper for all static file routes.

--- a/core/backend/src/index.ts
+++ b/core/backend/src/index.ts
@@ -1,5 +1,5 @@
 import type { Server } from "bun";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { PluginManager } from "./plugin-manager";
 import { logger } from "hono/logger";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
@@ -174,6 +174,13 @@ app.get("/.well-known/jwks.json", async (c) => {
 const frontendDistPath = process.env.CHECKSTACK_FRONTEND_DIST;
 if (frontendDistPath && fs.existsSync(frontendDistPath)) {
   rootLogger.info(`📦 Serving frontend from: ${frontendDistPath}`);
+  /** Serve a static file via Hono's context to preserve headers through middleware. */
+  const serveFile = async (c: Context, filePath: string) => {
+    const file = Bun.file(filePath);
+    c.header("Content-Type", file.type);
+    c.header("Content-Length", String(file.size));
+    return c.body(file.stream());
+  };
 
   // Serve static assets (JS, CSS, images, etc.)
   app.get("/assets/*", async (c) => {
@@ -181,10 +188,7 @@ if (frontendDistPath && fs.existsSync(frontendDistPath)) {
     const filePath = path.join(frontendDistPath, "assets", assetPath);
 
     if (fs.existsSync(filePath)) {
-      const file = Bun.file(filePath);
-      return new Response(file, {
-        headers: { "Content-Type": file.type },
-      });
+      return serveFile(c, filePath);
     }
     return c.notFound();
   });
@@ -195,10 +199,7 @@ if (frontendDistPath && fs.existsSync(frontendDistPath)) {
     const filePath = path.join(frontendDistPath, "vendor", vendorPath);
 
     if (fs.existsSync(filePath)) {
-      const file = Bun.file(filePath);
-      return new Response(file, {
-        headers: { "Content-Type": file.type },
-      });
+      return serveFile(c, filePath);
     }
     return c.notFound();
   });
@@ -218,20 +219,14 @@ if (frontendDistPath && fs.existsSync(frontendDistPath)) {
       const staticFilePath = path.join(frontendDistPath, reqPath);
       // Only serve if it's a file (not a directory) and exists
       if (fs.existsSync(staticFilePath) && fs.statSync(staticFilePath).isFile()) {
-        const file = Bun.file(staticFilePath);
-        return new Response(file, {
-          headers: { "Content-Type": file.type },
-        });
+        return serveFile(c, staticFilePath);
       }
     }
 
     // SPA fallback: serve index.html for all remaining non-API routes
     const indexPath = path.join(frontendDistPath, "index.html");
     if (fs.existsSync(indexPath)) {
-      const file = Bun.file(indexPath);
-      return new Response(file, {
-        headers: { "Content-Type": "text/html" },
-      });
+      return serveFile(c, indexPath);
     }
     return c.notFound();
   });


### PR DESCRIPTION
## Problem

Static files served in the production container have `content-length: 0` despite the body being sent correctly. Browsers see the zero-length header and fail to parse the response body, causing errors like:

> `This page contains the following error: error on line 1 at column 1: Start tag expected, '<' not found`

### Root cause

Hono's CORS middleware (applied via `app.use('*', cors(...))`) wraps raw `Response` objects returned from route handlers. When a handler returns `new Response(BunFile)` or `new Response(BunFile, { headers })`, Bun's auto-generated `Content-Type` and `Content-Length` headers are lost during the middleware wrapping.

### Verified via Docker

```
# Before fix
content-length: 0  ❌

# After fix  
Content-Type: image/svg+xml
content-length: 1098  ✅
```

## Fix

Use Hono's `c.body()` + `c.header()` API instead of raw `Response` objects, so headers survive the middleware pipeline:

```typescript
const serveFile = async (c: Context, filePath: string) => {
  const file = Bun.file(filePath);
  c.header('Content-Type', file.type);
  c.header('Content-Length', String(file.size));
  return c.body(file.stream());
};
```

Extracted as a shared `serveFile` helper used by all three static file routes (`/assets/*`, `/vendor/*`, `*` catch-all).