### PR TITLE
feat: in-context healthcheck assignment from system & create flows

### DIFF
--- a/.changeset/inline-healthcheck-assignment.md
+++ b/.changeset/inline-healthcheck-assignment.md
@@ -1,0 +1,10 @@
+---
+"@checkstack/healthcheck-frontend": minor
+---
+
+Streamline system → healthcheck assignment flow by allowing in-context creation in both directions.
+
+- Adds an "Assign to systems" multi-select section to the healthcheck create flow (new "Systems" tree node), so a fresh check can be wired to one or more systems in a single save.
+- Adds a "+ Create new check" button on the system assignment IDE that opens the create flow pre-targeted at that system; on save, the new check is auto-assigned and the user is returned to the assignment IDE.
+- Pre-selects the originating system when the create flow is entered with a `?systemId=` query param, and forwards that param through the strategy picker.
+- Includes an info banner noting that health checks are reusable templates and can be assigned to additional systems at any time, to preserve the "configs are reusable" mental model.

--- a/core/healthcheck-frontend/src/components/editor/EditorPanel.tsx
+++ b/core/healthcheck-frontend/src/components/editor/EditorPanel.tsx
@@ -8,6 +8,7 @@ import type { TreeNodeId } from "./EditorTree";
 import { GeneralSection } from "./GeneralSection";
 import { CollectorSection } from "./CollectorSection";
 import { CollectorPicker } from "./CollectorPicker";
+import { SystemsSection } from "./SystemsSection";
 import { TeamAccessEditor } from "@checkstack/auth-frontend";
 
 // =============================================================================
@@ -43,6 +44,11 @@ interface EditorPanelProps {
   onCollectorRemove: (entryId: string) => void;
   onCollectorAdd: (collectorId: string) => void;
   strategyId: string;
+  showSystemsSection?: boolean;
+  systems?: Array<{ id: string; name: string; description?: string | null }>;
+  systemsLoading?: boolean;
+  selectedSystemIds?: string[];
+  onSystemsChange?: (systemIds: string[]) => void;
 }
 
 // =============================================================================
@@ -67,6 +73,11 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
   onCollectorRemove,
   onCollectorAdd,
   strategyId,
