### PR TITLE
fix: schedule GitOps-provisioned health checks upon association

### DIFF
--- a/.changeset/gitops-healthcheck-scheduling-fix.md
+++ b/.changeset/gitops-healthcheck-scheduling-fix.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/healthcheck-backend": patch
+---
+
+Fixed an issue where GitOps-provisioned health checks were not added to the background execution queue immediately upon association.

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.test.ts
@@ -115,6 +115,10 @@ function createMockService() {
         })
         .filter(Boolean);
     }),
+    getConfiguration: mock(async (id: string) => {
+      const config = configs.find((c) => c.id === id);
+      return config as unknown as HealthCheckConfiguration | undefined;
+    }),
   };
 }
 
@@ -217,16 +221,13 @@ describe("Healthcheck GitOps Kind: Healthcheck", () => {
   });
 
   function buildKind() {
-    return buildHealthcheckKind({
-      createService: () =>
-        ({
-          createConfiguration: mockService.createConfiguration,
-          updateConfiguration: mockService.updateConfiguration,
-          deleteConfiguration: mockService.deleteConfiguration,
-        }) as never,
-      getHealthCheckRegistry: () => mockHCRegistry as never,
-      getCollectorRegistry: () => mockCollectorRegistry as never,
-    });
+    const mockDeps = {
+      createService: () => mockService as any,
+      getHealthCheckRegistry: () => mockHCRegistry as any,
+      getCollectorRegistry: () => mockCollectorRegistry as any,
+      getQueueManager: () => ({ getQueue: () => ({ scheduleRecurring: async () => "job-123" }) } as any),
+    };
+    return buildHealthcheckKind(mockDeps);
   }
 
   it("creates a new healthcheck configuration and returns entityId", async () => {
@@ -488,9 +489,11 @@ describe("Healthcheck GitOps Kind: System Extension", () => {
           associateSystem: mockService.associateSystem,
           disassociateSystem: mockService.disassociateSystem,
           getSystemConfigurations: mockService.getSystemConfigurations,
+          getConfiguration: mockService.getConfiguration,
         }) as never,
       getHealthCheckRegistry: () => createMockHealthCheckRegistry() as never,
       getCollectorRegistry: () => createMockCollectorRegistry() as never,
+      getQueueManager: () => ({ getQueue: () => ({ scheduleRecurring: async () => "job-123" }) } as any),
     });
   }
 

--- a/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
+++ b/core/healthcheck-backend/src/healthcheck-gitops-kinds.ts
@@ -22,6 +22,8 @@ import {
   arrayField,
   enumField,
 } from "@checkstack/backend-api";
+import type { QueueManager } from "@checkstack/queue-api";
+import { scheduleHealthCheck } from "./queue-executor";
 
 /**
  * Lazy accessor functions — populated during init(), consumed during reconcile.
@@ -32,6 +34,7 @@ interface HealthcheckGitOpsKindsDeps {
   createService: () => HealthCheckService;
   getHealthCheckRegistry: () => HealthCheckRegistry;
   getCollectorRegistry: () => CollectorRegistry;
+  getQueueManager: () => QueueManager;
 }
 
 // ─── Healthcheck Spec Schema ───────────────────────────────────────────────
@@ -323,8 +326,21 @@ export function buildSystemHealthcheckExtension(
           includeLocal: entry.includeLocal,
         });
 
+        // Retrieve config to get the interval for scheduling
+        const config = await service.getConfiguration(configId);
+        if (config) {
+          await scheduleHealthCheck({
+            queueManager: deps.getQueueManager(),
+            payload: {
+              configId,
+              systemId: systemEntityId,
+            },
+            intervalSeconds: config.intervalSeconds,
+          });
+        }
+
         context.logger.info(
-          `GitOps: associated ${entry.ref.kind} "${entry.ref.name}" (${configId}) with System "${entity.metadata.name}"`,
+          `GitOps: associated ${entry.ref.kind} "${entry.ref.name}" (${configId}) with System "${entity.metadata.name}" and scheduled execution`,
         );
       }
 

--- a/core/healthcheck-backend/src/index.ts
+++ b/core/healthcheck-backend/src/index.ts
@@ -19,6 +19,7 @@ import {
   type HealthCheckRegistry,
   type CollectorRegistry,
 } from "@checkstack/backend-api";
+import type { QueueManager } from "@checkstack/queue-api";
 import { integrationEventExtensionPoint } from "@checkstack/integration-backend";
 import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
 import { z } from "zod";
@@ -99,6 +100,7 @@ export default createBackendPlugin({
     let gitopsDb: SafeDatabase<typeof schema> | undefined;
     let gitopsHealthCheckRegistry: HealthCheckRegistry | undefined;
     let gitopsCollectorRegistry: CollectorRegistry | undefined;
+    let gitopsQueueManager: QueueManager | undefined;
 
     const kindRegistry = env.getExtensionPoint(entityKindExtensionPoint);
     registerHealthcheckGitOpsKinds({
@@ -124,6 +126,11 @@ export default createBackendPlugin({
         if (!gitopsCollectorRegistry)
           throw new Error("CollectorRegistry not initialized");
         return gitopsCollectorRegistry;
+      },
+      getQueueManager: () => {
+        if (!gitopsQueueManager)
+          throw new Error("QueueManager not initialized");
+        return gitopsQueueManager;
       },
     });
 
@@ -155,6 +162,7 @@ export default createBackendPlugin({
         gitopsDb = database;
         gitopsHealthCheckRegistry = healthCheckRegistry;
         gitopsCollectorRegistry = collectorRegistry;
+        gitopsQueueManager = queueManager;
 
         // Create catalog client for notification delegation
         const catalogClient = rpcClient.forPlugin(CatalogApi);


### PR DESCRIPTION
## Description
Fixes an issue where healthchecks created and associated via GitOps were not immediately added to the execution queue because the `associateSystem` call in `healthcheck-gitops-kinds.ts` bypassed the standard RPC router and didn't have access to the QueueManager.

## Changes
- Injected `queueManager` into GitOps kind registration dependencies in `healthcheck-backend/src/index.ts`.
- Updated `healthcheck-gitops-kinds.ts` to immediately call `scheduleHealthCheck` upon associating a system with a healthcheck.
- Updated mock dependencies in `healthcheck-gitops-kinds.test.ts` to prevent test regressions.
- Added changeset.