### PR TITLE
feat: improve notification clarity and deduplicate upstream cascades

### DIFF
--- a/.changeset/notification-system-optimizations.md
+++ b/.changeset/notification-system-optimizations.md
@@ -1,0 +1,16 @@
+---
+"@checkstack/healthcheck-backend": minor
+"@checkstack/incident-backend": minor
+"@checkstack/maintenance-backend": minor
+"@checkstack/dependency-backend": minor
+"@checkstack/catalog-common": minor
+"@checkstack/catalog-backend": minor
+---
+
+### Notification System Optimizations
+
+**System context in notifications**: All notification senders (healthcheck, incident, maintenance, dependency) now include the affected system name in the notification title and body. Users can immediately identify which system is affected without clicking through to the detail page.
+
+**Upstream notification deduplication**: When an upstream dependency goes down affecting multiple downstream systems, the dependency notification sidecar now sends **one personalized notification per user** instead of one notification per affected system. Each user's notification lists only the systems they are subscribed to, with a link to the upstream root cause system. This prevents notification floods for users subscribed to groups containing many dependent systems.
+
+**New catalog endpoint**: Added `getSystemGroupIds` S2S RPC endpoint on the catalog to resolve which catalog groups contain a given system, used by the dependency plugin for efficient subscriber resolution during batched notification dispatch.