+  showSystemsSection = false,
+  systems = [],
+  systemsLoading = false,
+  selectedSystemIds = [],
+  onSystemsChange,
 }) => {
   // --- General Section ---
   if (selectedNode === "general") {
@@ -96,6 +107,20 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
           loading={collectorsLoading}
           onAdd={onCollectorAdd}
           strategyId={strategyId}
+        />
+      </div>
+    );
+  }
+
+  // --- Systems Section ---
+  if (selectedNode === "systems" && showSystemsSection) {
+    return (
+      <div className="p-6">
+        <SystemsSection
+          systems={systems}
+          selectedSystemIds={selectedSystemIds}
+          loading={systemsLoading}
+          onChange={(ids) => onSystemsChange?.(ids)}
         />
       </div>
     );

--- a/core/healthcheck-frontend/src/components/editor/EditorTree.tsx
+++ b/core/healthcheck-frontend/src/components/editor/EditorTree.tsx
@@ -3,7 +3,7 @@ import type {
   CollectorConfigEntry,
   CollectorDto,
 } from "@checkstack/healthcheck-common";
-import { Plus, Settings, Shield, ChevronRight } from "lucide-react";
+import { Plus, Settings, Shield, ChevronRight, Server } from "lucide-react";
 import { isBuiltInCollector } from "../../hooks/useCollectors";
 import {
   IDETreeNode,
@@ -20,6 +20,7 @@ import { HealthCheckConfigIDENodeSlot } from "../../slots";
 export type TreeNodeId =
   | "general"
   | "access"
+  | "systems"
   | "collector-picker"
   | `collector:${string}`
   | (string & {});
@@ -33,6 +34,8 @@ interface EditorTreeProps {
   validationIssues: ValidationIssue[];
   strategyId: string;
   configId?: string;
+  showSystemsNode?: boolean;
+  selectedSystemCount?: number;
 }
 
 // =============================================================================
@@ -47,6 +50,8 @@ export const EditorTree: React.FC<EditorTreeProps> = ({
   validationIssues,
   strategyId,
   configId,
+  showSystemsNode = false,
+  selectedSystemCount = 0,
 }) => {
   // Check if there are addable collectors remaining
   const hasAddableCollectors = useMemo(() => {
@@ -107,6 +112,23 @@ export const EditorTree: React.FC<EditorTreeProps> = ({
           <Plus className="h-4 w-4 shrink-0" />
           <span className="truncate">Add check item...</span>
         </button>
+      )}
+
+      {showSystemsNode && (
+        <>
+          <IDETreeSection label="Assignment" />
+          <IDETreeNode
+            nodeId="systems"
+            label="Systems"
+            icon={Server}
+            selected={selectedNode === "systems"}
+            onClick={() => onSelectNode("systems")}
+            issues={validationIssues}
+            badge={
+              selectedSystemCount > 0 ? String(selectedSystemCount) : undefined
+            }
+          />
+        </>
       )}
 
       {/* Access Control */}

--- a/core/healthcheck-frontend/src/components/editor/SystemsSection.tsx
+++ b/core/healthcheck-frontend/src/components/editor/SystemsSection.tsx
@@ -1,0 +1,126 @@
+import React, { useMemo, useState } from "react";
+import { Checkbox, Input, InfoBanner, InfoBannerContent } from "@checkstack/ui";
+import { Info, Search } from "lucide-react";
+
+interface SystemOption {
+  id: string;
+  name: string;
+  description?: string | null;
+}
+
+interface SystemsSectionProps {
+  systems: SystemOption[];
+  selectedSystemIds: string[];
+  loading: boolean;
+  onChange: (systemIds: string[]) => void;
+}
+
+export const SystemsSection: React.FC<SystemsSectionProps> = ({
+  systems,
+  selectedSystemIds,
+  loading,
+  onChange,
+}) => {
+  const [query, setQuery] = useState("");
+
+  const selectedSet = useMemo(
+    () => new Set(selectedSystemIds),
+    [selectedSystemIds],
+  );
+
+  const filteredSystems = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return systems;
+    return systems.filter((s) => s.name.toLowerCase().includes(trimmed));
+  }, [systems, query]);
+
+  const toggle = ({ systemId }: { systemId: string }) => {
+    if (selectedSet.has(systemId)) {
+      onChange(selectedSystemIds.filter((id) => id !== systemId));
+    } else {
+      onChange([...selectedSystemIds, systemId]);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">Assign to systems</h2>
+        <p className="text-sm text-muted-foreground">
+          Optionally pick systems this check should monitor. You can also
+          assign it later from a system&apos;s catalog page.
+        </p>
+      </div>
+
+      <InfoBanner variant="info">
+        <Info className="h-4 w-4 shrink-0 mt-0.5" />
+        <InfoBannerContent>
+          Health checks are reusable templates — they can be assigned to
+          additional systems at any time.
+        </InfoBannerContent>
+      </InfoBanner>
+
+      <div className="space-y-2">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search systems..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="pl-9"
+            disabled={loading}
+          />
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-muted-foreground italic px-1">
+            Loading systems...
+          </p>
+        ) : filteredSystems.length === 0 ? (
+          <p className="text-sm text-muted-foreground italic px-1">
+            {systems.length === 0
+              ? "No systems exist yet. Create one from the catalog first."
+              : "No systems match your search."}
+          </p>
+        ) : (
+          <div className="max-h-[420px] overflow-y-auto rounded-md border border-border/50 divide-y divide-border/50">
+            {filteredSystems.map((system) => {
+              const isChecked = selectedSet.has(system.id);
+              return (
+                <button
+                  key={system.id}
+                  type="button"
+                  onClick={() => toggle({ systemId: system.id })}
+                  className="flex items-start gap-3 w-full px-3 py-2.5 text-left hover:bg-muted/40 transition-colors"
+                >
+                  <Checkbox
+                    checked={isChecked}
+                    onCheckedChange={() => toggle({ systemId: system.id })}
+                    className="mt-0.5"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium truncate">
+                      {system.name}
+                    </div>
+                    {system.description && (
+                      <div className="text-xs text-muted-foreground truncate">
+                        {system.description}
+                      </div>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {selectedSystemIds.length > 0 && (
+          <p className="text-xs text-muted-foreground px-1">
+            {selectedSystemIds.length} system
+            {selectedSystemIds.length === 1 ? "" : "s"} selected
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/core/healthcheck-frontend/src/pages/AssignmentIDEPage.tsx
+++ b/core/healthcheck-frontend/src/pages/AssignmentIDEPage.tsx
@@ -8,10 +8,11 @@ import {
   DEFAULT_RETENTION_CONFIG,
 } from "@checkstack/healthcheck-common";
 import type { StateThresholds } from "@checkstack/healthcheck-common";
-import { PageLayout, IDELayout, useToast, BackLink } from "@checkstack/ui";
-import { Settings } from "lucide-react";
+import { PageLayout, IDELayout, useToast, BackLink, Button } from "@checkstack/ui";
+import { Settings, Plus } from "lucide-react";
 import { extractErrorMessage, resolveRoute } from "@checkstack/common";
 import { catalogRoutes } from "@checkstack/catalog-common";
+import { healthcheckRoutes } from "@checkstack/healthcheck-common";
 import {
   AssignmentTree,
   type AssignmentNodeId,
@@ -480,11 +481,26 @@ const AssignmentIDEPageContent = () => {
       icon={Settings}
       maxWidth="full"
       actions={
-        <BackLink
-          onClick={() => navigate(resolveRoute(catalogRoutes.routes.config))}
-        >
-          Back to Systems
-        </BackLink>
+        <div className="flex items-center gap-2">
+          {!isLocked && systemId && (
+            <Button
+              size="sm"
+              onClick={() =>
+                navigate(
+                  `${resolveRoute(healthcheckRoutes.routes.create)}?systemId=${encodeURIComponent(systemId)}`,
+                )
+              }
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Create new check
+            </Button>
+          )}
+          <BackLink
+            onClick={() => navigate(resolveRoute(catalogRoutes.routes.config))}
+          >
+            Back to Systems
+          </BackLink>
+        </div>
       }
     >
       {isLocked && provenance && (

--- a/core/healthcheck-frontend/src/pages/HealthCheckIDEPage.tsx
+++ b/core/healthcheck-frontend/src/pages/HealthCheckIDEPage.tsx
@@ -10,7 +10,9 @@ import { HealthCheckConfigIDEPanelSlot } from "../slots";
 import {
   healthcheckRoutes,
   type CollectorConfigEntry,
+  DEFAULT_STATE_THRESHOLDS,
 } from "@checkstack/healthcheck-common";
+import { CatalogApi } from "@checkstack/catalog-common";
 import { PageLayout, Button, useToast, IDELayout, type ValidationIssue } from "@checkstack/ui";
 import { Save, Settings } from "lucide-react";
 import { resolveRoute, extractErrorMessage} from "@checkstack/common";
@@ -44,6 +46,8 @@ const HealthCheckIDEPageContent = () => {
 
   const isEditMode = !!configId && configId !== "new";
   const strategyIdFromUrl = searchParams.get("strategy") ?? undefined;
+  const systemIdFromUrl = searchParams.get("systemId") ?? undefined;
+  const catalogClient = usePluginClient(CatalogApi);
 
   // --- GitOps Provenance Lock ---
   const { isLocked, provenance } = useProvenanceLock({
@@ -79,6 +83,19 @@ const HealthCheckIDEPageContent = () => {
   const { collectors: availableCollectors, loading: collectorsLoading } =
     useCollectors(activeStrategyId ?? "");
 
+  // Fetch systems for assignment (only in create mode)
+  const { data: systemsData, isLoading: systemsLoading } =
+    catalogClient.getSystems.useQuery({}, { enabled: !isEditMode });
+  const systems = useMemo(
+    () =>
+      (systemsData?.systems ?? []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        description: s.description,
+      })),
+    [systemsData],
+  );
+
   // --- Form State ---
 
   const [formState, setFormState] = useState<EditorFormState>({
@@ -94,6 +111,9 @@ const HealthCheckIDEPageContent = () => {
     Record<string, boolean>
   >({});
   const [isDirty, setIsDirty] = useState(false);
+  const [selectedSystemIds, setSelectedSystemIds] = useState<string[]>(
+    systemIdFromUrl ? [systemIdFromUrl] : [],
+  );
 
   // Initialize form from existing configuration (edit mode)
   useEffect(() => {
@@ -250,11 +270,55 @@ const HealthCheckIDEPageContent = () => {
 
   // --- Save ---
 
+  const associateMutation = healthCheckClient.associateSystem.useMutation();
+
   const createMutation = healthCheckClient.createConfiguration.useMutation({
-    onSuccess: () => {
+    onSuccess: async (created) => {
       setIsDirty(false);
-      toast.success("Health check created");
-      navigate(resolveRoute(healthcheckRoutes.routes.config));
+
+      // Fan-out: assign the new config to each selected system.
+      if (selectedSystemIds.length > 0 && created?.id) {
+        const results = await Promise.allSettled(
+          selectedSystemIds.map((systemId) =>
+            associateMutation.mutateAsync({
+              systemId,
+              body: {
+                configurationId: created.id,
+                enabled: true,
+                stateThresholds: DEFAULT_STATE_THRESHOLDS,
+                includeLocal: true,
+              },
+            }),
+          ),
+        );
+        const failed = results.filter((r) => r.status === "rejected").length;
+        if (failed > 0) {
+          toast.error(
+            `Health check created, but ${failed} of ${selectedSystemIds.length} system assignment${selectedSystemIds.length === 1 ? "" : "s"} failed.`,
+          );
+        } else {
+          toast.success(
+            `Health check created and assigned to ${selectedSystemIds.length} system${selectedSystemIds.length === 1 ? "" : "s"}`,
+          );
+        }
+      } else {
+        toast.success("Health check created");
+      }
+
+      // Where to land: prefer back to the originating system's assignment IDE
+      // when the user came from there, otherwise the config list.
+      if (
+        systemIdFromUrl &&
+        selectedSystemIds.includes(systemIdFromUrl)
+      ) {
+        navigate(
+          resolveRoute(healthcheckRoutes.routes.assignments, {
+            systemId: systemIdFromUrl,
+          }),
+        );
+      } else {
+        navigate(resolveRoute(healthcheckRoutes.routes.config));
+      }
     },
     onError: (error) => {
       toast.error(extractErrorMessage(error, "Failed to create"));
@@ -352,6 +416,8 @@ const HealthCheckIDEPageContent = () => {
             validationIssues={validationIssues}
             strategyId={activeStrategyId ?? ""}
             configId={configId}
+            showSystemsNode={!isEditMode}
+            selectedSystemCount={selectedSystemIds.length}
           />
         }
         panel={
@@ -378,6 +444,14 @@ const HealthCheckIDEPageContent = () => {
               onCollectorRemove={handleCollectorRemove}
               onCollectorAdd={handleCollectorAdd}
               strategyId={activeStrategyId ?? ""}
+              showSystemsSection={!isEditMode}
+              systems={systems}
+              systemsLoading={systemsLoading}
+              selectedSystemIds={selectedSystemIds}
+              onSystemsChange={(ids) => {
+                setSelectedSystemIds(ids);
+                setIsDirty(true);
+              }}
             />
             {configId && (
               <ExtensionSlot

--- a/core/healthcheck-frontend/src/pages/StrategyPickerPage.tsx
+++ b/core/healthcheck-frontend/src/pages/StrategyPickerPage.tsx
@@ -16,7 +16,7 @@ import {
   Badge,
 } from "@checkstack/ui";
 import { Search, Zap } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { resolveRoute } from "@checkstack/common";
 
 /**
@@ -61,6 +61,8 @@ function StrategyCard({
 const StrategyPickerPageContent = () => {
   const healthCheckClient = usePluginClient(HealthCheckApi);
   const navigate = useNavigate();
+  const [urlParams] = useSearchParams();
+  const systemIdFromUrl = urlParams.get("systemId");
   const [searchQuery, setSearchQuery] = useState("");
 
   const { data: strategies = [] } = healthCheckClient.getStrategies.useQuery(
@@ -96,8 +98,13 @@ const StrategyPickerPageContent = () => {
   }, [strategies, searchQuery]);
 
   const handleSelectStrategy = (strategy: HealthCheckStrategyDto) => {
+    const params = new URLSearchParams();
+    params.set("strategy", strategy.id);
+    if (systemIdFromUrl) {
+      params.set("systemId", systemIdFromUrl);
+    }
     navigate(
-      `${resolveRoute(healthcheckRoutes.routes.edit, { configId: "new" })}?strategy=${encodeURIComponent(strategy.id)}`,
+      `${resolveRoute(healthcheckRoutes.routes.edit, { configId: "new" })}?${params.toString()}`,
     );
   };
 


### PR DESCRIPTION
## Summary

Eliminates the 5-step back-and-forth that's needed today to monitor a new system (create system → navigate to Health Checks → create config → navigate back to system → assignment IDE → "+"). Adds in-context creation in both directions:

- **From a system → create-and-assign in one shot.** New "+ Create new check" button on the system assignment IDE jumps to the create flow pre-targeted at that system; on save the new check is auto-assigned and the user is returned to the assignment IDE.
- **From the create flow → multi-assign on save.** New "Systems" tree node (under a new "Assignment" section) opens a searchable multi-select of systems; on `createConfiguration` success, fans out `associateSystem` with sensible defaults (`enabled: true`, `DEFAULT_STATE_THRESHOLDS`, `includeLocal: true`). Pre-selects the originating system when entered with `?systemId=`.
- **InfoBanner** in the Systems section reminds users that health checks are reusable templates, so the multi-select doesn't undermine the "configs are reusable" mental model.

Per-assignment knobs (thresholds, satellites, retention) still live in the per-system assignment IDE — this PR only touches the assign/disassociate dimension.

## Scoping notes

- **Create mode only.** Edit mode intentionally still hides the Systems node. Bulk re-assigning an existing config from the editor would need a diff-based save with confirm-on-disassociate (since disassociate silently drops per-system thresholds). Deferred until a clear use case shows up.
- **Schema/contracts unchanged.** No data model or API surface changes — purely UX wiring on top of existing `createConfiguration` + `associateSystem`.
- **No new tests.** `healthcheck-frontend` has no FE test infrastructure; standing it up was out of scope.

## Test plan

- [ ] **Happy path A (system-first):** Catalog → create system → open its assignment IDE → "+ Create new check" → strategy → fill form → save → lands back in assignment IDE with the new check assigned and enabled.
- [ ] **Happy path B (config-first):** Health Checks page → "+ Create Check" → strategy → fill form → click "Systems" node → multi-select 2-3 systems → save → toast says "assigned to N systems" → all selected systems show the assignment.
- [ ] **No-system case:** Create flow without selecting any systems → save → standard "Health check created" toast → lands on config list (existing behavior preserved).
- [ ] **Partial failure:** Force one `associateSystem` to fail (e.g., GitOps lock) → toast surfaces "X of N system assignments failed".
- [ ] **Edit mode:** Open existing config for edit → confirm Systems node is **not** present in the tree.
- [ ] **GitOps lock:** Locked system → "+ Create new check" button is hidden on assignment IDE.
- [ ] **Strategy picker forwarding:** Land on `/healthcheck/config/create?systemId=X` → pick strategy → editor URL retains `systemId=X` and Systems node has system X pre-selected.
- [ ] `bun run typecheck` passes (verified locally — all 117 packages clean).
- [ ] `bun run lint` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)