### PR TITLE
fix(queue): remove maxWidth constraint on queue config page

### DIFF
--- a/.changeset/fix-queue-layout.md
+++ b/.changeset/fix-queue-layout.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/queue-frontend": patch
+---
+
+Fix layout issue on the Queue Config page by removing maxWidth constraint

--- a/core/queue-frontend/src/pages/QueueConfigPage.tsx
+++ b/core/queue-frontend/src/pages/QueueConfigPage.tsx
@@ -82,7 +82,6 @@ const QueueConfigPageContent = () => {
       icon={Gauge}
       loading={accessLoading}
       allowed={canRead}
-      maxWidth="3xl"
     >
       <QueueLagAlert requireAccess={false} />
       <div className="space-y-6">


### PR DESCRIPTION
Fixes a layout issue where the Queue Config page was constrained to 3xl max-width.