--- a/bun.lock
+++ b/bun.lock
@@ -269,7 +269,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "0.5.1",
+      "version": "0.5.4",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -314,7 +314,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -404,7 +404,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -433,7 +433,7 @@
     },
     "core/dependency-backend": {
       "name": "@checkstack/dependency-backend",
-      "version": "0.2.12",
+      "version": "0.2.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -444,6 +444,7 @@
         "@checkstack/healthcheck-common": "workspace:*",
         "@checkstack/incident-common": "workspace:*",
         "@checkstack/maintenance-common": "workspace:*",
+        "@checkstack/notification-common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
         "@orpc/server": "^1.13.2",
         "drizzle-orm": "^0.45.0",
@@ -476,7 +477,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -507,7 +508,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.3.19",
+      "version": "0.3.20",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -568,7 +569,7 @@
     },
     "core/gitops-backend": {
       "name": "@checkstack/gitops-backend",
-      "version": "0.2.0",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -608,7 +609,7 @@
     },
     "core/gitops-frontend": {
       "name": "@checkstack/gitops-frontend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -627,7 +628,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "0.16.1",
+      "version": "0.16.5",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -677,7 +678,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -708,7 +709,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "0.4.22",
+      "version": "0.4.25",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -751,7 +752,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -876,7 +877,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -1029,7 +1030,7 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.66.0",
+      "version": "0.70.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
@@ -1048,7 +1049,7 @@
     },
     "core/satellite-backend": {
       "name": "@checkstack/satellite-backend",
-      "version": "0.2.9",
+      "version": "0.2.13",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1170,7 +1171,7 @@
     },
     "core/slo-backend": {
       "name": "@checkstack/slo-backend",
-      "version": "0.2.10",
+      "version": "0.2.14",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -1216,7 +1217,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -3863,19 +3864,31 @@
 
     "@checkstack/backend-api/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
+    "@checkstack/catalog-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@checkstack/command-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@checkstack/command-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
     "@checkstack/command-frontend/react-router-dom": ["react-router-dom@7.14.1", "", { "dependencies": { "react-router": "7.14.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA=="],
 
     "@checkstack/common/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
+    "@checkstack/dependency-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@checkstack/frontend-api/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@checkstack/gitops-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@checkstack/healthcheck-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@checkstack/queue-backend/@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
     "@checkstack/queue-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
     "@checkstack/queue-frontend/react-router-dom": ["react-router-dom@7.14.1", "", { "dependencies": { "react-router": "7.14.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA=="],
+
+    "@checkstack/satellite-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@checkstack/test-utils-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
@@ -4037,11 +4050,23 @@
 
     "@checkstack/backend-api/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
+    "@checkstack/catalog-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@checkstack/command-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@checkstack/command-frontend/react-router-dom/react-router": ["react-router@7.14.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="],
+
+    "@checkstack/dependency-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@checkstack/frontend-api/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
+    "@checkstack/gitops-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@checkstack/healthcheck-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@checkstack/queue-frontend/react-router-dom/react-router": ["react-router@7.14.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="],
+
+    "@checkstack/satellite-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@checkstack/test-utils-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 

--- a/core/catalog-backend/src/router.ts
+++ b/core/catalog-backend/src/router.ts
@@ -415,6 +415,21 @@ export const createCatalogRouter = ({
     },
   );
 
+  /**
+   * Get the catalog group IDs that contain a specific system.
+   * Used by the dependency plugin for batched notification deduplication.
+   */
+  const getSystemGroupIds = os.getSystemGroupIds.handler(
+    async ({ input }) => {
+      const systemGroups = await database
+        .select({ groupId: schema.systemsGroups.groupId })
+        .from(schema.systemsGroups)
+        .where(eq(schema.systemsGroups.systemId, input.systemId));
+
+      return { groupIds: systemGroups.map((sg) => sg.groupId) };
+    },
+  );
+
   // Build and return the router
   return os.router({
     getEntities,
@@ -435,7 +450,9 @@ export const createCatalogRouter = ({
     getViews,
     createView,
     notifySystemSubscribers,
+    getSystemGroupIds,
   });
 };
+
 
 export type CatalogRouter = ReturnType<typeof createCatalogRouter>;

--- a/core/catalog-common/src/rpc-contract.ts
+++ b/core/catalog-common/src/rpc-contract.ts
@@ -266,6 +266,19 @@ export const catalogContract = {
       }),
     )
     .output(z.object({ notifiedCount: z.number() })),
+
+  /**
+   * Get the catalog group IDs that contain a specific system.
+   * Returns raw group IDs (not namespaced with notification prefix).
+   * Used by the dependency plugin for batched notification deduplication.
+   */
+  getSystemGroupIds: proc({
+    operationType: "query",
+    userType: "service",
+    access: [],
+  })
+    .input(z.object({ systemId: z.string() }))
+    .output(z.object({ groupIds: z.array(z.string()) })),
 };
 
 // Export contract type

--- a/core/dependency-backend/package.json
+++ b/core/dependency-backend/package.json
@@ -21,6 +21,7 @@
     "@checkstack/healthcheck-backend": "workspace:*",
     "@checkstack/maintenance-common": "workspace:*",
     "@checkstack/incident-common": "workspace:*",
+    "@checkstack/notification-common": "workspace:*",
     "@checkstack/signal-common": "workspace:*",
     "@checkstack/common": "workspace:*",
     "drizzle-orm": "^0.45.0",

--- a/core/dependency-backend/src/index.ts
+++ b/core/dependency-backend/src/index.ts
@@ -14,6 +14,7 @@ import { CatalogApi } from "@checkstack/catalog-common";
 import { HealthCheckApi } from "@checkstack/healthcheck-common";
 import { MaintenanceApi } from "@checkstack/maintenance-common";
 import { IncidentApi } from "@checkstack/incident-common";
+import { NotificationApi } from "@checkstack/notification-common";
 import { catalogHooks } from "@checkstack/catalog-backend";
 import { healthCheckHooks } from "@checkstack/healthcheck-backend";
 import { evaluateAndNotifyDownstream } from "./notifications";
@@ -73,6 +74,7 @@ export default createBackendPlugin({
         const healthCheckClient = rpcClient.forPlugin(HealthCheckApi);
         const maintenanceClient = rpcClient.forPlugin(MaintenanceApi);
         const incidentClient = rpcClient.forPlugin(IncidentApi);
+        const notificationClient = rpcClient.forPlugin(NotificationApi);
 
         /**
          * Build system statuses for warning evaluation.
@@ -161,6 +163,7 @@ export default createBackendPlugin({
               warningService,
               fetchSystemStatuses,
               catalogClient,
+              notificationClient,
               maintenanceClient,
               incidentClient,
               signalService,
@@ -186,6 +189,7 @@ export default createBackendPlugin({
               warningService,
               fetchSystemStatuses,
               catalogClient,
+              notificationClient,
               maintenanceClient,
               incidentClient,
               signalService,

--- a/core/dependency-backend/src/notifications.ts
+++ b/core/dependency-backend/src/notifications.ts
@@ -5,6 +5,7 @@ import type { CatalogApi } from "@checkstack/catalog-common";
 import { catalogRoutes } from "@checkstack/catalog-common";
 import type { MaintenanceApi } from "@checkstack/maintenance-common";
 import type { IncidentApi } from "@checkstack/incident-common";
+import type { NotificationApi } from "@checkstack/notification-common";
 import type { DerivedState } from "@checkstack/dependency-common";
 import { DEPENDENCY_WARNINGS_CHANGED } from "@checkstack/dependency-common";
 import type { DependencyService } from "./services/dependency-service";
@@ -45,26 +46,30 @@ function derivedStateToImportance(
 export function buildNotificationTitle({
   derivedState,
   isRecovery,
+  systemName,
 }: {
   derivedState?: DerivedState;
   isRecovery: boolean;
+  systemName?: string;
 }): string {
+  const prefix = systemName ? `${systemName}: ` : "";
+
   if (isRecovery) {
-    return "Dependency impact resolved";
+    return `${prefix}Dependency impact resolved`;
   }
 
   switch (derivedState) {
     case "info": {
-      return "Upstream dependency issue (informational)";
+      return `${prefix}Upstream dependency issue (informational)`;
     }
     case "degraded": {
-      return "Availability impacted by upstream dependency";
+      return `${prefix}Availability impacted by upstream dependency`;
     }
     case "down": {
-      return "Availability critically impacted by upstream dependency";
+      return `${prefix}Availability critically impacted by upstream dependency`;
     }
     default: {
-      return "Dependency impact changed";
+      return `${prefix}Dependency impact changed`;
     }
   }
 }
@@ -76,29 +81,83 @@ export function buildNotificationBody({
   upstreamNames,
   derivedState,
   isRecovery,
+  systemName,
 }: {
   upstreamNames: string[];
   derivedState?: DerivedState;
   isRecovery: boolean;
+  systemName?: string;
 }): string {
   const upstreamList = upstreamNames.join(", ");
+  const systemRef = systemName ? `**${systemName}**` : "This system";
 
   if (isRecovery) {
-    return "All upstream dependencies have recovered. This system is no longer affected by dependency failures.";
+    return `All upstream dependencies have recovered. ${systemRef} is no longer affected by dependency failures.`;
   }
 
   switch (derivedState) {
     case "info": {
-      return `An upstream dependency (${upstreamList}) is experiencing issues. This is informational — no direct impact expected.`;
+      return `An upstream dependency (${upstreamList}) is experiencing issues. ${systemRef} — this is informational, no direct impact expected.`;
     }
     case "degraded": {
-      return `An upstream dependency (${upstreamList}) is experiencing issues. This system's availability may be degraded.`;
+      return `An upstream dependency (${upstreamList}) is experiencing issues. ${systemRef}'s availability may be degraded.`;
     }
     case "down": {
-      return `A critical upstream dependency (${upstreamList}) is down. This system is expected to be unavailable.`;
+      return `A critical upstream dependency (${upstreamList}) is down. ${systemRef} is expected to be unavailable.`;
     }
     default: {
       return `Upstream dependency status has changed (${upstreamList}).`;
+    }
+  }
+}
+
+/**
+ * Represents a downstream system that needs notification due to a state change.
+ */
+export interface SystemNotificationEntry {
+  systemId: string;
+  systemName: string;
+  derivedState?: DerivedState;
+  isRecovery: boolean;
+  importance: "info" | "warning" | "critical";
+  upstreamNames: string[];
+}
+
+/**
+ * Resolve the worst importance level from a list of notification entries.
+ */
+function resolveWorstImportance(
+  entries: SystemNotificationEntry[],
+): "info" | "warning" | "critical" {
+  let worst: "info" | "warning" | "critical" = "info";
+  for (const entry of entries) {
+    if (entry.importance === "critical") return "critical";
+    if (entry.importance === "warning") worst = "warning";
+  }
+  return worst;
+}
+
+/**
+ * Format a per-system impact line with criticality indicator for multi-system
+ * notification bodies.
+ */
+export function formatSystemImpactLine(entry: SystemNotificationEntry): string {
+  if (entry.isRecovery) {
+    return `- ✅ **${entry.systemName}** — recovered`;
+  }
+
+  switch (entry.derivedState) {
+    case "down": {
+      return `- 🔴 **${entry.systemName}** — critically impacted`;
+    }
+    case "degraded": {
+      return `- 🟡 **${entry.systemName}** — degraded`;
+    }
+    case "info": {
+      return `- ℹ️ **${entry.systemName}** — informational`;
+    }
+    default: {
+      return `- **${entry.systemName}** — impact changed`;
     }
   }
 }
@@ -109,6 +168,11 @@ export function buildNotificationBody({
  *
  * This is the Sidecar Notification Orchestration function.
  * It runs when an upstream system's health status changes.
+ *
+ * Notification deduplication: Instead of sending one notification per
+ * downstream system (which floods users subscribed to groups), we resolve
+ * all affected subscribers and send one personalized notification per user
+ * listing only the systems they are subscribed to.
  */
 export async function evaluateAndNotifyDownstream({
   changedSystemId,
@@ -117,6 +181,7 @@ export async function evaluateAndNotifyDownstream({
   warningService,
   fetchSystemStatuses,
   catalogClient,
+  notificationClient,
   maintenanceClient,
   incidentClient,
   signalService,
@@ -130,6 +195,7 @@ export async function evaluateAndNotifyDownstream({
     systemIds: string[],
   ) => Promise<Map<string, SystemStatus>>;
   catalogClient: InferClient<typeof CatalogApi>;
+  notificationClient: InferClient<typeof NotificationApi>;
   maintenanceClient: InferClient<typeof MaintenanceApi>;
   incidentClient: InferClient<typeof IncidentApi>;
   signalService: SignalService;
@@ -236,8 +302,10 @@ export async function evaluateAndNotifyDownstream({
       }
     }
 
-    // 6. Compare and notify for each downstream system
+    // 6. Evaluate state changes and collect systems that need notification
     const changedSystemIds: string[] = [];
+    const systemsToNotify: SystemNotificationEntry[] = [];
+
     for (const systemId of downstreamIds) {
       const currentWarning = warningMap.get(systemId);
       const currentState = currentWarning?.derivedState;
@@ -278,52 +346,40 @@ export async function evaluateAndNotifyDownstream({
         continue;
       }
 
-      // Build notification
+      // Collect notification entry instead of sending immediately
       const isRecovery = !currentState && !!previousState;
       const upstreamNames =
         currentWarning?.affectedUpstreams.map(
           (u) => u.systemName ?? u.systemId,
         ) ?? [];
+      const systemName =
+        statuses.get(systemId)?.systemName ?? systemId;
 
-      const title = buildNotificationTitle({
-        derivedState: currentState,
-        isRecovery,
-      });
-      const body = buildNotificationBody({
-        upstreamNames,
-        derivedState: currentState,
-        isRecovery,
-      });
-      const importance = isRecovery
-        ? ("info" as const)
-        : derivedStateToImportance(currentState!);
-
-      const systemDetailPath = resolveRoute(catalogRoutes.routes.systemDetail, {
+      systemsToNotify.push({
         systemId,
+        systemName,
+        derivedState: currentState,
+        isRecovery,
+        importance: isRecovery
+          ? "info"
+          : derivedStateToImportance(currentState!),
+        upstreamNames,
       });
-
-      try {
-        await catalogClient.notifySystemSubscribers({
-          systemId,
-          title,
-          body,
-          importance,
-          action: { label: "View System", url: systemDetailPath },
-          includeGroupSubscribers: true,
-        });
-        logger.debug(
-          `Dependency notification sent: ${systemId} ${previousState ?? "none"} → ${currentState ?? "none"}`,
-        );
-      } catch (error) {
-        // Notifications are best-effort
-        logger.warn(
-          `Failed to send dependency notification for ${systemId}:`,
-          error,
-        );
-      }
     }
 
-    // 7. Broadcast signal so frontends can react
+    // 7. Send batched per-user notifications (deduplication)
+    if (systemsToNotify.length > 0) {
+      await sendBatchedNotifications({
+        systemsToNotify,
+        changedSystemId,
+        statuses,
+        catalogClient,
+        notificationClient,
+        logger,
+      });
+    }
+
+    // 8. Broadcast signal so frontends can react
     if (changedSystemIds.length > 0) {
       await signalService.broadcast(DEPENDENCY_WARNINGS_CHANGED, {
         affectedSystemIds: changedSystemIds,
@@ -337,3 +393,148 @@ export async function evaluateAndNotifyDownstream({
     );
   }
 }
+
+/**
+ * Send batched, per-user personalized notifications.
+ *
+ * Instead of sending one notification per affected system (which causes
+ * floods for group subscribers), this function:
+ * 1. Resolves all notification group IDs for each affected system
+ * 2. Resolves subscribers per group and builds a user → systems reverse map
+ * 3. Sends one personalized notification per user with only their relevant systems
+ */
+async function sendBatchedNotifications({
+  systemsToNotify,
+  changedSystemId,
+  statuses,
+  catalogClient,
+  notificationClient,
+  logger,
+}: {
+  systemsToNotify: SystemNotificationEntry[];
+  changedSystemId: string;
+  statuses: Map<string, SystemStatus>;
+  catalogClient: InferClient<typeof CatalogApi>;
+  notificationClient: InferClient<typeof NotificationApi>;
+  logger: Logger;
+}): Promise<void> {
+  // Phase 1: Resolve all notification group IDs for affected systems
+  const systemToGroupIds = new Map<string, string[]>();
+  for (const system of systemsToNotify) {
+    const groupIds = [`catalog.system.${system.systemId}`];
+
+    try {
+      const { groupIds: catalogGroupIds } =
+        await catalogClient.getSystemGroupIds({
+          systemId: system.systemId,
+        });
+      groupIds.push(
+        ...catalogGroupIds.map((gid) => `catalog.group.${gid}`),
+      );
+    } catch (error) {
+      logger.warn(
+        `Failed to resolve group IDs for system ${system.systemId}:`,
+        error,
+      );
+    }
+
+    systemToGroupIds.set(system.systemId, groupIds);
+  }
+
+  // Phase 2: Resolve subscribers per group → build user → systems reverse map
+  const userSystems = new Map<string, Set<string>>();
+  for (const system of systemsToNotify) {
+    const groupIds = systemToGroupIds.get(system.systemId) ?? [];
+    for (const groupId of groupIds) {
+      try {
+        const { userIds } =
+          await notificationClient.getGroupSubscribers({ groupId });
+        for (const userId of userIds) {
+          if (!userSystems.has(userId)) {
+            userSystems.set(userId, new Set());
+          }
+          userSystems.get(userId)!.add(system.systemId);
+        }
+      } catch (error) {
+        logger.warn(
+          `Failed to resolve subscribers for group ${groupId}:`,
+          error,
+        );
+      }
+    }
+  }
+
+  if (userSystems.size === 0) {
+    return;
+  }
+
+  // Phase 3: Send one personalized notification per user
+  const upstreamName =
+    statuses.get(changedSystemId)?.systemName ?? changedSystemId;
+  const upstreamSystemDetailPath = resolveRoute(
+    catalogRoutes.routes.systemDetail,
+    { systemId: changedSystemId },
+  );
+
+  for (const [userId, subscribedSystemIds] of userSystems) {
+    const relevantSystems = systemsToNotify.filter((s) =>
+      subscribedSystemIds.has(s.systemId),
+    );
+    if (relevantSystems.length === 0) continue;
+
+    const allRecovery = relevantSystems.every((s) => s.isRecovery);
+    const systemNames = relevantSystems.map((s) => s.systemName);
+
+    let title: string;
+    let body: string;
+
+    if (relevantSystems.length === 1) {
+      // Single system — use detailed title/body
+      const entry = relevantSystems[0];
+      title = buildNotificationTitle({
+        derivedState: entry.derivedState,
+        isRecovery: entry.isRecovery,
+        systemName: entry.systemName,
+      });
+      body = buildNotificationBody({
+        upstreamNames: entry.upstreamNames,
+        derivedState: entry.derivedState,
+        isRecovery: entry.isRecovery,
+        systemName: entry.systemName,
+      });
+    } else if (allRecovery) {
+      title = `Dependency impact resolved: ${upstreamName}`;
+      body = `All upstream dependencies of **${systemNames.join("**, **")}** have recovered.`;
+    } else {
+      title = `Upstream dependency issue: ${upstreamName} — ${relevantSystems.length} systems affected`;
+      const systemLines = relevantSystems
+        .map((entry) => formatSystemImpactLine(entry))
+        .join("\n");
+      body = `An upstream dependency (**${upstreamName}**) is affecting:\n\n${systemLines}`;
+    }
+
+    const importance = allRecovery
+      ? ("info" as const)
+      : resolveWorstImportance(relevantSystems);
+
+    try {
+      await notificationClient.notifyUsers({
+        userIds: [userId],
+        title,
+        body,
+        importance,
+        action: { label: "View Root Cause", url: upstreamSystemDetailPath },
+      });
+      logger.debug(
+        `Dependency notification sent to user ${userId}: ${relevantSystems.length} system(s)`,
+      );
+    } catch (error) {
+      // Notifications are best-effort
+      logger.warn(
+        `Failed to send dependency notification to user ${userId}:`,
+        error,
+      );
+    }
+  }
+}
+

--- a/core/dependency-backend/tests/notifications.test.ts
+++ b/core/dependency-backend/tests/notifications.test.ts
@@ -2,7 +2,9 @@ import { describe, test, expect } from "bun:test";
 import {
   buildNotificationTitle,
   buildNotificationBody,
+  formatSystemImpactLine,
 } from "../src/notifications";
+import type { SystemNotificationEntry } from "../src/notifications";
 import type { DerivedState } from "@checkstack/dependency-common";
 
 describe("Dependency Notification Sidecar", () => {
@@ -15,11 +17,30 @@ describe("Dependency Notification Sidecar", () => {
       expect(title).toBe("Dependency impact resolved");
     });
 
+    test("returns recovery title with system name prefix", () => {
+      const title = buildNotificationTitle({
+        derivedState: undefined,
+        isRecovery: true,
+        systemName: "API Gateway",
+      });
+      expect(title).toBe("API Gateway: Dependency impact resolved");
+    });
+
     test("returns info title for info derived state", () => {
       const title = buildNotificationTitle({
         derivedState: "info",
         isRecovery: false,
       });
+      expect(title).toContain("informational");
+    });
+
+    test("returns info title with system name prefix", () => {
+      const title = buildNotificationTitle({
+        derivedState: "info",
+        isRecovery: false,
+        systemName: "Web Frontend",
+      });
+      expect(title).toStartWith("Web Frontend: ");
       expect(title).toContain("informational");
     });
 
@@ -31,11 +52,31 @@ describe("Dependency Notification Sidecar", () => {
       expect(title).toContain("impacted");
     });
 
+    test("returns degraded title with system name prefix", () => {
+      const title = buildNotificationTitle({
+        derivedState: "degraded",
+        isRecovery: false,
+        systemName: "Payment Service",
+      });
+      expect(title).toStartWith("Payment Service: ");
+      expect(title).toContain("impacted");
+    });
+
     test("returns critical title for down derived state", () => {
       const title = buildNotificationTitle({
         derivedState: "down",
         isRecovery: false,
       });
+      expect(title).toContain("critically impacted");
+    });
+
+    test("returns critical title with system name prefix", () => {
+      const title = buildNotificationTitle({
+        derivedState: "down",
+        isRecovery: false,
+        systemName: "Database",
+      });
+      expect(title).toStartWith("Database: ");
       expect(title).toContain("critically impacted");
     });
 
@@ -45,6 +86,15 @@ describe("Dependency Notification Sidecar", () => {
         isRecovery: false,
       });
       expect(title).toBe("Dependency impact changed");
+    });
+
+    test("returns fallback title with system name prefix", () => {
+      const title = buildNotificationTitle({
+        derivedState: undefined,
+        isRecovery: false,
+        systemName: "Monitoring",
+      });
+      expect(title).toBe("Monitoring: Dependency impact changed");
     });
   });
 
@@ -59,6 +109,17 @@ describe("Dependency Notification Sidecar", () => {
       expect(body).toContain("no longer affected");
     });
 
+    test("returns recovery body with system name reference", () => {
+      const body = buildNotificationBody({
+        upstreamNames: ["Database"],
+        derivedState: undefined,
+        isRecovery: true,
+        systemName: "API Gateway",
+      });
+      expect(body).toContain("recovered");
+      expect(body).toContain("**API Gateway**");
+    });
+
     test("includes upstream name in info body", () => {
       const body = buildNotificationBody({
         upstreamNames: ["Redis"],
@@ -67,6 +128,17 @@ describe("Dependency Notification Sidecar", () => {
       });
       expect(body).toContain("Redis");
       expect(body).toContain("informational");
+    });
+
+    test("includes system name in info body", () => {
+      const body = buildNotificationBody({
+        upstreamNames: ["Redis"],
+        derivedState: "info",
+        isRecovery: false,
+        systemName: "Cache Layer",
+      });
+      expect(body).toContain("Redis");
+      expect(body).toContain("**Cache Layer**");
     });
 
     test("includes upstream name in degraded body", () => {
@@ -96,6 +168,26 @@ describe("Dependency Notification Sidecar", () => {
         isRecovery: false,
       });
       expect(body).toContain("Service A, Service B");
+    });
+
+    test("uses 'This system' when no systemName is provided", () => {
+      const body = buildNotificationBody({
+        upstreamNames: ["Redis"],
+        derivedState: "degraded",
+        isRecovery: false,
+      });
+      expect(body).toContain("This system");
+    });
+
+    test("uses bold system name when provided", () => {
+      const body = buildNotificationBody({
+        upstreamNames: ["Redis"],
+        derivedState: "degraded",
+        isRecovery: false,
+        systemName: "My App",
+      });
+      expect(body).toContain("**My App**");
+      expect(body).not.toContain("This system");
     });
   });
 
@@ -151,5 +243,99 @@ describe("Dependency Notification Sidecar", () => {
         expect(body).toContain("Test System");
       });
     }
+
+    for (const state of ["info", "degraded", "down"] as DerivedState[]) {
+      test(`non-recovery '${state}' with system name produces meaningful title and body`, () => {
+        const title = buildNotificationTitle({
+          derivedState: state,
+          isRecovery: false,
+          systemName: "My Service",
+        });
+        const body = buildNotificationBody({
+          upstreamNames: ["Upstream DB"],
+          derivedState: state,
+          isRecovery: false,
+          systemName: "My Service",
+        });
+
+        expect(title).toStartWith("My Service: ");
+        expect(body).toContain("**My Service**");
+        expect(body).toContain("Upstream DB");
+      });
+    }
+  });
+
+  describe("formatSystemImpactLine", () => {
+    const baseEntry: SystemNotificationEntry = {
+      systemId: "sys-1",
+      systemName: "API Gateway",
+      isRecovery: false,
+      importance: "info",
+      upstreamNames: ["Database"],
+    };
+
+    test("formats critically impacted system with red indicator", () => {
+      const line = formatSystemImpactLine({
+        ...baseEntry,
+        derivedState: "down",
+        importance: "critical",
+      });
+      expect(line).toContain("🔴");
+      expect(line).toContain("**API Gateway**");
+      expect(line).toContain("critically impacted");
+    });
+
+    test("formats degraded system with yellow indicator", () => {
+      const line = formatSystemImpactLine({
+        ...baseEntry,
+        derivedState: "degraded",
+        importance: "warning",
+      });
+      expect(line).toContain("🟡");
+      expect(line).toContain("**API Gateway**");
+      expect(line).toContain("degraded");
+    });
+
+    test("formats informational system with info indicator", () => {
+      const line = formatSystemImpactLine({
+        ...baseEntry,
+        derivedState: "info",
+        importance: "info",
+      });
+      expect(line).toContain("ℹ️");
+      expect(line).toContain("**API Gateway**");
+      expect(line).toContain("informational");
+    });
+
+    test("formats recovered system with checkmark indicator", () => {
+      const line = formatSystemImpactLine({
+        ...baseEntry,
+        isRecovery: true,
+        importance: "info",
+      });
+      expect(line).toContain("✅");
+      expect(line).toContain("**API Gateway**");
+      expect(line).toContain("recovered");
+    });
+
+    test("formats system with undefined state", () => {
+      const line = formatSystemImpactLine({
+        ...baseEntry,
+        derivedState: undefined,
+        importance: "info",
+      });
+      expect(line).toContain("**API Gateway**");
+      expect(line).toContain("impact changed");
+    });
+
+    test("all lines start with markdown list prefix", () => {
+      for (const state of ["info", "degraded", "down"] as DerivedState[]) {
+        const line = formatSystemImpactLine({
+          ...baseEntry,
+          derivedState: state,
+        });
+        expect(line).toStartWith("- ");
+      }
+    });
   });
 });

--- a/core/healthcheck-backend/src/queue-executor.ts
+++ b/core/healthcheck-backend/src/queue-executor.ts
@@ -101,6 +101,7 @@ export async function scheduleHealthCheck(props: {
  */
 async function notifyStateChange(props: {
   systemId: string;
+  systemName: string;
   previousStatus: HealthCheckStatus;
   newStatus: HealthCheckStatus;
   catalogClient: CatalogClient;
@@ -110,6 +111,7 @@ async function notifyStateChange(props: {
 }): Promise<void> {
   const {
     systemId,
+    systemName,
     previousStatus,
     newStatus,
     catalogClient,
@@ -168,18 +170,18 @@ async function notifyStateChange(props: {
   let importance: "info" | "warning" | "critical";
 
   if (isRecovery) {
-    title = "System health restored";
+    title = `System health restored: ${systemName}`;
     body =
-      "All health checks are now passing. The system has returned to normal operation.";
+      `All health checks for **${systemName}** are now passing. The system has returned to normal operation.`;
     importance = "info";
   } else if (isUnhealthy) {
-    title = "System health critical";
-    body = "Health checks indicate the system is unhealthy and may be down.";
+    title = `System health critical: ${systemName}`;
+    body = `Health checks indicate **${systemName}** is unhealthy and may be down.`;
     importance = "critical";
   } else if (isDegraded) {
-    title = "System health degraded";
+    title = `System health degraded: ${systemName}`;
     body =
-      "Some health checks are failing. The system may be experiencing issues.";
+      `Some health checks for **${systemName}** are failing. The system may be experiencing issues.`;
     importance = "warning";
   } else {
     // No notification for healthy → healthy (if somehow missed above)
@@ -535,6 +537,7 @@ async function executeHealthCheckJob(props: {
       if (newState.status !== previousStatus) {
         await notifyStateChange({
           systemId,
+          systemName,
           previousStatus,
           newStatus: newState.status,
           catalogClient,
@@ -615,6 +618,7 @@ async function executeHealthCheckJob(props: {
     if (newState.status !== previousStatus) {
       await notifyStateChange({
         systemId,
+        systemName,
         previousStatus,
         newStatus: newState.status,
         catalogClient,
@@ -732,6 +736,7 @@ async function executeHealthCheckJob(props: {
     if (newState.status !== previousStatus) {
       await notifyStateChange({
         systemId,
+        systemName,
         previousStatus,
         newStatus: newState.status,
         catalogClient,

--- a/core/incident-backend/src/notifications.test.ts
+++ b/core/incident-backend/src/notifications.test.ts
@@ -115,7 +115,7 @@ describe("notifyAffectedSystems", () => {
 
       expect(mockCatalogClient.notifySystemSubscribers).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: "Incident reported",
+          title: "Incident reported: sys-1",
           body: expect.stringContaining("reported"),
         }),
       );
@@ -134,7 +134,7 @@ describe("notifyAffectedSystems", () => {
 
       expect(mockCatalogClient.notifySystemSubscribers).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: "Incident reopened",
+          title: "Incident reopened: sys-1",
           body: expect.stringContaining("reopened"),
         }),
       );
@@ -180,4 +180,50 @@ describe("notifyAffectedSystems", () => {
       expect(mockLogger.warn).toHaveBeenCalled();
     });
   });
+
+  describe("system name inclusion", () => {
+    it("should include system name in title and body when systemNames map is provided", async () => {
+      const systemNames = new Map([
+        ["sys-1", "Production Database"],
+      ]);
+
+      await notifyAffectedSystems({
+        catalogClient: mockCatalogClient as never,
+        logger: mockLogger as never,
+        incidentId: "inc-1",
+        incidentTitle: "DB Outage",
+        systemIds: ["sys-1"],
+        systemNames,
+        action: "created",
+        severity: "critical",
+      });
+
+      expect(mockCatalogClient.notifySystemSubscribers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Incident reported: Production Database",
+          body: expect.stringContaining("**Production Database**"),
+        }),
+      );
+    });
+
+    it("should fall back to systemId when systemNames map is not provided", async () => {
+      await notifyAffectedSystems({
+        catalogClient: mockCatalogClient as never,
+        logger: mockLogger as never,
+        incidentId: "inc-1",
+        incidentTitle: "Test Incident",
+        systemIds: ["sys-1"],
+        action: "resolved",
+        severity: "minor",
+      });
+
+      expect(mockCatalogClient.notifySystemSubscribers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Incident resolved: sys-1",
+          body: expect.stringContaining("**sys-1**"),
+        }),
+      );
+    });
+  });
 });
+

--- a/core/incident-backend/src/notifications.ts
+++ b/core/incident-backend/src/notifications.ts
@@ -39,6 +39,7 @@ export async function notifyAffectedSystems(props: {
   incidentId: string;
   incidentTitle: string;
   systemIds: string[];
+  systemNames?: Map<string, string>;
   action: "created" | "updated" | "resolved" | "reopened";
   severity: string;
 }): Promise<void> {
@@ -48,6 +49,7 @@ export async function notifyAffectedSystems(props: {
     incidentId,
     incidentTitle,
     systemIds,
+    systemNames,
     action,
     severity,
   } = props;
@@ -69,11 +71,14 @@ export async function notifyAffectedSystems(props: {
   const uniqueSystemIds = [...new Set(systemIds)];
 
   for (const systemId of uniqueSystemIds) {
+    // Resolve system name from provided map, or fall back to systemId
+    const systemName = systemNames?.get(systemId) ?? systemId;
+
     try {
       await catalogClient.notifySystemSubscribers({
         systemId,
-        title: `Incident ${actionText}`,
-        body: `Incident **"${incidentTitle}"** has been ${actionText} for a system you're subscribed to.`,
+        title: `Incident ${actionText}: ${systemName}`,
+        body: `Incident **"${incidentTitle}"** has been ${actionText} affecting **${systemName}**.`,
         importance,
         action: { label: "View Incident", url: incidentDetailPath },
         includeGroupSubscribers: true,
@@ -87,3 +92,4 @@ export async function notifyAffectedSystems(props: {
     }
   }
 }
+

--- a/core/maintenance-backend/src/notifications.test.ts
+++ b/core/maintenance-backend/src/notifications.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { notifyAffectedSystems } from "./notifications";
+
+// Mock catalog client
+function createMockCatalogClient() {
+  return {
+    notifySystemSubscribers: mock(() => Promise.resolve()),
+  };
+}
+
+// Mock logger
+function createMockLogger() {
+  return {
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    info: mock(() => {}),
+    debug: mock(() => {}),
+  };
+}
+
+describe("notifyAffectedSystems (maintenance)", () => {
+  let mockCatalogClient: ReturnType<typeof createMockCatalogClient>;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockCatalogClient = createMockCatalogClient();
+    mockLogger = createMockLogger();
+  });
+
+  describe("system name inclusion", () => {
+    it("should include system name in title when systemNames map is provided", async () => {
+      const systemNames = new Map([
+        ["sys-1", "Production Database"],
+      ]);
+
+      await notifyAffectedSystems({
+        catalogClient: mockCatalogClient as never,
+        logger: mockLogger as never,
+        maintenanceId: "maint-1",
+        maintenanceTitle: "Scheduled DB Upgrade",
+        systemIds: ["sys-1"],
+        systemNames,
+        action: "created",
+      });
+
+      expect(mockCatalogClient.notifySystemSubscribers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Maintenance scheduled: Production Database",
+          body: expect.stringContaining("**Production Database**"),
+        }),
+      );
+    });
+
+    it("should fall back to systemId when systemNames map is not provided", async () => {
+      await notifyAffectedSystems({
+        catalogClient: mockCatalogClient as never,
+        logger: mockLogger as never,
+        maintenanceId: "maint-1",
+        maintenanceTitle: "Scheduled DB Upgrade",
+        systemIds: ["sys-1"],
+        action: "started",
+      });
+
+      expect(mockCatalogClient.notifySystemSubscribers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Maintenance started: sys-1",
+          body: expect.stringContaining("**sys-1**"),
+        }),
+      );
+    });
+  });
+
+  describe("action text mapping", () => {
+    it("should use 'scheduled' for created action", async () => {
+      await notifyAffectedSystems({
+        catalogClient: mockCatalogClient as never,
+        logger: mockLogger as never,
+        maintenanceId: "maint-1",
+        maintenanceTitle: "Test",
+        systemIds: ["sys-1"],
+        action: "created",
+      });
+
+      expect(mockCatalogClient.notifySystemSubscribers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining("scheduled"),
+        }),
+      );
+    });
+
+    it("should use 'completed' for completed action", async () => {
+      await notifyAffectedSystems({
+        catalogClient: mockCatalogClient as never,
+        logger: mockLogger as never,
+        maintenanceId: "maint-1",
+        maintenanceTitle: "Test",
+        systemIds: ["sys-1"],
+        action: "completed",
+      });
+
+      expect(mockCatalogClient.notifySystemSubscribers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining("completed"),
+        }),
+      );
+    });
+  });
+
+  describe("importance", () => {
+    it("should always use 'info' importance", async () => {
+      await notifyAffectedSystems({
+        catalogClient: mockCatalogClient as never,
+        logger: mockLogger as never,
+        maintenanceId: "maint-1",
+        maintenanceTitle: "Test",
+        systemIds: ["sys-1"],
+        action: "started",
+      });
+
+      expect(mockCatalogClient.notifySystemSubscribers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          importance: "info",
+        }),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("should log warning but not throw when notification fails", async () => {
+      mockCatalogClient.notifySystemSubscribers.mockRejectedValue(
+        new Error("Network error"),
+      );
+
+      await notifyAffectedSystems({
+        catalogClient: mockCatalogClient as never,
+        logger: mockLogger as never,
+        maintenanceId: "maint-1",
+        maintenanceTitle: "Test",
+        systemIds: ["sys-1"],
+        action: "created",
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+  });
+});

--- a/core/maintenance-backend/src/notifications.ts
+++ b/core/maintenance-backend/src/notifications.ts
@@ -15,6 +15,7 @@ export async function notifyAffectedSystems(props: {
   maintenanceId: string;
   maintenanceTitle: string;
   systemIds: string[];
+  systemNames?: Map<string, string>;
   action: "created" | "updated" | "started" | "completed";
 }): Promise<void> {
   const {
@@ -23,6 +24,7 @@ export async function notifyAffectedSystems(props: {
     maintenanceId,
     maintenanceTitle,
     systemIds,
+    systemNames,
     action,
   } = props;
 
@@ -38,11 +40,14 @@ export async function notifyAffectedSystems(props: {
   });
 
   for (const systemId of systemIds) {
+    // Resolve system name from provided map, or fall back to systemId
+    const systemName = systemNames?.get(systemId) ?? systemId;
+
     try {
       await catalogClient.notifySystemSubscribers({
         systemId,
-        title: `Maintenance ${actionText}`,
-        body: `A maintenance **"${maintenanceTitle}"** has been ${actionText} for a system you're subscribed to.`,
+        title: `Maintenance ${actionText}: ${systemName}`,
+        body: `Maintenance **"${maintenanceTitle}"** has been ${actionText} for **${systemName}**.`,
         importance: "info",
         action: { label: "View Maintenance", url: maintenanceDetailPath },
         includeGroupSubscribers: true,
@@ -56,3 +61,4 @@ export async function notifyAffectedSystems(props: {
     }
   }
 }
+


### PR DESCRIPTION
## Summary

Two targeted improvements to the notification system:

### 1. System Context in Notifications
All notification senders now include the affected **system name** in the notification title and body. Users can immediately identify which system is affected without clicking through to the detail page.

**Before:** `System health critical`
**After:** `System health critical: Production API`

Affected senders: healthcheck, incident, maintenance, dependency.

### 2. Upstream Notification Deduplication
When an upstream dependency goes down affecting multiple downstream systems, the dependency notification sidecar now sends **one personalized notification per user** instead of one notification per affected system.

Each user's notification:
- Lists only the systems **they are subscribed to** (not all affected systems)
- Shows **per-system criticality indicators** (🔴 critical, 🟡 degraded, ℹ️ informational)
- Links to the **upstream root cause** system

**Example multi-system notification body:**
```
An upstream dependency (**Database Server**) is affecting:

- 🔴 **API Gateway** — critically impacted
- 🟡 **Web Frontend** — degraded
- ℹ️ **Monitoring Dashboard** — informational
```

### Changes

| Package | Change |
|---|---|
| `healthcheck-backend` | System name in notification title/body |
| `incident-backend` | System name in notification title/body |
| `maintenance-backend` | System name in notification title/body |
| `dependency-backend` | System name + batched per-user notifications |
| `catalog-common` | New `getSystemGroupIds` S2S endpoint |
| `catalog-backend` | Implement `getSystemGroupIds` handler |

### Testing

- 51 tests across 3 test files (all passing)
- Lint clean, 105/105 packages typecheck
- Changeset included