### PR TITLE
feat: centralize realtime cache invalidation via auto-invalidator

### DIFF
--- a/.changeset/signals-auto-invalidation.md
+++ b/.changeset/signals-auto-invalidation.md
@@ -1,0 +1,54 @@
+---
+"@checkstack/signal-common": minor
+"@checkstack/signal-backend": minor
+"@checkstack/signal-frontend": minor
+"@checkstack/frontend-api": minor
+"@checkstack/frontend": minor
+"@checkstack/anomaly-common": minor
+"@checkstack/announcement-common": minor
+"@checkstack/dependency-common": minor
+"@checkstack/healthcheck-common": minor
+"@checkstack/incident-common": minor
+"@checkstack/integration-common": minor
+"@checkstack/maintenance-common": minor
+"@checkstack/notification-common": minor
+"@checkstack/queue-common": minor
+"@checkstack/satellite-common": minor
+"@checkstack/slo-common": minor
+"@checkstack/announcement-frontend": patch
+"@checkstack/dashboard-frontend": patch
+"@checkstack/dependency-frontend": patch
+"@checkstack/healthcheck-frontend": patch
+"@checkstack/incident-frontend": patch
+"@checkstack/maintenance-frontend": patch
+"@checkstack/notification-frontend": patch
+"@checkstack/satellite-frontend": patch
+"@checkstack/slo-frontend": patch
+---
+
+Centralize realtime cache invalidation: signals now carry their owning `pluginId` end-to-end, and a single `SignalAutoInvalidator` mounted near the React Query client invalidates `[[pluginId]]` for every incoming signal automatically.
+
+**Breaking change to `createSignal`** (`@checkstack/signal-common`): the factory now takes a single object argument with `pluginMetadata`, `event`, and `payloadSchema`. The signal id is constructed as `${pluginMetadata.pluginId}.${event}` and the resulting `Signal` carries a `pluginId` field. The `SignalMessage` wire envelope and `ServerToClientMessage` `signal` variant gained a `pluginId` field so the frontend can route invalidations without parsing the id.
+
+```ts
+// Before
+export const ANOMALY_STATE_CHANGED = createSignal(
+  "anomaly.state_changed",
+  z.object({ ... }),
+);
+
+// After
+export const ANOMALY_STATE_CHANGED = createSignal({
+  pluginMetadata,
+  event: "state_changed",
+  payloadSchema: z.object({ ... }),
+});
+```
+
+**New plugin field**: `FrontendPlugin.foreignSignals?: Signal<unknown>[]` lets a plugin opt its `[[pluginId]]` cache into invalidation when another plugin's signal fires (e.g. `dependency-frontend` declares `[SYSTEM_STATUS_CHANGED]` because dependency payloads embed system status). Same-plugin signals must NOT be listed — they are always auto-invalidated.
+
+**Removed boilerplate**: per-component `useSignal(X, () => refetch())` and `useSignal(X, () => queryClient.invalidateQueries(...))` calls have been removed across `incident-frontend`, `maintenance-frontend`, `healthcheck-frontend`, `slo-frontend`, `dependency-frontend`, `satellite-frontend`, `announcement-frontend`, `notification-frontend`, and `dashboard-frontend`. The `NotificationBell` unread count is now derived directly from the `getUnreadCount` query (auto-invalidated) instead of a local state mirror.
+
+**User-visible bug fix**: the system detail page anomaly widget (`SystemAnomalyWidget`) now updates in real-time when anomalies change, with no per-widget signal subscription required. The dashboard status page also stays fresh on `ANOMALY_STATE_CHANGED`, `ANOMALY_BASELINE_UPDATED`, and `ANOMALY_TREND_DETECTED`.
+
+UI-state consumers that legitimately need a `useSignal` (the dashboard activity terminal, the queue lag alert, and the rolling-preset date refresh in `useHealthCheckData`) keep their handlers; the auto-invalidator runs alongside them.

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "core/about-common": {
       "name": "@checkstack/about-common",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -37,7 +37,7 @@
     },
     "core/about-frontend": {
       "name": "@checkstack/about-frontend",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@checkstack/about-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -56,7 +56,7 @@
     },
     "core/announcement-backend": {
       "name": "@checkstack/announcement-backend",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-backend": "workspace:*",
@@ -81,7 +81,7 @@
     },
     "core/announcement-common": {
       "name": "@checkstack/announcement-common",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -96,7 +96,7 @@
     },
     "core/announcement-frontend": {
       "name": "@checkstack/announcement-frontend",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -118,7 +118,7 @@
     },
     "core/anomaly-backend": {
       "name": "@checkstack/anomaly-backend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -146,7 +146,7 @@
     },
     "core/anomaly-common": {
       "name": "@checkstack/anomaly-common",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -160,7 +160,7 @@
     },
     "core/anomaly-frontend": {
       "name": "@checkstack/anomaly-frontend",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "core/api-docs-common": {
       "name": "@checkstack/api-docs-common",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -197,7 +197,7 @@
     },
     "core/api-docs-frontend": {
       "name": "@checkstack/api-docs-frontend",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "core/auth-backend": {
       "name": "@checkstack/auth-backend",
-      "version": "0.4.19",
+      "version": "0.4.20",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -240,7 +240,7 @@
     },
     "core/auth-common": {
       "name": "@checkstack/auth-common",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -254,7 +254,7 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.5.29",
+      "version": "0.5.30",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -276,7 +276,7 @@
     },
     "core/backend": {
       "name": "@checkstack/backend",
-      "version": "0.6.6",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -311,7 +311,7 @@
     },
     "core/backend-api": {
       "name": "@checkstack/backend-api",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@checkstack/cache-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -340,7 +340,7 @@
     },
     "core/cache-api": {
       "name": "@checkstack/cache-api",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -352,7 +352,7 @@
     },
     "core/cache-backend": {
       "name": "@checkstack/cache-backend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -369,7 +369,7 @@
     },
     "core/cache-common": {
       "name": "@checkstack/cache-common",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -383,7 +383,7 @@
     },
     "core/cache-frontend": {
       "name": "@checkstack/cache-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/cache-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -402,7 +402,7 @@
     },
     "core/cache-utils": {
       "name": "@checkstack/cache-utils",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/cache-api": "workspace:*",
       },
@@ -415,7 +415,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -446,7 +446,7 @@
     },
     "core/catalog-common": {
       "name": "@checkstack/catalog-common",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -462,7 +462,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -487,7 +487,7 @@
     },
     "core/command-backend": {
       "name": "@checkstack/command-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-common": "workspace:*",
@@ -505,7 +505,7 @@
     },
     "core/command-common": {
       "name": "@checkstack/command-common",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -519,7 +519,7 @@
     },
     "core/command-frontend": {
       "name": "@checkstack/command-frontend",
-      "version": "0.2.30",
+      "version": "0.2.31",
       "dependencies": {
         "@checkstack/command-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -538,7 +538,7 @@
     },
     "core/common": {
       "name": "@checkstack/common",
-      "version": "0.6.5",
+      "version": "0.7.0",
       "dependencies": {
         "@orpc/contract": "^1.13.14",
         "lucide-react": "0.562.0",
@@ -552,7 +552,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.4.6",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -583,7 +583,7 @@
     },
     "core/dependency-backend": {
       "name": "@checkstack/dependency-backend",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -611,7 +611,7 @@
     },
     "core/dependency-common": {
       "name": "@checkstack/dependency-common",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -627,7 +627,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -658,7 +658,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -698,9 +698,10 @@
     },
     "core/frontend-api": {
       "name": "@checkstack/frontend-api",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "dependencies": {
         "@checkstack/common": "workspace:*",
+        "@checkstack/signal-common": "workspace:*",
         "@orpc/client": "^1.13.14",
         "@orpc/react-query": "1.13.4",
         "@orpc/tanstack-query": "^1.13.2",
@@ -719,7 +720,7 @@
     },
     "core/gitops-backend": {
       "name": "@checkstack/gitops-backend",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -745,7 +746,7 @@
     },
     "core/gitops-common": {
       "name": "@checkstack/gitops-common",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -759,7 +760,7 @@
     },
     "core/gitops-frontend": {
       "name": "@checkstack/gitops-frontend",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -778,7 +779,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -816,7 +817,7 @@
     },
     "core/healthcheck-common": {
       "name": "@checkstack/healthcheck-common",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -830,7 +831,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.16.5",
+      "version": "0.17.1",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -862,7 +863,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -891,7 +892,7 @@
     },
     "core/incident-common": {
       "name": "@checkstack/incident-common",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -907,7 +908,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.5.6",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -931,7 +932,7 @@
     },
     "core/infrastructure-common": {
       "name": "@checkstack/infrastructure-common",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -946,7 +947,7 @@
     },
     "core/infrastructure-frontend": {
       "name": "@checkstack/infrastructure-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -965,7 +966,7 @@
     },
     "core/integration-backend": {
       "name": "@checkstack/integration-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -988,7 +989,7 @@
     },
     "core/integration-common": {
       "name": "@checkstack/integration-common",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1003,7 +1004,7 @@
     },
     "core/integration-frontend": {
       "name": "@checkstack/integration-frontend",
-      "version": "0.2.30",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1023,7 +1024,7 @@
     },
     "core/maintenance-backend": {
       "name": "@checkstack/maintenance-backend",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1052,7 +1053,7 @@
     },
     "core/maintenance-common": {
       "name": "@checkstack/maintenance-common",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1068,7 +1069,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -1092,7 +1093,7 @@
     },
     "core/notification-backend": {
       "name": "@checkstack/notification-backend",
-      "version": "0.1.23",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1118,7 +1119,7 @@
     },
     "core/notification-common": {
       "name": "@checkstack/notification-common",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1133,7 +1134,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.2.34",
+      "version": "0.2.35",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1154,7 +1155,7 @@
     },
     "core/queue-api": {
       "name": "@checkstack/queue-api",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -1166,7 +1167,7 @@
     },
     "core/queue-backend": {
       "name": "@checkstack/queue-backend",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1185,7 +1186,7 @@
     },
     "core/queue-common": {
       "name": "@checkstack/queue-common",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1200,7 +1201,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.2.31",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1224,11 +1225,11 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.73.0",
+      "version": "0.75.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1243,7 +1244,7 @@
     },
     "core/satellite-backend": {
       "name": "@checkstack/satellite-backend",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1267,7 +1268,7 @@
     },
     "core/satellite-common": {
       "name": "@checkstack/satellite-common",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
@@ -1283,7 +1284,7 @@
     },
     "core/satellite-frontend": {
       "name": "@checkstack/satellite-frontend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1320,7 +1321,7 @@
     },
     "core/signal-backend": {
       "name": "@checkstack/signal-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1336,7 +1337,7 @@
     },
     "core/signal-common": {
       "name": "@checkstack/signal-common",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
@@ -1349,7 +1350,7 @@
     },
     "core/signal-frontend": {
       "name": "@checkstack/signal-frontend",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@checkstack/signal-common": "workspace:*",
       },
@@ -1365,7 +1366,7 @@
     },
     "core/slo-backend": {
       "name": "@checkstack/slo-backend",
-      "version": "0.2.16",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -1397,7 +1398,7 @@
     },
     "core/slo-common": {
       "name": "@checkstack/slo-common",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1413,7 +1414,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1439,7 +1440,7 @@
     },
     "core/test-utils-backend": {
       "name": "@checkstack/test-utils-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1475,7 +1476,7 @@
     },
     "core/theme-backend": {
       "name": "@checkstack/theme-backend",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1496,7 +1497,7 @@
     },
     "core/theme-common": {
       "name": "@checkstack/theme-common",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -1510,7 +1511,7 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1536,7 +1537,7 @@
     },
     "core/ui": {
       "name": "@checkstack/ui",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1574,7 +1575,7 @@
     },
     "plugins/auth-credential-backend": {
       "name": "@checkstack/auth-credential-backend",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1588,7 +1589,7 @@
     },
     "plugins/auth-github-backend": {
       "name": "@checkstack/auth-github-backend",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1602,7 +1603,7 @@
     },
     "plugins/auth-ldap-backend": {
       "name": "@checkstack/auth-ldap-backend",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1621,7 +1622,7 @@
     },
     "plugins/auth-saml-backend": {
       "name": "@checkstack/auth-saml-backend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1639,7 +1640,7 @@
     },
     "plugins/cache-memory-backend": {
       "name": "@checkstack/cache-memory-backend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -1655,7 +1656,7 @@
     },
     "plugins/cache-memory-common": {
       "name": "@checkstack/cache-memory-common",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -1666,7 +1667,7 @@
     },
     "plugins/collector-hardware-backend": {
       "name": "@checkstack/collector-hardware-backend",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1682,7 +1683,7 @@
     },
     "plugins/healthcheck-dns-backend": {
       "name": "@checkstack/healthcheck-dns-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1697,7 +1698,7 @@
     },
     "plugins/healthcheck-grpc-backend": {
       "name": "@checkstack/healthcheck-grpc-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1713,7 +1714,7 @@
     },
     "plugins/healthcheck-http-backend": {
       "name": "@checkstack/healthcheck-http-backend",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1729,7 +1730,7 @@
     },
     "plugins/healthcheck-jenkins-backend": {
       "name": "@checkstack/healthcheck-jenkins-backend",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1744,7 +1745,7 @@
     },
     "plugins/healthcheck-mysql-backend": {
       "name": "@checkstack/healthcheck-mysql-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1760,7 +1761,7 @@
     },
     "plugins/healthcheck-ping-backend": {
       "name": "@checkstack/healthcheck-ping-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1775,7 +1776,7 @@
     },
     "plugins/healthcheck-postgres-backend": {
       "name": "@checkstack/healthcheck-postgres-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1792,7 +1793,7 @@
     },
     "plugins/healthcheck-rcon-backend": {
       "name": "@checkstack/healthcheck-rcon-backend",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1809,7 +1810,7 @@
     },
     "plugins/healthcheck-rcon-common": {
       "name": "@checkstack/healthcheck-rcon-common",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -1822,7 +1823,7 @@
     },
     "plugins/healthcheck-redis-backend": {
       "name": "@checkstack/healthcheck-redis-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1838,7 +1839,7 @@
     },
     "plugins/healthcheck-script-backend": {
       "name": "@checkstack/healthcheck-script-backend",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1853,7 +1854,7 @@
     },
     "plugins/healthcheck-ssh-backend": {
       "name": "@checkstack/healthcheck-ssh-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1871,7 +1872,7 @@
     },
     "plugins/healthcheck-ssh-common": {
       "name": "@checkstack/healthcheck-ssh-common",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -1884,7 +1885,7 @@
     },
     "plugins/healthcheck-tcp-backend": {
       "name": "@checkstack/healthcheck-tcp-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1899,7 +1900,7 @@
     },
     "plugins/healthcheck-tls-backend": {
       "name": "@checkstack/healthcheck-tls-backend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1914,7 +1915,7 @@
     },
     "plugins/integration-jira-backend": {
       "name": "@checkstack/integration-jira-backend",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1933,7 +1934,7 @@
     },
     "plugins/integration-jira-common": {
       "name": "@checkstack/integration-jira-common",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/integration-common": "workspace:*",
@@ -1949,7 +1950,7 @@
     },
     "plugins/integration-script-backend": {
       "name": "@checkstack/integration-script-backend",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1966,7 +1967,7 @@
     },
     "plugins/integration-teams-backend": {
       "name": "@checkstack/integration-teams-backend",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1981,7 +1982,7 @@
     },
     "plugins/integration-webex-backend": {
       "name": "@checkstack/integration-webex-backend",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1996,7 +1997,7 @@
     },
     "plugins/integration-webhook-backend": {
       "name": "@checkstack/integration-webhook-backend",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2013,7 +2014,7 @@
     },
     "plugins/notification-backstage-backend": {
       "name": "@checkstack/notification-backstage-backend",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2027,7 +2028,7 @@
     },
     "plugins/notification-discord-backend": {
       "name": "@checkstack/notification-discord-backend",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2041,7 +2042,7 @@
     },
     "plugins/notification-gotify-backend": {
       "name": "@checkstack/notification-gotify-backend",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2055,7 +2056,7 @@
     },
     "plugins/notification-pushover-backend": {
       "name": "@checkstack/notification-pushover-backend",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2069,7 +2070,7 @@
     },
     "plugins/notification-slack-backend": {
       "name": "@checkstack/notification-slack-backend",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2083,7 +2084,7 @@
     },
     "plugins/notification-smtp-backend": {
       "name": "@checkstack/notification-smtp-backend",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2099,7 +2100,7 @@
     },
     "plugins/notification-teams-backend": {
       "name": "@checkstack/notification-teams-backend",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2113,7 +2114,7 @@
     },
     "plugins/notification-telegram-backend": {
       "name": "@checkstack/notification-telegram-backend",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2129,7 +2130,7 @@
     },
     "plugins/notification-webex-backend": {
       "name": "@checkstack/notification-webex-backend",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2143,7 +2144,7 @@
     },
     "plugins/queue-bullmq-backend": {
       "name": "@checkstack/queue-bullmq-backend",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2161,7 +2162,7 @@
     },
     "plugins/queue-bullmq-common": {
       "name": "@checkstack/queue-bullmq-common",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -2173,7 +2174,7 @@
     },
     "plugins/queue-memory-backend": {
       "name": "@checkstack/queue-memory-backend",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2190,7 +2191,7 @@
     },
     "plugins/queue-memory-common": {
       "name": "@checkstack/queue-memory-common",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },

--- a/core/announcement-common/src/signals.ts
+++ b/core/announcement-common/src/signals.ts
@@ -1,14 +1,16 @@
 import { z } from "zod";
 import { createSignal } from "@checkstack/signal-common";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Broadcast when an announcement is created, updated, or deleted.
  * Frontend components listening to this signal should refetch active announcements.
  */
-export const ANNOUNCEMENT_UPDATED = createSignal(
-  "announcement.updated",
-  z.object({
+export const ANNOUNCEMENT_UPDATED = createSignal({
+  pluginMetadata,
+  event: "updated",
+  payloadSchema: z.object({
     announcementId: z.string(),
     action: z.enum(["created", "updated", "deleted"]),
   }),
-);
+});

--- a/core/announcement-frontend/src/components/AnnouncementBanner.tsx
+++ b/core/announcement-frontend/src/components/AnnouncementBanner.tsx
@@ -2,10 +2,8 @@ import React, { useState, useCallback } from "react";
 import { usePluginClient } from "@checkstack/frontend-api";
 import {
   AnnouncementApi,
-  ANNOUNCEMENT_UPDATED,
   type Announcement,
 } from "@checkstack/announcement-common";
-import { useSignal } from "@checkstack/signal-frontend";
 import { MarkdownBlock } from "@checkstack/ui";
 import {
   Info,
@@ -183,15 +181,7 @@ export const AnnouncementBanner: React.FC = () => {
     getLocalDismissedIds(),
   );
 
-  const { data, isLoading, refetch } =
-    announcementClient.getActiveAnnouncements.useQuery();
-
-  // Refetch own query immediately + invalidate all announcement queries
-  // (including the dashboard's includeDismissed variant) for cross-component freshness.
-  // oRPC query keys are structured as [[...path], { type, input }].
-  useSignal(ANNOUNCEMENT_UPDATED, () => {
-    void refetch();
-  });
+  const { data, isLoading } = announcementClient.getActiveAnnouncements.useQuery();
 
   // Server-side dismiss — extract stable mutate function to avoid re-renders
   const { mutate: dismissOnServer } =

--- a/core/announcement-frontend/src/components/DashboardAnnouncements.tsx
+++ b/core/announcement-frontend/src/components/DashboardAnnouncements.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { usePluginClient } from "@checkstack/frontend-api";
-import { AnnouncementApi, ANNOUNCEMENT_UPDATED, type Announcement } from "@checkstack/announcement-common";
-import { useSignal } from "@checkstack/signal-frontend";
+import { AnnouncementApi, type Announcement } from "@checkstack/announcement-common";
 import { MarkdownBlock } from "@checkstack/ui";
 import {
   Info,
@@ -103,16 +102,11 @@ export const DashboardAnnouncements: React.FC = () => {
   const announcementClient = usePluginClient(AnnouncementApi);
 
   // Always refetch on mount so the dashboard shows fresh data when navigated to.
-  // Also subscribe to signals for instant updates while actively viewing.
-  const { data, isLoading, refetch } =
-    announcementClient.getActiveAnnouncements.useQuery(
-      { includeDismissed: true },
-      { refetchOnMount: "always" },
-    );
-
-  useSignal(ANNOUNCEMENT_UPDATED, () => {
-    void refetch();
-  });
+  // Realtime updates arrive via SignalAutoInvalidator on `[["announcement"]]`.
+  const { data, isLoading } = announcementClient.getActiveAnnouncements.useQuery(
+    { includeDismissed: true },
+    { refetchOnMount: "always" },
+  );
 
   const dashboardAnnouncements = React.useMemo(() => {
     if (!data?.announcements) return [];

--- a/core/anomaly-common/src/index.ts
+++ b/core/anomaly-common/src/index.ts
@@ -10,33 +10,37 @@ export * from "./plugin-metadata";
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
 import { AnomalyStateSchema } from "./schema";
+import { pluginMetadata } from "./plugin-metadata";
 
-export const ANOMALY_STATE_CHANGED = createSignal(
-  "anomaly.state_changed",
-  z.object({
+export const ANOMALY_STATE_CHANGED = createSignal({
+  pluginMetadata,
+  event: "state_changed",
+  payloadSchema: z.object({
     systemId: z.string(),
     anomalyId: z.string(),
     newState: AnomalyStateSchema,
-  })
-);
+  }),
+});
 
-export const ANOMALY_BASELINE_UPDATED = createSignal(
-  "anomaly.baseline_updated",
-  z.object({
+export const ANOMALY_BASELINE_UPDATED = createSignal({
+  pluginMetadata,
+  event: "baseline_updated",
+  payloadSchema: z.object({
     systemId: z.string(),
     configurationId: z.string(),
     fieldPath: z.string(),
     mean: z.number(),
     stdDev: z.number(),
     sampleCount: z.number(),
-  })
-);
+  }),
+});
 
-export const ANOMALY_TREND_DETECTED = createSignal(
-  "anomaly.trend_detected",
-  z.object({
+export const ANOMALY_TREND_DETECTED = createSignal({
+  pluginMetadata,
+  event: "trend_detected",
+  payloadSchema: z.object({
     systemId: z.string(),
     anomalyId: z.string(),
     fieldPath: z.string(),
-  })
-);
+  }),
+});

--- a/core/dashboard-frontend/src/components/SystemBadgeDataProvider.tsx
+++ b/core/dashboard-frontend/src/components/SystemBadgeDataProvider.tsx
@@ -1,19 +1,15 @@
 import React, { createContext, useContext, useCallback, useMemo } from "react";
-import { usePluginClient, useQueryClient } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
+import { usePluginClient } from "@checkstack/frontend-api";
 import {
   HealthCheckApi,
-  SYSTEM_STATUS_CHANGED,
   type SystemHealthStatusResponse,
 } from "@checkstack/healthcheck-common";
 import {
   IncidentApi,
-  INCIDENT_UPDATED,
   type IncidentWithSystems,
 } from "@checkstack/incident-common";
 import {
   MaintenanceApi,
-  MAINTENANCE_UPDATED,
   type MaintenanceWithSystems,
 } from "@checkstack/maintenance-common";
 
@@ -46,11 +42,14 @@ interface SystemBadgeDataProviderProps {
 /**
  * Provider that bulk-fetches badge data (health, incidents, maintenances)
  * for multiple systems using TanStack Query and provides it via context.
+ *
+ * Realtime invalidation of `[["healthcheck"]]`, `[["incident"]]`, and
+ * `[["maintenance"]]` is handled centrally by SignalAutoInvalidator — no
+ * per-component signal handlers needed here.
  */
 export const SystemBadgeDataProvider: React.FC<
   SystemBadgeDataProviderProps
 > = ({ systemIds, children }) => {
-  const queryClient = useQueryClient();
   const healthCheckClient = usePluginClient(HealthCheckApi);
   const incidentClient = usePluginClient(IncidentApi);
   const maintenanceClient = usePluginClient(MaintenanceApi);
@@ -81,56 +80,6 @@ export const SystemBadgeDataProvider: React.FC<
     );
 
   const loading = healthLoading || incidentLoading || maintenanceLoading;
-
-  // -------------------------------------------------------------------------
-  // SIGNAL HANDLERS - Invalidate queries on updates
-  // -------------------------------------------------------------------------
-
-  const refetchHealth = useCallback(
-    (systemId: string) => {
-      if (systemIds.includes(systemId)) {
-        // Invalidate the bulk query to refetch
-        queryClient.invalidateQueries({ queryKey: [["healthcheck"]] });
-      }
-    },
-    [systemIds, queryClient]
-  );
-
-  useSignal(SYSTEM_STATUS_CHANGED, ({ systemId }) => {
-    refetchHealth(systemId);
-  });
-
-  const refetchIncidents = useCallback(
-    (affectedSystemIds: string[]) => {
-      const hasAffected = affectedSystemIds.some((id) =>
-        systemIds.includes(id)
-      );
-      if (hasAffected) {
-        queryClient.invalidateQueries({ queryKey: [["incident"]] });
-      }
-    },
-    [systemIds, queryClient]
-  );
-
-  useSignal(INCIDENT_UPDATED, ({ systemIds: affectedIds }) => {
-    refetchIncidents(affectedIds);
-  });
-
-  const refetchMaintenances = useCallback(
-    (affectedSystemIds: string[]) => {
-      const hasAffected = affectedSystemIds.some((id) =>
-        systemIds.includes(id)
-      );
-      if (hasAffected) {
-        queryClient.invalidateQueries({ queryKey: [["maintenance"]] });
-      }
-    },
-    [systemIds, queryClient]
-  );
-
-  useSignal(MAINTENANCE_UPDATED, ({ systemIds: affectedIds }) => {
-    refetchMaintenances(affectedIds);
-  });
 
   // -------------------------------------------------------------------------
   // CONTEXT VALUE

--- a/core/dependency-common/src/index.ts
+++ b/core/dependency-common/src/index.ts
@@ -34,28 +34,31 @@ export { dependencyRoutes } from "./routes";
 
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Broadcast when dependency definitions change (created, updated, deleted).
  * Frontend components can refetch the dependency graph.
  */
-export const DEPENDENCY_CHANGED = createSignal(
-  "dependency.changed",
-  z.object({
+export const DEPENDENCY_CHANGED = createSignal({
+  pluginMetadata,
+  event: "changed",
+  payloadSchema: z.object({
     dependencyId: z.string(),
     sourceSystemId: z.string(),
     targetSystemId: z.string(),
     action: z.enum(["created", "updated", "deleted"]),
   }),
-);
+});
 
 /**
  * Broadcast when computed dependency warnings change for one or more systems.
  * Badge components listen to this to refresh without polling.
  */
-export const DEPENDENCY_WARNINGS_CHANGED = createSignal(
-  "dependency.warnings.changed",
-  z.object({
+export const DEPENDENCY_WARNINGS_CHANGED = createSignal({
+  pluginMetadata,
+  event: "warnings.changed",
+  payloadSchema: z.object({
     affectedSystemIds: z.array(z.string()),
   }),
-);
+});

--- a/core/dependency-frontend/src/components/DependencyAlert.tsx
+++ b/core/dependency-frontend/src/components/DependencyAlert.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { usePluginClient, type SlotContext } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SystemDetailsTopSlot } from "@checkstack/catalog-common";
 import {
   DependencyApi,
-  DEPENDENCY_CHANGED,
-  DEPENDENCY_WARNINGS_CHANGED,
   type DerivedState,
   type AffectedUpstream,
 } from "@checkstack/dependency-common";
@@ -79,22 +76,10 @@ function getImpactBadge(impactType: string): React.ReactNode {
 export const DependencyAlert: React.FC<Props> = ({ system }) => {
   const depClient = usePluginClient(DependencyApi);
 
-  const { data, refetch } = depClient.getWarningsForSystem.useQuery(
+  const { data } = depClient.getWarningsForSystem.useQuery(
     { systemId: system?.id ?? "" },
     { enabled: !!system?.id },
   );
-
-  // Listen for dependency graph changes
-  useSignal(DEPENDENCY_CHANGED, () => {
-    void refetch();
-  });
-
-  // Listen for warning re-evaluations
-  useSignal(DEPENDENCY_WARNINGS_CHANGED, ({ affectedSystemIds }) => {
-    if (system?.id && affectedSystemIds.includes(system.id)) {
-      void refetch();
-    }
-  });
 
   if (!data || data.affectedUpstreams.length === 0) return;
 

--- a/core/dependency-frontend/src/components/DependencyBadge.tsx
+++ b/core/dependency-frontend/src/components/DependencyBadge.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { usePluginClient, type SlotContext } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SystemStateBadgesSlot } from "@checkstack/catalog-common";
 import {
   DependencyApi,
-  DEPENDENCY_CHANGED,
-  DEPENDENCY_WARNINGS_CHANGED,
   type DerivedState,
 } from "@checkstack/dependency-common";
 import { Badge } from "@checkstack/ui";
@@ -46,27 +43,17 @@ function getBadgeLabel(state: DerivedState): string {
  * Displays a dependency warning badge for a system on the dashboard.
  * Shows nothing if no upstream systems are affected.
  *
- * Listens for realtime updates via signals.
+ * Realtime updates arrive via SignalAutoInvalidator on `[["dependency"]]`,
+ * including foreign-signal invalidation on SYSTEM_STATUS_CHANGED (declared in
+ * the dependency plugin's `foreignSignals`).
  */
 export const DependencyBadge: React.FC<Props> = ({ system }) => {
   const depClient = usePluginClient(DependencyApi);
 
-  const { data, refetch } = depClient.getWarningsForSystem.useQuery(
+  const { data } = depClient.getWarningsForSystem.useQuery(
     { systemId: system?.id ?? "" },
     { enabled: !!system?.id },
   );
-
-  // Listen for dependency changes
-  useSignal(DEPENDENCY_CHANGED, () => {
-    void refetch();
-  });
-
-  // Listen for warning re-evaluations
-  useSignal(DEPENDENCY_WARNINGS_CHANGED, ({ affectedSystemIds }) => {
-    if (system?.id && affectedSystemIds.includes(system.id)) {
-      void refetch();
-    }
-  });
 
   if (!data) return;
 

--- a/core/dependency-frontend/src/components/DependencyEditor.tsx
+++ b/core/dependency-frontend/src/components/DependencyEditor.tsx
@@ -4,11 +4,9 @@ import {
   usePluginClient,
   type SlotContext,
 } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SystemEditorSlot } from "@checkstack/catalog-common";
 import {
   DependencyApi,
-  DEPENDENCY_CHANGED,
   dependencyRoutes,
   type Dependency,
   type ImpactType,
@@ -90,11 +88,6 @@ export const DependencyEditor: React.FC<Props> = ({ systemId }) => {
     }
     return map;
   }, [systemsData]);
-
-  // Listen for realtime changes
-  useSignal(DEPENDENCY_CHANGED, () => {
-    void refetchDeps();
-  });
 
   const createMutation = depClient.createDependency.useMutation({
     onSuccess: () => {

--- a/core/dependency-frontend/src/components/DependencyMapPage.tsx
+++ b/core/dependency-frontend/src/components/DependencyMapPage.tsx
@@ -15,13 +15,10 @@ import {
 import "@xyflow/react/dist/style.css";
 
 import { usePluginClient, wrapInSuspense } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { CatalogApi } from "@checkstack/catalog-common";
-import { HealthCheckApi, SYSTEM_STATUS_CHANGED } from "@checkstack/healthcheck-common";
+import { HealthCheckApi } from "@checkstack/healthcheck-common";
 import {
   DependencyApi,
-  DEPENDENCY_CHANGED,
-  DEPENDENCY_WARNINGS_CHANGED,
   type Dependency,
   type NodePosition,
 } from "@checkstack/dependency-common";
@@ -137,12 +134,12 @@ function DependencyMapContent() {
       { enabled: systemIds.length > 0 },
     );
 
-  // Fetch real health statuses for all systems
-  const { data: healthData, refetch: refetchHealth } =
-    healthCheckClient.getBulkSystemHealthStatus.useQuery(
-      { systemIds },
-      { enabled: systemIds.length > 0 },
-    );
+  // Fetch real health statuses for all systems — kept fresh via SignalAutoInvalidator
+  // (foreignSignals declares SYSTEM_STATUS_CHANGED on the dependency plugin).
+  const { data: healthData } = healthCheckClient.getBulkSystemHealthStatus.useQuery(
+    { systemIds },
+    { enabled: systemIds.length > 0 },
+  );
 
   // Save positions mutation
   const saveMutation = depClient.saveNodePositions.useMutation({
@@ -380,20 +377,6 @@ function DependencyMapContent() {
 
     savePositions({ positions });
   }, [savePositions]);
-
-  // Listen for realtime dependency changes
-  useSignal(DEPENDENCY_CHANGED, () => {
-    void refetchDeps();
-  });
-
-  useSignal(DEPENDENCY_WARNINGS_CHANGED, () => {
-    void refetchWarnings();
-  });
-
-  useSignal(SYSTEM_STATUS_CHANGED, () => {
-    void refetchHealth();
-    void refetchWarnings();
-  });
 
   // Cleanup timeout on unmount
   useEffect(() => {

--- a/core/dependency-frontend/src/index.tsx
+++ b/core/dependency-frontend/src/index.tsx
@@ -8,6 +8,7 @@ import {
   dependencyRoutes,
   dependencyAccess,
 } from "@checkstack/dependency-common";
+import { SYSTEM_STATUS_CHANGED } from "@checkstack/healthcheck-common";
 import {
   SystemDetailsTopSlot,
   SystemStateBadgesSlot,
@@ -21,6 +22,10 @@ import { DependencyMenuItems } from "./components/DependencyMenuItems";
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
+  // Dependency queries embed system health, so a system status change must
+  // also invalidate this plugin's cache. Same-plugin signals (DEPENDENCY_*)
+  // are auto-invalidated and must NOT be listed here.
+  foreignSignals: [SYSTEM_STATUS_CHANGED],
   routes: [
     {
       route: dependencyRoutes.routes.map,

--- a/core/frontend-api/package.json
+++ b/core/frontend-api/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@checkstack/common": "workspace:*",
+    "@checkstack/signal-common": "workspace:*",
     "@orpc/client": "^1.13.14",
     "@orpc/react-query": "1.13.4",
     "@orpc/tanstack-query": "^1.13.2",

--- a/core/frontend-api/src/plugin.ts
+++ b/core/frontend-api/src/plugin.ts
@@ -6,6 +6,7 @@ import type {
   PluginMetadata,
   AccessRule,
 } from "@checkstack/common";
+import type { Signal } from "@checkstack/signal-common";
 
 /**
  * Extract the context type from a SlotDefinition
@@ -68,6 +69,18 @@ export interface FrontendPlugin {
     factory: (deps: { get: <T>(ref: ApiRef<T>) => T }) => unknown;
   }[];
   routes?: PluginRoute[];
+
+  /**
+   * Foreign signals that should also invalidate this plugin's react-query
+   * cache (`[[pluginId]]`) when received. The signal's own plugin will already
+   * be auto-invalidated; this opts the current plugin in as well.
+   *
+   * Use ONLY for genuine cross-plugin reactivity (e.g. dependency-frontend
+   * needs to refetch when healthcheck status changes because dependency
+   * payloads embed system status). Same-plugin signals are handled
+   * automatically and must not be listed here.
+   */
+  foreignSignals?: Signal<unknown>[];
 }
 
 export function createFrontendPlugin(plugin: FrontendPlugin): FrontendPlugin {

--- a/core/frontend/src/App.tsx
+++ b/core/frontend/src/App.tsx
@@ -42,6 +42,7 @@ import {
   cn,
 } from "@checkstack/ui";
 import { SignalProvider } from "@checkstack/signal-frontend";
+import { SignalAutoInvalidator } from "./components/SignalAutoInvalidator";
 import { SessionProvider } from "@checkstack/auth-frontend";
 import { usePluginLifecycle } from "./hooks/usePluginLifecycle";
 import { useCommands, useGlobalShortcuts } from "@checkstack/command-frontend";
@@ -293,6 +294,7 @@ function AppWithApis() {
         <OrpcQueryProvider>
           <SessionProvider>
             <SignalProvider backendUrl={baseUrl}>
+              <SignalAutoInvalidator />
               <ToastProvider>
                 <PerformanceProvider>
                   <AppContent />

--- a/core/frontend/src/components/SignalAutoInvalidator.tsx
+++ b/core/frontend/src/components/SignalAutoInvalidator.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { pluginRegistry, useQueryClient } from "@checkstack/frontend-api";
+import { useSubscribeAllSignals } from "@checkstack/signal-frontend";
+
+/**
+ * Subscribes to every incoming signal and invalidates the matching plugin's
+ * react-query cache (`[[pluginId]]`).
+ *
+ * Two invalidation passes per signal:
+ *   1. Always invalidate the OWNING plugin's queries (auto, no registration).
+ *   2. Invalidate any other plugin that opted in via `foreignSignals` on its
+ *      `FrontendPlugin` config.
+ *
+ * Renders nothing. Mount once near the QueryClientProvider so its useQueryClient
+ * call resolves to the same client used by the rest of the app.
+ */
+export function SignalAutoInvalidator(): React.ReactNode {
+  const queryClient = useQueryClient();
+  const foreignSubscriberPluginIds = useForeignSignalMap();
+
+  useSubscribeAllSignals(({ signalId, pluginId }) => {
+    queryClient.invalidateQueries({ queryKey: [[pluginId]] });
+
+    const subscriberPluginIds = foreignSubscriberPluginIds.get(signalId);
+    if (subscriberPluginIds) {
+      for (const subscriberPluginId of subscriberPluginIds) {
+        queryClient.invalidateQueries({ queryKey: [[subscriberPluginId]] });
+      }
+    }
+  });
+
+  // eslint-disable-next-line unicorn/no-null
+  return null;
+}
+
+/**
+ * Builds a `signalId → Set<pluginId>` map from the `foreignSignals`
+ * declarations of all currently registered plugins. Rebuilds when plugins
+ * are dynamically loaded or unloaded.
+ */
+function useForeignSignalMap(): Map<string, Set<string>> {
+  const [map, setMap] = useState<Map<string, Set<string>>>(() =>
+    buildForeignSignalMap(),
+  );
+
+  useEffect(() => {
+    return pluginRegistry.subscribe(() => {
+      setMap(buildForeignSignalMap());
+    });
+  }, []);
+
+  return map;
+}
+
+function buildForeignSignalMap(): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  for (const plugin of pluginRegistry.getPlugins()) {
+    if (!plugin.foreignSignals) continue;
+    for (const signal of plugin.foreignSignals) {
+      let subscribers = map.get(signal.id);
+      if (!subscribers) {
+        subscribers = new Set();
+        map.set(signal.id, subscribers);
+      }
+      subscribers.add(plugin.metadata.pluginId);
+    }
+  }
+  return map;
+}

--- a/core/healthcheck-common/src/index.ts
+++ b/core/healthcheck-common/src/index.ts
@@ -49,14 +49,16 @@ export { healthcheckRoutes } from "./routes";
 
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Broadcast when a health check run completes.
  * Frontend components listening to this signal can update live activity feeds.
  */
-export const HEALTH_CHECK_RUN_COMPLETED = createSignal(
-  "healthcheck.run.completed",
-  z.object({
+export const HEALTH_CHECK_RUN_COMPLETED = createSignal({
+  pluginMetadata,
+  event: "run.completed",
+  payloadSchema: z.object({
     systemId: z.string(),
     systemName: z.string(),
     configurationId: z.string(),
@@ -64,7 +66,7 @@ export const HEALTH_CHECK_RUN_COMPLETED = createSignal(
     status: z.enum(["healthy", "degraded", "unhealthy"]),
     latencyMs: z.number().optional(),
   }),
-);
+});
 
 /**
  * Broadcast when a system's overall health status transitions.
@@ -72,11 +74,12 @@ export const HEALTH_CHECK_RUN_COMPLETED = createSignal(
  * NOT on every individual health check run. Use this for coarse-grained reactivity
  * like dashboard badges and dependency map node statuses.
  */
-export const SYSTEM_STATUS_CHANGED = createSignal(
-  "healthcheck.system.status-changed",
-  z.object({
+export const SYSTEM_STATUS_CHANGED = createSignal({
+  pluginMetadata,
+  event: "system.status_changed",
+  payloadSchema: z.object({
     systemId: z.string(),
     previousStatus: z.enum(["healthy", "degraded", "unhealthy"]),
     newStatus: z.enum(["healthy", "degraded", "unhealthy"]),
   }),
-);
+});

--- a/core/healthcheck-frontend/src/components/HealthCheckDrawer.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckDrawer.tsx
@@ -7,9 +7,7 @@ import {
   useApi,
   accessApiRef,
 } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import {
-  HEALTH_CHECK_RUN_COMPLETED,
   HealthCheckApi,
   healthCheckAccess,
   healthcheckRoutes,
@@ -199,11 +197,8 @@ export const HealthCheckDrawer: React.FC<HealthCheckDrawerProps> = ({
   // Pagination for history table
   const pagination = usePagination({ defaultLimit: 5 });
 
-  const {
-    data: historyData,
-    isLoading: historyLoading,
-    refetch,
-  } = healthCheckClient.getHistory.useQuery({
+  const { data: historyData, isLoading: historyLoading } =
+    healthCheckClient.getHistory.useQuery({
     systemId,
     configurationId: item.configurationId,
     limit: pagination.limit,
@@ -225,13 +220,6 @@ export const HealthCheckDrawer: React.FC<HealthCheckDrawerProps> = ({
     prevRunsRef.current = rawRuns;
   }
   const runs = displayRuns;
-
-  // Realtime updates
-  useSignal(HEALTH_CHECK_RUN_COMPLETED, ({ systemId: changedId }) => {
-    if (changedId === systemId) {
-      void refetch();
-    }
-  });
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>

--- a/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
@@ -1,14 +1,10 @@
-import React, { useState, useCallback } from "react";
+import React, { useState } from "react";
 import {
   usePluginClient,
   type SlotContext,
 } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SystemDetailsSlot } from "@checkstack/catalog-common";
-import {
-  HEALTH_CHECK_RUN_COMPLETED,
-  HealthCheckApi,
-} from "@checkstack/healthcheck-common";
+import { HealthCheckApi } from "@checkstack/healthcheck-common";
 import {
   HealthBadge,
   LoadingSpinner,
@@ -63,14 +59,11 @@ export function HealthCheckSystemOverview(props: SlotProps) {
     HealthCheckOverviewItem | undefined
   >();
 
-  // Fetch health check overview using useQuery
-  const {
-    data: overviewData,
-    isLoading: initialLoading,
-    refetch,
-  } = healthCheckClient.getSystemHealthOverview.useQuery({
-    systemId,
-  });
+  // Fetch health check overview using useQuery — kept fresh via SignalAutoInvalidator.
+  const { data: overviewData, isLoading: initialLoading } =
+    healthCheckClient.getSystemHealthOverview.useQuery({
+      systemId,
+    });
 
   // Transform API response to component format
   const overview: HealthCheckOverviewItem[] = React.useMemo(() => {
@@ -88,19 +81,6 @@ export function HealthCheckSystemOverview(props: SlotProps) {
       recentStatusHistory: check.recentRuns.map((r) => r.status),
     }));
   }, [overviewData]);
-
-  // Listen for realtime health check updates to refresh overview
-  useSignal(
-    HEALTH_CHECK_RUN_COMPLETED,
-    useCallback(
-      ({ systemId: changedId }) => {
-        if (changedId === systemId) {
-          void refetch();
-        }
-      },
-      [systemId, refetch],
-    ),
-  );
 
   if (initialLoading) {
     return <LoadingSpinner />;

--- a/core/healthcheck-frontend/src/components/SystemHealthBadge.tsx
+++ b/core/healthcheck-frontend/src/components/SystemHealthBadge.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { usePluginClient, type SlotContext } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SystemStateBadgesSlot } from "@checkstack/catalog-common";
-import { SYSTEM_STATUS_CHANGED } from "@checkstack/healthcheck-common";
 import { HealthCheckApi } from "../api";
 import { HealthBadge } from "@checkstack/ui";
 import { useSystemBadgeDataOptional } from "@checkstack/dashboard-frontend";
@@ -17,37 +15,25 @@ type Props = SlotContext<typeof SystemStateBadgesSlot>;
  * When rendered within SystemBadgeDataProvider, uses bulk-fetched data.
  * Otherwise, falls back to individual fetch.
  *
- * Listens for realtime updates via signals.
+ * Realtime updates arrive via the SignalAutoInvalidator (auto-invalidates
+ * `[["healthcheck"]]` queries when SYSTEM_STATUS_CHANGED fires).
  */
 export const SystemHealthBadge: React.FC<Props> = ({ system }) => {
   const healthCheckClient = usePluginClient(HealthCheckApi);
   const badgeData = useSystemBadgeDataOptional();
 
-  // Try to get data from provider first
   const providerData = badgeData?.getSystemBadgeData(system?.id ?? "");
   const providerStatus = providerData?.health?.status;
 
-  // Query for health status if not using provider
-  // When badgeData exists (inside provider), this query is disabled
-  const { data: healthData, refetch } =
-    healthCheckClient.getSystemHealthStatus.useQuery(
-      { systemId: system?.id ?? "" },
-      {
-        enabled: !badgeData && !!system?.id,
-        staleTime: 30_000, // Prevent unnecessary refetches
-      },
-    );
+  const { data: healthData } = healthCheckClient.getSystemHealthStatus.useQuery(
+    { systemId: system?.id ?? "" },
+    {
+      enabled: !badgeData && !!system?.id,
+      staleTime: 30_000,
+    },
+  );
 
   const localStatus = healthData?.status;
-
-  // Listen for realtime system status changes (only in fallback mode)
-  useSignal(SYSTEM_STATUS_CHANGED, ({ systemId: changedId }) => {
-    if (!badgeData && changedId === system?.id) {
-      void refetch();
-    }
-  });
-
-  // Use provider data if available, otherwise use local state
   const status = providerStatus ?? localStatus;
 
   if (!status || status === "healthy") return <></>;

--- a/core/healthcheck-frontend/src/hooks/useHealthCheckData.ts
+++ b/core/healthcheck-frontend/src/hooks/useHealthCheckData.ts
@@ -74,35 +74,38 @@ export function useHealthCheckData({
     healthCheckAccess.details,
   );
 
-  // Always use aggregated data with fixed target points
-  const {
-    data: aggregatedData,
-    isLoading,
-    refetch,
-  } = healthCheckClient.getDetailedAggregatedHistory.useQuery(
-    {
-      systemId,
-      configurationId,
-      startDate: dateRange.startDate,
-      endDate: dateRange.endDate,
-      sourceFilter,
-      targetPoints: 500,
-    },
-    {
-      enabled: !!systemId && !!configurationId && hasAccess && !accessLoading,
-      // Keep previous data visible during refetch to prevent layout shift
-      placeholderData: (prev) => prev,
-    },
-  );
+  // Always use aggregated data with fixed target points.
+  // Realtime refetches happen via SignalAutoInvalidator (auto-invalidates
+  // `[["healthcheck"]]` on HEALTH_CHECK_RUN_COMPLETED).
+  const { data: aggregatedData, isLoading } =
+    healthCheckClient.getDetailedAggregatedHistory.useQuery(
+      {
+        systemId,
+        configurationId,
+        startDate: dateRange.startDate,
+        endDate: dateRange.endDate,
+        sourceFilter,
+        targetPoints: 500,
+      },
+      {
+        enabled: !!systemId && !!configurationId && hasAccess && !accessLoading,
+        // Keep previous data visible during refetch to prevent layout shift
+        placeholderData: (prev) => prev,
+      },
+    );
 
-  // Listen for realtime health check updates to refresh data silently
+  // For rolling presets, we still need an explicit signal handler to advance
+  // the endDate alongside cache invalidation — this is UI state (date range),
+  // not cache, so auto-invalidation is not enough.
   useSignal(HEALTH_CHECK_RUN_COMPLETED, ({ systemId: changedId }) => {
-    if (changedId === systemId && hasAccess && !accessLoading) {
-      // Update endDate to current time only for rolling presets (not custom ranges)
-      if (isRollingPreset && onDateRangeRefresh) {
-        onDateRangeRefresh(new Date());
-      }
-      void refetch();
+    if (
+      changedId === systemId &&
+      hasAccess &&
+      !accessLoading &&
+      isRollingPreset &&
+      onDateRangeRefresh
+    ) {
+      onDateRangeRefresh(new Date());
     }
   });
 

--- a/core/incident-common/src/index.ts
+++ b/core/incident-common/src/index.ts
@@ -34,16 +34,18 @@ export { incidentRoutes } from "./routes";
 
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Broadcast when an incident is created, updated, or resolved.
  * Frontend components listening to this signal can refetch state for affected systems.
  */
-export const INCIDENT_UPDATED = createSignal(
-  "incident.updated",
-  z.object({
+export const INCIDENT_UPDATED = createSignal({
+  pluginMetadata,
+  event: "updated",
+  payloadSchema: z.object({
     incidentId: z.string(),
     systemIds: z.array(z.string()),
     action: z.enum(["created", "updated", "resolved", "deleted"]),
-  })
-);
+  }),
+});

--- a/core/incident-frontend/src/components/SystemIncidentBadge.tsx
+++ b/core/incident-frontend/src/components/SystemIncidentBadge.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { usePluginClient, type SlotContext } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SystemStateBadgesSlot } from "@checkstack/catalog-common";
 import { IncidentApi } from "../api";
-import {
-  INCIDENT_UPDATED,
-  type IncidentWithSystems,
-} from "@checkstack/incident-common";
+import { type IncidentWithSystems } from "@checkstack/incident-common";
 import { Badge } from "@checkstack/ui";
 import { useSystemBadgeDataOptional } from "@checkstack/dashboard-frontend";
 
@@ -50,22 +46,14 @@ export const SystemIncidentBadge: React.FC<Props> = ({ system }) => {
     : undefined;
 
   // Query for incidents if not using provider
-  const { data: incidents, refetch } =
-    incidentClient.getIncidentsForSystem.useQuery(
-      { systemId: system?.id ?? "" },
-      { enabled: !badgeData && !!system?.id }
-    );
+  const { data: incidents } = incidentClient.getIncidentsForSystem.useQuery(
+    { systemId: system?.id ?? "" },
+    { enabled: !badgeData && !!system?.id }
+  );
 
   const localIncident = incidents
     ? getMostSevereIncident(incidents)
     : undefined;
-
-  // Listen for realtime incident updates (only in fallback mode)
-  useSignal(INCIDENT_UPDATED, ({ systemIds }) => {
-    if (!badgeData && system?.id && systemIds.includes(system.id)) {
-      void refetch();
-    }
-  });
 
   // Use provider data if available, otherwise use local state
   const activeIncident = badgeData ? providerIncident : localIncident;

--- a/core/incident-frontend/src/components/SystemIncidentPanel.tsx
+++ b/core/incident-frontend/src/components/SystemIncidentPanel.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { usePluginClient, type SlotContext } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { resolveRoute } from "@checkstack/common";
 import { SystemDetailsTopSlot } from "@checkstack/catalog-common";
 import { IncidentApi } from "../api";
 import {
   incidentRoutes,
-  INCIDENT_UPDATED,
   type IncidentWithSystems,
 } from "@checkstack/incident-common";
 import { Badge, LoadingSpinner, Button } from "@checkstack/ui";
@@ -43,21 +41,11 @@ export const SystemIncidentPanel: React.FC<Props> = ({ system }) => {
   const incidentClient = usePluginClient(IncidentApi);
 
   // Fetch incidents with useQuery
-  const {
-    data: incidents = [],
-    isLoading: loading,
-    refetch,
-  } = incidentClient.getIncidentsForSystem.useQuery(
-    { systemId: system?.id ?? "" },
-    { enabled: !!system?.id }
-  );
-
-  // Listen for realtime incident updates
-  useSignal(INCIDENT_UPDATED, ({ systemIds }) => {
-    if (system?.id && systemIds.includes(system.id)) {
-      void refetch();
-    }
-  });
+  const { data: incidents = [], isLoading: loading } =
+    incidentClient.getIncidentsForSystem.useQuery(
+      { systemId: system?.id ?? "" },
+      { enabled: !!system?.id }
+    );
 
   if (loading) {
     return (

--- a/core/incident-frontend/src/pages/IncidentDetailPage.tsx
+++ b/core/incident-frontend/src/pages/IncidentDetailPage.tsx
@@ -6,14 +6,9 @@ import {
   useApi,
   wrapInSuspense,
 } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { resolveRoute, extractErrorMessage} from "@checkstack/common";
 import { IncidentApi } from "../api";
-import {
-  incidentRoutes,
-  INCIDENT_UPDATED,
-  incidentAccess,
-} from "@checkstack/incident-common";
+import { incidentRoutes, incidentAccess } from "@checkstack/incident-common";
 import { CatalogApi } from "@checkstack/catalog-common";
 import {
   Card,
@@ -76,13 +71,6 @@ const IncidentDetailPageContent: React.FC = () => {
 
   const systems = systemsData?.systems ?? [];
   const loading = incidentLoading || systemsLoading;
-
-  // Listen for realtime updates
-  useSignal(INCIDENT_UPDATED, ({ incidentId: updatedId }) => {
-    if (incidentId === updatedId) {
-      void refetchIncident();
-    }
-  });
 
   // Resolve mutation
   const resolveMutation = incidentClient.resolveIncident.useMutation({

--- a/core/incident-frontend/src/pages/SystemIncidentHistoryPage.tsx
+++ b/core/incident-frontend/src/pages/SystemIncidentHistoryPage.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { usePluginClient, wrapInSuspense } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { resolveRoute } from "@checkstack/common";
 import { IncidentApi } from "../api";
 import {
   incidentRoutes,
-  INCIDENT_UPDATED,
   type IncidentStatus,
 } from "@checkstack/incident-common";
 import { CatalogApi, catalogRoutes } from "@checkstack/catalog-common";
@@ -27,15 +25,12 @@ const SystemIncidentHistoryPageContent: React.FC = () => {
   const incidentClient = usePluginClient(IncidentApi);
   const catalogClient = usePluginClient(CatalogApi);
 
-  // Fetch incidents with useQuery
-  const {
-    data: incidentsData,
-    isLoading: incidentsLoading,
-    refetch: refetchIncidents,
-  } = incidentClient.listIncidents.useQuery(
-    { systemId, includeResolved: true },
-    { enabled: !!systemId },
-  );
+  // Fetch incidents with useQuery — kept fresh via SignalAutoInvalidator.
+  const { data: incidentsData, isLoading: incidentsLoading } =
+    incidentClient.listIncidents.useQuery(
+      { systemId, includeResolved: true },
+      { enabled: !!systemId },
+    );
 
   // Fetch systems with useQuery
   const { data: systemsData, isLoading: systemsLoading } =
@@ -45,13 +40,6 @@ const SystemIncidentHistoryPageContent: React.FC = () => {
   const systems = systemsData?.systems ?? [];
   const system = systems.find((s) => s.id === systemId);
   const loading = incidentsLoading || systemsLoading;
-
-  // Listen for realtime updates
-  useSignal(INCIDENT_UPDATED, ({ systemIds }) => {
-    if (systemId && systemIds.includes(systemId)) {
-      void refetchIncidents();
-    }
-  });
 
   const getStatusBadge = (status: IncidentStatus) => {
     switch (status) {

--- a/core/integration-common/src/signals.ts
+++ b/core/integration-common/src/signals.ts
@@ -1,31 +1,34 @@
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
 import { DeliveryStatusSchema } from "./schemas";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Signal emitted when a delivery completes (success or failure).
  * Used to update the delivery logs UI in real-time.
  */
-export const INTEGRATION_DELIVERY_COMPLETED = createSignal(
-  "INTEGRATION_DELIVERY_COMPLETED",
-  z.object({
+export const INTEGRATION_DELIVERY_COMPLETED = createSignal({
+  pluginMetadata,
+  event: "delivery_completed",
+  payloadSchema: z.object({
     logId: z.string(),
     subscriptionId: z.string(),
     eventType: z.string(),
     status: DeliveryStatusSchema,
     externalId: z.string().optional(),
     errorMessage: z.string().optional(),
-  })
-);
+  }),
+});
 
 /**
  * Signal emitted when a subscription is created, updated, or deleted.
  * Used to refresh the subscriptions list in real-time.
  */
-export const INTEGRATION_SUBSCRIPTION_CHANGED = createSignal(
-  "INTEGRATION_SUBSCRIPTION_CHANGED",
-  z.object({
+export const INTEGRATION_SUBSCRIPTION_CHANGED = createSignal({
+  pluginMetadata,
+  event: "subscription_changed",
+  payloadSchema: z.object({
     action: z.enum(["created", "updated", "deleted"]),
     subscriptionId: z.string(),
-  })
-);
+  }),
+});

--- a/core/maintenance-common/src/index.ts
+++ b/core/maintenance-common/src/index.ts
@@ -32,16 +32,18 @@ export { maintenanceRoutes } from "./routes";
 
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Broadcast when a maintenance is created, updated, or closed.
  * Frontend components listening to this signal can refetch state for affected systems.
  */
-export const MAINTENANCE_UPDATED = createSignal(
-  "maintenance.updated",
-  z.object({
+export const MAINTENANCE_UPDATED = createSignal({
+  pluginMetadata,
+  event: "updated",
+  payloadSchema: z.object({
     maintenanceId: z.string(),
     systemIds: z.array(z.string()),
     action: z.enum(["created", "updated", "closed"]),
-  })
-);
+  }),
+});

--- a/core/maintenance-frontend/src/components/SystemMaintenanceBadge.tsx
+++ b/core/maintenance-frontend/src/components/SystemMaintenanceBadge.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { usePluginClient, type SlotContext } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SystemStateBadgesSlot } from "@checkstack/catalog-common";
 import { MaintenanceApi } from "../api";
-import {
-  MAINTENANCE_UPDATED,
-  type MaintenanceWithSystems,
-} from "@checkstack/maintenance-common";
+import { type MaintenanceWithSystems } from "@checkstack/maintenance-common";
 import { Badge } from "@checkstack/ui";
 import { useSystemBadgeDataOptional } from "@checkstack/dashboard-frontend";
 
@@ -26,20 +22,19 @@ function hasActiveMaintenance(maintenances: MaintenanceWithSystems[]): boolean {
  * When rendered within SystemBadgeDataProvider, uses bulk-fetched data.
  * Otherwise, falls back to individual fetch.
  *
- * Listens for realtime updates via signals.
+ * Realtime updates arrive via the SignalAutoInvalidator (auto-invalidates
+ * `[["maintenance"]]` queries when MAINTENANCE_UPDATED fires).
  */
 export const SystemMaintenanceBadge: React.FC<Props> = ({ system }) => {
   const maintenanceClient = usePluginClient(MaintenanceApi);
   const badgeData = useSystemBadgeDataOptional();
 
-  // Try to get data from provider first
   const providerData = badgeData?.getSystemBadgeData(system?.id ?? "");
   const providerHasActive = providerData
     ? hasActiveMaintenance(providerData.maintenances)
     : false;
 
-  // Query for maintenances if not using provider
-  const { data: maintenances, refetch } =
+  const { data: maintenances } =
     maintenanceClient.getMaintenancesForSystem.useQuery(
       { systemId: system?.id ?? "" },
       { enabled: !badgeData && !!system?.id }
@@ -49,14 +44,6 @@ export const SystemMaintenanceBadge: React.FC<Props> = ({ system }) => {
     ? hasActiveMaintenance(maintenances)
     : false;
 
-  // Listen for realtime maintenance updates (only in fallback mode)
-  useSignal(MAINTENANCE_UPDATED, ({ systemIds }) => {
-    if (!badgeData && system?.id && systemIds.includes(system.id)) {
-      void refetch();
-    }
-  });
-
-  // Use provider data if available, otherwise use local state
   const hasActive = badgeData ? providerHasActive : localHasActive;
 
   if (!hasActive) return;

--- a/core/maintenance-frontend/src/components/SystemMaintenancePanel.tsx
+++ b/core/maintenance-frontend/src/components/SystemMaintenancePanel.tsx
@@ -1,14 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { usePluginClient, type SlotContext } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { resolveRoute } from "@checkstack/common";
 import { SystemDetailsSlot } from "@checkstack/catalog-common";
 import { MaintenanceApi } from "../api";
-import {
-  maintenanceRoutes,
-  MAINTENANCE_UPDATED,
-} from "@checkstack/maintenance-common";
+import { maintenanceRoutes } from "@checkstack/maintenance-common";
 import { LoadingSpinner, Button } from "@checkstack/ui";
 import { Wrench, History } from "lucide-react";
 
@@ -21,22 +17,12 @@ type Props = SlotContext<typeof SystemDetailsSlot>;
 export const SystemMaintenancePanel: React.FC<Props> = ({ system }) => {
   const maintenanceClient = usePluginClient(MaintenanceApi);
 
-  // Fetch maintenances with useQuery
-  const {
-    data: maintenances = [],
-    isLoading: loading,
-    refetch,
-  } = maintenanceClient.getMaintenancesForSystem.useQuery(
-    { systemId: system?.id ?? "" },
-    { enabled: !!system?.id }
-  );
-
-  // Listen for realtime maintenance updates
-  useSignal(MAINTENANCE_UPDATED, ({ systemIds }) => {
-    if (system?.id && systemIds.includes(system.id)) {
-      void refetch();
-    }
-  });
+  // Fetch maintenances with useQuery — kept fresh via SignalAutoInvalidator.
+  const { data: maintenances = [], isLoading: loading } =
+    maintenanceClient.getMaintenancesForSystem.useQuery(
+      { systemId: system?.id ?? "" },
+      { enabled: !!system?.id }
+    );
 
   if (loading) {
     return (

--- a/core/notification-common/src/signals.ts
+++ b/core/notification-common/src/signals.ts
@@ -1,38 +1,42 @@
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
 import { ImportanceSchema } from "./schemas";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Signal emitted when a new notification is received.
  * Used to update the notification bell count and show realtime notifications.
  */
-export const NOTIFICATION_RECEIVED = createSignal(
-  "notification.received",
-  z.object({
+export const NOTIFICATION_RECEIVED = createSignal({
+  pluginMetadata,
+  event: "received",
+  payloadSchema: z.object({
     id: z.string(),
     title: z.string(),
     body: z.string(),
     importance: ImportanceSchema,
-  })
-);
+  }),
+});
 
 /**
  * Signal emitted when the unread notification count changes.
  * Used to update the badge count on the notification bell.
  */
-export const NOTIFICATION_COUNT_CHANGED = createSignal(
-  "notification.countChanged",
-  z.object({
+export const NOTIFICATION_COUNT_CHANGED = createSignal({
+  pluginMetadata,
+  event: "countChanged",
+  payloadSchema: z.object({
     unreadCount: z.number(),
-  })
-);
+  }),
+});
 
 /**
  * Signal emitted when a notification is marked as read.
  */
-export const NOTIFICATION_READ = createSignal(
-  "notification.read",
-  z.object({
+export const NOTIFICATION_READ = createSignal({
+  pluginMetadata,
+  event: "read",
+  payloadSchema: z.object({
     notificationId: z.string().optional(), // undefined means all marked as read
-  })
-);
+  }),
+});

--- a/core/notification-frontend/src/components/NotificationBell.tsx
+++ b/core/notification-frontend/src/components/NotificationBell.tsx
@@ -13,14 +13,9 @@ import {
   useToast,
 } from "@checkstack/ui";
 import { useApi, usePluginClient } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { resolveRoute } from "@checkstack/common";
-import type { Notification } from "@checkstack/notification-common";
 import {
   NotificationApi,
-  NOTIFICATION_RECEIVED,
-  NOTIFICATION_COUNT_CHANGED,
-  NOTIFICATION_READ,
   notificationRoutes,
 } from "@checkstack/notification-common";
 import { authApiRef } from "@checkstack/auth-frontend/api";
@@ -33,22 +28,14 @@ export const NotificationBell = () => {
 
   const [isOpen, setIsOpen] = useState(false);
 
-  // State for real-time updates
-  const [signalUnreadCount, setSignalUnreadCount] = useState<
-    number | undefined
-  >();
-  const [signalNotifications, setSignalNotifications] = useState<
-    Notification[] | undefined
-  >();
-
-  // Fetch unread count via useQuery
+  // Realtime updates arrive via SignalAutoInvalidator on `[["notification"]]`,
+  // so both queries stay fresh without per-component signal handlers.
   const { data: unreadData, isLoading: unreadLoading } =
     notificationClient.getUnreadCount.useQuery(undefined, {
       enabled: !!session,
       staleTime: 30_000,
     });
 
-  // Fetch recent notifications via useQuery
   const { data: notificationsData, isLoading: notificationsLoading } =
     notificationClient.getNotifications.useQuery(
       { limit: 5, offset: 0, unreadOnly: true },
@@ -58,80 +45,14 @@ export const NotificationBell = () => {
       },
     );
 
-  // Mark all as read mutation
   const markAsReadMutation = notificationClient.markAsRead.useMutation();
 
-  // Use signal data if available, otherwise use query data
-  const unreadCount = signalUnreadCount ?? unreadData?.count ?? 0;
-  const recentNotifications =
-    signalNotifications ?? notificationsData?.notifications ?? [];
-
-  // ==========================================================================
-  // REALTIME SIGNAL SUBSCRIPTIONS (replaces polling)
-  // ==========================================================================
-
-  // Handle new notification received
-  useSignal(
-    NOTIFICATION_RECEIVED,
-    useCallback((payload) => {
-      // Increment unread count
-      setSignalUnreadCount((prev) => (prev ?? 0) + 1);
-
-      // Add to recent notifications if dropdown is open
-      setSignalNotifications((prev) => [
-        {
-          id: payload.id,
-          title: payload.title,
-          body: payload.body,
-          importance: payload.importance,
-          userId: "", // Not needed for display
-          isRead: false,
-          createdAt: new Date(),
-        },
-        ...(prev ?? []).slice(0, 4), // Keep only 5 items
-      ]);
-    }, []),
-  );
-
-  // Handle count changes from other sources
-  useSignal(
-    NOTIFICATION_COUNT_CHANGED,
-    useCallback((payload) => {
-      setSignalUnreadCount(payload.unreadCount);
-    }, []),
-  );
-
-  // Handle notification marked as read
-  useSignal(
-    NOTIFICATION_READ,
-    useCallback(
-      (payload) => {
-        if (payload.notificationId) {
-          // Single notification marked as read - remove from list
-          setSignalNotifications((prev) =>
-            (prev ?? []).filter((n) => n.id !== payload.notificationId),
-          );
-          // Use unreadData?.count as fallback when signalUnreadCount hasn't been set yet
-          setSignalUnreadCount((prev) =>
-            Math.max(0, (prev ?? unreadData?.count ?? 1) - 1),
-          );
-        } else {
-          // All marked as read - clear the list
-          setSignalNotifications([]);
-          setSignalUnreadCount(0);
-        }
-      },
-      [unreadData?.count],
-    ),
-  );
-
-  // ==========================================================================
+  const unreadCount = unreadData?.count ?? 0;
+  const recentNotifications = notificationsData?.notifications ?? [];
 
   const handleMarkAllAsRead = async () => {
     try {
       await markAsReadMutation.mutateAsync({});
-      setSignalUnreadCount(0);
-      setSignalNotifications([]);
     } catch {
       toast.error("Failed to mark all as read");
     }

--- a/core/queue-common/src/signals.ts
+++ b/core/queue-common/src/signals.ts
@@ -1,15 +1,17 @@
 import { z } from "zod";
 import { createSignal } from "@checkstack/signal-common";
 import { LagSeveritySchema } from "./schemas";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Signal broadcast when queue lag status changes.
  * Frontend listens to update lag warning UI in real-time.
  */
-export const QUEUE_LAG_CHANGED = createSignal(
-  "queue.lag.changed",
-  z.object({
+export const QUEUE_LAG_CHANGED = createSignal({
+  pluginMetadata,
+  event: "lag.changed",
+  payloadSchema: z.object({
     pending: z.number(),
     severity: LagSeveritySchema,
-  })
-);
+  }),
+});

--- a/core/satellite-common/src/signals.ts
+++ b/core/satellite-common/src/signals.ts
@@ -1,28 +1,31 @@
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
 import { SatelliteStatusSchema } from "./schemas";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Broadcast when a satellite's connection status changes (online ↔ offline).
  * Frontend components listening to this signal can update status badges in real-time.
  */
-export const SATELLITE_STATUS_CHANGED = createSignal(
-  "satellite.status.changed",
-  z.object({
+export const SATELLITE_STATUS_CHANGED = createSignal({
+  pluginMetadata,
+  event: "status.changed",
+  payloadSchema: z.object({
     satelliteId: z.string(),
     status: SatelliteStatusSchema,
     name: z.string(),
     region: z.string(),
   }),
-);
+});
 
 /**
  * Broadcast when satellite configuration changes (assignments updated).
  * Frontend components listening to this signal can refetch satellite data.
  */
-export const SATELLITE_CONFIG_CHANGED = createSignal(
-  "satellite.config.changed",
-  z.object({
+export const SATELLITE_CONFIG_CHANGED = createSignal({
+  pluginMetadata,
+  event: "config.changed",
+  payloadSchema: z.object({
     satelliteId: z.string(),
   }),
-);
+});

--- a/core/satellite-frontend/src/pages/SatelliteListPage.tsx
+++ b/core/satellite-frontend/src/pages/SatelliteListPage.tsx
@@ -5,11 +5,9 @@ import {
   useApi,
   wrapInSuspense,
 } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import {
   SatelliteApi,
   satelliteAccess,
-  SATELLITE_STATUS_CHANGED,
 } from "@checkstack/satellite-common";
 import type { SatelliteWithStatus } from "@checkstack/satellite-common";
 import {
@@ -54,11 +52,6 @@ const SatelliteListPageContent: React.FC = () => {
     isLoading,
     refetch,
   } = satelliteClient.listSatellites.useQuery();
-
-  // Real-time status updates
-  useSignal(SATELLITE_STATUS_CHANGED, () => {
-    void refetch();
-  });
 
   const deleteMutation = satelliteClient.deleteSatellite.useMutation({
     onSuccess: () => {

--- a/core/signal-backend/src/signal-service-impl.test.ts
+++ b/core/signal-backend/src/signal-service-impl.test.ts
@@ -6,15 +6,19 @@ import { z } from "zod";
 import type { EventBus, Logger } from "@checkstack/backend-api";
 
 // Test signals
-const TEST_BROADCAST_SIGNAL = createSignal(
-  "test.broadcast",
-  z.object({ message: z.string() })
-);
+const testPluginMetadata = { pluginId: "test" };
 
-const TEST_USER_SIGNAL = createSignal(
-  "test.user",
-  z.object({ notification: z.string(), count: z.number() })
-);
+const TEST_BROADCAST_SIGNAL = createSignal({
+  pluginMetadata: testPluginMetadata,
+  event: "broadcast",
+  payloadSchema: z.object({ message: z.string() }),
+});
+
+const TEST_USER_SIGNAL = createSignal({
+  pluginMetadata: testPluginMetadata,
+  event: "user",
+  payloadSchema: z.object({ notification: z.string(), count: z.number() }),
+});
 
 describe("SignalServiceImpl", () => {
   let signalService: SignalServiceImpl;
@@ -55,10 +59,12 @@ describe("SignalServiceImpl", () => {
 
       const message = emittedEvents[0].payload as {
         signalId: string;
+        pluginId: string;
         payload: typeof payload;
         timestamp: string;
       };
       expect(message.signalId).toBe("test.broadcast");
+      expect(message.pluginId).toBe("test");
       expect(message.payload).toEqual(payload);
       expect(typeof message.timestamp).toBe("string");
     });
@@ -96,10 +102,15 @@ describe("SignalServiceImpl", () => {
 
       const emitted = emittedEvents[0].payload as {
         userId: string;
-        message: { signalId: string; payload: typeof payload };
+        message: {
+          signalId: string;
+          pluginId: string;
+          payload: typeof payload;
+        };
       };
       expect(emitted.userId).toBe(userId);
       expect(emitted.message.signalId).toBe("test.user");
+      expect(emitted.message.pluginId).toBe("test");
       expect(emitted.message.payload).toEqual(payload);
     });
 

--- a/core/signal-backend/src/signal-service-impl.ts
+++ b/core/signal-backend/src/signal-service-impl.ts
@@ -40,6 +40,7 @@ export class SignalServiceImpl implements SignalService {
   async broadcast<T>(signal: Signal<T>, payload: T): Promise<void> {
     const message: SignalMessage<T> = {
       signalId: signal.id,
+      pluginId: signal.pluginId,
       payload,
       timestamp: new Date().toISOString(),
     };
@@ -57,6 +58,7 @@ export class SignalServiceImpl implements SignalService {
   ): Promise<void> {
     const message: SignalMessage<T> = {
       signalId: signal.id,
+      pluginId: signal.pluginId,
       payload,
       timestamp: new Date().toISOString(),
     };

--- a/core/signal-backend/src/websocket-handler.test.ts
+++ b/core/signal-backend/src/websocket-handler.test.ts
@@ -296,6 +296,7 @@ describe("createWebSocketHandler", () => {
 
       await broadcastSubscription!.handler({
         signalId: "test.signal",
+        pluginId: "test",
         payload: { data: "test" },
         timestamp: new Date().toISOString(),
       });
@@ -306,6 +307,7 @@ describe("createWebSocketHandler", () => {
       const parsed = JSON.parse(publishedMessage!);
       expect(parsed.type).toBe("signal");
       expect(parsed.signalId).toBe("test.signal");
+      expect(parsed.pluginId).toBe("test");
     });
 
     it("should publish user signals to user-specific channel", async () => {
@@ -336,6 +338,7 @@ describe("createWebSocketHandler", () => {
         userId: "target-user",
         message: {
           signalId: "notification.received",
+          pluginId: "notification",
           payload: { id: "n-1" },
           timestamp: new Date().toISOString(),
         },
@@ -347,6 +350,7 @@ describe("createWebSocketHandler", () => {
       const parsed = JSON.parse(publishedMessage!);
       expect(parsed.type).toBe("signal");
       expect(parsed.signalId).toBe("notification.received");
+      expect(parsed.pluginId).toBe("notification");
     });
   });
 });

--- a/core/signal-backend/src/websocket-handler.ts
+++ b/core/signal-backend/src/websocket-handler.ts
@@ -86,6 +86,7 @@ export function createWebSocketHandler(
         const payload: ServerToClientMessage = {
           type: "signal",
           signalId: message.signalId,
+          pluginId: message.pluginId,
           payload: message.payload,
           timestamp: message.timestamp,
         };
@@ -103,6 +104,7 @@ export function createWebSocketHandler(
         const payload: ServerToClientMessage = {
           type: "signal",
           signalId: message.signalId,
+          pluginId: message.pluginId,
           payload: message.payload,
           timestamp: message.timestamp,
         };

--- a/core/signal-common/src/index.test.ts
+++ b/core/signal-common/src/index.test.ts
@@ -1,162 +1,132 @@
 import { describe, it, expect } from "bun:test";
 import { createSignal, type Signal, type SignalMessage } from "../src/index";
 import { z } from "zod";
+import type { PluginMetadata } from "@checkstack/common";
+
+const testPlugin: PluginMetadata = { pluginId: "notification" };
+const otherPlugin: PluginMetadata = { pluginId: "system" };
 
 describe("createSignal", () => {
-  it("should create a signal with the given id and schema", () => {
+  it("constructs id as `${pluginId}.${event}` and stores pluginId", () => {
     const schema = z.object({ message: z.string() });
-    const signal = createSignal("test.signal", schema);
+    const signal = createSignal({
+      pluginMetadata: testPlugin,
+      event: "test",
+      payloadSchema: schema,
+    });
 
-    expect(signal.id).toBe("test.signal");
+    expect(signal.id).toBe("notification.test");
+    expect(signal.pluginId).toBe("notification");
     expect(signal.payloadSchema).toBe(schema);
   });
 
-  it("should create signals with different payload types", () => {
-    const stringSignal = createSignal("string.signal", z.string());
-    const numberSignal = createSignal("number.signal", z.number());
-    const objectSignal = createSignal(
-      "object.signal",
-      z.object({
-        id: z.string(),
-        count: z.number(),
-        active: z.boolean(),
-      })
-    );
+  it("creates signals with different payload types and pluginIds", () => {
+    const stringSignal = createSignal({
+      pluginMetadata: testPlugin,
+      event: "string",
+      payloadSchema: z.string(),
+    });
+    const numberSignal = createSignal({
+      pluginMetadata: otherPlugin,
+      event: "number",
+      payloadSchema: z.number(),
+    });
 
-    expect(stringSignal.id).toBe("string.signal");
-    expect(numberSignal.id).toBe("number.signal");
-    expect(objectSignal.id).toBe("object.signal");
+    expect(stringSignal.id).toBe("notification.string");
+    expect(stringSignal.pluginId).toBe("notification");
+    expect(numberSignal.id).toBe("system.number");
+    expect(numberSignal.pluginId).toBe("system");
   });
 
-  it("should validate payload against schema", () => {
-    const signal = createSignal(
-      "notification.received",
-      z.object({
+  it("validates payload against schema", () => {
+    const signal = createSignal({
+      pluginMetadata: testPlugin,
+      event: "received",
+      payloadSchema: z.object({
         id: z.string(),
         title: z.string(),
         importance: z.enum(["info", "warning", "critical"]),
-      })
-    );
+      }),
+    });
 
-    // Valid payload
-    const validPayload = {
+    const validResult = signal.payloadSchema.safeParse({
       id: "n-123",
-      title: "Test Notification",
+      title: "Test",
       importance: "info" as const,
-    };
-    const validResult = signal.payloadSchema.safeParse(validPayload);
+    });
     expect(validResult.success).toBe(true);
 
-    // Invalid payload - missing required field
-    const invalidPayload = {
+    const invalidResult = signal.payloadSchema.safeParse({
       id: "n-123",
       title: "Test",
-    };
-    const invalidResult = signal.payloadSchema.safeParse(invalidPayload);
+    });
     expect(invalidResult.success).toBe(false);
-
-    // Invalid payload - wrong enum value
-    const wrongEnumPayload = {
-      id: "n-123",
-      title: "Test",
-      importance: "urgent",
-    };
-    const wrongEnumResult = signal.payloadSchema.safeParse(wrongEnumPayload);
-    expect(wrongEnumResult.success).toBe(false);
   });
 
-  it("should support nested object schemas", () => {
-    const signal = createSignal(
-      "complex.signal",
-      z.object({
-        user: z.object({
-          id: z.string(),
-          name: z.string(),
-        }),
-        metadata: z.record(z.string(), z.string()),
-        tags: z.array(z.string()),
-      })
-    );
-
-    const payload = {
-      user: { id: "u-1", name: "Test User" },
-      metadata: { source: "api" },
-      tags: ["important", "system"],
-    };
-
-    const result = signal.payloadSchema.safeParse(payload);
-    expect(result.success).toBe(true);
-  });
-
-  it("should support optional fields in schema", () => {
-    const signal = createSignal(
-      "optional.signal",
-      z.object({
-        required: z.string(),
-        optional: z.string().optional(),
-      })
-    );
-
-    // With optional field
-    const withOptional = signal.payloadSchema.safeParse({
-      required: "value",
-      optional: "optional value",
+  it("supports multi-segment event names", () => {
+    const signal = createSignal({
+      pluginMetadata: { pluginId: "healthcheck" },
+      event: "system.status_changed",
+      payloadSchema: z.object({ systemId: z.string() }),
     });
-    expect(withOptional.success).toBe(true);
 
-    // Without optional field
-    const withoutOptional = signal.payloadSchema.safeParse({
-      required: "value",
-    });
-    expect(withoutOptional.success).toBe(true);
+    expect(signal.id).toBe("healthcheck.system.status_changed");
+    expect(signal.pluginId).toBe("healthcheck");
   });
 });
 
 describe("Signal type inference", () => {
-  it("should correctly infer payload type from schema", () => {
-    const signal = createSignal(
-      "typed.signal",
-      z.object({
-        count: z.number(),
-        name: z.string(),
-      })
-    );
+  it("infers payload type from schema", () => {
+    const signal = createSignal({
+      pluginMetadata: testPlugin,
+      event: "typed",
+      payloadSchema: z.object({ count: z.number(), name: z.string() }),
+    });
 
-    // TypeScript should infer that payload is { count: number, name: string }
-    type InferredPayload = z.infer<typeof signal.payloadSchema>;
-
-    // This test ensures the types compile correctly
-    const payload: InferredPayload = { count: 42, name: "test" };
+    type Inferred = z.infer<typeof signal.payloadSchema>;
+    const payload: Inferred = { count: 42, name: "test" };
     expect(payload.count).toBe(42);
-    expect(payload.name).toBe("test");
   });
 });
 
-describe("SignalMessage structure", () => {
-  it("should have correct message envelope structure", () => {
+describe("SignalMessage envelope", () => {
+  it("carries signalId, pluginId, payload, and timestamp", () => {
     const message: SignalMessage<{ text: string }> = {
-      signalId: "test.message",
+      signalId: "notification.test",
+      pluginId: "notification",
       payload: { text: "Hello" },
       timestamp: new Date().toISOString(),
     };
 
-    expect(message.signalId).toBe("test.message");
+    expect(message.signalId).toBe("notification.test");
+    expect(message.pluginId).toBe("notification");
     expect(message.payload.text).toBe("Hello");
     expect(typeof message.timestamp).toBe("string");
   });
 });
 
 describe("Signal ID conventions", () => {
-  it("should follow dot-notation naming convention", () => {
-    const signals = [
-      createSignal("notification.received", z.string()),
-      createSignal("notification.read", z.string()),
-      createSignal("system.maintenance.scheduled", z.string()),
-      createSignal("healthcheck.status.changed", z.string()),
+  it("follows dot-notation naming convention", () => {
+    const signals: Signal<unknown>[] = [
+      createSignal({
+        pluginMetadata: { pluginId: "notification" },
+        event: "received",
+        payloadSchema: z.string(),
+      }),
+      createSignal({
+        pluginMetadata: { pluginId: "notification" },
+        event: "read",
+        payloadSchema: z.string(),
+      }),
+      createSignal({
+        pluginMetadata: { pluginId: "system" },
+        event: "maintenance.scheduled",
+        payloadSchema: z.string(),
+      }),
     ];
 
     for (const signal of signals) {
-      expect(signal.id).toMatch(/^[a-z]+(\.[a-z]+)+$/);
+      expect(signal.id).toMatch(/^[a-z]+(\.[a-z_]+)+$/);
     }
   });
 });

--- a/core/signal-common/src/index.ts
+++ b/core/signal-common/src/index.ts
@@ -7,29 +7,44 @@ import type { AccessRule, PluginMetadata } from "@checkstack/common";
 
 /**
  * A Signal is a typed event that can be broadcast from backend to frontend.
- * Similar to the Hook pattern but for realtime WebSocket communication.
+ * The `pluginId` field lets the realtime layer auto-invalidate
+ * react-query caches keyed `[[pluginId]]` without per-consumer wiring.
  */
 export interface Signal<T = unknown> {
   id: string;
+  pluginId: string;
   payloadSchema: z.ZodType<T>;
 }
 
 /**
  * Factory function for creating type-safe signals.
  *
+ * The signal id is constructed as `${pluginMetadata.pluginId}.${event}`
+ * so the owning plugin is encoded into the wire format and the frontend
+ * can route invalidations to `[[pluginId]]` automatically.
+ *
  * @example
  * ```typescript
- * const NOTIFICATION_RECEIVED = createSignal(
- *   "notification.received",
- *   z.object({ id: z.string(), title: z.string() })
- * );
+ * import { pluginMetadata } from "./plugin-metadata";
+ *
+ * export const NOTIFICATION_RECEIVED = createSignal({
+ *   pluginMetadata,
+ *   event: "received",
+ *   payloadSchema: z.object({ id: z.string(), title: z.string() }),
+ * });
  * ```
  */
-export function createSignal<T>(
-  id: string,
-  payloadSchema: z.ZodType<T>
-): Signal<T> {
-  return { id, payloadSchema };
+export function createSignal<T>(props: {
+  pluginMetadata: PluginMetadata;
+  event: string;
+  payloadSchema: z.ZodType<T>;
+}): Signal<T> {
+  const { pluginMetadata, event, payloadSchema } = props;
+  return {
+    id: `${pluginMetadata.pluginId}.${event}`,
+    pluginId: pluginMetadata.pluginId,
+    payloadSchema,
+  };
 }
 
 // =============================================================================
@@ -38,9 +53,13 @@ export function createSignal<T>(
 
 /**
  * The message envelope sent over WebSocket containing a signal payload.
+ *
+ * `pluginId` is carried alongside `signalId` so the frontend can route
+ * cache invalidations to `[[pluginId]]` without parsing the id.
  */
 export interface SignalMessage<T = unknown> {
   signalId: string;
+  pluginId: string;
   payload: T;
   timestamp: string;
 }
@@ -71,7 +90,13 @@ export type ClientToServerMessage = { type: "ping" };
 export type ServerToClientMessage =
   | { type: "pong" }
   | { type: "connected"; userId: string }
-  | { type: "signal"; signalId: string; payload: unknown; timestamp: string }
+  | {
+      type: "signal";
+      signalId: string;
+      pluginId: string;
+      payload: unknown;
+      timestamp: string;
+    }
   | { type: "error"; message: string };
 
 // =============================================================================
@@ -157,23 +182,32 @@ export interface SignalService {
 // =============================================================================
 
 /**
+ * Synthetic metadata for framework-level signals that are not owned by any plugin.
+ * The "core" pluginId reserves a top-level namespace; no plugin may register itself
+ * with that id.
+ */
+const coreSignalsPluginMetadata: PluginMetadata = { pluginId: "core" };
+
+/**
  * Broadcast to all frontends when a plugin has been fully installed on the backend.
  * Frontends should dynamically load the plugin's UI assets.
  */
-export const PLUGIN_INSTALLED = createSignal(
-  "core.plugin.installed",
-  z.object({
+export const PLUGIN_INSTALLED = createSignal({
+  pluginMetadata: coreSignalsPluginMetadata,
+  event: "plugin.installed",
+  payloadSchema: z.object({
     pluginId: z.string(),
-  })
-);
+  }),
+});
 
 /**
  * Broadcast to all frontends when a plugin has been deregistered from the backend.
  * Frontends should remove the plugin's extensions and routes.
  */
-export const PLUGIN_DEREGISTERED = createSignal(
-  "core.plugin.deregistered",
-  z.object({
+export const PLUGIN_DEREGISTERED = createSignal({
+  pluginMetadata: coreSignalsPluginMetadata,
+  event: "plugin.deregistered",
+  payloadSchema: z.object({
     pluginId: z.string(),
-  })
-);
+  }),
+});

--- a/core/signal-frontend/src/SignalProvider.tsx
+++ b/core/signal-frontend/src/SignalProvider.tsx
@@ -15,11 +15,27 @@ import type {
 // CONTEXT TYPES
 // =============================================================================
 
+/**
+ * Wildcard subscription callback. Fires for every incoming signal message
+ * regardless of signalId, with the pluginId already extracted from the wire envelope.
+ * Used by the auto-invalidation layer; not intended for component-level use.
+ */
+export type SignalAllCallback = (props: {
+  signalId: string;
+  pluginId: string;
+  payload: unknown;
+}) => void;
+
 interface SignalContextValue {
   /** Whether the WebSocket connection is established */
   isConnected: boolean;
-  /** Subscribe to a signal. Returns an unsubscribe function. */
+  /** Subscribe to a specific signal. Returns an unsubscribe function. */
   subscribe<T>(signal: Signal<T>, callback: (payload: T) => void): () => void;
+  /**
+   * Subscribe to ALL incoming signals. Returns an unsubscribe function.
+   * Used by the auto-invalidation layer to receive every message.
+   */
+  subscribeAll(callback: SignalAllCallback): () => void;
 }
 
 const SignalContext = createContext<SignalContextValue | undefined>(undefined);
@@ -58,6 +74,7 @@ export const SignalProvider: React.FC<SignalProviderProps> = ({
   const listenersRef = useRef<Map<string, Set<(payload: unknown) => void>>>(
     new Map()
   );
+  const allListenersRef = useRef<Set<SignalAllCallback>>(new Set());
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
   );
@@ -115,6 +132,14 @@ export const SignalProvider: React.FC<SignalProviderProps> = ({
                 callback(message.payload);
               }
             }
+            // Notify wildcard listeners (auto-invalidator etc.)
+            for (const callback of allListenersRef.current) {
+              callback({
+                signalId: message.signalId,
+                pluginId: message.pluginId,
+                payload: message.payload,
+              });
+            }
           }
           // Ignore "connected" and "pong" messages
         } catch (error) {
@@ -154,9 +179,17 @@ export const SignalProvider: React.FC<SignalProviderProps> = ({
     []
   );
 
+  const subscribeAll = useCallback((callback: SignalAllCallback) => {
+    allListenersRef.current.add(callback);
+    return () => {
+      allListenersRef.current.delete(callback);
+    };
+  }, []);
+
   const value: SignalContextValue = {
     isConnected,
     subscribe,
+    subscribeAll,
   };
 
   return (

--- a/core/signal-frontend/src/index.ts
+++ b/core/signal-frontend/src/index.ts
@@ -1,5 +1,13 @@
 // Provider component
-export { SignalProvider, useSignalContext } from "./SignalProvider";
+export {
+  SignalProvider,
+  useSignalContext,
+  type SignalAllCallback,
+} from "./SignalProvider";
 
 // Hooks
-export { useSignal, useSignalConnection } from "./useSignal";
+export {
+  useSignal,
+  useSignalConnection,
+  useSubscribeAllSignals,
+} from "./useSignal";

--- a/core/signal-frontend/src/useSignal.ts
+++ b/core/signal-frontend/src/useSignal.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { Signal } from "@checkstack/signal-common";
-import { useSignalContext } from "./SignalProvider";
+import { useSignalContext, type SignalAllCallback } from "./SignalProvider";
 
 /**
  * Subscribe to a signal and receive typed payloads.
@@ -64,4 +64,28 @@ export function useSignal<T>(
 export function useSignalConnection(): { isConnected: boolean } {
   const { isConnected } = useSignalContext();
   return { isConnected };
+}
+
+/**
+ * Subscribe to ALL incoming signals. Used by the auto-invalidation layer.
+ *
+ * The callback receives `signalId`, `pluginId`, and the raw payload for every
+ * signal message that arrives over the WebSocket. Subscriptions are automatically
+ * cleaned up on unmount; the latest callback is always used (no stale closures).
+ *
+ * Component code should prefer the typed `useSignal(signal, ...)` hook over this.
+ */
+export function useSubscribeAllSignals(callback: SignalAllCallback): void {
+  const { subscribeAll } = useSignalContext();
+
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    const stableCallback: SignalAllCallback = (props) => {
+      callbackRef.current(props);
+    };
+
+    return subscribeAll(stableCallback);
+  }, [subscribeAll]);
 }

--- a/core/slo-common/src/index.ts
+++ b/core/slo-common/src/index.ts
@@ -37,43 +37,47 @@ export { sloRoutes } from "./routes";
 
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
+import { pluginMetadata } from "./plugin-metadata";
 
 /**
  * Broadcast when an SLO's status changes (budget consumed, breach started/ended).
  * Frontend components can refetch SLO data for the affected system.
  */
-export const SLO_STATUS_CHANGED = createSignal(
-  "slo.status.changed",
-  z.object({
+export const SLO_STATUS_CHANGED = createSignal({
+  pluginMetadata,
+  event: "status.changed",
+  payloadSchema: z.object({
     systemId: z.string(),
     objectiveId: z.string(),
     budgetRemainingPercent: z.number(),
     isBreaching: z.boolean(),
   }),
-);
+});
 
 /**
  * Broadcast when a streak is updated (incremented or broken).
  * Used to update streak counter UI in real-time.
  */
-export const SLO_STREAK_UPDATED = createSignal(
-  "slo.streak.updated",
-  z.object({
+export const SLO_STREAK_UPDATED = createSignal({
+  pluginMetadata,
+  event: "streak.updated",
+  payloadSchema: z.object({
     systemId: z.string(),
     objectiveId: z.string(),
     currentStreak: z.number(),
     broken: z.boolean(),
   }),
-);
+});
 
 /**
  * Broadcast when a system unlocks a new achievement.
  * Used to trigger celebration UI and milestone feed updates.
  */
-export const SLO_ACHIEVEMENT_UNLOCKED = createSignal(
-  "slo.achievement.unlocked",
-  z.object({
+export const SLO_ACHIEVEMENT_UNLOCKED = createSignal({
+  pluginMetadata,
+  event: "achievement.unlocked",
+  payloadSchema: z.object({
     systemId: z.string(),
     achievement: z.string(),
   }),
-);
+});

--- a/core/slo-frontend/src/components/SystemSloBadge.tsx
+++ b/core/slo-frontend/src/components/SystemSloBadge.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { usePluginClient, type SlotContext } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SystemStateBadgesSlot } from "@checkstack/catalog-common";
 import { SloApi } from "../api";
-import { SLO_STATUS_CHANGED } from "@checkstack/slo-common";
 import { Badge } from "@checkstack/ui";
 
 type Props = SlotContext<typeof SystemStateBadgesSlot>;
@@ -11,20 +9,16 @@ type Props = SlotContext<typeof SystemStateBadgesSlot>;
 /**
  * Badge displaying if a system's SLO is breaching, degraded, or at risk.
  * Rendered in SystemStateBadgesSlot on the catalog/dashboard.
+ *
+ * Realtime updates arrive via SignalAutoInvalidator on `[["slo"]]`.
  */
 export const SystemSloBadge: React.FC<Props> = ({ system }) => {
   const sloClient = usePluginClient(SloApi);
 
-  const { data, refetch } = sloClient.getObjectivesForSystem.useQuery(
+  const { data } = sloClient.getObjectivesForSystem.useQuery(
     { systemId: system?.id ?? "" },
     { enabled: !!system?.id },
   );
-
-  useSignal(SLO_STATUS_CHANGED, ({ systemId }) => {
-    if (system?.id && systemId === system.id) {
-      void refetch();
-    }
-  });
 
   if (!data || data.length === 0) return;
 

--- a/core/slo-frontend/src/components/SystemSloPanel.tsx
+++ b/core/slo-frontend/src/components/SystemSloPanel.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { usePluginClient, type SlotContext } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SystemDetailsTopSlot } from "@checkstack/catalog-common";
 import { SloApi } from "../api";
-import { SLO_STATUS_CHANGED, sloRoutes } from "@checkstack/slo-common";
+import { sloRoutes } from "@checkstack/slo-common";
 import { resolveRoute } from "@checkstack/common";
 import { ErrorBudgetBar } from "./ErrorBudgetBar";
 import { BurnRateIndicator } from "./BurnRateIndicator";
@@ -19,17 +18,10 @@ type Props = SlotContext<typeof SystemDetailsTopSlot>;
 export const SystemSloPanel: React.FC<Props> = ({ system }) => {
   const sloClient = usePluginClient(SloApi);
 
-  const { data: objectives, refetch } =
-    sloClient.getObjectivesForSystem.useQuery(
-      { systemId: system?.id ?? "" },
-      { enabled: !!system?.id },
-    );
-
-  useSignal(SLO_STATUS_CHANGED, ({ systemId }) => {
-    if (system?.id && systemId === system.id) {
-      void refetch();
-    }
-  });
+  const { data: objectives } = sloClient.getObjectivesForSystem.useQuery(
+    { systemId: system?.id ?? "" },
+    { enabled: !!system?.id },
+  );
 
   if (!objectives || objectives.length === 0) return;
 

--- a/core/slo-frontend/src/pages/SloDetailPage.tsx
+++ b/core/slo-frontend/src/pages/SloDetailPage.tsx
@@ -1,9 +1,7 @@
 import React, { useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { usePluginClient, wrapInSuspense } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SloApi } from "../api";
-import { SLO_STATUS_CHANGED } from "@checkstack/slo-common";
 import { CatalogApi } from "@checkstack/catalog-common";
 import { ErrorBudgetBar } from "../components/ErrorBudgetBar";
 import { BurnRateIndicator } from "../components/BurnRateIndicator";
@@ -41,16 +39,15 @@ const SloDetailPageContent: React.FC = () => {
   const sloClient = usePluginClient(SloApi);
   const catalogClient = usePluginClient(CatalogApi);
 
-  const { data, isLoading, refetch } = sloClient.getObjective.useQuery(
+  const { data, isLoading } = sloClient.getObjective.useQuery(
     { id: sloId ?? "" },
     { enabled: !!sloId },
   );
 
-  const { data: eventsData, refetch: refetchEvents } =
-    sloClient.getDowntimeEvents.useQuery(
-      { objectiveId: sloId ?? "", limit: 20 },
-      { enabled: !!sloId },
-    );
+  const { data: eventsData } = sloClient.getDowntimeEvents.useQuery(
+    { objectiveId: sloId ?? "", limit: 20 },
+    { enabled: !!sloId },
+  );
 
   const { data: streaksData } = sloClient.getStreaks.useQuery({});
 
@@ -79,13 +76,6 @@ const SloDetailPageContent: React.FC = () => {
   );
 
   const events = eventsData?.events;
-
-  useSignal(SLO_STATUS_CHANGED, ({ objectiveId }) => {
-    if (objectiveId === sloId) {
-      void refetch();
-      void refetchEvents();
-    }
-  });
 
   if (isLoading || !data) {
     return (

--- a/core/slo-frontend/src/pages/SloOverviewPage.tsx
+++ b/core/slo-frontend/src/pages/SloOverviewPage.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo } from "react";
 import { usePluginClient, wrapInSuspense } from "@checkstack/frontend-api";
-import { useSignal } from "@checkstack/signal-frontend";
 import { SloApi } from "../api";
-import { SLO_STATUS_CHANGED, sloRoutes } from "@checkstack/slo-common";
+import { sloRoutes } from "@checkstack/slo-common";
 import { CatalogApi } from "@checkstack/catalog-common";
 import { ErrorBudgetBar } from "../components/ErrorBudgetBar";
 import { BurnRateIndicator } from "../components/BurnRateIndicator";
@@ -25,18 +24,11 @@ const SloOverviewPageContent: React.FC = () => {
   const sloClient = usePluginClient(SloApi);
   const catalogClient = usePluginClient(CatalogApi);
 
-  const {
-    data: objectivesData,
-    isLoading: objectivesLoading,
-    refetch,
-  } = sloClient.listObjectives.useQuery({});
+  const { data: objectivesData, isLoading: objectivesLoading } =
+    sloClient.listObjectives.useQuery({});
 
   const { data: systemsData, isLoading: systemsLoading } =
     catalogClient.getSystems.useQuery({});
-
-  useSignal(SLO_STATUS_CHANGED, () => {
-    void refetch();
-  });
 
   const objectives = objectivesData?.objectives ?? [];
   const isLoading = objectivesLoading || systemsLoading;

--- a/core/test-utils-backend/src/mock-signal-service.test.ts
+++ b/core/test-utils-backend/src/mock-signal-service.test.ts
@@ -7,15 +7,19 @@ import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
 
 // Test signals
-const TEST_SIGNAL_A = createSignal(
-  "test.signalA",
-  z.object({ value: z.string() })
-);
+const testPluginMetadata = { pluginId: "test" };
 
-const TEST_SIGNAL_B = createSignal(
-  "test.signalB",
-  z.object({ count: z.number() })
-);
+const TEST_SIGNAL_A = createSignal({
+  pluginMetadata: testPluginMetadata,
+  event: "signalA",
+  payloadSchema: z.object({ value: z.string() }),
+});
+
+const TEST_SIGNAL_B = createSignal({
+  pluginMetadata: testPluginMetadata,
+  event: "signalB",
+  payloadSchema: z.object({ count: z.number() }),
+});
 
 describe("createMockSignalService", () => {
   let mockService: MockSignalService;

--- a/docs/backend/signals.md
+++ b/docs/backend/signals.md
@@ -4,6 +4,8 @@
 
 The Signal Service provides realtime backend-to-frontend communication via WebSockets. It enables plugins to push typed events to connected clients, replacing polling mechanisms with instant updates.
 
+Every signal is owned by a single plugin (its `pluginId`). The pluginId travels alongside the signal id end-to-end — from `createSignal()` on the backend, through the WebSocket envelope, to the frontend `SignalAutoInvalidator` — so React Query caches keyed `[[pluginId]]` are invalidated automatically when a signal arrives. Components no longer need their own `useSignal(...)` calls just to refetch a query.
+
 ## Overview
 
 ```mermaid
@@ -13,18 +15,23 @@ graph LR
         SS --> EB[EventBus]
         EB --> WSH[WebSocket Handler]
     end
-    
+
     subgraph Frontend
         WSH --- WS((WebSocket))
         WS --- SP[SignalProvider]
+        SP --> AI[SignalAutoInvalidator]
+        AI --> QC[QueryClient<br/>invalidates &#91;&#91;pluginId&#93;&#93;]
         SP --> US[useSignal Hook]
-        US --> C[Component]
+        US --> C[Component<br/>local UI state]
     end
 ```
 
 ### Key Features
 
 - **Type-safe signals** with Zod schema validation
+- **Plugin-owned signals** — id, pluginId, and ownership encoded by the factory
+- **Automatic cache invalidation** — react-query `[[pluginId]]` keys are invalidated for every incoming signal, no per-component wiring required
+- **Cross-plugin opt-in** via `foreignSignals` for the rare case where one plugin's data depends on another plugin's signal
 - **Multi-instance coordination** via EventBus (works across backend replicas)
 - **Broadcast channels** for all clients (anonymous allowed)
 - **User-specific channels** for private messages (authentication required)
@@ -38,38 +45,48 @@ graph LR
 |---------|---------|
 | `@checkstack/signal-common` | Shared types, `Signal` interface, `createSignal()` factory |
 | `@checkstack/signal-backend` | `SignalServiceImpl`, WebSocket handler for Bun |
-| `@checkstack/signal-frontend` | React `SignalProvider` and `useSignal()` hook |
+| `@checkstack/signal-frontend` | React `SignalProvider`, `useSignal()`, `useSubscribeAllSignals()` |
+| `@checkstack/frontend` | `SignalAutoInvalidator` (mounted once near `QueryClientProvider`) |
 
 ---
 
 ## Defining Signals
 
-Signals are defined in `-common` packages using `createSignal()`:
+Signals are defined in `-common` packages using `createSignal()`. The factory takes a single object: the plugin's `pluginMetadata`, an `event` name, and the Zod `payloadSchema`. The signal id is constructed automatically as `${pluginMetadata.pluginId}.${event}`, and the resulting `Signal` carries a `pluginId` field.
 
 ```typescript
 import { createSignal } from "@checkstack/signal-common";
 import { z } from "zod";
+import { pluginMetadata } from "./plugin-metadata"; // pluginId: "notification"
 
-export const NOTIFICATION_RECEIVED = createSignal(
-  "notification.received",
-  z.object({
+export const NOTIFICATION_RECEIVED = createSignal({
+  pluginMetadata,
+  event: "received",
+  payloadSchema: z.object({
     id: z.string(),
     title: z.string(),
-    description: z.string(),
+    body: z.string(),
     importance: z.enum(["info", "warning", "critical"]),
-  })
-);
+  }),
+});
+// → { id: "notification.received", pluginId: "notification", payloadSchema: ... }
 ```
 
 ### Signal ID Naming Convention
 
-Use dot-notation: `{domain}.{action}`
+The id is always `${pluginId}.${event}`, enforced by the factory. Use lower-snake / lower-dot for the event part:
 
-Examples:
 - `notification.received`
-- `notification.countChanged`
-- `healthcheck.statusChanged`
-- `system.maintenanceScheduled`
+- `notification.count_changed`
+- `healthcheck.run.completed`
+- `healthcheck.system.status_changed`
+- `dependency.warnings.changed`
+
+> **Don't hand-roll signal ids.** Always use `createSignal({...})`. The id and `pluginId` field are what the auto-invalidator routes on; off-convention ids would break invalidation silently.
+
+### Framework-Level Signals
+
+`@checkstack/signal-common` itself defines `PLUGIN_INSTALLED` and `PLUGIN_DEREGISTERED` under the synthetic pluginId `"core"`. No plugin may register itself with the `core` pluginId.
 
 ---
 
@@ -87,6 +104,8 @@ const signalService = await services.get(coreServices.signalService);
 ```
 
 ### Emitting Signals
+
+The broadcast / sendToUser / sendToUsers / sendToAuthorizedUsers methods all read `signal.pluginId` and put it on the wire envelope automatically. Plugin code does not need to think about it.
 
 #### Broadcast (All Clients)
 
@@ -109,7 +128,7 @@ import { NOTIFICATION_RECEIVED } from "@checkstack/notification-common";
 await signalService.sendToUser(NOTIFICATION_RECEIVED, userId, {
   id: notificationId,
   title: "New message",
-  description: "You have a new notification",
+  body: "You have a new notification",
   importance: "info",
 });
 ```
@@ -120,7 +139,7 @@ await signalService.sendToUser(NOTIFICATION_RECEIVED, userId, {
 await signalService.sendToUsers(NOTIFICATION_RECEIVED, [user1, user2], {
   id: notificationId,
   title: "Team alert",
-  description: "Important update for the team",
+  body: "Important update for the team",
   importance: "warning",
 });
 ```
@@ -150,7 +169,7 @@ await signalService.sendToAuthorizedUsers(
   HEALTH_STATE_CHANGED,
   subscriberUserIds,
   { systemId, newState: "degraded" },
-  pluginMetadata,  // Typed PluginMetadata from common package
+  pluginMetadata,
   access.healthcheckStatusRead
 );
 ```
@@ -161,49 +180,91 @@ await signalService.sendToAuthorizedUsers(
 
 ## Frontend Usage
 
-### SignalProvider
+### SignalProvider + SignalAutoInvalidator
 
-The `SignalProvider` wraps the application and manages the WebSocket connection:
+`SignalProvider` opens a single shared WebSocket; `SignalAutoInvalidator` is mounted once inside it (and inside `QueryClientProvider`). The auto-invalidator subscribes to **every** incoming signal and invalidates `[[pluginId]]` on the React Query client. Both are wired in `core/frontend/src/App.tsx` and you should not need to change them.
 
 ```tsx
-// App.tsx
-import { SignalProvider } from "@checkstack/signal-frontend";
-
-function App() {
-  return (
-    <SignalProvider backendUrl={import.meta.env.VITE_API_BASE_URL}>
-      <YourApp />
-    </SignalProvider>
-  );
-}
+// core/frontend/src/App.tsx (excerpt)
+<QueryClientProvider client={queryClient}>
+  <ApiProvider registry={apiRegistry}>
+    <OrpcQueryProvider>
+      <SessionProvider>
+        <SignalProvider backendUrl={baseUrl}>
+          <SignalAutoInvalidator />
+          {/* ...rest of app */}
+        </SignalProvider>
+      </SessionProvider>
+    </OrpcQueryProvider>
+  </ApiProvider>
+</QueryClientProvider>
 ```
 
-### useSignal Hook
+### Default behaviour: do nothing
 
-Subscribe to signals in any component:
+For typical "I want my data to update when something changes" cases, plugin code does **not** need to subscribe to signals. Just write a normal `useQuery`:
+
+```tsx
+const { data } = anomalyClient.getAnomalies.useQuery({ systemId });
+```
+
+When the backend broadcasts `anomaly.state_changed`, the auto-invalidator will invalidate every query keyed `[["anomaly"]]`, and React Query refetches whatever is currently mounted. No `useSignal` call needed.
+
+### Cross-plugin reactivity: `foreignSignals`
+
+Sometimes one plugin's data depends on another plugin's signal. The classic example is the dependency map: dependency queries embed system health, so they must refetch when `healthcheck.system.status_changed` fires. Declare this on the plugin:
+
+```tsx
+// core/dependency-frontend/src/index.tsx
+import { createFrontendPlugin } from "@checkstack/frontend-api";
+import { pluginMetadata } from "@checkstack/dependency-common";
+import { SYSTEM_STATUS_CHANGED } from "@checkstack/healthcheck-common";
+
+export default createFrontendPlugin({
+  metadata: pluginMetadata, // pluginId: "dependency"
+
+  // SYSTEM_STATUS_CHANGED is owned by `healthcheck`. Listing it here means
+  // [["dependency"]] queries will ALSO be invalidated when it fires.
+  // Same-plugin signals (DEPENDENCY_*) must NOT be listed — they are
+  // auto-invalidated already.
+  foreignSignals: [SYSTEM_STATUS_CHANGED],
+
+  // ...routes, extensions, apis
+});
+```
+
+Rules:
+- **Pass actual `Signal` objects, not strings.** This stays type-safe through refactors.
+- **Do not list your own signals.** They are auto-invalidated; listing them here would no-op (still gets invalidated once) but adds noise.
+- **Use only when needed.** If your plugin's queries don't embed another plugin's data, you don't need `foreignSignals`.
+
+`foreignSignals` declarations are picked up immediately when a plugin is registered — including dynamically-loaded plugins via `PLUGIN_INSTALLED`.
+
+### `useSignal` — for genuine UI state, not for refetching
+
+`useSignal` still exists, but use it only when you need to do **something other than invalidate a query**. Concretely:
+- Append to an in-memory event log (e.g. dashboard activity terminal).
+- Update transient UI state that is not derivable from a query.
+- Trigger a side effect (toast, animation, scroll).
 
 ```tsx
 import { useSignal } from "@checkstack/signal-frontend";
-import { NOTIFICATION_RECEIVED } from "@checkstack/notification-common";
-import { useCallback } from "react";
+import { HEALTH_CHECK_RUN_COMPLETED } from "@checkstack/healthcheck-common";
 
-function NotificationBell() {
-  const [count, setCount] = useState(0);
-
-  useSignal(
-    NOTIFICATION_RECEIVED,
-    useCallback((payload) => {
-      // payload is fully typed!
-      console.log("New notification:", payload.title);
-      setCount((prev) => prev + 1);
-    }, [])
-  );
-
-  return <Badge count={count} />;
-}
+useSignal(HEALTH_CHECK_RUN_COMPLETED, ({ systemName, status, latencyMs }) => {
+  // Append to local terminal feed — not derivable from cache
+  setTerminalEntries((prev) => [
+    { systemName, status, latencyMs, timestamp: new Date() },
+    ...prev,
+  ].slice(0, MAX_ENTRIES));
+});
 ```
 
-> **Important**: Wrap the callback in `useCallback` to avoid unnecessary re-subscriptions.
+> **If your handler body is just `refetch()` or `queryClient.invalidateQueries(...)`, delete the handler.** The auto-invalidator already does it.
+
+### `useSubscribeAllSignals` — for advanced wildcard subscriptions
+
+`useSubscribeAllSignals` fires for every incoming signal with `{ signalId, pluginId, payload }`. It's used by `SignalAutoInvalidator` itself and is exported for niche cases (e.g. an admin debug page that prints every signal). Avoid it in normal plugin code.
 
 ### useSignalConnection Hook
 
@@ -214,7 +275,6 @@ import { useSignalConnection } from "@checkstack/signal-frontend";
 
 function ConnectionIndicator() {
   const { isConnected } = useSignalConnection();
-
   return (
     <div className={isConnected ? "text-green-500" : "text-red-500"}>
       {isConnected ? "Connected" : "Disconnected"}
@@ -235,8 +295,8 @@ ws://{backend-url}/api/signals/ws
 
 ### Authentication
 
-- **Anonymous connections allowed** - receive broadcast signals
-- **Authenticated connections** - receive broadcasts + private user channel
+- **Anonymous connections allowed** — receive broadcast signals
+- **Authenticated connections** — receive broadcasts + private user channel
 - Authentication uses the session cookie (same as HTTP requests)
 
 ### Message Types
@@ -246,7 +306,7 @@ ws://{backend-url}/api/signals/ws
 | Type | Description |
 |------|-------------|
 | `connected` | Connection confirmed, includes `userId` if authenticated |
-| `signal` | Signal payload with `signalId`, `payload`, `timestamp` |
+| `signal` | Signal payload — `signalId`, `pluginId`, `payload`, `timestamp` |
 | `pong` | Response to client ping |
 | `error` | Error message |
 
@@ -262,10 +322,11 @@ ws://{backend-url}/api/signals/ws
 // Server: Connection confirmed
 { "type": "connected", "userId": "user-123" }
 
-// Server: Signal received
+// Server: Signal received — note the explicit pluginId field
 {
   "type": "signal",
   "signalId": "notification.received",
+  "pluginId": "notification",
   "payload": { "id": "n-1", "title": "Hello" },
   "timestamp": "2024-01-15T12:00:00Z"
 }
@@ -284,12 +345,12 @@ graph TB
         SS1 --> EB1[EventBus]
         WSH1[WebSocket Handler] --> C1[Clients]
     end
-    
+
     subgraph "Backend Instance 2"
         WSH2[WebSocket Handler] --> C2[Clients]
         EB2[EventBus]
     end
-    
+
     EB1 <--> Q[(Queue/Redis)]
     Q <--> EB2
     EB2 --> WSH2
@@ -321,50 +382,41 @@ Bun's native pub/sub is used for efficient routing:
 Keep signal definitions in the `-common` package so both backend and frontend can import them:
 
 ```
-plugins/notification-common/src/signals.ts  # Define here
-plugins/notification-backend/src/service.ts # Emit here
-plugins/notification-frontend/src/...       # Consume here
+core/notification-common/src/signals.ts   # Define here
+core/notification-backend/src/service.ts  # Emit here
+core/notification-frontend/src/...        # Consume only if you need UI side-effects
 ```
 
-### 2. Use Specific Signal Types
+### 2. Trust the auto-invalidator
+
+For "data should refresh when X changes" cases, just keep the relevant signals firing on the backend and write normal queries on the frontend. Do not add `useSignal` handlers that only call `refetch()` or `queryClient.invalidateQueries(...)` — they are noise that the auto-invalidator covers automatically.
+
+### 3. Use Specific Signal Types
 
 Prefer multiple specific signals over one generic signal:
 
 ```typescript
 // ✅ Good
-const NOTIFICATION_RECEIVED = createSignal("notification.received", ...);
-const NOTIFICATION_READ = createSignal("notification.read", ...);
+const NOTIFICATION_RECEIVED = createSignal({ pluginMetadata, event: "received", payloadSchema: ... });
+const NOTIFICATION_READ     = createSignal({ pluginMetadata, event: "read",     payloadSchema: ... });
 
 // ❌ Avoid
-const NOTIFICATION_EVENT = createSignal("notification.event", z.object({
-  type: z.enum(["received", "read", ...]),
-  ...
-}));
+const NOTIFICATION_EVENT = createSignal({
+  pluginMetadata,
+  event: "event",
+  payloadSchema: z.object({ type: z.enum(["received", "read"]), ... }),
+});
 ```
 
-### 3. Handle Reconnection Gracefully
+### 4. Use `foreignSignals` sparingly
 
-The SignalProvider auto-reconnects, but components should handle the gap:
+If your plugin's `[[pluginId]]` queries truly embed data owned by another plugin (e.g. dependency map embedding system health), declare a `foreignSignals` entry. Don't use it as a hammer — most of the time, each plugin's data is independent.
 
-```tsx
-function NotificationBell() {
-  const { isConnected } = useSignalConnection();
-  
-  // Refetch on reconnection to catch missed signals
-  useEffect(() => {
-    if (isConnected) {
-      refetchNotifications();
-    }
-  }, [isConnected]);
-}
-```
-
-### 4. Emit Signals Asynchronously
+### 5. Emit Signals Asynchronously
 
 Use `void` to emit signals without blocking:
 
 ```typescript
-// Don't await if the caller doesn't need to wait
 if (signalService) {
   void signalService.sendToUser(NOTIFICATION_RECEIVED, userId, payload);
 }
@@ -401,36 +453,29 @@ DEBUG Relayed signal notification.received to user user-123
 
 ### Frontend Console
 
-Check WebSocket connection in browser DevTools:
-- Network tab → WS filter
-- Look for `/api/signals/ws`
+- Network tab → WS filter → `/api/signals/ws` to inspect the WebSocket frames (each `signal` message includes `signalId` and `pluginId`).
+- React Query Devtools → watch the `[[pluginId]]` queries flip to "fetching" the moment a signal arrives.
 
 ---
 
-## Migration from Polling
+## Migration: Removing Per-Component Signal Handlers
 
-To migrate an existing polling-based component:
-
-1. **Define signals** in the common package
-2. **Emit signals** from the backend where state changes
-3. **Replace polling** with `useSignal` in the frontend
-
-### Before (Polling)
+Before this architecture, components manually subscribed to signals just to invalidate their cache:
 
 ```tsx
-useEffect(() => {
-  const interval = setInterval(fetchCount, 60000);
-  return () => clearInterval(interval);
-}, []);
+// ❌ Before — pure cache invalidation, redundant
+const { data, refetch } = client.getThing.useQuery({ systemId });
+useSignal(THING_CHANGED, ({ systemIds }) => {
+  if (systemIds.includes(systemId)) void refetch();
+});
 ```
-
-### After (Signals)
 
 ```tsx
-useSignal(NOTIFICATION_COUNT_CHANGED, useCallback((payload) => {
-  setCount(payload.unreadCount);
-}, []));
+// ✅ After — auto-invalidator handles it
+const { data } = client.getThing.useQuery({ systemId });
 ```
+
+If you find a `useSignal` handler whose body is only a `refetch()` or `queryClient.invalidateQueries(...)`, delete it. If the signal is owned by a different plugin than the query you want to refresh, add it to `foreignSignals` on your plugin instead.
 
 ---
 
@@ -439,13 +484,26 @@ useSignal(NOTIFICATION_COUNT_CHANGED, useCallback((payload) => {
 ### signal-common
 
 ```typescript
-// Create a typed signal
-function createSignal<T>(id: string, payloadSchema: z.ZodType<T>): Signal<T>
+// Create a typed signal — id is always `${pluginId}.${event}`
+function createSignal<T>(props: {
+  pluginMetadata: PluginMetadata;
+  event: string;
+  payloadSchema: z.ZodType<T>;
+}): Signal<T>
 
 // Signal interface
 interface Signal<T> {
   id: string;
+  pluginId: string;
   payloadSchema: z.ZodType<T>;
+}
+
+// Wire envelope
+interface SignalMessage<T> {
+  signalId: string;
+  pluginId: string;
+  payload: T;
+  timestamp: string;
 }
 
 // SignalService interface
@@ -458,7 +516,7 @@ interface SignalService {
     userIds: string[],
     payload: T,
     pluginMetadata: PluginMetadata,
-    accessRule: AccessRule
+    accessRule: AccessRule,
   ): Promise<void>;
 }
 ```
@@ -466,20 +524,48 @@ interface SignalService {
 ### signal-frontend
 
 ```typescript
-// Provider component
+// Provider component (mounts the WebSocket)
 function SignalProvider(props: {
   children: React.ReactNode;
   backendUrl?: string;
 }): JSX.Element;
 
-// Subscribe to a signal
+// Subscribe to a single typed signal — use ONLY for non-cache UI side-effects.
 function useSignal<T>(
   signal: Signal<T>,
-  callback: (payload: T) => void
+  callback: (payload: T) => void,
 ): void;
 
-// Get connection status
+// Subscribe to ALL incoming signals (advanced; used by the auto-invalidator).
+type SignalAllCallback = (props: {
+  signalId: string;
+  pluginId: string;
+  payload: unknown;
+}) => void;
+
+function useSubscribeAllSignals(callback: SignalAllCallback): void;
+
+// Connection status
 function useSignalConnection(): { isConnected: boolean };
+```
+
+### frontend-api
+
+```typescript
+// Plugin definition gains a foreignSignals field
+interface FrontendPlugin {
+  metadata: PluginMetadata;
+  apis?: ApiFactory<unknown>[];
+  extensions?: Extension[];
+  routes?: PluginRoute[];
+
+  /**
+   * Foreign signals that should ALSO invalidate this plugin's [[pluginId]]
+   * cache when received. Same-plugin signals are auto-invalidated and must
+   * NOT be listed here.
+   */
+  foreignSignals?: Signal<unknown>[];
+}
 ```
 
 ---

--- a/docs/frontend/plugins.md
+++ b/docs/frontend/plugins.md
@@ -201,6 +201,22 @@ extensions: [
 ]
 ```
 
+#### `foreignSignals` (optional)
+
+Cross-plugin realtime invalidation. The frontend `SignalAutoInvalidator` already invalidates `[[pluginId]]` for **every** signal owned by your plugin — you do not register your own signals here. Use `foreignSignals` only when your plugin's queries embed data owned by **another** plugin and must refetch when that plugin's signals fire.
+
+```typescript
+import { SYSTEM_STATUS_CHANGED } from "@checkstack/healthcheck-common";
+
+// dependency-frontend embeds system health status in its queries, so it
+// must refetch when healthcheck.system.status_changed fires.
+foreignSignals: [SYSTEM_STATUS_CHANGED],
+```
+
+Pass actual `Signal` objects, not strings. Same-plugin signals must NOT be listed.
+
+See [Signals](../backend/signals.md) for the full signal architecture.
+
 ## Using Plugin APIs in Components
 
 Components access plugin APIs using the `usePluginClient` hook with TanStack Query integration.


### PR DESCRIPTION
## Summary

- Signals now carry `pluginId` end-to-end (factory → wire envelope → frontend), and a single `SignalAutoInvalidator` mounted near `QueryClientProvider` invalidates `[[pluginId]]` for every incoming signal — no per-component wiring required.
- Removed ~25 redundant `useSignal(...refetch/invalidateQueries)` handlers across the frontend packages. Genuine UI-state subscriptions (queue lag alert, dashboard terminal feed, rolling-preset date refresh, plugin lifecycle) preserved.
- Cross-plugin reactivity is opt-in via `FrontendPlugin.foreignSignals: Signal[]` (currently used only by `dependency-frontend` for `SYSTEM_STATUS_CHANGED`, since dependency payloads embed system health).
- Fixes the original report: `SystemAnomalyWidget` on the system detail page now updates in realtime automatically. The status page dashboard also stays fresh on every anomaly signal.

## Breaking change

`createSignal` in `@checkstack/signal-common` now takes a single object argument:

```ts
// Before
createSignal("anomaly.state_changed", schema)

// After
createSignal({ pluginMetadata, event: "state_changed", payloadSchema: schema })
```

The `Signal` type gained a `pluginId` field; the wire envelope (`SignalMessage`, `ServerToClientMessage` `signal` variant) gained a `pluginId` field. All 24 in-tree call sites updated. Documented in [`docs/backend/signals.md`](docs/backend/signals.md) and [`docs/frontend/plugins.md`](docs/frontend/plugins.md). Changeset bumps the affected `*-common` packages and signal infrastructure as `minor`, frontend packages as `patch`.

## Test plan

- [x] `bun run typecheck` — all 117 packages pass
- [x] `bun run lint` — clean
- [x] `bun test` — 1748 tests pass
- [x] Smoke test in dev: open the system detail page, trigger an anomaly state change on the backend, verify the widget updates without reload
- [x] Smoke test the status page dashboard: anomaly state changes, system status changes, incident/maintenance create/close all reflect immediately
- [x] Verify `dependency-frontend` map updates when system status changes (cross-plugin via `foreignSignals`)
- [x] Verify the notification bell unread count updates in realtime (now query-driven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)