### PR TITLE
Fix truncated static file responses — use ArrayBuffer instead of stream

### DIFF
--- a/.changeset/fix-truncated-static-responses.md
+++ b/.changeset/fix-truncated-static-responses.md
@@ -1,0 +1,7 @@
+---
+"@checkstack/backend": patch
+---
+
+Fix truncated static file responses in production container
+
+Hono's `c.body()` wasn't fully consuming Bun's `ReadableStream` from `file.stream()`, causing truncated responses (e.g. 129B instead of 1098B for the favicon). Switched to reading the file as `ArrayBuffer` before passing to `c.body()`, ensuring the full content is delivered.

--- a/core/backend/src/index.ts
+++ b/core/backend/src/index.ts
@@ -177,9 +177,9 @@ if (frontendDistPath && fs.existsSync(frontendDistPath)) {
   /** Serve a static file via Hono's context to preserve headers through middleware. */
   const serveFile = async (c: Context, filePath: string) => {
     const file = Bun.file(filePath);
+    const content = await file.arrayBuffer();
     c.header("Content-Type", file.type);
-    c.header("Content-Length", String(file.size));
-    return c.body(file.stream());
+    return c.body(content);
   };
 
   // Serve static assets (JS, CSS, images, etc.)


### PR DESCRIPTION
## Problem

Static files in the production container are truncated (e.g. favicon.svg returns 129B instead of 1098B), causing the browser to fail rendering them.

### Root cause

Hono's `c.body()` wasn't fully consuming Bun's `ReadableStream` from `file.stream()`. The stream was being closed/truncated before all chunks were read.

## Fix

Read the file as `ArrayBuffer` before passing to `c.body()`:

```diff
-    c.header('Content-Length', String(file.size));
-    return c.body(file.stream());
+    const content = await file.arrayBuffer();
+    c.header('Content-Type', file.type);
+    return c.body(content);
```

### Verified

- ✅ `curl -s http://localhost:7001/favicon.svg | wc -c` returns `1098` (full file)
- ✅ `Content-Type: image/svg+xml` header present
- ✅ Favicon renders correctly in browser