### PR TITLE
fix: resolve session loss for LDAP/SAML auth strategies

### DIFF
--- a/.changeset/fix-session-cookie-corruption.md
+++ b/.changeset/fix-session-cookie-corruption.md
@@ -1,0 +1,12 @@
+---
+"@checkstack/auth-common": patch
+"@checkstack/auth-backend": patch
+"@checkstack/auth-ldap-backend": patch
+"@checkstack/auth-saml-backend": patch
+---
+
+Fix session loss for LDAP and SAML authentication strategies
+
+The auth bridge was joining multiple `Set-Cookie` headers into a single comma-separated string, which corrupted cookie attributes. This caused the `session_token` cookie to inherit the 5-minute `maxAge` from the `session_data` cache cookie instead of the intended 7-day expiry. After the cookie expired from the browser, `get-session` returned `null` and all API calls failed with 401.
+
+Changed the `createSession` RPC contract to return `setCookies: string[]` (array) instead of `setCookie: string`, and updated LDAP/SAML consumers to use `Headers.append("Set-Cookie", ...)` to set each cookie as a separate header.

--- a/core/auth-backend/src/router.test.ts
+++ b/core/auth-backend/src/router.test.ts
@@ -359,11 +359,12 @@ describe("Auth Router", () => {
 
     const mockResponse = { sessionId: "session-123" };
     const mockHandler = mock(async (_req: Request) => {
+      const headers = new Headers();
+      headers.append("Set-Cookie", "better-auth.session_token=test-token; Path=/; HttpOnly; Max-Age=604800");
+      headers.append("Set-Cookie", "better-auth.session_data=test-data; Path=/; HttpOnly; Max-Age=300");
       return new Response(JSON.stringify(mockResponse), {
         status: 200,
-        headers: {
-          "Set-Cookie": "better-auth.session_token=test-token; Path=/; HttpOnly",
-        },
+        headers,
       });
     });
 
@@ -386,7 +387,9 @@ describe("Auth Router", () => {
     );
 
     expect(result.sessionId).toBe("session-123");
-    expect(result.setCookie).toContain("better-auth.session_token=test-token");
+    expect(result.setCookies).toBeArrayOfSize(2);
+    expect(result.setCookies[0]).toContain("better-auth.session_token=test-token");
+    expect(result.setCookies[1]).toContain("better-auth.session_data=test-data");
     expect(mockHandler).toHaveBeenCalled();
 
     // Verify the virtual request headers

--- a/core/auth-backend/src/router.ts
+++ b/core/auth-backend/src/router.ts
@@ -1106,14 +1106,12 @@ export const createAuthRouter = (
       });
     }
 
-    // Extract Set-Cookie. Use getSetCookie() if available (Bun/Node 20+), otherwise fallback to get()
-    // get() usually joins multiple cookies with a comma, which is often correct but sometimes brittle
-    const setCookie =
-      typeof res.headers.getSetCookie === "function"
-        ? res.headers.getSetCookie().join(", ")
-        : res.headers.get("set-cookie");
+    // Extract Set-Cookie headers as individual strings (one per cookie)
+    // Using getSetCookie() preserves each cookie separately — joining with commas
+    // corrupts cookie attributes that contain commas (e.g. Expires dates)
+    const setCookies = res.headers.getSetCookie();
 
-    if (!setCookie) {
+    if (setCookies.length === 0) {
       const headers: Record<string, string> = {};
       // eslint-disable-next-line unicorn/no-array-for-each
       res.headers.forEach((value, key) => {
@@ -1133,7 +1131,7 @@ export const createAuthRouter = (
 
     return {
       sessionId: body.sessionId,
-      setCookie,
+      setCookies,
     };
   });
 

--- a/core/auth-common/src/rpc-contract.ts
+++ b/core/auth-common/src/rpc-contract.ts
@@ -356,7 +356,7 @@ export const authContract = {
     access: [],
   })
     .input(CreateSessionInputSchema)
-    .output(z.object({ sessionId: z.string(), setCookie: z.string() })),
+    .output(z.object({ sessionId: z.string(), setCookies: z.array(z.string()) })),
 
   getUserById: proc({
     operationType: "query",

--- a/plugins/auth-ldap-backend/src/index.ts
+++ b/plugins/auth-ldap-backend/src/index.ts
@@ -636,7 +636,7 @@ export default createBackendPlugin({
             const ipAddress = req.headers.get("x-forwarded-for")?.split(",")[0].trim() || undefined;
             const userAgent = req.headers.get("user-agent") || undefined;
 
-            const { setCookie } = await authClient.createSession({
+            const { setCookies } = await authClient.createSession({
               userId,
               ipAddress,
               userAgent,
@@ -644,7 +644,13 @@ export default createBackendPlugin({
 
             logger.info(`Created bridged session for LDAP user: ${email} (IP: ${ipAddress ?? "unknown"})`);
 
-            // Return user info and include the signed session cookie from better-auth
+            // Return user info and include the signed session cookies from better-auth
+            // Each cookie must be set as a separate Set-Cookie header
+            const headers = new Headers();
+            for (const cookie of setCookies) {
+              headers.append("Set-Cookie", cookie);
+            }
+
             return Response.json(
               {
                 success: true,
@@ -654,11 +660,7 @@ export default createBackendPlugin({
                   name,
                 },
               },
-              {
-                headers: {
-                  "Set-Cookie": setCookie,
-                },
-              },
+              { headers },
             );
           } catch (error) {
             logger.error("LDAP login error:", error);

--- a/plugins/auth-saml-backend/src/index.ts
+++ b/plugins/auth-saml-backend/src/index.ts
@@ -548,7 +548,7 @@ export default createBackendPlugin({
             const ipAddress = req.headers.get("x-forwarded-for")?.split(",")[0].trim() || undefined;
             const userAgent = req.headers.get("user-agent") || undefined;
 
-            const { setCookie } = await authClient.createSession({
+            const { setCookies } = await authClient.createSession({
               userId,
               ipAddress,
               userAgent,
@@ -556,13 +556,16 @@ export default createBackendPlugin({
 
             logger.info(`Created bridged session for SAML user: ${email} (IP: ${ipAddress ?? "unknown"})`);
 
-            // Redirect to home with the signed session cookie from better-auth
+            // Redirect to home with the signed session cookies from better-auth
+            // Each cookie must be set as a separate Set-Cookie header
+            const headers = new Headers({ Location: "/" });
+            for (const cookie of setCookies) {
+              headers.append("Set-Cookie", cookie);
+            }
+
             return new Response(undefined, {
               status: 302,
-              headers: {
-                Location: "/",
-                "Set-Cookie": setCookie,
-              },
+              headers,
             });
           } catch (error) {
             logger.error("SAML ACS error:", error);


### PR DESCRIPTION
## Problem

Sessions created via LDAP or SAML authentication were expiring after ~5 minutes instead of the configured 7 days. The `/api/auth/get-session` endpoint returned `null` (HTTP 200) after the cookie expired, causing cascading 401 errors.

## Root Cause

The `createSession` RPC bridge joined multiple `Set-Cookie` headers from better-auth into a single comma-separated string:

```typescript
res.headers.getSetCookie().join(", ")  // Corrupts cookie attributes!
```

Cookie attributes like `Expires=Thu, 01 Jan 2026` contain commas, so the joined string was unparseable. The browser received garbled cookies where the `session_token` (7-day expiry) inherited the `session_data` cache cookie's 5-minute `maxAge`.

## Fix

- **Contract**: Changed `setCookie: string` → `setCookies: string[]` in the `createSession` RPC output
- **Bridge**: Use `getSetCookie()` directly to get individual cookie strings
- **LDAP/SAML plugins**: Use `Headers.append("Set-Cookie", ...)` to properly set multiple cookies

## Changed Packages

| Package | Change |
|---------|--------|
| `@checkstack/auth-common` | RPC contract shape |
| `@checkstack/auth-backend` | Bridge handler + test |
| `@checkstack/auth-ldap-backend` | Cookie forwarding |
| `@checkstack/auth-saml-backend` | Cookie forwarding |

## Verification

- ✅ `bun run typecheck` — 105/105 packages pass
- ✅ `bun run lint` — clean
- ✅ `auth-backend` tests — 46 pass
- ✅ `auth-ldap-backend` tests — 44 pass
- ✅ `auth-saml-backend` tests — 18 pass

## Manual Verification After Deploy

1. Login via LDAP → verify `session_token` cookie has ~7-day expiry (not 5 min)
2. Wait >5 minutes → session should persist