### PR TITLE
fix: resilient startup — topological afterPluginsReady, daily rollup upsert

### DIFF
--- a/.changeset/fix-plugin-loader-after-ready-order-and-retention-merge.md
+++ b/.changeset/fix-plugin-loader-after-ready-order-and-retention-merge.md
@@ -1,0 +1,29 @@
+---
+"@checkstack/backend": patch
+"@checkstack/healthcheck-backend": patch
+---
+
+fix: run afterPluginsReady in topological order; merge daily rollups on conflict
+
+Two resilience fixes for the dependency chain:
+
+1. **Plugin loader**: Phase 3 (`afterPluginsReady`) now iterates plugins
+   in the same topologically-sorted order as Phase 2 (`init`). Previously
+   it iterated `pendingInits` in registration order, which raced
+   subscription-spec dependencies — catalog's afterPluginsReady registers
+   `catalog.system` and `catalog.group` notification targets, and emitting
+   plugins (incident, maintenance, …) call `registerSubscriptionSpec`
+   against those targets in their own afterPluginsReady. With registration
+   order, an emitter could run before catalog and hit
+   `Target type catalog.group is not registered`. Sorted order encodes
+   the dependency via `spec.target.ownerPlugin`, so the emitter now
+   always runs after the target owner.
+
+2. **Healthcheck retention job**: the daily rollup now upserts
+   `health_check_aggregates` with `ON CONFLICT DO UPDATE` instead of a
+   plain insert. Previously, late-arriving hourly aggregates (e.g. from
+   a satellite that was offline when the prior rollup ran) would crash
+   the rollup with a unique-constraint violation on
+   `(configuration_id, system_id, bucket_start, bucket_size, source_id)`.
+   The merge sums counts and folds min/max/p95 into the existing daily
+   row.

--- a/core/backend/src/plugin-manager/plugin-loader.ts
+++ b/core/backend/src/plugin-manager/plugin-loader.ts
@@ -515,7 +515,15 @@ export async function loadPlugins({
       );
     }
   }
