### PR TITLE
fix: GitOps entity update failures due to pending error records

### DIFF
--- a/.changeset/fix-pending-updates.md
+++ b/.changeset/fix-pending-updates.md
@@ -1,0 +1,10 @@
+---
+"@checkstack/gitops-backend": patch
+"@checkstack/healthcheck-backend": patch
+---
+
+Fix GitOps entity update failures due to pending error records
+
+- Ensured the `existingEntityId` parameter in the Reconciler engine is set to `undefined` instead of a `"pending-UUID"` when handling entities that failed to sync initially.
+- Hardened the `Healthcheck` GitOps kind logic to explicitly ignore `"pending-"` IDs, preventing SQL update errors on synthetic provenance IDs.
+- Fixed a bug where resolving YAML syntax errors would cause the subsequent sync to fail with `failed query: update [...]` because it attempted to update the nonexistent `"pending-"` entity instead of creating a new one.

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "core/announcement-backend": {
       "name": "@checkstack/announcement-backend",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-backend": "workspace:*",
@@ -94,7 +94,7 @@
     },
     "core/announcement-frontend": {
       "name": "@checkstack/announcement-frontend",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -147,7 +147,7 @@
     },
     "core/auth-backend": {
       "name": "@checkstack/auth-backend",
-      "version": "0.4.18",
+      "version": "0.4.19",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -171,7 +171,7 @@
     },
     "core/auth-common": {
       "name": "@checkstack/auth-common",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -185,7 +185,7 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.5.27",
+      "version": "0.5.28",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -207,7 +207,7 @@
     },
     "core/backend": {
       "name": "@checkstack/backend",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -269,7 +269,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "core/catalog-common": {
       "name": "@checkstack/catalog-common",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -314,7 +314,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -404,7 +404,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -433,7 +433,7 @@
     },
     "core/dependency-backend": {
       "name": "@checkstack/dependency-backend",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -476,7 +476,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -507,7 +507,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -627,7 +627,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -677,7 +677,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -708,7 +708,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "0.4.21",
+      "version": "0.4.22",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -751,7 +751,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -833,7 +833,7 @@
     },
     "core/maintenance-backend": {
       "name": "@checkstack/maintenance-backend",
-      "version": "0.5.16",
+      "version": "0.5.17",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -876,7 +876,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -900,7 +900,7 @@
     },
     "core/notification-backend": {
       "name": "@checkstack/notification-backend",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -939,7 +939,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.2.32",
+      "version": "0.2.33",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1006,7 +1006,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1029,7 +1029,7 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.65.0",
+      "version": "0.66.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
@@ -1048,7 +1048,7 @@
     },
     "core/satellite-backend": {
       "name": "@checkstack/satellite-backend",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1170,7 +1170,7 @@
     },
     "core/slo-backend": {
       "name": "@checkstack/slo-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -1216,7 +1216,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1278,7 +1278,7 @@
     },
     "core/theme-backend": {
       "name": "@checkstack/theme-backend",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1313,7 +1313,7 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1376,7 +1376,7 @@
     },
     "plugins/auth-credential-backend": {
       "name": "@checkstack/auth-credential-backend",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1390,7 +1390,7 @@
     },
     "plugins/auth-github-backend": {
       "name": "@checkstack/auth-github-backend",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1404,7 +1404,7 @@
     },
     "plugins/auth-ldap-backend": {
       "name": "@checkstack/auth-ldap-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1423,7 +1423,7 @@
     },
     "plugins/auth-saml-backend": {
       "name": "@checkstack/auth-saml-backend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1788,7 +1788,7 @@
     },
     "plugins/notification-backstage-backend": {
       "name": "@checkstack/notification-backstage-backend",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1802,7 +1802,7 @@
     },
     "plugins/notification-discord-backend": {
       "name": "@checkstack/notification-discord-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1816,7 +1816,7 @@
     },
     "plugins/notification-gotify-backend": {
       "name": "@checkstack/notification-gotify-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1830,7 +1830,7 @@
     },
     "plugins/notification-pushover-backend": {
       "name": "@checkstack/notification-pushover-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1844,7 +1844,7 @@
     },
     "plugins/notification-slack-backend": {
       "name": "@checkstack/notification-slack-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1858,7 +1858,7 @@
     },
     "plugins/notification-smtp-backend": {
       "name": "@checkstack/notification-smtp-backend",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1874,7 +1874,7 @@
     },
     "plugins/notification-teams-backend": {
       "name": "@checkstack/notification-teams-backend",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1888,7 +1888,7 @@
     },
     "plugins/notification-telegram-backend": {
       "name": "@checkstack/notification-telegram-backend",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1904,7 +1904,7 @@
     },
     "plugins/notification-webex-backend": {
       "name": "@checkstack/notification-webex-backend",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",

--- a/core/gitops-backend/src/sync/reconciler.ts
+++ b/core/gitops-backend/src/sync/reconciler.ts
@@ -308,7 +308,7 @@ async function reconcileEntity(params: {
   // Plugins use context.resolveSecretsBySchema() to resolve specific fields.
   const reconcileResult = await kindDef.reconcile({
     entity: entity as typeof entity & { spec: Record<string, unknown> },
-    existingEntityId: existing?.entityId ?? undefined,
+    existingEntityId: existing && !existing.entityId.startsWith("pending-") ? existing.entityId : undefined,
     context,
   });
 

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
@@ -259,6 +259,36 @@ describe("Healthcheck GitOps Kind: Healthcheck", () => {
     expect(mockService.configs[0].strategyId).toBe("postgres");
   });
 
+  it("creates a new configuration when existingEntityId is a pending error record", async () => {
+    const kind = buildKind();
+
+    const result = await kind.reconcile({
+      entity: {
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        metadata: { name: "payment-db-check" },
+        spec: {
+          strategy: "postgres",
+          intervalSeconds: 30,
+          config: {
+            host: "db.internal",
+            port: 5432,
+            database: "payments",
+            user: "monitor",
+            password: "secret",
+          },
+        },
+      },
+      existingEntityId: "pending-12345",
+      context: mockContext,
+    });
+
+    expect(result.entityId).toBe("hc-1");
+    expect(mockService.createConfiguration).toHaveBeenCalledTimes(1);
+    expect(mockService.updateConfiguration).not.toHaveBeenCalled();
+    expect(mockService.configs).toHaveLength(1);
+  });
+
   it("updates an existing configuration using existingEntityId", async () => {
     const kind = buildKind();
 

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
@@ -196,7 +196,7 @@ export function buildHealthcheckKind(
       // Create or update configuration
       const displayName = entity.metadata.title ?? entity.metadata.name;
 
-      if (existingEntityId) {
+      if (existingEntityId && !existingEntityId.startsWith("pending-")) {
         await service.updateConfiguration(existingEntityId, {
           name: displayName,
           strategyId: spec.strategy,


### PR DESCRIPTION
Fixes a bug where resolving YAML syntax errors would cause the subsequent sync to fail with `failed query: update [...]` because it attempted to update the nonexistent `pending-` entity instead of creating a new one.

### Changes
- **Backend Reconciler:** Ensured the `existingEntityId` parameter in the Reconciler engine is set to `undefined` instead of a `pending-UUID` when handling entities that failed to sync initially. This fixes the issue for ALL GitOps kinds system-wide.
- **Healthcheck GitOps Plugin:** Hardened the `Healthcheck` GitOps kind logic to explicitly ignore `pending-` IDs, preventing SQL update errors on synthetic provenance IDs.
- **Testing:** Added a unit test to `healthcheck-gitops-kinds.test.ts` that proves the GitOps reconciliation engine correctly creates a new entity (instead of updating) when the `existingEntityId` is a pending error record.