### PR TITLE
fix: gitops engine skips retrying failed entities

### DIFF
--- a/.changeset/fix-gitops-retry-logic.md
+++ b/.changeset/fix-gitops-retry-logic.md
@@ -1,0 +1,8 @@
+---
+"@checkstack/gitops-backend": patch
+---
+
+Fix GitOps engine skipping retry of failed entities
+
+- Updated the fast-path condition in the Reconciler engine to only skip reconciliation if the entity is in a `synced` state. 
+- Prevents entities from remaining permanently stuck in an error state without being retried if the underlying YAML file is not modified.

--- a/core/gitops-backend/src/sync/reconciler-fast-path.test.ts
+++ b/core/gitops-backend/src/sync/reconciler-fast-path.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, mock } from "bun:test";
+import { reconcileProvider } from "./reconciler";
+import { createEntityKindRegistry } from "../kind-registry";
+import { CHECKSTACK_API_VERSION } from "@checkstack/gitops-common";
+import { z } from "zod";
+import { computeHash } from "./document-parser";
+
+const DUMMY_YAML = `apiVersion: ${CHECKSTACK_API_VERSION}
+kind: TestKind
+metadata:
+  name: test-entity
+spec: {}`;
+
+describe("GitOps reconciler fast-path retry logic", () => {
+  it("skips reconciliation if file hash matches and status is synced", async () => {
+    const hash = computeHash({ input: DUMMY_YAML });
+    let whereCalls = 0;
+    
+    const mockDb = {
+      select: () => mockDb,
+      from: () => mockDb,
+      where: async () => {
+        whereCalls++;
+        if (whereCalls === 1) { // existingProvenance lookup
+          return [{
+            id: "prov-1",
+            status: "synced",
+            lastSyncHash: hash,
+            entityId: "real-id"
+          }];
+        }
+        return [];
+      },
+      update: () => mockDb,
+      set: () => mockDb,
+      insert: () => mockDb,
+      values: async () => [],
+      delete: () => mockDb,
+    } as any;
+
+    const kindRegistry = createEntityKindRegistry();
+    const reconcileMock = mock(async () => ({ entityId: "new-id" }));
+    kindRegistry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "TestKind",
+      specSchema: z.object({}),
+      reconcile: reconcileMock,
+    });
+
+    const result = await reconcileProvider({
+      providerId: "test-provider",
+      providerType: "github",
+      target: "test-target",
+      pathPattern: "*.yaml",
+      deletionPolicy: "orphan",
+      db: mockDb,
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } as any,
+      kindRegistry,
+      secretStore: { resolve: async () => {} } as any,
+      scraper: {
+        discoverFiles: async () => [{
+          repository: "repo",
+          filePath: "test.yaml",
+          branch: "main",
+          content: DUMMY_YAML,
+        }],
+      },
+    });
+
+    // Should skip because hash matches and status is synced
+    expect(result.unchanged).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.created).toBe(0);
+    expect(reconcileMock).not.toHaveBeenCalled();
+  });
+
+  it("retries reconciliation if file hash matches but status is error", async () => {
+    const hash = computeHash({ input: DUMMY_YAML });
+    let whereCalls = 0;
+    
+    const mockDb = {
+      select: () => mockDb,
+      from: () => mockDb,
+      where: async () => {
+        whereCalls++;
+        if (whereCalls === 1) { // existingProvenance lookup
+          return [{
+            id: "prov-1",
+            status: "error",
+            lastSyncHash: hash,
+            entityId: "pending-123"
+          }];
+        }
+        return [];
+      },
+      update: () => mockDb,
+      set: () => mockDb,
+      insert: () => mockDb,
+      values: async () => [],
+      delete: () => mockDb,
+    } as any;
+
+    const kindRegistry = createEntityKindRegistry();
+    const reconcileMock = mock(async () => ({ entityId: "new-id" }));
+    kindRegistry.registerKind({
+      apiVersion: CHECKSTACK_API_VERSION,
+      kind: "TestKind",
+      specSchema: z.object({}),
+      reconcile: reconcileMock,
+    });
+
+    const result = await reconcileProvider({
+      providerId: "test-provider",
+      providerType: "github",
+      target: "test-target",
+      pathPattern: "*.yaml",
+      deletionPolicy: "orphan",
+      db: mockDb,
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } as any,
+      kindRegistry,
+      secretStore: { resolve: async () => {} } as any,
+      scraper: {
+        discoverFiles: async () => [{
+          repository: "repo",
+          filePath: "test.yaml",
+          branch: "main",
+          content: DUMMY_YAML,
+        }],
+      },
+    });
+
+    // Should retry because status is error, even if hash matches
+    expect(result.unchanged).toBe(0);
+    expect(result.updated).toBe(1);
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/core/gitops-backend/src/sync/reconciler.ts
+++ b/core/gitops-backend/src/sync/reconciler.ts
@@ -298,8 +298,8 @@ async function reconcileEntity(params: {
 
   const existing = existingProvenance[0];
 
-  if (existing && existing.lastSyncHash === contentHash) {
-    // Unchanged — skip reconciliation
+  if (existing && existing.status === "synced" && existing.lastSyncHash === contentHash) {
+    // Unchanged and synced — skip reconciliation
     result.unchanged++;
     return;
   }


### PR DESCRIPTION
Fixes a bug where the GitOps engine skips reconciliation if the file hash matches, leaving the entity stuck in an error state perpetually. Now it forces a retry if the entity's status is 'error'.