### PR TITLE
Better BASE_URL misconfig hint + fix stale changeset target

### DIFF
--- a/.changeset/base-url-error-suggestion.md
+++ b/.changeset/base-url-error-suggestion.md
@@ -1,0 +1,5 @@
+---
+"@checkstack/frontend": patch
+---
+
+fix: suggest a `BASE_URL` value derived from the URL the user actually opened on the misconfiguration error screen, instead of always recommending `http://localhost:3000`. Makes the diagnostic actionable when the app is reached over a LAN IP, custom port, or proxied domain.

--- a/.changeset/typecheck-tsgo-references.md
+++ b/.changeset/typecheck-tsgo-references.md
@@ -1,5 +1,5 @@
 ---
-"checkstack-monorepo": patch
+"@checkstack/tsconfig": patch
 ---
 
 build: switch typecheck to tsgo with project references (~4× cold, ~200× warm)

--- a/core/frontend/src/App.tsx
+++ b/core/frontend/src/App.tsx
@@ -249,6 +249,13 @@ function AppWithApis() {
   // Config probe failed — baseUrl is not reachable (misconfigured BASE_URL).
   // Surface a clear diagnostic rather than a broken empty dashboard.
   if (!runtimeConfig || configError) {
+    // Derive the suggested BASE_URL from the URL the user actually has open
+    // in their browser — that's almost certainly the value they want.
+    const suggestedBaseUrl =
+      globalThis.window !== undefined && globalThis.location?.origin
+        ? globalThis.location.origin
+        : "http://localhost:3000";
+
     return (
       <div className="h-screen flex items-center justify-center bg-background p-8">
         <div className="max-w-lg w-full rounded-xl border border-destructive/50 bg-destructive/10 p-8 space-y-4 text-center">
@@ -264,9 +271,9 @@ function AppWithApis() {
           </p>
           <div className="text-left bg-muted rounded-lg p-4 space-y-1 text-sm font-mono">
             <p className="text-muted-foreground">
-              # For a default Docker setup:
+              # Based on the URL you opened, try:
             </p>
-            <p className="text-foreground">BASE_URL=http://localhost:3000</p>
+            <p className="text-foreground">BASE_URL={suggestedBaseUrl}</p>
           </div>
           <p className="text-sm text-muted-foreground">
             After updating your{" "}


### PR DESCRIPTION
## Summary
- BASE_URL error screen now derives the suggested value from `window.location.origin` (the URL the user actually opened) instead of always hinting `http://localhost:3000`. Useful when reaching the app over a LAN IP, custom port, or proxied domain.
- Retargets `.changeset/typecheck-tsgo-references.md` from the non-workspace root package `checkstack-monorepo` to `@checkstack/tsconfig`, which was breaking the Changesets release PR job (`Found changeset typecheck-tsgo-references for package checkstack-monorepo which is not in the workspace`).
- Adds a patch changeset for `@checkstack/frontend`.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bunx @changesets/cli status` runs without the previous "not in the workspace" error
- [ ] Manually trigger BASE_URL error screen (e.g. visit via host that doesn't match `BASE_URL`) and confirm suggestion reflects current origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)