-  for (const p of pendingInits) {
+  // Run afterPluginsReady in topologically-sorted order, matching Phase
+  // 2 init order. Iterating `pendingInits` directly would use registration
+  // order, which races dependency chains: e.g. catalog's
+  // afterPluginsReady registers `catalog.group` as a notification target,
+  // and emitting plugins' afterPluginsReady call `registerSubscriptionSpec`
+  // against it — so the emitters MUST run after catalog. Topo order
+  // already encodes this dependency (via spec.target.ownerPlugin).
+  for (const id of sortedIds) {
+    const p = pendingInits.find((x) => x.metadata.pluginId === id)!;
     if (p.afterPluginsReady) {
       try {
         const resolvedDeps: Record<string, unknown> = {};

--- a/core/healthcheck-backend/src/retention-job.ts
+++ b/core/healthcheck-backend/src/retention-job.ts
@@ -6,7 +6,7 @@ import {
   healthCheckAggregates,
   DEFAULT_RETENTION_CONFIG,
 } from "./schema";
-import { eq, and, lt } from "drizzle-orm";
+import { eq, and, lt, sql } from "drizzle-orm";
 import type { QueueManager } from "@checkstack/queue-api";
 
 type Db = SafeDatabase<typeof schema>;
@@ -228,23 +228,59 @@ async function rollupHourlyAggregates(params: RollupParams) {
     const p95LatencyMs =
       p95Values.length > 0 ? Math.max(...p95Values) : undefined;
 
-    // Insert daily aggregate
-    await db.insert(healthCheckAggregates).values({
-      configurationId,
-      systemId,
-      bucketStart: bucket.bucketStart,
-      bucketSize: "daily",
-      runCount,
-      healthyCount,
-      degradedCount,
-      unhealthyCount,
-      latencySumMs: latencySumMs > 0 ? latencySumMs : undefined,
-      avgLatencyMs,
-      minLatencyMs,
-      maxLatencyMs,
-      p95LatencyMs,
-      aggregatedResult: undefined, // Cannot combine result across hours
-    });
+    // Upsert the daily aggregate. A row may already exist for this
+    // (configurationId, systemId, day, daily, sourceId=null) tuple if a
+    // prior rollup ran and then late-arriving hourly buckets (e.g. from
+    // a satellite that was offline) were rolled up afterwards. Merge in
+    // that case rather than crashing — sums add, min/max/p95 fold.
+    const newLatencySum = latencySumMs > 0 ? latencySumMs : undefined;
+    await db
+      .insert(healthCheckAggregates)
+      .values({
+        configurationId,
+        systemId,
+        bucketStart: bucket.bucketStart,
+        bucketSize: "daily",
+        runCount,
+        healthyCount,
+        degradedCount,
+        unhealthyCount,
+        latencySumMs: newLatencySum,
+        avgLatencyMs,
+        minLatencyMs,
+        maxLatencyMs,
+        p95LatencyMs,
+        aggregatedResult: undefined, // Cannot combine result across hours
+      })
+      .onConflictDoUpdate({
+        target: [
+          healthCheckAggregates.configurationId,
+          healthCheckAggregates.systemId,
+          healthCheckAggregates.bucketStart,
+          healthCheckAggregates.bucketSize,
+          healthCheckAggregates.sourceId,
+        ],
+        set: {
+          runCount: sql`${healthCheckAggregates.runCount} + ${runCount}`,
+          healthyCount: sql`${healthCheckAggregates.healthyCount} + ${healthyCount}`,
+          degradedCount: sql`${healthCheckAggregates.degradedCount} + ${degradedCount}`,
+          unhealthyCount: sql`${healthCheckAggregates.unhealthyCount} + ${unhealthyCount}`,
+          latencySumMs: sql`COALESCE(${healthCheckAggregates.latencySumMs}, 0) + ${newLatencySum ?? 0}`,
+          avgLatencyMs: sql`CASE WHEN (${healthCheckAggregates.runCount} + ${runCount}) > 0 THEN (COALESCE(${healthCheckAggregates.latencySumMs}, 0) + ${newLatencySum ?? 0}) / (${healthCheckAggregates.runCount} + ${runCount}) ELSE ${healthCheckAggregates.avgLatencyMs} END`,
+          minLatencyMs:
+            minLatencyMs === undefined
+              ? sql`${healthCheckAggregates.minLatencyMs}`
+              : sql`LEAST(COALESCE(${healthCheckAggregates.minLatencyMs}, ${minLatencyMs}), ${minLatencyMs})`,
+          maxLatencyMs:
+            maxLatencyMs === undefined
+              ? sql`${healthCheckAggregates.maxLatencyMs}`
+              : sql`GREATEST(COALESCE(${healthCheckAggregates.maxLatencyMs}, ${maxLatencyMs}), ${maxLatencyMs})`,
+          p95LatencyMs:
+            p95LatencyMs === undefined
+              ? sql`${healthCheckAggregates.p95LatencyMs}`
+              : sql`GREATEST(COALESCE(${healthCheckAggregates.p95LatencyMs}, ${p95LatencyMs}), ${p95LatencyMs})`,
+        },
+      });
 
     // Delete processed hourly aggregates
     for (const hourly of bucket.aggregates) {


### PR DESCRIPTION
## Summary

Two resilience fixes uncovered by container restarts on the notification-target branch:

- **Plugin loader Phase 3 was racing the spec dependency chain.** `afterPluginsReady` iterated `pendingInits` in registration order rather than the topologically-sorted ids used by Phase 2. Catalog's `afterPluginsReady` registers `catalog.system` and `catalog.group` notification targets; emitter plugins (incident, maintenance, …) call `registerSubscriptionSpec` against those targets in their own `afterPluginsReady`. With the wrong order, an emitter could run before catalog and crash with `Target type catalog.group is not registered`. Phase 3 now iterates `sortedIds`.

- **Healthcheck retention job crashed on late-arriving hourly buckets.** Daily rollup did a plain `INSERT` and hit `health_check_aggregates_bucket_unique` when a daily row already existed (typical when a satellite was offline during the prior rollup, then hourlies for an already-rolled day appear later). Now uses `onConflictDoUpdate` — counts sum, latency sum/avg recompute, min/max/p95 fold via `LEAST/GREATEST`.

## Test plan

- [ ] Container boots cleanly with no `Target type X is not registered` errors during initial init or restarts
- [ ] `bun run typecheck` and `bun run lint` pass (verified locally)
- [ ] Retention job tolerates re-running over a day that already has a daily aggregate (existing row's counts grow, min/max/p95 stay sane)
- [ ] Existing realtime hourly aggregation still works (uses the same upsert pattern, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)