### PR TITLE
feat: GitOps optimizations — source link + anomaly/SLO/satellite/dependency kinds

### DIFF
--- a/.changeset/gitops-anomaly-extensions.md
+++ b/.changeset/gitops-anomaly-extensions.md
@@ -1,0 +1,24 @@
+---
+"@checkstack/anomaly-backend": minor
+---
+
+Add GitOps extensions for declarative anomaly configuration.
+
+Two extensions are now registered against the kind registry:
+
+- `Healthcheck.anomaly` — accepts the full `AnomalySettings` shape and
+  applies it to the healthcheck's anomaly template via
+  `updateAnomalyConfig` on reconcile.
+- `System.anomaly` — accepts an array of per-healthcheck overrides,
+  each scoped via `healthcheckRef: { kind: Healthcheck, name: ... }`,
+  and applies them with `updateAnomalyAssignmentConfig`. The
+  healthcheck reference is the GitOps source of truth; UI edits to
+  managed entries are blocked by the existing assignment-level lock.
+
+Spec schema documentation for `Healthcheck.anomaly.fieldOverrides` is
+registered **per collector field**, conditioned on the selected
+`collectors[].config` variant — same pattern the `collectors[].assertions`
+docs use, so the kind-registry browser pre-populates the available
+result fields once a collector is chosen. The System extension's
+`fieldOverrides` falls back to a generic variant since the relevant
+collector lives on the referenced Healthcheck rather than a sibling.

--- a/.changeset/gitops-satellite-kind.md
+++ b/.changeset/gitops-satellite-kind.md
@@ -1,0 +1,31 @@
+---
+"@checkstack/satellite-common": minor
+"@checkstack/satellite-backend": minor
+"@checkstack/satellite-frontend": minor
+---
+
+Add a GitOps `Satellite` kind plus a UI affordance for resetting tokens.
+
+GitOps owns satellite **metadata only** — `metadata.name`,
+`spec.region`, and `metadata.labels` (used as the satellite's runtime
+tags). The bcrypt token is intentionally never expressed in YAML; on
+first reconcile a satellite is created with a random token that is
+discarded, and operators must use the Satellites page to retrieve a
+working credential.
+
+To support that flow:
+
+- New service methods: `updateSatelliteMetadata`, `rotateSatelliteToken`,
+  `getSatelliteByName`.
+- New RPC procs: `updateSatellite`, `rotateSatelliteToken`.
+- New `RotateSatelliteTokenDialog` and a "Reset token" key icon on the
+  Satellites list. The dialog reuses the one-time-reveal layout from
+  `CreateSatelliteDialog`.
+- The Satellites list shows a `GitOpsSourceBadge` next to managed
+  satellites and disables the delete button while leaving the
+  token-reset button enabled (so operators can always re-issue a
+  credential without touching YAML).
+
+The satellite kind reconciler adopts pre-existing satellites by name on
+first sync, so this is safe to roll out against installations that
+already have manually-created satellites.

--- a/.changeset/gitops-slo-kind.md
+++ b/.changeset/gitops-slo-kind.md
@@ -1,0 +1,26 @@
+---
+"@checkstack/slo-backend": minor
+---
+
+Add a GitOps `SLO` kind so reliability targets can be declared in YAML.
+
+The kind references its target system via `systemRef` and may optionally
+narrow to a single healthcheck via `healthcheckRef`. Excluded
+dependencies are referenced by ref and resolved to system IDs at
+reconcile time.
+
+```yaml
+apiVersion: checkstack.io/v1alpha1
+kind: SLO
+metadata:
+  name: payments-availability
+spec:
+  systemRef: { kind: System, name: payments-api }
+  target: 99.9
+  windowDays: 30
+```
+
+Reconcile maps to `SloService.createObjective` /
+`updateObjective` / `deleteObjective`; the entity ID stored in
+provenance is the SLO objective UUID, so renames in YAML preserve
+identity.

--- a/.changeset/gitops-source-link-popover.md
+++ b/.changeset/gitops-source-link-popover.md
@@ -1,0 +1,27 @@
+---
+"@checkstack/gitops-common": minor
+"@checkstack/gitops-backend": minor
+"@checkstack/gitops-frontend": minor
+"@checkstack/catalog-frontend": patch
+---
+
+Surface the source repository for GitOps-managed entities and gate the
+system→group remove button on the system's lock state.
+
+- `provenanceSchema` now carries a `sourceUrl` field, derived on the
+  backend from the provider type, baseUrl, repository and filePath. URLs
+  are constructed for github.com / gitlab.com and self-hosted
+  GitHub/GitLab where the API base ends in `/api/v3` or `/api/v4`. Other
+  baseUrls fall back to `null` so the UI keeps showing the raw path.
+- New `useProvenanceLocks` hook (bulk variant of `useProvenanceLock`)
+  for views that render many entities and need to look up locks
+  client-side.
+- New `<GitOpsSourceBadge>` popover component that replaces the bare
+  GitBranch icon on system and group catalog cards. The popover
+  surfaces the repository, file path, and a "View in source provider"
+  deep link.
+- `<GitOpsLockBanner>` repo line is now a real link when a sourceUrl is
+  available.
+- The system→group remove button in the catalog now disables itself
+  when the system is GitOps-managed, matching the backend lock that was
+  already in place.

--- a/.changeset/gitops-system-dependencies.md
+++ b/.changeset/gitops-system-dependencies.md
@@ -1,0 +1,36 @@
+---
+"@checkstack/dependency-backend": minor
+"@checkstack/dependency-frontend": minor
+---
+
+Add a GitOps `System.dependencies` extension and lock the matching UI.
+
+Each entry references an upstream system by ref and tunes the impact:
+
+```yaml
+apiVersion: checkstack.io/v1alpha1
+kind: System
+metadata: { name: payments-api }
+spec:
+  dependencies:
+    - targetRef: { kind: System, name: payments-db }
+      impactType: critical
+      transitive: false
+      label: "primary store"
+```
+
+The reconciler diffs the YAML-declared edges against the persisted ones
+where this system is the source and converges via
+create / update / delete. GitOps is the source of truth, so any edges
+no longer listed are removed. Refs that resolve to the source system
+itself are rejected; refs that fail to resolve abort the diff before
+any mutation.
+
+UI gates:
+
+- The `DependencyEditor` (system editor drawer) hides Add and disables
+  Edit/Delete on upstream rows when the source system is GitOps-managed.
+  Downstream rows are gated per-row by the *other* system's lock.
+- The `DependencyMap` blocks `onConnect` when the source is locked,
+  surfaces a "Managed by GitOps" notice in the edge editor panel, and
+  disables Save/Delete there.

--- a/bun.lock
+++ b/bun.lock
@@ -128,6 +128,8 @@
         "@checkstack/catalog-backend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
+        "@checkstack/gitops-backend": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
         "@checkstack/healthcheck-backend": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
         "@checkstack/notification-common": "workspace:*",
@@ -609,6 +611,8 @@
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/dependency-common": "workspace:*",
+        "@checkstack/gitops-backend": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
         "@checkstack/healthcheck-backend": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
         "@checkstack/incident-common": "workspace:*",
@@ -656,6 +660,8 @@
         "@checkstack/dashboard-frontend": "workspace:*",
         "@checkstack/dependency-common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
+        "@checkstack/gitops-frontend": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
         "@checkstack/signal-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
@@ -673,7 +679,7 @@
     },
     "core/dev-server": {
       "name": "@checkstack/dev-server",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "checkstack-dev": "./src/dev-server.ts",
       },
@@ -1327,7 +1333,7 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.80.0",
+      "version": "0.81.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
@@ -1350,6 +1356,8 @@
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
+        "@checkstack/gitops-backend": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
         "@checkstack/healthcheck-backend": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
         "@checkstack/queue-api": "workspace:*",
@@ -1391,6 +1399,8 @@
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
+        "@checkstack/gitops-frontend": "workspace:*",
         "@checkstack/satellite-common": "workspace:*",
         "@checkstack/signal-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
@@ -1407,7 +1417,7 @@
     },
     "core/scripts": {
       "name": "@checkstack/scripts",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bin": {
         "checkstack-scripts": "./src/cli.ts",
       },
@@ -1481,6 +1491,8 @@
         "@checkstack/command-backend": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/dependency-common": "workspace:*",
+        "@checkstack/gitops-backend": "workspace:*",
+        "@checkstack/gitops-common": "workspace:*",
         "@checkstack/healthcheck-backend": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
         "@checkstack/integration-backend": "workspace:*",

--- a/core/anomaly-backend/package.json
+++ b/core/anomaly-backend/package.json
@@ -24,6 +24,8 @@
     "@checkstack/cache-utils": "workspace:*",
     "@checkstack/healthcheck-backend": "workspace:*",
     "@checkstack/catalog-backend": "workspace:*",
+    "@checkstack/gitops-backend": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
     "@checkstack/catalog-common": "workspace:*",
     "@checkstack/notification-common": "workspace:*",
     "drizzle-orm": "^0.45.0",

--- a/core/anomaly-backend/src/anomaly-gitops-kinds.test.ts
+++ b/core/anomaly-backend/src/anomaly-gitops-kinds.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { ReconcileContext } from "@checkstack/gitops-common";
+import type { AnomalyService } from "./service";
+import {
+  buildHealthcheckAnomalyExtension,
+  buildSystemAnomalyExtension,
+} from "./anomaly-gitops-kinds";
+
+/**
+ * Reconcile-time tests for the anomaly-backend GitOps kind extensions.
+ *
+ * Exercises the `Healthcheck.anomaly` and `System.anomalyExceptions`
+ * extensions in isolation against a stub AnomalyService.
+ */
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const buildContext = (
+  overrides: Partial<ReconcileContext> = {},
+): ReconcileContext =>
+  ({
+    logger: noopLogger,
+    resolveEntityRef: async () => undefined,
+    resolveSecretsBySchema: async ({ value }) => ({
+      resolved: value,
+      warnings: [],
+    }),
+    ...overrides,
+  }) as ReconcileContext;
+
+const stubService = () => {
+  const updateAnomalyConfig = mock(async () => ({}));
+  const updateAnomalyAssignmentConfig = mock(async () => ({}));
+  return {
+    updateAnomalyConfig,
+    updateAnomalyAssignmentConfig,
+    service: {
+      updateAnomalyConfig,
+      updateAnomalyAssignmentConfig,
+    } as unknown as AnomalyService,
+  };
+};
+
+describe("buildHealthcheckAnomalyExtension", () => {
+  let stub: ReturnType<typeof stubService>;
+  let extension: ReturnType<typeof buildHealthcheckAnomalyExtension>;
+
+  beforeEach(() => {
+    stub = stubService();
+    extension = buildHealthcheckAnomalyExtension({
+      getService: () => stub.service,
+    });
+  });
+
+  it("registers under the right kind/namespace", () => {
+    expect(extension.kind).toBe("Healthcheck");
+    expect(extension.namespace).toBe("anomaly");
+  });
+
+  it("calls updateAnomalyConfig with the spec when present", async () => {
+    await extension.reconcile({
+      entity: {} as never,
+      extensionSpec: {
+        enabled: false,
+        sensitivity: 2,
+        confirmationWindow: 5,
+        baselineWindow: "14d",
+        notify: false,
+        driftEnabled: false,
+        driftThreshold: 3,
+      },
+      entityId: "hc-1",
+      context: buildContext(),
+    });
+    expect(stub.updateAnomalyConfig).toHaveBeenCalledTimes(1);
+    expect(stub.updateAnomalyConfig).toHaveBeenCalledWith("hc-1", {
+      enabled: false,
+      sensitivity: 2,
+      confirmationWindow: 5,
+      baselineWindow: "14d",
+      notify: false,
+      driftEnabled: false,
+      driftThreshold: 3,
+    });
+  });
+
+  it("is a no-op when extensionSpec is undefined", async () => {
+    await extension.reconcile({
+      entity: {} as never,
+      extensionSpec: undefined,
+      entityId: "hc-1",
+      context: buildContext(),
+    });
+    expect(stub.updateAnomalyConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildSystemAnomalyExtension", () => {
+  let stub: ReturnType<typeof stubService>;
+  let extension: ReturnType<typeof buildSystemAnomalyExtension>;
+
+  beforeEach(() => {
+    stub = stubService();
+    extension = buildSystemAnomalyExtension({
+      getService: () => stub.service,
+    });
+  });
+
+  it("registers on the System kind under namespace 'anomaly'", () => {
+    expect(extension.kind).toBe("System");
+    expect(extension.namespace).toBe("anomaly");
+  });
+
+  it("resolves each healthcheckRef and writes assignment overrides", async () => {
+    const refMap: Record<string, string> = {
+      "hc-cpu": "cfg-cpu",
+      "hc-mem": "cfg-mem",
+    };
+
+    await extension.reconcile({
+      entity: {} as never,
+      extensionSpec: [
+        {
+          healthcheckRef: { kind: "Healthcheck", name: "hc-cpu" },
+          enabled: false,
+          fieldOverrides: {
+            "cpu.usage": { sensitivity: 0.5 },
+          },
+        },
+        {
+          healthcheckRef: { kind: "Healthcheck", name: "hc-mem" },
+          driftThreshold: 5,
+        },
+      ],
+      entityId: "sys-1",
+      context: buildContext({
+        resolveEntityRef: async ({ entityName }) => refMap[entityName],
+      }),
+    });
+
+    expect(stub.updateAnomalyAssignmentConfig).toHaveBeenCalledTimes(2);
+    expect(stub.updateAnomalyAssignmentConfig).toHaveBeenNthCalledWith(
+      1,
+      "sys-1",
+      "cfg-cpu",
+      {
+        enabled: false,
+        fieldOverrides: { "cpu.usage": { sensitivity: 0.5 } },
+      },
+    );
+    expect(stub.updateAnomalyAssignmentConfig).toHaveBeenNthCalledWith(
+      2,
+      "sys-1",
+      "cfg-mem",
+      { driftThreshold: 5 },
+    );
+  });
+
+  it("throws when a healthcheck ref cannot be resolved", async () => {
+    await expect(
+      extension.reconcile({
+        entity: {} as never,
+        extensionSpec: [
+          {
+            healthcheckRef: { kind: "Healthcheck", name: "missing" },
+            enabled: false,
+          },
+        ],
+        entityId: "sys-1",
+        context: buildContext({
+          resolveEntityRef: async () => undefined,
+        }),
+      }),
+    ).rejects.toThrow(/Cannot resolve Healthcheck ref "missing"/);
+  });
+
+  it("is a no-op for empty/undefined specs", async () => {
+    await extension.reconcile({
+      entity: {} as never,
+      extensionSpec: [],
+      entityId: "sys-1",
+      context: buildContext(),
+    });
+    await extension.reconcile({
+      entity: {} as never,
+      extensionSpec: undefined,
+      entityId: "sys-1",
+      context: buildContext(),
+    });
+    expect(stub.updateAnomalyAssignmentConfig).not.toHaveBeenCalled();
+  });
+});

--- a/core/anomaly-backend/src/anomaly-gitops-kinds.ts
+++ b/core/anomaly-backend/src/anomaly-gitops-kinds.ts
@@ -1,0 +1,238 @@
+import { z } from "zod";
+import {
+  CHECKSTACK_API_VERSION,
+  type EntityKindExtensionDefinition,
+  type EntityKindRegistry,
+  type ReconcileContext,
+} from "@checkstack/gitops-common";
+import {
+  AnomalySettingsSchema,
+  AnomalyFieldConfigSchema,
+} from "@checkstack/anomaly-common";
+import type { CollectorRegistry } from "@checkstack/backend-api";
+import type { AnomalyService } from "./service";
+
+interface AnomalyGitOpsKindsDeps {
+  /**
+   * Lazy accessor — populated during init(), invoked at reconcile time.
+   * Mirrors the pattern healthcheck-backend uses to expose its service to
+   * the GitOps reconciler without bleeding init order into kind registration.
+   */
+  getService: () => AnomalyService;
+}
+
+// ─── Shared schemas ─────────────────────────────────────────────────────────
+
+/**
+ * A reference to a Healthcheck entity. Constrained so YAML callers can't
+ * accidentally point an anomaly override at a non-Healthcheck kind.
+ */
+const healthcheckRefSchema = z
+  .object({
+    kind: z.literal("Healthcheck"),
+    name: z.string().min(1),
+  })
+  .describe("Reference to the Healthcheck this anomaly override applies to.");
+
+// ─── Healthcheck → anomaly extension ────────────────────────────────────────
+//
+// Declares the *template-level* AnomalySettings for a Healthcheck. GitOps is
+// the source of truth, so the entire AnomalySettings record is replaced.
+
+const healthcheckAnomalyExtensionSchema = AnomalySettingsSchema.optional();
+type HealthcheckAnomalyExtension = z.infer<
+  typeof healthcheckAnomalyExtensionSchema
+>;
+
+export function buildHealthcheckAnomalyExtension(
+  deps: AnomalyGitOpsKindsDeps,
+): EntityKindExtensionDefinition<HealthcheckAnomalyExtension> {
+  return {
+    apiVersion: CHECKSTACK_API_VERSION,
+    kind: "Healthcheck",
+    namespace: "anomaly",
+    specSchema: healthcheckAnomalyExtensionSchema,
+
+    reconcile: async ({
+      extensionSpec,
+      entityId,
+      context,
+    }: {
+      extensionSpec: HealthcheckAnomalyExtension;
+      entityId: string;
+      context: ReconcileContext;
+    }) => {
+      if (!extensionSpec) return;
+      await deps.getService().updateAnomalyConfig(entityId, extensionSpec);
+      context.logger.info(
+        `GitOps: applied anomaly defaults to Healthcheck (id: ${entityId})`,
+      );
+    },
+  };
+}
+
+// ─── System → anomaly extension ─────────────────────────────────────────────
+//
+// Declares per-assignment AnomalySettings overrides ("exceptions"), keyed by
+// healthcheck ref. Lives under namespace `anomaly` on the System kind so the
+// YAML naming mirrors the Healthcheck.anomaly extension.
+
+const systemAnomalyEntrySchema = z.object({
+  healthcheckRef: healthcheckRefSchema,
+  enabled: z.boolean().optional(),
+  sensitivity: z.number().optional(),
+  confirmationWindow: z.number().int().optional(),
+  baselineWindow: z.string().optional(),
+  notify: z.boolean().optional(),
+  driftEnabled: z.boolean().optional(),
+  driftThreshold: z.number().optional(),
+  fieldOverrides: z.record(z.string(), AnomalyFieldConfigSchema).optional(),
+});
+
+const systemAnomalyExtensionSchema = z.array(systemAnomalyEntrySchema).optional();
+
+type SystemAnomalyExtension = z.infer<typeof systemAnomalyExtensionSchema>;
+
+export function buildSystemAnomalyExtension(
+  deps: AnomalyGitOpsKindsDeps,
+): EntityKindExtensionDefinition<SystemAnomalyExtension> {
+  return {
+    apiVersion: CHECKSTACK_API_VERSION,
+    kind: "System",
+    namespace: "anomaly",
+    specSchema: systemAnomalyExtensionSchema,
+
+    reconcile: async ({
+      extensionSpec,
+      entityId,
+      context,
+    }: {
+      extensionSpec: SystemAnomalyExtension;
+      entityId: string;
+      context: ReconcileContext;
+    }) => {
+      if (!extensionSpec || extensionSpec.length === 0) return;
+
+      const service = deps.getService();
+      const systemId = entityId;
+
+      for (const entry of extensionSpec) {
+        const configurationId = await context.resolveEntityRef({
+          kind: entry.healthcheckRef.kind,
+          entityName: entry.healthcheckRef.name,
+        });
+        if (!configurationId) {
+          throw new Error(
+            `Cannot resolve Healthcheck ref "${entry.healthcheckRef.name}" — anomaly overrides require the healthcheck to exist`,
+          );
+        }
+
+        const { healthcheckRef: _ref, ...overrides } = entry;
+        void _ref;
+
+        await service.updateAnomalyAssignmentConfig(
+          systemId,
+          configurationId,
+          overrides,
+        );
+
+        context.logger.info(
+          `GitOps: applied anomaly overrides for Healthcheck "${entry.healthcheckRef.name}" on System (id: ${systemId})`,
+        );
+      }
+    },
+  };
+}
+
+// ─── Documentation ──────────────────────────────────────────────────────────
+
+/**
+ * Mirrors the unwrap helper in healthcheck-gitops-kinds — peels Optional /
+ * Nullable / Default wrappers so we can introspect a collector's result
+ * shape and enumerate its field names.
+ */
+function unwrapZodType(type: z.ZodTypeAny): z.ZodTypeAny {
+  let current = type;
+  while (current) {
+    if (current instanceof z.ZodOptional || current instanceof z.ZodNullable) {
+      current = current.unwrap() as z.ZodTypeAny;
+    } else if (current instanceof z.ZodDefault) {
+      current = current._def.innerType as z.ZodTypeAny;
+    } else if ("innerType" in current && typeof current.innerType === "function") {
+      current = current.innerType() as z.ZodTypeAny;
+    } else {
+      break;
+    }
+  }
+  return current;
+}
+
+/**
+ * Register schema documentation for the anomaly extensions. Called from
+ * anomaly-backend's `afterPluginsReady` once the kind registry and the
+ * collector registry have been populated.
+ *
+ * The Healthcheck.anomaly.fieldOverrides documentation is registered
+ * **per collector field**: each variant is gated on the matching
+ * collectors[].config selection so the kind-registry browser can pre-populate
+ * the available result fields once the user picks a collector.
+ *
+ * The System.anomaly[].fieldOverrides path can't be conditioned on a sibling
+ * config (the collector lives on the referenced Healthcheck, not on the
+ * System spec), so it falls back to a generic AnomalyFieldConfig variant.
+ */
+export function registerAnomalyGitOpsDocumentation({
+  kindRegistry,
+  collectorRegistry,
+}: {
+  kindRegistry: EntityKindRegistry;
+  collectorRegistry: CollectorRegistry;
+}): void {
+  // Per-collector, per-field variants conditioned on the chosen collector.
+  for (const registered of collectorRegistry.getCollectors()) {
+    const unwrapped = unwrapZodType(registered.collector.result.schema);
+    if (!(unwrapped instanceof z.ZodObject)) continue;
+
+    for (const fieldName of Object.keys(unwrapped.shape)) {
+      kindRegistry.registerSpecSchemaDocumentation({
+        apiVersion: CHECKSTACK_API_VERSION,
+        kind: "Healthcheck",
+        fieldPath: "anomaly.fieldOverrides",
+        variantId: `${registered.qualifiedId}.field.${fieldName}`,
+        label: `Field: ${fieldName}`,
+        description: `Anomaly engine override for the "${fieldName}" result field of ${registered.collector.displayName}. The map key is "${fieldName}".`,
+        schema: AnomalyFieldConfigSchema,
+        conditions: [
+          {
+            fieldPath: "collectors[].config",
+            variantIds: [registered.qualifiedId],
+          },
+        ],
+      });
+    }
+  }
+
+  // Generic fallback for the System extension — the relevant collector lives
+  // on the referenced Healthcheck, so we can't gate on a sibling.
+  kindRegistry.registerSpecSchemaDocumentation({
+    apiVersion: CHECKSTACK_API_VERSION,
+    kind: "System",
+    fieldPath: "anomaly[].fieldOverrides",
+    label: "Anomaly field override",
+    description:
+      "Per-result-field overrides applied to the System ↔ Healthcheck assignment. The map key is the field path of the referenced healthcheck's result (e.g. \"cpu.usage\", \"latencyMs\").",
+    schema: AnomalyFieldConfigSchema,
+  });
+}
+
+// ─── Registration entry point ───────────────────────────────────────────────
+
+export function registerAnomalyGitOpsKinds({
+  kindRegistry,
+  ...deps
+}: AnomalyGitOpsKindsDeps & {
+  kindRegistry: EntityKindRegistry;
+}): void {
+  kindRegistry.registerKindExtension(buildHealthcheckAnomalyExtension(deps));
+  kindRegistry.registerKindExtension(buildSystemAnomalyExtension(deps));
+}

--- a/core/anomaly-backend/src/plugin.ts
+++ b/core/anomaly-backend/src/plugin.ts
@@ -16,6 +16,11 @@ import {
 } from "@checkstack/anomaly-common";
 import { specToRegistration } from "@checkstack/notification-common";
 import { HealthCheckApi } from "@checkstack/healthcheck-common";
+import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
+import {
+  registerAnomalyGitOpsKinds,
+  registerAnomalyGitOpsDocumentation,
+} from "./anomaly-gitops-kinds";
 
 import { definePluginMetadata } from "@checkstack/common";
 
@@ -36,6 +41,20 @@ export const plugin = createBackendPlugin({
     ]);
 
     let routerCache: AnomalyRouterCache | undefined;
+
+    // ─── GitOps Entity Kind Registration ─────────────────────────────
+    // Mutable ref populated during init(); the reconciler closure pulls
+    // the service via the lazy accessor at sync time.
+    let gitopsService: AnomalyService | undefined;
+    const kindRegistry = env.getExtensionPoint(entityKindExtensionPoint);
+    registerAnomalyGitOpsKinds({
+      kindRegistry,
+      getService: () => {
+        if (!gitopsService)
+          throw new Error("AnomalyService not initialized");
+        return gitopsService;
+      },
+    });
 
     env.registerInit({
       schema,
@@ -71,6 +90,7 @@ export const plugin = createBackendPlugin({
         });
 
         const service = new AnomalyService(typedDb);
+        gitopsService = service;
         routerCache = createAnomalyRouterCache({ cacheManager, logger });
         const router = createRouter(service, logger, routerCache);
         rpc.registerRouter(router, anomalyContract);
@@ -96,6 +116,14 @@ export const plugin = createBackendPlugin({
             specToRegistration(anomalyGroupSubscription),
           ),
         ]);
+
+        // GitOps spec-schema docs need the collector registry to be
+        // populated so we can enumerate per-collector result fields and
+        // register conditional variants under `anomaly.fieldOverrides`.
+        registerAnomalyGitOpsDocumentation({
+          kindRegistry,
+          collectorRegistry,
+        });
 
         onHook(healthCheckHooks.checkCompleted, async (payload) => {
           await processCheckCompleted({

--- a/core/anomaly-backend/tsconfig.json
+++ b/core/anomaly-backend/tsconfig.json
@@ -29,6 +29,12 @@
       "path": "../drizzle-helper"
     },
     {
+      "path": "../gitops-backend"
+    },
+    {
+      "path": "../gitops-common"
+    },
+    {
       "path": "../healthcheck-backend"
     },
     {

--- a/core/catalog-frontend/src/components/DraggableSystem.tsx
+++ b/core/catalog-frontend/src/components/DraggableSystem.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
 import { useDraggable } from "@dnd-kit/core";
-import { GripVertical, Edit, Trash2, FolderPlus, GitBranch } from "lucide-react";
+import { GripVertical, Edit, Trash2, FolderPlus } from "lucide-react";
 import { Button } from "@checkstack/ui";
 import { ExtensionSlot } from "@checkstack/frontend-api";
 import { CatalogSystemActionsSlot } from "@checkstack/catalog-common";
-import { useProvenanceLock } from "@checkstack/gitops-frontend";
+import {
+  useProvenanceLock,
+  GitOpsSourceBadge,
+} from "@checkstack/gitops-frontend";
 import type { Group, System } from "../api";
 
 interface DraggableSystemProps {
@@ -39,7 +42,7 @@ export const DraggableSystem = ({
 }: DraggableSystemProps) => {
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
-  const { isLocked } = useProvenanceLock({
+  const { isLocked, provenance } = useProvenanceLock({
     kind: "System",
     entityId: system.id,
   });
@@ -58,23 +61,23 @@ export const DraggableSystem = ({
     >
       {/* Main row: grip + name/description */}
       <div className="flex items-start gap-2 p-3 pb-2">
-        {/* Grip handle — only this element triggers the drag */}
-        <div
-          {...listeners}
-          {...attributes}
-          className={`flex-shrink-0 mt-0.5 text-muted-foreground/40 touch-none ${
-            isLocked
-              ? "cursor-not-allowed opacity-30"
-              : "cursor-grab active:cursor-grabbing hover:text-muted-foreground"
-          }`}
-          aria-label={isLocked ? `${system.name} is managed by GitOps` : `Drag ${system.name}`}
-        >
-          {isLocked ? (
-            <GitBranch className="w-4 h-4 text-primary" />
-          ) : (
+        {/* Grip handle — only this element triggers the drag.
+            When GitOps-locked, swap in the source badge so users can click
+            through to the file that owns this system. */}
+        {isLocked && provenance ? (
+          <div className="flex-shrink-0 mt-0.5">
+            <GitOpsSourceBadge provenance={provenance} />
+          </div>
+        ) : (
+          <div
+            {...listeners}
+            {...attributes}
+            className="flex-shrink-0 mt-0.5 text-muted-foreground/40 touch-none cursor-grab active:cursor-grabbing hover:text-muted-foreground"
+            aria-label={`Drag ${system.name}`}
+          >
             <GripVertical className="w-4 h-4" />
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Name + description — gets all remaining width, never truncated */}
         <div className="flex-1 min-w-0">

--- a/core/catalog-frontend/src/components/DroppableGroup.tsx
+++ b/core/catalog-frontend/src/components/DroppableGroup.tsx
@@ -1,7 +1,11 @@
 import { useDroppable } from "@dnd-kit/core";
 import { EditableText, Button } from "@checkstack/ui";
-import { Trash2, GitBranch } from "lucide-react";
-import { useProvenanceLock } from "@checkstack/gitops-frontend";
+import { Trash2 } from "lucide-react";
+import {
+  useProvenanceLock,
+  useProvenanceLocks,
+  GitOpsSourceBadge,
+} from "@checkstack/gitops-frontend";
 import type { Group, System } from "../api";
 
 interface DroppableGroupProps {
@@ -36,10 +40,12 @@ export const DroppableGroup = ({
 }: DroppableGroupProps) => {
   const { setNodeRef } = useDroppable({ id: group.id });
 
-  const { isLocked } = useProvenanceLock({
+  const { isLocked, provenance } = useProvenanceLock({
     kind: "Group",
     entityId: group.id,
   });
+
+  const { getLock } = useProvenanceLocks();
 
   const groupSystems = (group.systemIds ?? [])
     .map((sysId) => systems.find((s) => s.id === sysId))
@@ -63,10 +69,8 @@ export const DroppableGroup = ({
       {/* Group header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 flex-1">
-          {isLocked && (
-            <span title="Managed by GitOps">
-              <GitBranch className="w-4 h-4 text-primary shrink-0" />
-            </span>
+          {isLocked && provenance && (
+            <GitOpsSourceBadge provenance={provenance} />
           )}
           <div className="flex-1">
             <EditableText
@@ -110,6 +114,8 @@ export const DroppableGroup = ({
         <div className="pl-2 space-y-1">
           {groupSystems.map((sys) => {
             const isNew = newlyAddedSystemId === sys.id;
+            const systemLock = getLock({ kind: "System", entityId: sys.id });
+            const systemLocked = systemLock.isLocked;
             return (
               <div
                 key={sys.id}
@@ -119,11 +125,25 @@ export const DroppableGroup = ({
                     : "border-border shadow-none"
                 }`}
               >
-                <span className="text-foreground truncate">{sys.name}</span>
+                <span className="text-foreground truncate flex items-center gap-1.5">
+                  {systemLocked && systemLock.provenance ? (
+                    <GitOpsSourceBadge
+                      provenance={systemLock.provenance}
+                      iconClassName="w-3 h-3 text-primary"
+                    />
+                  ) : null}
+                  {sys.name}
+                </span>
                 <Button
                   variant="ghost"
                   className="text-destructive/60 hover:text-destructive h-6 w-6 p-0 flex-shrink-0"
                   onClick={() => onRemoveSystem(group.id, sys.id)}
+                  disabled={systemLocked}
+                  title={
+                    systemLocked
+                      ? "Managed by GitOps"
+                      : `Remove ${sys.name} from ${group.name}`
+                  }
                   aria-label={`Remove ${sys.name} from ${group.name}`}
                 >
                   <Trash2 className="w-3 h-3" />

--- a/core/dependency-backend/package.json
+++ b/core/dependency-backend/package.json
@@ -24,6 +24,8 @@
     "@checkstack/incident-common": "workspace:*",
     "@checkstack/notification-common": "workspace:*",
     "@checkstack/signal-common": "workspace:*",
+    "@checkstack/gitops-backend": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
     "@checkstack/common": "workspace:*",
     "drizzle-orm": "^0.45.0",
     "zod": "^4.2.1",

--- a/core/dependency-backend/src/dependency-gitops-kinds.test.ts
+++ b/core/dependency-backend/src/dependency-gitops-kinds.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { ReconcileContext } from "@checkstack/gitops-common";
+import type { Dependency } from "@checkstack/dependency-common";
+import type { DependencyService } from "./services/dependency-service";
+import { buildSystemDependenciesExtension } from "./dependency-gitops-kinds";
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const buildContext = (
+  overrides: Partial<ReconcileContext> = {},
+): ReconcileContext =>
+  ({
+    logger: noopLogger,
+    resolveEntityRef: async () => undefined,
+    resolveSecretsBySchema: async ({ value }) => ({
+      resolved: value,
+      warnings: [],
+    }),
+    ...overrides,
+  }) as ReconcileContext;
+
+const refResolver =
+  (table: Record<string, string>) =>
+  async ({ entityName }: { kind: string; entityName: string }) =>
+    table[entityName];
+
+const dep = (
+  id: string,
+  sourceSystemId: string,
+  targetSystemId: string,
+  overrides: Partial<Dependency> = {},
+): Dependency => ({
+  id,
+  sourceSystemId,
+  targetSystemId,
+  impactType: "degraded",
+  transitive: false,
+  label: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const stubService = (existing: Dependency[] = []) => {
+  let store = [...existing];
+  const getDependencies = mock(
+    async ({
+      systemId,
+      direction,
+    }: {
+      systemId: string;
+      direction?: "upstream" | "downstream" | "both";
+    }) => {
+      if (direction === "upstream") {
+        return store.filter((d) => d.sourceSystemId === systemId);
+      }
+      if (direction === "downstream") {
+        return store.filter((d) => d.targetSystemId === systemId);
+      }
+      return store.filter(
+        (d) => d.sourceSystemId === systemId || d.targetSystemId === systemId,
+      );
+    },
+  );
+  const createDependency = mock(
+    async (input: {
+      sourceSystemId: string;
+      targetSystemId: string;
+      impactType: "informational" | "degraded" | "critical";
+      transitive?: boolean;
+      label?: string;
+    }) => {
+      const created = dep(
+        `dep-${store.length + 1}`,
+        input.sourceSystemId,
+        input.targetSystemId,
+        {
+          impactType: input.impactType,
+          transitive: input.transitive ?? false,
+          label: input.label ?? null,
+        },
+      );
+      store.push(created);
+      return created;
+    },
+  );
+  const updateDependency = mock(
+    async (input: {
+      id: string;
+      systemId: string;
+      impactType?: "informational" | "degraded" | "critical";
+      transitive?: boolean;
+      label?: string | null;
+    }) => {
+      store = store.map((d) =>
+        d.id === input.id
+          ? {
+              ...d,
+              impactType: input.impactType ?? d.impactType,
+              transitive: input.transitive ?? d.transitive,
+              label: input.label === undefined ? d.label : input.label,
+            }
+          : d,
+      );
+      return store.find((d) => d.id === input.id);
+    },
+  );
+  const deleteDependency = mock(async (id: string) => {
+    const before = store.length;
+    store = store.filter((d) => d.id !== id);
+    return store.length < before;
+  });
+  return {
+    getDependencies,
+    createDependency,
+    updateDependency,
+    deleteDependency,
+    service: {
+      getDependencies,
+      createDependency,
+      updateDependency,
+      deleteDependency,
+    } as unknown as DependencyService,
+    get current() {
+      return store;
+    },
+  };
+};
+
+describe("buildSystemDependenciesExtension", () => {
+  let stub: ReturnType<typeof stubService>;
+  let extension: ReturnType<typeof buildSystemDependenciesExtension>;
+
+  beforeEach(() => {
+    stub = stubService();
+    extension = buildSystemDependenciesExtension({
+      getService: () => stub.service,
+    });
+  });
+
+  it("registers under System kind, namespace 'dependencies'", () => {
+    expect(extension.kind).toBe("System");
+    expect(extension.namespace).toBe("dependencies");
+  });
+
+  it("creates declared dependencies on first sync", async () => {
+    await extension.reconcile({
+      entity: {} as never,
+      entityId: "sys-payments",
+      extensionSpec: [
+        {
+          targetRef: { kind: "System", name: "db" },
+          impactType: "critical",
+          transitive: false,
+        },
+        {
+          targetRef: { kind: "System", name: "cache" },
+          impactType: "degraded",
+          transitive: true,
+          label: "fast path",
+        },
+      ],
+      context: buildContext({
+        resolveEntityRef: refResolver({ db: "sys-db", cache: "sys-cache" }),
+      }),
+    });
+
+    expect(stub.createDependency).toHaveBeenCalledTimes(2);
+    expect(stub.createDependency).toHaveBeenNthCalledWith(1, {
+      sourceSystemId: "sys-payments",
+      targetSystemId: "sys-db",
+      impactType: "critical",
+      transitive: false,
+      label: undefined,
+      healthCheckRules: [],
+    });
+    expect(stub.createDependency).toHaveBeenNthCalledWith(2, {
+      sourceSystemId: "sys-payments",
+      targetSystemId: "sys-cache",
+      impactType: "degraded",
+      transitive: true,
+      label: "fast path",
+      healthCheckRules: [],
+    });
+  });
+
+  it("removes dependencies that are no longer declared", async () => {
+    stub = stubService([
+      dep("d1", "sys-payments", "sys-db"),
+      dep("d2", "sys-payments", "sys-cache"),
+    ]);
+    extension = buildSystemDependenciesExtension({
+      getService: () => stub.service,
+    });
+
+    await extension.reconcile({
+      entity: {} as never,
+      entityId: "sys-payments",
+      extensionSpec: [
+        {
+          targetRef: { kind: "System", name: "db" },
+          impactType: "degraded",
+          transitive: false,
+        },
+      ],
+      context: buildContext({
+        resolveEntityRef: refResolver({ db: "sys-db" }),
+      }),
+    });
+
+    expect(stub.deleteDependency).toHaveBeenCalledTimes(1);
+    expect(stub.deleteDependency).toHaveBeenCalledWith("d2");
+    expect(stub.createDependency).not.toHaveBeenCalled();
+  });
+
+  it("updates an existing edge when impactType, transitive, or label changes", async () => {
+    stub = stubService([
+      dep("d1", "sys-payments", "sys-db", {
+        impactType: "degraded",
+        transitive: false,
+        label: null,
+      }),
+    ]);
+    extension = buildSystemDependenciesExtension({
+      getService: () => stub.service,
+    });
+
+    await extension.reconcile({
+      entity: {} as never,
+      entityId: "sys-payments",
+      extensionSpec: [
+        {
+          targetRef: { kind: "System", name: "db" },
+          impactType: "critical",
+          transitive: true,
+          label: "primary",
+        },
+      ],
+      context: buildContext({
+        resolveEntityRef: refResolver({ db: "sys-db" }),
+      }),
+    });
+
+    expect(stub.updateDependency).toHaveBeenCalledWith({
+      id: "d1",
+      systemId: "sys-payments",
+      impactType: "critical",
+      transitive: true,
+      label: "primary",
+    });
+  });
+
+  it("is a no-op when an edge already matches the spec", async () => {
+    stub = stubService([
+      dep("d1", "sys-payments", "sys-db", {
+        impactType: "critical",
+        transitive: false,
+        label: null,
+      }),
+    ]);
+    extension = buildSystemDependenciesExtension({
+      getService: () => stub.service,
+    });
+
+    await extension.reconcile({
+      entity: {} as never,
+      entityId: "sys-payments",
+      extensionSpec: [
+        {
+          targetRef: { kind: "System", name: "db" },
+          impactType: "critical",
+          transitive: false,
+        },
+      ],
+      context: buildContext({
+        resolveEntityRef: refResolver({ db: "sys-db" }),
+      }),
+    });
+
+    expect(stub.updateDependency).not.toHaveBeenCalled();
+    expect(stub.createDependency).not.toHaveBeenCalled();
+    expect(stub.deleteDependency).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty/undefined spec as 'remove all my upstream deps'", async () => {
+    stub = stubService([
+      dep("d1", "sys-payments", "sys-db"),
+      dep("d2", "sys-other", "sys-payments"), // downstream — must NOT be touched
+    ]);
+    extension = buildSystemDependenciesExtension({
+      getService: () => stub.service,
+    });
+
+    await extension.reconcile({
+      entity: {} as never,
+      entityId: "sys-payments",
+      extensionSpec: [],
+      context: buildContext(),
+    });
+
+    expect(stub.deleteDependency).toHaveBeenCalledTimes(1);
+    expect(stub.deleteDependency).toHaveBeenCalledWith("d1");
+  });
+
+  it("rejects refs that resolve to the source system itself", async () => {
+    await expect(
+      extension.reconcile({
+        entity: {} as never,
+        entityId: "sys-payments",
+        extensionSpec: [
+          {
+            targetRef: { kind: "System", name: "self" },
+            impactType: "degraded",
+            transitive: false,
+          },
+        ],
+        context: buildContext({
+          resolveEntityRef: refResolver({ self: "sys-payments" }),
+        }),
+      }),
+    ).rejects.toThrow(/cannot depend on itself/);
+  });
+
+  it("aborts the diff when a ref cannot be resolved (no mutations)", async () => {
+    stub = stubService([dep("d1", "sys-payments", "sys-db")]);
+    extension = buildSystemDependenciesExtension({
+      getService: () => stub.service,
+    });
+
+    await expect(
+      extension.reconcile({
+        entity: {} as never,
+        entityId: "sys-payments",
+        extensionSpec: [
+          {
+            targetRef: { kind: "System", name: "missing" },
+            impactType: "degraded",
+            transitive: false,
+          },
+        ],
+        context: buildContext({
+          resolveEntityRef: async () => undefined,
+        }),
+      }),
+    ).rejects.toThrow(/Cannot resolve System ref "missing"/);
+
+    expect(stub.deleteDependency).not.toHaveBeenCalled();
+    expect(stub.createDependency).not.toHaveBeenCalled();
+    expect(stub.updateDependency).not.toHaveBeenCalled();
+  });
+});

--- a/core/dependency-backend/src/dependency-gitops-kinds.ts
+++ b/core/dependency-backend/src/dependency-gitops-kinds.ts
@@ -1,0 +1,173 @@
+import { z } from "zod";
+import {
+  CHECKSTACK_API_VERSION,
+  type EntityKindExtensionDefinition,
+  type EntityKindRegistry,
+  type ReconcileContext,
+} from "@checkstack/gitops-common";
+import { ImpactTypeSchema } from "@checkstack/dependency-common";
+import type { DependencyService } from "./services/dependency-service";
+
+interface DependencyGitOpsKindsDeps {
+  /** Lazy accessor — populated during init(), invoked at reconcile time. */
+  getService: () => DependencyService;
+}
+
+// ─── System.dependencies extension ──────────────────────────────────────────
+//
+// Declares upstream dependencies for a System. GitOps is the source of truth:
+// the reconciler diffs the YAML-declared edges against the persisted ones for
+// this system and applies create/update/delete to converge.
+//
+// `targetRef` references another System by name; `kind` is constrained to the
+// literal "System" so the relationship is self-documenting.
+
+const systemRefSchema = z
+  .object({
+    kind: z.literal("System"),
+    name: z.string().min(1),
+  })
+  .describe("Reference to the upstream System this system depends on.");
+
+const dependencyEntrySchema = z.object({
+  targetRef: systemRefSchema,
+  impactType: ImpactTypeSchema.optional().default("degraded"),
+  transitive: z.boolean().optional().default(false),
+  label: z.string().optional(),
+});
+
+const systemDependenciesExtensionSchema = z
+  .array(dependencyEntrySchema)
+  .optional();
+
+type SystemDependenciesExtension = z.infer<
+  typeof systemDependenciesExtensionSchema
+>;
+
+const edgeKey = (sourceId: string, targetId: string) =>
+  `${sourceId}->${targetId}`;
+
+export function buildSystemDependenciesExtension(
+  deps: DependencyGitOpsKindsDeps,
+): EntityKindExtensionDefinition<SystemDependenciesExtension> {
+  return {
+    apiVersion: CHECKSTACK_API_VERSION,
+    kind: "System",
+    namespace: "dependencies",
+    specSchema: systemDependenciesExtensionSchema,
+
+    reconcile: async ({
+      extensionSpec,
+      entityId,
+      context,
+    }: {
+      extensionSpec: SystemDependenciesExtension;
+      entityId: string;
+      context: ReconcileContext;
+    }) => {
+      const service = deps.getService();
+      const sourceSystemId = entityId;
+      const desired = extensionSpec ?? [];
+
+      // Resolve all target refs up-front so a single bad ref aborts the diff
+      // before we mutate anything.
+      const resolved: Array<{
+        targetSystemId: string;
+        impactType: "informational" | "degraded" | "critical";
+        transitive: boolean;
+        label: string | null;
+      }> = [];
+      for (const entry of desired) {
+        const targetSystemId = await context.resolveEntityRef({
+          kind: entry.targetRef.kind,
+          entityName: entry.targetRef.name,
+        });
+        if (!targetSystemId) {
+          throw new Error(
+            `Cannot resolve System ref "${entry.targetRef.name}" — ensure the upstream system exists`,
+          );
+        }
+        if (targetSystemId === sourceSystemId) {
+          throw new Error(
+            `Dependency target "${entry.targetRef.name}" resolves to the same system as the source — a system cannot depend on itself`,
+          );
+        }
+        resolved.push({
+          targetSystemId,
+          impactType: entry.impactType,
+          transitive: entry.transitive,
+          label: entry.label ?? null,
+        });
+      }
+
+      // Existing edges where this system is the source (upstream deps).
+      const existing = await service.getDependencies({
+        systemId: sourceSystemId,
+        direction: "upstream",
+      });
+
+      const existingByTarget = new Map(
+        existing.map((dep) => [edgeKey(dep.sourceSystemId, dep.targetSystemId), dep]),
+      );
+      const desiredKeys = new Set(
+        resolved.map((r) => edgeKey(sourceSystemId, r.targetSystemId)),
+      );
+
+      // Remove edges that are no longer declared.
+      for (const [key, dep] of existingByTarget) {
+        if (!desiredKeys.has(key)) {
+          await service.deleteDependency(dep.id);
+          context.logger.info(
+            `GitOps: removed dependency ${dep.sourceSystemId} → ${dep.targetSystemId}`,
+          );
+        }
+      }
+
+      // Add or update declared edges.
+      for (const entry of resolved) {
+        const key = edgeKey(sourceSystemId, entry.targetSystemId);
+        const current = existingByTarget.get(key);
+        if (!current) {
+          await service.createDependency({
+            sourceSystemId,
+            targetSystemId: entry.targetSystemId,
+            impactType: entry.impactType,
+            transitive: entry.transitive,
+            label: entry.label ?? undefined,
+            healthCheckRules: [],
+          });
+          context.logger.info(
+            `GitOps: created dependency ${sourceSystemId} → ${entry.targetSystemId} (${entry.impactType})`,
+          );
+          continue;
+        }
+
+        const needsUpdate =
+          current.impactType !== entry.impactType ||
+          current.transitive !== entry.transitive ||
+          (current.label ?? null) !== entry.label;
+        if (needsUpdate) {
+          await service.updateDependency({
+            id: current.id,
+            systemId: sourceSystemId,
+            impactType: entry.impactType,
+            transitive: entry.transitive,
+            label: entry.label,
+          });
+          context.logger.info(
+            `GitOps: updated dependency ${sourceSystemId} → ${entry.targetSystemId}`,
+          );
+        }
+      }
+    },
+  };
+}
+
+export function registerDependencyGitOpsKinds({
+  kindRegistry,
+  ...deps
+}: DependencyGitOpsKindsDeps & {
+  kindRegistry: EntityKindRegistry;
+}): void {
+  kindRegistry.registerKindExtension(buildSystemDependenciesExtension(deps));
+}

--- a/core/dependency-backend/src/index.ts
+++ b/core/dependency-backend/src/index.ts
@@ -20,6 +20,8 @@ import { NotificationApi } from "@checkstack/notification-common";
 import { catalogHooks } from "@checkstack/catalog-backend";
 import { healthCheckHooks } from "@checkstack/healthcheck-backend";
 import { evaluateAndNotifyDownstream } from "./notifications";
+import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
+import { registerDependencyGitOpsKinds } from "./dependency-gitops-kinds";
 
 // =============================================================================
 // Plugin Definition
@@ -33,6 +35,18 @@ export default createBackendPlugin({
       dependencySystemSubscription,
       dependencyGroupSubscription,
     ]);
+
+    // ─── GitOps Entity Kind Registration ─────────────────────────────
+    let gitopsService: DependencyService | undefined;
+    const kindRegistry = env.getExtensionPoint(entityKindExtensionPoint);
+    registerDependencyGitOpsKinds({
+      kindRegistry,
+      getService: () => {
+        if (!gitopsService)
+          throw new Error("DependencyService not initialized");
+        return gitopsService;
+      },
+    });
 
     env.registerInit({
       schema,
@@ -51,6 +65,7 @@ export default createBackendPlugin({
         const service = new DependencyService(
           database as SafeDatabase<typeof schema>,
         );
+        gitopsService = service;
         const warningService = new WarningEvaluationService();
 
         const router = createRouter({

--- a/core/dependency-backend/tsconfig.json
+++ b/core/dependency-backend/tsconfig.json
@@ -23,6 +23,12 @@
       "path": "../drizzle-helper"
     },
     {
+      "path": "../gitops-backend"
+    },
+    {
+      "path": "../gitops-common"
+    },
+    {
       "path": "../healthcheck-backend"
     },
     {

--- a/core/dependency-frontend/package.json
+++ b/core/dependency-frontend/package.json
@@ -18,6 +18,8 @@
     "@checkstack/dashboard-frontend": "workspace:*",
     "@checkstack/dependency-common": "workspace:*",
     "@checkstack/frontend-api": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
+    "@checkstack/gitops-frontend": "workspace:*",
     "@checkstack/healthcheck-common": "workspace:*",
     "@checkstack/signal-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",

--- a/core/dependency-frontend/src/components/DependencyEditor.tsx
+++ b/core/dependency-frontend/src/components/DependencyEditor.tsx
@@ -31,7 +31,12 @@ import {
   AlertTriangle,
   RotateCcw,
   MapIcon,
+  GitBranch,
 } from "lucide-react";
+import {
+  useProvenanceLock,
+  useProvenanceLocks,
+} from "@checkstack/gitops-frontend";
 
 type Props = SlotContext<typeof SystemEditorSlot>;
 
@@ -57,6 +62,16 @@ function getImpactBadge(impactType: ImpactType): React.ReactNode {
 export const DependencyEditor: React.FC<Props> = ({ systemId }) => {
   const depClient = usePluginClient(DependencyApi);
   const catalogClient = usePluginClient(CatalogApi);
+
+  // GitOps owns the *source* system's `dependencies` extension. Edits to
+  // upstream rows (this system → ...) are blocked when this system is
+  // managed; downstream rows belong to other source systems and are gated
+  // per-row via the bulk hook.
+  const { isLocked: sourceLocked } = useProvenanceLock({
+    kind: "System",
+    entityId: systemId,
+  });
+  const { getLock: getSystemLock } = useProvenanceLocks();
 
   const [isAdding, setIsAdding] = useState(false);
   const [selectedTargetId, setSelectedTargetId] = useState("");
@@ -168,12 +183,29 @@ export const DependencyEditor: React.FC<Props> = ({ systemId }) => {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <Label>Dependencies</Label>
+        <Label className="flex items-center gap-2">
+          Dependencies
+          {sourceLocked && (
+            <span
+              className="inline-flex items-center gap-1 text-xs font-normal text-primary"
+              title="Managed by GitOps — edit the source YAML"
+            >
+              <GitBranch className="h-3 w-3" />
+              GitOps
+            </span>
+          )}
+        </Label>
         <Button
           type="button"
           variant="outline"
           size="sm"
           onClick={() => setIsAdding(!isAdding)}
+          disabled={sourceLocked}
+          title={
+            sourceLocked
+              ? "Managed by GitOps — declare dependencies in the System's YAML"
+              : undefined
+          }
         >
           <Plus className="h-3.5 w-3.5 mr-1" />
           Add
@@ -187,7 +219,7 @@ export const DependencyEditor: React.FC<Props> = ({ systemId }) => {
       )}
 
       {/* Add dependency form */}
-      {isAdding && (
+      {isAdding && !sourceLocked && (
         <div className="p-3 rounded-lg border border-border bg-muted/30 space-y-3">
           <div className="space-y-2">
             <label className="text-sm font-medium">Depends on (upstream)</label>
@@ -257,6 +289,7 @@ export const DependencyEditor: React.FC<Props> = ({ systemId }) => {
                 onDelete={() => handleDelete(dep)}
                 onUpdate={handleUpdate}
                 isUpdating={updateMutation.isPending}
+                isLocked={sourceLocked}
               />
             ))}
           </div>
@@ -271,17 +304,26 @@ export const DependencyEditor: React.FC<Props> = ({ systemId }) => {
             Depended By ({downstreamDeps.length})
           </h4>
           <div className="space-y-1">
-            {downstreamDeps.map((dep) => (
-              <DependencyRow
-                key={dep.id}
-                dependency={dep}
-                systemName={systemNameMap.get(dep.sourceSystemId) ?? dep.sourceSystemId}
-                direction="downstream"
-                onDelete={() => handleDelete(dep)}
-                onUpdate={handleUpdate}
-                isUpdating={updateMutation.isPending}
-              />
-            ))}
+            {downstreamDeps.map((dep) => {
+              // The "source" of a downstream edge is *another* system —
+              // its lock is what governs editability.
+              const otherSourceLocked = getSystemLock({
+                kind: "System",
+                entityId: dep.sourceSystemId,
+              }).isLocked;
+              return (
+                <DependencyRow
+                  key={dep.id}
+                  dependency={dep}
+                  systemName={systemNameMap.get(dep.sourceSystemId) ?? dep.sourceSystemId}
+                  direction="downstream"
+                  onDelete={() => handleDelete(dep)}
+                  onUpdate={handleUpdate}
+                  isUpdating={updateMutation.isPending}
+                  isLocked={otherSourceLocked}
+                />
+              );
+            })}
           </div>
         </div>
       )}
@@ -322,6 +364,7 @@ function DependencyRow({
   onDelete,
   onUpdate,
   isUpdating,
+  isLocked = false,
 }: {
   dependency: Dependency;
   systemName: string;
@@ -334,6 +377,8 @@ function DependencyRow({
     healthCheckRules?: { healthCheckId: string; overrideImpactType: ImpactType }[];
   }) => void;
   isUpdating: boolean;
+  /** When true, the source system of this edge is GitOps-managed. */
+  isLocked?: boolean;
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [editImpact, setEditImpact] = useState<ImpactType>(
@@ -366,7 +411,7 @@ function DependencyRow({
     setIsEditing(false);
   };
 
-  if (isEditing) {
+  if (isEditing && !isLocked) {
     return (
       <div className="p-3 rounded-lg border border-primary/30 bg-muted/30 space-y-3">
         <div className="flex items-center gap-2">
@@ -415,24 +460,35 @@ function DependencyRow({
     );
   }
 
+  const interactive = !isLocked;
   return (
     <div
-      className="flex items-center justify-between p-2 rounded border border-border bg-background hover:bg-muted/30 transition-colors cursor-pointer"
-      onClick={() => setIsEditing(true)}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          setIsEditing(true);
-        }
-      }}
+      className={`flex items-center justify-between p-2 rounded border border-border bg-background transition-colors ${
+        interactive ? "hover:bg-muted/30 cursor-pointer" : ""
+      }`}
+      onClick={interactive ? () => setIsEditing(true) : undefined}
+      role={interactive ? "button" : undefined}
+      tabIndex={interactive ? 0 : -1}
+      onKeyDown={
+        interactive
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setIsEditing(true);
+              }
+            }
+          : undefined
+      }
+      title={isLocked ? "Managed by GitOps" : undefined}
     >
       <div className="flex items-center gap-2">
         {direction === "upstream" ? (
           <ArrowUpRight className="h-4 w-4 text-muted-foreground" />
         ) : (
           <ArrowDownRight className="h-4 w-4 text-muted-foreground" />
+        )}
+        {isLocked && (
+          <GitBranch className="h-3 w-3 text-primary" aria-label="Managed by GitOps" />
         )}
         <span className="text-sm font-medium">{systemName}</span>
         {dependency.label && (
@@ -460,6 +516,8 @@ function DependencyRow({
           variant="ghost"
           size="icon"
           className="h-7 w-7"
+          disabled={isLocked}
+          title={isLocked ? "Managed by GitOps" : undefined}
           onClick={(e) => {
             e.stopPropagation();
             onDelete();

--- a/core/dependency-frontend/src/components/DependencyMapPage.tsx
+++ b/core/dependency-frontend/src/components/DependencyMapPage.tsx
@@ -31,6 +31,7 @@ import {
 import { Maximize2, Save, RefreshCw, Trash2 } from "lucide-react";
 import type { ImpactType } from "@checkstack/dependency-common";
 import { DependencyEdgeForm } from "./DependencyEdgeForm";
+import { useProvenanceLocks } from "@checkstack/gitops-frontend";
 
 import {
   SystemNodeComponent,
@@ -86,6 +87,9 @@ function DependencyMapContent() {
   const catalogClient = usePluginClient(CatalogApi);
   const healthCheckClient = usePluginClient(HealthCheckApi);
   const { fitView } = useReactFlow();
+  // GitOps owns the *source* system's `dependencies` extension. We use the
+  // bulk hook to gate edge mutations per edge based on the source's lock.
+  const { getLock: getSystemLock } = useProvenanceLocks();
   const [nodes, setNodes, onNodesChange] = useNodesState<SystemNode>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<DependencyEdge>([]);
   const [hasUnsaved, setHasUnsaved] = useState(false);
@@ -217,6 +221,17 @@ function DependencyMapContent() {
       if (!connection.source || !connection.target) return;
       if (connection.source === connection.target) return;
 
+      const sourceLocked = getSystemLock({
+        kind: "System",
+        entityId: connection.source,
+      }).isLocked;
+      if (sourceLocked) {
+        toast.error(
+          "Source system is managed by GitOps — declare the dependency in its YAML.",
+        );
+        return;
+      }
+
       createDependency({
         sourceSystemId: connection.source,
         targetSystemId: connection.target,
@@ -224,7 +239,7 @@ function DependencyMapContent() {
         transitive: false,
       });
     },
-    [createDependency],
+    [createDependency, getSystemLock, toast],
   );
 
   // Track node positions for saving and for preserving in-memory positions
@@ -568,12 +583,17 @@ function DependencyMapContent() {
         </Panel>
 
         {/* Edge editor panel */}
-        {selectedEdge && (
+        {selectedEdge && (() => {
+          const edgeSourceLocked = getSystemLock({
+            kind: "System",
+            entityId: selectedEdge.sourceSystemId,
+          }).isLocked;
+          return (
           <Panel position="top-left">
             <div className="bg-card/95 backdrop-blur-sm border border-border rounded-lg shadow-lg p-4 w-72 space-y-3">
               <div className="space-y-1">
                 <p className="text-sm font-semibold text-foreground">
-                  Edit Dependency
+                  {edgeSourceLocked ? "Dependency (GitOps)" : "Edit Dependency"}
                 </p>
                 <p className="text-xs text-muted-foreground">
                   {systemNameMap.get(selectedEdge.sourceSystemId) ??
@@ -582,6 +602,12 @@ function DependencyMapContent() {
                   {systemNameMap.get(selectedEdge.targetSystemId) ??
                     selectedEdge.targetSystemId}
                 </p>
+                {edgeSourceLocked && (
+                  <p className="text-xs text-warning">
+                    The source system is managed by GitOps. Edit the
+                    dependency in its YAML.
+                  </p>
+                )}
               </div>
               <DependencyEdgeForm
                 impactType={selectedEdge.impactType}
@@ -610,7 +636,8 @@ function DependencyMapContent() {
                       systemId: selectedEdge.sourceSystemId,
                     })
                   }
-                  disabled={deleteMutation.isPending}
+                  disabled={deleteMutation.isPending || edgeSourceLocked}
+                  title={edgeSourceLocked ? "Managed by GitOps" : undefined}
                 >
                   <Trash2 className="h-3.5 w-3.5 mr-1" />
                   Delete
@@ -622,7 +649,7 @@ function DependencyMapContent() {
                     size="sm"
                     onClick={() => setSelectedEdge(undefined)}
                   >
-                    Cancel
+                    {edgeSourceLocked ? "Close" : "Cancel"}
                   </Button>
                   <Button
                     type="button"
@@ -639,7 +666,8 @@ function DependencyMapContent() {
                             : [],
                       })
                     }
-                    disabled={updateMutation.isPending}
+                    disabled={updateMutation.isPending || edgeSourceLocked}
+                    title={edgeSourceLocked ? "Managed by GitOps" : undefined}
                   >
                     {updateMutation.isPending ? "Saving..." : "Save"}
                   </Button>
@@ -647,7 +675,8 @@ function DependencyMapContent() {
               </div>
             </div>
           </Panel>
-        )}
+          );
+        })()}
       </ReactFlow>
     </div>
   );

--- a/core/dependency-frontend/tsconfig.json
+++ b/core/dependency-frontend/tsconfig.json
@@ -20,6 +20,12 @@
       "path": "../frontend-api"
     },
     {
+      "path": "../gitops-common"
+    },
+    {
+      "path": "../gitops-frontend"
+    },
+    {
       "path": "../healthcheck-common"
     },
     {

--- a/core/gitops-backend/src/router.ts
+++ b/core/gitops-backend/src/router.ts
@@ -2,7 +2,7 @@ import { implement, ORPCError } from "@orpc/server";
 import { z } from "zod";
 import { autoAuthMiddleware, type RpcContext } from "@checkstack/backend-api";
 import { encrypt, decrypt } from "@checkstack/backend-api";
-import { gitopsContract } from "@checkstack/gitops-common";
+import { gitopsContract, deriveSourceUrl } from "@checkstack/gitops-common";
 import type { SafeDatabase } from "@checkstack/backend-api";
 import type { QueueManager } from "@checkstack/queue-api";
 import type { InternalEntityKindRegistry } from "./kind-registry";
@@ -34,6 +34,36 @@ export const createGitOpsRouter = ({
 }: GitOpsRouterDeps) => {
   // ─── Provenance ──────────────────────────────────────────────────────
 
+  type ProviderMeta = {
+    type: "github" | "gitlab";
+    baseUrl: string | null;
+  };
+
+  const buildProviderLookup = async (): Promise<Map<string, ProviderMeta>> => {
+    const providers = await db.select().from(schema.providers);
+    const map = new Map<string, ProviderMeta>();
+    for (const p of providers) {
+      map.set(p.id, { type: p.type, baseUrl: p.baseUrl });
+    }
+    return map;
+  };
+
+  const decorateProvenance = (
+    row: typeof schema.provenance.$inferSelect,
+    providers: Map<string, ProviderMeta>,
+  ) => {
+    const provider = providers.get(row.providerId);
+    const sourceUrl = provider
+      ? deriveSourceUrl({
+          providerType: provider.type,
+          baseUrl: provider.baseUrl,
+          repository: row.repository,
+          filePath: row.filePath,
+        })
+      : null;
+    return { ...row, warnings: row.warnings ?? [], sourceUrl };
+  };
+
   const getProvenance = os.getProvenance.handler(async ({ input }) => {
     const conditions = [eq(schema.provenance.kind, input.kind)];
 
@@ -49,14 +79,15 @@ export const createGitOpsRouter = ({
       .from(schema.provenance)
       .where(and(...conditions));
     const row = result[0];
-     
-    return row ? { ...row, warnings: row.warnings ?? [] } : null;
+    if (!row) return null;
+    const providers = await buildProviderLookup();
+    return decorateProvenance(row, providers);
   });
 
   const listProvenance = os.listProvenance.handler(async ({ input }) => {
     const rawRows = await db.select().from(schema.provenance);
-    // Normalize: ensure warnings is always a string[] (Drizzle may return null for pre-migration rows)
-    const rows = rawRows.map((row) => ({ ...row, warnings: row.warnings ?? [] }));
+    const providers = await buildProviderLookup();
+    const rows = rawRows.map((row) => decorateProvenance(row, providers));
     if (!input) return rows;
 
     return rows.filter((row) => {

--- a/core/gitops-common/src/index.ts
+++ b/core/gitops-common/src/index.ts
@@ -36,3 +36,7 @@ export {
   type DeletionPolicy,
 } from "./provenance-types";
 export { gitopsContract, GitOpsApi, type GitOpsContract } from "./rpc-contract";
+export {
+  deriveSourceUrl,
+  type DeriveSourceUrlInput,
+} from "./source-url";

--- a/core/gitops-common/src/provenance-types.ts
+++ b/core/gitops-common/src/provenance-types.ts
@@ -16,6 +16,12 @@ export const provenanceSchema = z.object({
   providerId: z.string(),
   repository: z.string(),
   filePath: z.string(),
+  /**
+   * Browsable web URL pointing to the entity's defining file in its source
+   * provider, derived from the provider type, baseUrl, repository and filePath.
+   * Null when the URL cannot be safely derived (unknown baseUrl shape, etc.).
+   */
+  sourceUrl: z.string().nullable(),
   lastSyncHash: z.string(),
   status: provenanceStatusSchema,
   errorMessage: z.string().nullable(),

--- a/core/gitops-common/src/source-url.test.ts
+++ b/core/gitops-common/src/source-url.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { deriveSourceUrl } from "./source-url";
+
+describe("deriveSourceUrl", () => {
+  test("public github.com", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: null,
+        repository: "acme/checkstack",
+        filePath: "catalog/system.yaml",
+      }),
+    ).toBe("https://github.com/acme/checkstack/blob/HEAD/catalog/system.yaml");
+  });
+
+  test("public gitlab.com", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "gitlab",
+        baseUrl: null,
+        repository: "acme/checkstack",
+        filePath: "catalog/system.yaml",
+      }),
+    ).toBe(
+      "https://gitlab.com/acme/checkstack/-/blob/HEAD/catalog/system.yaml",
+    );
+  });
+
+  test("api.github.com baseUrl maps to public host", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: "https://api.github.com",
+        repository: "acme/checkstack",
+        filePath: "catalog/system.yaml",
+      }),
+    ).toBe("https://github.com/acme/checkstack/blob/HEAD/catalog/system.yaml");
+  });
+
+  test("github enterprise baseUrl strips /api/v3", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: "https://github.example.com/api/v3",
+        repository: "acme/checkstack",
+        filePath: "catalog/system.yaml",
+      }),
+    ).toBe(
+      "https://github.example.com/acme/checkstack/blob/HEAD/catalog/system.yaml",
+    );
+  });
+
+  test("self-hosted gitlab baseUrl strips /api/v4", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "gitlab",
+        baseUrl: "https://gitlab.example.com/api/v4",
+        repository: "team/sub/checkstack",
+        filePath: "catalog/system.yaml",
+      }),
+    ).toBe(
+      "https://gitlab.example.com/team/sub/checkstack/-/blob/HEAD/catalog/system.yaml",
+    );
+  });
+
+  test("nested gitlab namespaces preserved", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "gitlab",
+        baseUrl: null,
+        repository: "group/sub/project",
+        filePath: "a/b.yaml",
+      }),
+    ).toBe("https://gitlab.com/group/sub/project/-/blob/HEAD/a/b.yaml");
+  });
+
+  test("encodes spaces and special characters in path segments", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: null,
+        repository: "acme/checkstack",
+        filePath: "catalog/my system.yaml",
+      }),
+    ).toBe(
+      "https://github.com/acme/checkstack/blob/HEAD/catalog/my%20system.yaml",
+    );
+  });
+
+  test("strips leading slashes from filePath", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: null,
+        repository: "acme/checkstack",
+        filePath: "/catalog/system.yaml",
+      }),
+    ).toBe("https://github.com/acme/checkstack/blob/HEAD/catalog/system.yaml");
+  });
+
+  test("returns null for unknown self-hosted baseUrl", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: "https://github.example.com/some/weird/path",
+        repository: "acme/checkstack",
+        filePath: "catalog/system.yaml",
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for traversal attempts", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: null,
+        repository: "acme/checkstack",
+        filePath: "../etc/passwd",
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for empty inputs", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: null,
+        repository: "",
+        filePath: "x.yaml",
+      }),
+    ).toBeNull();
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: null,
+        repository: "a/b",
+        filePath: "",
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for malformed baseUrl", () => {
+    expect(
+      deriveSourceUrl({
+        providerType: "github",
+        baseUrl: "not a url",
+        repository: "acme/checkstack",
+        filePath: "x.yaml",
+      }),
+    ).toBeNull();
+  });
+});

--- a/core/gitops-common/src/source-url.ts
+++ b/core/gitops-common/src/source-url.ts
@@ -1,0 +1,89 @@
+/**
+ * Derive a human-browsable source URL for a GitOps-managed entity.
+ *
+ * Returns null when we don't have enough information to construct a stable URL
+ * (e.g., unknown provider type or a malformed `repository` value). Callers
+ * should fall back to displaying the raw `repository`/`filePath` text.
+ *
+ * The URL points at the file on the default branch via the `HEAD` ref so we
+ * don't need to know the branch name. Both GitHub and GitLab resolve `HEAD`
+ * server-side for blob URLs.
+ */
+export interface DeriveSourceUrlInput {
+  providerType: "github" | "gitlab";
+  /** The provider's `baseUrl` (API base) — null for public github.com/gitlab.com. */
+  baseUrl: string | null;
+  /** GitHub: `owner/repo`. GitLab: `group/project` (or nested `group/sub/project`). */
+  repository: string;
+  filePath: string;
+}
+
+const GITHUB_PUBLIC_HOST = "https://github.com";
+const GITLAB_PUBLIC_HOST = "https://gitlab.com";
+
+const stripApiSuffix = ({
+  providerType,
+  baseUrl,
+}: {
+  providerType: "github" | "gitlab";
+  baseUrl: string;
+}): string | null => {
+  // We only know how to strip the well-known API path suffixes. Anything else
+  // we treat as untrusted and bail out — better to fall back to text than to
+  // construct a broken link.
+  try {
+    const url = new URL(baseUrl);
+    if (providerType === "github") {
+      // api.github.com → github.com (public host has no API path component)
+      if (url.host === "api.github.com") return GITHUB_PUBLIC_HOST;
+      // GitHub Enterprise: https://github.example.com/api/v3
+      if (url.pathname.replace(/\/$/, "") === "/api/v3") {
+        return `${url.protocol}//${url.host}`;
+      }
+      return null;
+    }
+    // GitLab: https://gitlab.example.com/api/v4
+    if (url.pathname.replace(/\/$/, "") === "/api/v4") {
+      return `${url.protocol}//${url.host}`;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const encodeFilePath = (filePath: string) =>
+  filePath
+    .replace(/^\/+/, "")
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+export const deriveSourceUrl = ({
+  providerType,
+  baseUrl,
+  repository,
+  filePath,
+}: DeriveSourceUrlInput): string | null => {
+  if (!repository || !filePath) return null;
+  // Reject backslashes and absolute-looking paths to keep things tidy.
+  if (repository.includes("..") || filePath.includes("..")) return null;
+
+  const host = baseUrl
+    ? stripApiSuffix({ providerType, baseUrl })
+    : providerType === "github"
+      ? GITHUB_PUBLIC_HOST
+      : GITLAB_PUBLIC_HOST;
+  if (!host) return null;
+
+  const repoPath = repository
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const encodedFile = encodeFilePath(filePath);
+
+  if (providerType === "github") {
+    return `${host}/${repoPath}/blob/HEAD/${encodedFile}`;
+  }
+  return `${host}/${repoPath}/-/blob/HEAD/${encodedFile}`;
+};

--- a/core/gitops-frontend/src/components/GitOpsLockBanner.tsx
+++ b/core/gitops-frontend/src/components/GitOpsLockBanner.tsx
@@ -23,12 +23,23 @@ export const GitOpsLockBanner: React.FC<GitOpsLockBannerProps> = ({
         <span className="text-muted-foreground ml-1">
           — edits are disabled. Changes must be made in Git.
         </span>
-        <div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-1">
-          <span className="truncate">
+        {provenance.sourceUrl ? (
+          <a
+            href={provenance.sourceUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-xs text-primary hover:underline mt-0.5 flex items-center gap-1"
+          >
+            <span className="truncate">
+              {provenance.repository}/{provenance.filePath}
+            </span>
+            <ExternalLink className="w-3 h-3 shrink-0" />
+          </a>
+        ) : (
+          <div className="text-xs text-muted-foreground mt-0.5 truncate">
             {provenance.repository}/{provenance.filePath}
-          </span>
-          <ExternalLink className="w-3 h-3 shrink-0" />
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/core/gitops-frontend/src/components/GitOpsSourceBadge.tsx
+++ b/core/gitops-frontend/src/components/GitOpsSourceBadge.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { GitBranch, ExternalLink } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@checkstack/ui";
+import type { Provenance } from "@checkstack/gitops-common";
+
+interface GitOpsSourceBadgeProps {
+  provenance: Provenance;
+  iconClassName?: string;
+}
+
+/**
+ * Badge that signals an entity is GitOps-managed and, on click, surfaces the
+ * source repository, file path, and (when derivable) a "View in <provider>"
+ * deep link. Used on catalog cards alongside disabled controls so users can
+ * jump straight to the file that owns the entity.
+ */
+export const GitOpsSourceBadge: React.FC<GitOpsSourceBadgeProps> = ({
+  provenance,
+  iconClassName,
+}) => {
+  const { repository, filePath, sourceUrl } = provenance;
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="View GitOps source"
+          title="View GitOps source"
+          className="shrink-0 inline-flex items-center justify-center rounded hover:bg-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 p-0.5"
+        >
+          <GitBranch
+            className={iconClassName ?? "w-4 h-4 text-primary"}
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-3 space-y-2 text-sm">
+        <div className="flex items-center gap-2 font-medium text-foreground">
+          <GitBranch className="w-4 h-4 text-primary shrink-0" />
+          Managed by GitOps
+        </div>
+        <div className="space-y-1 text-xs">
+          <div>
+            <div className="text-muted-foreground">Repository</div>
+            <div className="font-mono text-foreground break-all">
+              {repository}
+            </div>
+          </div>
+          <div>
+            <div className="text-muted-foreground">File</div>
+            <div className="font-mono text-foreground break-all">
+              {filePath}
+            </div>
+          </div>
+        </div>
+        {sourceUrl ? (
+          <a
+            href={sourceUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            View in source provider
+          </a>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Open this file in your Git provider to make changes.
+          </p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/core/gitops-frontend/src/hooks/useProvenanceLocks.ts
+++ b/core/gitops-frontend/src/hooks/useProvenanceLocks.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { usePluginClient } from "@checkstack/frontend-api";
+import { GitOpsApi, type Provenance } from "@checkstack/gitops-common";
+
+export interface ProvenanceLock {
+  isLocked: boolean;
+  provenance: Provenance | null;
+}
+
+const lockKey = ({ kind, entityId }: { kind: string; entityId: string }) =>
+  `${kind}::${entityId}`;
+
+/**
+ * Bulk variant of `useProvenanceLock`. Issues a single `listProvenance` query
+ * for the whole tenant and returns a `getLock(kind, entityId)` lookup, so
+ * callers rendering many rows can avoid an N-query fan-out.
+ */
+export const useProvenanceLocks = () => {
+  const gitopsClient = usePluginClient(GitOpsApi);
+
+  const { data: provenances, isLoading } =
+    gitopsClient.listProvenance.useQuery();
+
+  const lockMap = useMemo(() => {
+    const map = new Map<string, Provenance>();
+    for (const p of provenances ?? []) {
+      if (p.status !== "synced") continue;
+      map.set(lockKey({ kind: p.kind, entityId: p.entityId }), p);
+    }
+    return map;
+  }, [provenances]);
+
+  const getLock = (params: {
+    kind: string;
+    entityId: string | undefined;
+  }): ProvenanceLock => {
+    if (!params.entityId) return { isLocked: false, provenance: null };
+    const provenance = lockMap.get(lockKey({ kind: params.kind, entityId: params.entityId })) ?? null;
+    return { isLocked: !!provenance, provenance };
+  };
+
+  return { getLock, isLoading };
+};

--- a/core/gitops-frontend/src/index.tsx
+++ b/core/gitops-frontend/src/index.tsx
@@ -43,4 +43,7 @@ export const gitopsPlugin = createFrontendPlugin({
 
 // Public API for other frontend plugins
 export { useProvenanceLock } from "./hooks/useProvenanceLock";
+export { useProvenanceLocks } from "./hooks/useProvenanceLocks";
+export type { ProvenanceLock } from "./hooks/useProvenanceLocks";
 export { GitOpsLockBanner } from "./components/GitOpsLockBanner";
+export { GitOpsSourceBadge } from "./components/GitOpsSourceBadge";

--- a/core/satellite-backend/package.json
+++ b/core/satellite-backend/package.json
@@ -19,6 +19,8 @@
     "@checkstack/healthcheck-common": "workspace:*",
     "@checkstack/signal-common": "workspace:*",
     "@checkstack/healthcheck-backend": "workspace:*",
+    "@checkstack/gitops-backend": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
     "@checkstack/common": "workspace:*",
     "@checkstack/queue-api": "workspace:*",
     "drizzle-orm": "^0.45.0",

--- a/core/satellite-backend/src/index.ts
+++ b/core/satellite-backend/src/index.ts
@@ -14,6 +14,8 @@ import { createSatelliteRouter } from "./router";
 import { HeartbeatMonitor } from "./heartbeat-monitor";
 import { SatelliteWsHandler } from "./satellite-ws-handler";
 import { ConfigRelay } from "./config-relay";
+import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
+import { registerSatelliteGitOpsKinds } from "./satellite-gitops-kinds";
 
 // Queue and job constants
 const HEARTBEAT_QUEUE = "satellite-heartbeat";
@@ -24,6 +26,17 @@ export default createBackendPlugin({
   metadata: pluginMetadata,
   register(env) {
     env.registerAccessRules(satelliteAccessRules);
+
+    // ─── GitOps Entity Kind Registration ─────────────────────────────
+    let gitopsService: SatelliteService | undefined;
+    const kindRegistry = env.getExtensionPoint(entityKindExtensionPoint);
+    registerSatelliteGitOpsKinds({
+      kindRegistry,
+      getService: () => {
+        if (!gitopsService) throw new Error("SatelliteService not initialized");
+        return gitopsService;
+      },
+    });
 
     env.registerInit({
       schema,
@@ -41,6 +54,7 @@ export default createBackendPlugin({
         const service = new SatelliteService(
           database as SafeDatabase<typeof schema>,
         );
+        gitopsService = service;
 
         const router = createSatelliteRouter({
           service,

--- a/core/satellite-backend/src/router.ts
+++ b/core/satellite-backend/src/router.ts
@@ -1,4 +1,4 @@
-import { implement } from "@orpc/server";
+import { implement, ORPCError } from "@orpc/server";
 import {
   satelliteContract,
   SATELLITE_STATUS_CHANGED,
@@ -73,6 +73,34 @@ export function createSatelliteRouter(props: {
         name: satellite.name,
         region: satellite.region,
       });
+    }),
+
+    updateSatellite: os.updateSatellite.handler(async ({ input }) => {
+      const updated = await service.updateSatelliteMetadata(input);
+      if (!updated) {
+        throw new ORPCError("NOT_FOUND", {
+          message: `Satellite not found: ${input.id}`,
+        });
+      }
+      logger.info(`Satellite metadata updated: ${updated.name}`);
+      await signalService.broadcast(SATELLITE_CONFIG_CHANGED, {
+        satelliteId: updated.id,
+      });
+      return updated;
+    }),
+
+    rotateSatelliteToken: os.rotateSatelliteToken.handler(async ({ input }) => {
+      const result = await service.rotateSatelliteToken(input.id);
+      if (!result) {
+        throw new ORPCError("NOT_FOUND", {
+          message: `Satellite not found: ${input.id}`,
+        });
+      }
+      logger.info(`Satellite token rotated: ${result.satellite.name}`);
+      await signalService.broadcast(SATELLITE_CONFIG_CHANGED, {
+        satelliteId: result.satellite.id,
+      });
+      return { satellite: result.satellite, token: result.plaintextToken };
     }),
 
     getOnlineSatelliteIds: os.getOnlineSatelliteIds.handler(async () => {

--- a/core/satellite-backend/src/satellite-gitops-kinds.test.ts
+++ b/core/satellite-backend/src/satellite-gitops-kinds.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import {
+  CHECKSTACK_API_VERSION,
+  type ReconcileContext,
+} from "@checkstack/gitops-common";
+import type { SatelliteWithStatus } from "@checkstack/satellite-common";
+import type { SatelliteService } from "./service";
+import { buildSatelliteKind } from "./satellite-gitops-kinds";
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const buildContext = (
+  overrides: Partial<ReconcileContext> = {},
+): ReconcileContext =>
+  ({
+    logger: noopLogger,
+    resolveEntityRef: async () => undefined,
+    resolveSecretsBySchema: async ({ value }) => ({
+      resolved: value,
+      warnings: [],
+    }),
+    ...overrides,
+  }) as ReconcileContext;
+
+const stubService = (initial?: SatelliteWithStatus | undefined) => {
+  let stored = initial;
+  const getSatellite = mock(async (id: string) =>
+    stored && stored.id === id ? stored : undefined,
+  );
+  const getSatelliteByName = mock(async (name: string) =>
+    stored && stored.name === name ? stored : undefined,
+  );
+  const createSatellite = mock(
+    async (props: {
+      name: string;
+      region: string;
+      tags: Record<string, string>;
+    }) => {
+      const satellite: SatelliteWithStatus = {
+        id: "sat-new",
+        name: props.name,
+        region: props.region,
+        tags: props.tags,
+        createdAt: new Date(),
+        status: "offline",
+      };
+      stored = satellite;
+      return { satellite, plaintextToken: "csat_test-token" };
+    },
+  );
+  const updateSatelliteMetadata = mock(
+    async (props: {
+      id: string;
+      name?: string;
+      region?: string;
+      tags?: Record<string, string>;
+    }) => {
+      if (!stored || stored.id !== props.id) return undefined;
+      stored = {
+        ...stored,
+        name: props.name ?? stored.name,
+        region: props.region ?? stored.region,
+        tags: props.tags ?? stored.tags,
+      };
+      return stored;
+    },
+  );
+  const deleteSatellite = mock(async (id: string) => {
+    if (stored && stored.id === id) stored = undefined;
+  });
+  return {
+    getSatellite,
+    getSatelliteByName,
+    createSatellite,
+    updateSatelliteMetadata,
+    deleteSatellite,
+    service: {
+      getSatellite,
+      getSatelliteByName,
+      createSatellite,
+      updateSatelliteMetadata,
+      deleteSatellite,
+    } as unknown as SatelliteService,
+    get current() {
+      return stored;
+    },
+  };
+};
+
+const mkEntity = (
+  name: string,
+  spec: { region: string },
+  metadataExtras: { labels?: Record<string, string> } = {},
+) => ({
+  apiVersion: CHECKSTACK_API_VERSION,
+  kind: "Satellite",
+  metadata: { name, ...metadataExtras },
+  spec,
+});
+
+describe("buildSatelliteKind", () => {
+  let kind: ReturnType<typeof buildSatelliteKind>;
+  let stub: ReturnType<typeof stubService>;
+
+  beforeEach(() => {
+    stub = stubService();
+    kind = buildSatelliteKind({ getService: () => stub.service });
+  });
+
+  it("registers as Satellite kind", () => {
+    expect(kind.kind).toBe("Satellite");
+  });
+
+  it("creates a satellite when none exists, discarding the plaintext token", async () => {
+    const result = await kind.reconcile({
+      entity: mkEntity(
+        "eu-west-1",
+        { region: "eu-west-1" },
+        { labels: { tier: "prod" } },
+      ),
+      context: buildContext(),
+    });
+
+    expect(stub.createSatellite).toHaveBeenCalledTimes(1);
+    expect(stub.createSatellite).toHaveBeenCalledWith({
+      name: "eu-west-1",
+      region: "eu-west-1",
+      tags: { tier: "prod" },
+    });
+    expect(result.entityId).toBe("sat-new");
+  });
+
+  it("adopts an existing satellite by name on first sync", async () => {
+    const existing: SatelliteWithStatus = {
+      id: "sat-existing",
+      name: "eu-west-1",
+      region: "eu-west-1",
+      tags: {},
+      createdAt: new Date(),
+      status: "online",
+    };
+    stub = stubService(existing);
+    kind = buildSatelliteKind({ getService: () => stub.service });
+
+    const result = await kind.reconcile({
+      entity: mkEntity(
+        "eu-west-1",
+        { region: "eu-west-2" },
+        { labels: { tier: "prod" } },
+      ),
+      context: buildContext(),
+    });
+
+    expect(stub.createSatellite).not.toHaveBeenCalled();
+    expect(stub.updateSatelliteMetadata).toHaveBeenCalledWith({
+      id: "sat-existing",
+      name: "eu-west-1",
+      region: "eu-west-2",
+      tags: { tier: "prod" },
+    });
+    expect(result.entityId).toBe("sat-existing");
+  });
+
+  it("uses the provenance entityId hint when provided", async () => {
+    const existing: SatelliteWithStatus = {
+      id: "sat-known",
+      name: "renamed",
+      region: "eu-west-1",
+      tags: {},
+      createdAt: new Date(),
+      status: "online",
+    };
+    stub = stubService(existing);
+    kind = buildSatelliteKind({ getService: () => stub.service });
+
+    const result = await kind.reconcile({
+      entity: mkEntity("renamed", { region: "eu-west-1" }),
+      existingEntityId: "sat-known",
+      context: buildContext(),
+    });
+
+    expect(stub.getSatellite).toHaveBeenCalledWith("sat-known");
+    expect(stub.getSatelliteByName).not.toHaveBeenCalled();
+    expect(result.entityId).toBe("sat-known");
+  });
+
+  it("treats pending-* entityIds as fresh and falls back to name lookup", async () => {
+    const existing: SatelliteWithStatus = {
+      id: "sat-existing",
+      name: "eu-west-1",
+      region: "eu-west-1",
+      tags: {},
+      createdAt: new Date(),
+      status: "online",
+    };
+    stub = stubService(existing);
+    kind = buildSatelliteKind({ getService: () => stub.service });
+
+    await kind.reconcile({
+      entity: mkEntity("eu-west-1", { region: "eu-west-1" }),
+      existingEntityId: "pending-foo",
+      context: buildContext(),
+    });
+
+    expect(stub.getSatellite).not.toHaveBeenCalledWith("pending-foo");
+    expect(stub.getSatelliteByName).toHaveBeenCalledWith("eu-west-1");
+  });
+
+  it("normalizes missing metadata.labels to an empty tags object", async () => {
+    await kind.reconcile({
+      entity: mkEntity("eu-west-1", { region: "eu-west-1" }),
+      context: buildContext(),
+    });
+    expect(stub.createSatellite).toHaveBeenCalledWith({
+      name: "eu-west-1",
+      region: "eu-west-1",
+      tags: {},
+    });
+  });
+
+  it("delegates delete to the service", async () => {
+    await kind.delete!({
+      entityName: "eu-west-1",
+      entityId: "sat-1",
+      context: buildContext(),
+    });
+    expect(stub.deleteSatellite).toHaveBeenCalledWith("sat-1");
+  });
+
+  it("delete is a no-op without entityId", async () => {
+    await kind.delete!({ entityName: "x", context: buildContext() });
+    expect(stub.deleteSatellite).not.toHaveBeenCalled();
+  });
+});

--- a/core/satellite-backend/src/satellite-gitops-kinds.ts
+++ b/core/satellite-backend/src/satellite-gitops-kinds.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+import {
+  CHECKSTACK_API_VERSION,
+  type EntityKindDefinition,
+  type EntityKindRegistry,
+  type ReconcileContext,
+} from "@checkstack/gitops-common";
+import type { SatelliteService } from "./service";
+
+interface SatelliteGitOpsKindsDeps {
+  /** Lazy accessor — populated during init(), invoked at reconcile time. */
+  getService: () => SatelliteService;
+}
+
+// ─── Satellite Spec Schema ─────────────────────────────────────────────────
+//
+// GitOps owns metadata only — name, region, and the satellite's runtime
+// tags (sourced from the envelope's `metadata.labels`, since the envelope
+// already provides a `Record<string, string>` for that purpose). The bcrypt
+// token is never committed to YAML; operators retrieve and reset tokens via
+// the Satellites page in the UI.
+
+const satelliteSpecSchema = z.object({
+  region: z.string().min(1),
+});
+
+type SatelliteSpec = z.infer<typeof satelliteSpecSchema>;
+
+export function buildSatelliteKind(
+  deps: SatelliteGitOpsKindsDeps,
+): EntityKindDefinition<SatelliteSpec> {
+  return {
+    apiVersion: CHECKSTACK_API_VERSION,
+    kind: "Satellite",
+    specSchema: satelliteSpecSchema,
+
+    reconcile: async ({
+      entity,
+      existingEntityId,
+      context,
+    }: {
+      entity: {
+        metadata: {
+          name: string;
+          title?: string;
+          description?: string;
+          labels?: Record<string, string>;
+        };
+        spec: SatelliteSpec;
+      };
+      existingEntityId?: string;
+      context: ReconcileContext;
+    }) => {
+      const service = deps.getService();
+      const { spec, metadata } = entity;
+      const tags = metadata.labels ?? {};
+
+      // Try the provenance hint first; fall back to a name lookup so we
+      // adopt pre-existing satellites that match by name on first sync.
+      const existing =
+        existingEntityId && !existingEntityId.startsWith("pending-")
+          ? await service.getSatellite(existingEntityId)
+          : await service.getSatelliteByName(metadata.name);
+
+      if (existing) {
+        const updated = await service.updateSatelliteMetadata({
+          id: existing.id,
+          name: metadata.name,
+          region: spec.region,
+          tags,
+        });
+        const finalId = updated?.id ?? existing.id;
+        context.logger.info(
+          `GitOps: updated Satellite "${metadata.name}" (id: ${finalId})`,
+        );
+        return { entityId: finalId };
+      }
+
+      // First-time create. The plaintext token is intentionally discarded —
+      // an operator must use the UI's "Reset token" affordance to retrieve a
+      // working token. This keeps the secret out of YAML and out of logs.
+      const created = await service.createSatellite({
+        name: metadata.name,
+        region: spec.region,
+        tags,
+      });
+      context.logger.info(
+        `GitOps: created Satellite "${metadata.name}" (id: ${created.satellite.id}). ` +
+          `Reset the token via the Satellites page to obtain a working credential.`,
+      );
+      return { entityId: created.satellite.id };
+    },
+
+    delete: async ({
+      entityId,
+      context,
+    }: {
+      entityName: string;
+      entityId?: string;
+      context: ReconcileContext;
+    }) => {
+      if (!entityId) return;
+      await deps.getService().deleteSatellite(entityId);
+      context.logger.info(`GitOps: deleted Satellite (id: ${entityId})`);
+    },
+  };
+}
+
+export function registerSatelliteGitOpsKinds({
+  kindRegistry,
+  ...deps
+}: SatelliteGitOpsKindsDeps & {
+  kindRegistry: EntityKindRegistry;
+}): void {
+  kindRegistry.registerKind(buildSatelliteKind(deps));
+}

--- a/core/satellite-backend/src/service.ts
+++ b/core/satellite-backend/src/service.ts
@@ -81,6 +81,72 @@ export class SatelliteService {
   }
 
   /**
+   * Update a satellite's metadata (name, region, tags). Token is left intact —
+   * use `rotateSatelliteToken` to issue a new one.
+   */
+  async updateSatelliteMetadata(props: {
+    id: string;
+    name?: string;
+    region?: string;
+    tags?: Record<string, string>;
+  }): Promise<SatelliteWithStatus | undefined> {
+    const updates: Partial<typeof satellites.$inferInsert> = {};
+    if (props.name !== undefined) updates.name = props.name;
+    if (props.region !== undefined) updates.region = props.region;
+    if (props.tags !== undefined) updates.tags = props.tags;
+    if (Object.keys(updates).length === 0) return this.getSatellite(props.id);
+
+    const [row] = await this.db
+      .update(satellites)
+      .set(updates)
+      .where(eq(satellites.id, props.id))
+      .returning();
+    return row ? this.toSatelliteWithStatus(row) : undefined;
+  }
+
+  /**
+   * Rotate the token for an existing satellite. Generates a fresh plaintext
+   * token, stores its bcrypt hash, and returns the plaintext for one-time
+   * display. The previous token is invalidated immediately.
+   */
+  async rotateSatelliteToken(
+    id: string,
+  ): Promise<{ satellite: SatelliteWithStatus; plaintextToken: string } | undefined> {
+    const randomBytes = crypto.getRandomValues(new Uint8Array(32));
+    const tokenBody = Buffer.from(randomBytes).toString("base64url");
+    const plaintextToken = `csat_${tokenBody}`;
+
+    const tokenHash = await Bun.password.hash(plaintextToken, {
+      algorithm: "bcrypt",
+      cost: 10,
+    });
+
+    const [row] = await this.db
+      .update(satellites)
+      .set({ tokenHash })
+      .where(eq(satellites.id, id))
+      .returning();
+    if (!row) return undefined;
+
+    return {
+      satellite: this.toSatelliteWithStatus(row),
+      plaintextToken,
+    };
+  }
+
+  /**
+   * Lookup helper — returns a satellite by its `name`. Used by GitOps to
+   * resolve a YAML-declared satellite name to the persisted UUID.
+   */
+  async getSatelliteByName(name: string): Promise<SatelliteWithStatus | undefined> {
+    const [row] = await this.db
+      .select()
+      .from(satellites)
+      .where(eq(satellites.name, name));
+    return row ? this.toSatelliteWithStatus(row) : undefined;
+  }
+
+  /**
    * List all satellites with computed online/offline status.
    */
   async listSatellites(): Promise<SatelliteWithStatus[]> {

--- a/core/satellite-backend/tsconfig.json
+++ b/core/satellite-backend/tsconfig.json
@@ -14,6 +14,12 @@
       "path": "../drizzle-helper"
     },
     {
+      "path": "../gitops-backend"
+    },
+    {
+      "path": "../gitops-common"
+    },
+    {
       "path": "../healthcheck-common"
     },
     {

--- a/core/satellite-common/src/rpc-contract.ts
+++ b/core/satellite-common/src/rpc-contract.ts
@@ -56,6 +56,42 @@ export const satelliteContract = {
     .output(z.void()),
 
   /**
+   * Update a satellite's metadata. Token is unaffected — use
+   * `rotateSatelliteToken` to issue a new token.
+   */
+  updateSatellite: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [satelliteAccess.satellite.manage],
+  })
+    .input(
+      z.object({
+        id: z.string(),
+        name: z.string().min(1).optional(),
+        region: z.string().min(1).optional(),
+        tags: z.record(z.string(), z.string()).optional(),
+      }),
+    )
+    .output(SatelliteWithStatusSchema),
+
+  /**
+   * Rotate (reset) a satellite's token. Returns the new plaintext token,
+   * shown once. The previous token is invalidated immediately.
+   */
+  rotateSatelliteToken: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [satelliteAccess.satellite.manage],
+  })
+    .input(z.object({ id: z.string() }))
+    .output(
+      z.object({
+        satellite: SatelliteWithStatusSchema,
+        token: z.string(),
+      }),
+    ),
+
+  /**
    * Get the list of online satellite IDs.
    * Used internally by healthcheck-backend for stale source exclusion
    * during health state evaluation.

--- a/core/satellite-frontend/package.json
+++ b/core/satellite-frontend/package.json
@@ -17,6 +17,8 @@
     "@checkstack/frontend-api": "workspace:*",
     "@checkstack/satellite-common": "workspace:*",
     "@checkstack/signal-frontend": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
+    "@checkstack/gitops-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "lucide-react": "^0.344.0",
     "react": "^18.2.0",

--- a/core/satellite-frontend/src/components/RotateSatelliteTokenDialog.tsx
+++ b/core/satellite-frontend/src/components/RotateSatelliteTokenDialog.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useState } from "react";
+import { usePluginClient } from "@checkstack/frontend-api";
+import {
+  SatelliteApi,
+  type SatelliteWithStatus,
+} from "@checkstack/satellite-common";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  Button,
+  Input,
+  Label,
+  useToast,
+} from "@checkstack/ui";
+import { Copy, AlertTriangle, RefreshCw } from "lucide-react";
+import { extractErrorMessage } from "@checkstack/common";
+
+interface Props {
+  satellite: SatelliteWithStatus | undefined;
+  onClose: () => void;
+  onRotated: () => void;
+}
+
+interface RotatedCredentials {
+  clientId: string;
+  token: string;
+}
+
+/**
+ * Two-phase dialog: confirm intent → rotate → reveal new credentials once.
+ * Used for both ad-hoc resets and the GitOps "claim my token" workflow,
+ * since GitOps-managed satellites never receive a token via YAML.
+ */
+export const RotateSatelliteTokenDialog: React.FC<Props> = ({
+  satellite,
+  onClose,
+  onRotated,
+}) => {
+  const satelliteClient = usePluginClient(SatelliteApi);
+  const toast = useToast();
+  const [credentials, setCredentials] = useState<RotatedCredentials | undefined>();
+
+  useEffect(() => {
+    if (!satellite) setCredentials(undefined);
+  }, [satellite]);
+
+  const rotateMutation = satelliteClient.rotateSatelliteToken.useMutation({
+    onSuccess: (data) => {
+      setCredentials({
+        clientId: data.satellite.id,
+        token: data.token,
+      });
+      toast.success("Satellite token rotated");
+      onRotated();
+    },
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, "Failed to rotate token"));
+    },
+  });
+
+  const copyToClipboard = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(`${label} copied to clipboard`);
+    } catch {
+      toast.error("Failed to copy to clipboard");
+    }
+  };
+
+  const handleClose = () => {
+    setCredentials(undefined);
+    onClose();
+  };
+
+  if (!satellite) return null;
+
+  if (credentials) {
+    return (
+      <Dialog open onOpenChange={handleClose}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Token Issued</DialogTitle>
+            <DialogDescription>
+              Save the new token securely — the previous token has been
+              invalidated and the new one will not be shown again.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-4">
+            <div className="rounded-md border border-warning/50 bg-warning/10 p-3 flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 text-warning mt-0.5 shrink-0" />
+              <p className="text-sm text-warning">
+                Update the satellite&apos;s configuration with this token. Any
+                running satellite still using the previous token will be
+                disconnected.
+              </p>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="rotated-client-id">Client ID</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="rotated-client-id"
+                  value={credentials.clientId}
+                  readOnly
+                  className="font-mono text-sm"
+                />
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() =>
+                    void copyToClipboard(credentials.clientId, "Client ID")
+                  }
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="rotated-token">New Token</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="rotated-token"
+                  value={credentials.token}
+                  readOnly
+                  className="font-mono text-sm"
+                />
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() =>
+                    void copyToClipboard(credentials.token, "Token")
+                  }
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="grid gap-2 mt-2">
+              <Label>Environment Variables</Label>
+              <pre className="rounded-md bg-muted p-3 text-xs font-mono overflow-x-auto">
+                {`CHECKSTACK_CORE_URL=<your-core-url>\nCHECKSTACK_SATELLITE_CLIENT_ID=${credentials.clientId}\nCHECKSTACK_SATELLITE_TOKEN=${credentials.token}`}
+              </pre>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button onClick={handleClose}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open onOpenChange={handleClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reset Satellite Token</DialogTitle>
+          <DialogDescription>
+            Issue a new token for satellite &ldquo;{satellite.name}&rdquo;. The
+            existing token will stop working immediately.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-md border border-warning/50 bg-warning/10 p-3 flex items-start gap-2 my-2">
+          <AlertTriangle className="h-4 w-4 text-warning mt-0.5 shrink-0" />
+          <p className="text-sm text-warning">
+            Any running satellite using the previous token will be disconnected
+            until reconfigured with the new one.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => rotateMutation.mutate({ id: satellite.id })}
+            disabled={rotateMutation.isPending}
+          >
+            <RefreshCw className="h-4 w-4 mr-2" />
+            {rotateMutation.isPending ? "Rotating..." : "Rotate Token"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/core/satellite-frontend/src/pages/SatelliteListPage.tsx
+++ b/core/satellite-frontend/src/pages/SatelliteListPage.tsx
@@ -28,9 +28,14 @@ import {
   ConfirmationModal,
   PageLayout,
 } from "@checkstack/ui";
-import { Plus, Satellite, Trash2, MapPin } from "lucide-react";
+import { Plus, Satellite, Trash2, MapPin, KeyRound } from "lucide-react";
 import { SatelliteStatusBadge } from "../components/SatelliteStatusBadge";
 import { CreateSatelliteDialog } from "../components/CreateSatelliteDialog";
+import { RotateSatelliteTokenDialog } from "../components/RotateSatelliteTokenDialog";
+import {
+  useProvenanceLocks,
+  GitOpsSourceBadge,
+} from "@checkstack/gitops-frontend";
 import { extractErrorMessage } from "@checkstack/common";
 
 const SatelliteListPageContent: React.FC = () => {
@@ -46,6 +51,11 @@ const SatelliteListPageContent: React.FC = () => {
   const [deleteTarget, setDeleteTarget] = useState<
     SatelliteWithStatus | undefined
   >();
+  const [rotateTarget, setRotateTarget] = useState<
+    SatelliteWithStatus | undefined
+  >();
+
+  const { getLock } = useProvenanceLocks();
 
   const {
     data: satellites,
@@ -114,39 +124,68 @@ const SatelliteListPageContent: React.FC = () => {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {satelliteList.map((sat) => (
-                  <TableRow key={sat.id}>
-                    <TableCell>
-                      <p className="font-medium">{sat.name}</p>
-                      <p className="text-xs text-muted-foreground font-mono">
-                        {sat.id}
-                      </p>
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-                        <MapPin className="h-3.5 w-3.5" />
-                        {sat.region}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <SatelliteStatusBadge status={sat.status} />
-                    </TableCell>
-                    <TableCell>
-                      <span className="text-sm text-muted-foreground font-mono">
-                        {sat.version ?? "—"}
-                      </span>
-                    </TableCell>
-                    <TableCell>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setDeleteTarget(sat)}
-                      >
-                        <Trash2 className="h-4 w-4 text-destructive" />
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {satelliteList.map((sat) => {
+                  const lock = getLock({
+                    kind: "Satellite",
+                    entityId: sat.id,
+                  });
+                  return (
+                    <TableRow key={sat.id}>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          {lock.isLocked && lock.provenance && (
+                            <GitOpsSourceBadge provenance={lock.provenance} />
+                          )}
+                          <div>
+                            <p className="font-medium">{sat.name}</p>
+                            <p className="text-xs text-muted-foreground font-mono">
+                              {sat.id}
+                            </p>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                          <MapPin className="h-3.5 w-3.5" />
+                          {sat.region}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <SatelliteStatusBadge status={sat.status} />
+                      </TableCell>
+                      <TableCell>
+                        <span className="text-sm text-muted-foreground font-mono">
+                          {sat.version ?? "—"}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            title="Reset token"
+                            aria-label={`Reset token for ${sat.name}`}
+                            onClick={() => setRotateTarget(sat)}
+                          >
+                            <KeyRound className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            disabled={lock.isLocked}
+                            title={
+                              lock.isLocked ? "Managed by GitOps" : "Delete satellite"
+                            }
+                            aria-label={`Delete ${sat.name}`}
+                            onClick={() => setDeleteTarget(sat)}
+                          >
+                            <Trash2 className="h-4 w-4 text-destructive" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           )}
@@ -168,6 +207,12 @@ const SatelliteListPageContent: React.FC = () => {
         variant="danger"
         onConfirm={handleDelete}
         isLoading={deleteMutation.isPending}
+      />
+
+      <RotateSatelliteTokenDialog
+        satellite={rotateTarget}
+        onClose={() => setRotateTarget(undefined)}
+        onRotated={() => void refetch()}
       />
     </PageLayout>
   );

--- a/core/satellite-frontend/tsconfig.json
+++ b/core/satellite-frontend/tsconfig.json
@@ -11,6 +11,12 @@
       "path": "../frontend-api"
     },
     {
+      "path": "../gitops-common"
+    },
+    {
+      "path": "../gitops-frontend"
+    },
+    {
       "path": "../satellite-common"
     },
     {

--- a/core/slo-backend/package.json
+++ b/core/slo-backend/package.json
@@ -27,6 +27,8 @@
     "@checkstack/signal-common": "workspace:*",
     "@checkstack/integration-backend": "workspace:*",
     "@checkstack/integration-common": "workspace:*",
+    "@checkstack/gitops-backend": "workspace:*",
+    "@checkstack/gitops-common": "workspace:*",
     "@checkstack/common": "workspace:*",
     "@checkstack/queue-api": "workspace:*",
     "drizzle-orm": "^0.45.0",

--- a/core/slo-backend/src/index.ts
+++ b/core/slo-backend/src/index.ts
@@ -24,6 +24,8 @@ import { sloHooks } from "./hooks";
 import { setupDailySnapshotJob } from "./streak-calculator";
 import { setupWeeklyDigestJob } from "./weekly-digest";
 import { evaluateAchievements } from "./achievement-evaluator";
+import { entityKindExtensionPoint } from "@checkstack/gitops-backend";
+import { registerSloGitOpsKinds } from "./slo-gitops-kinds";
 
 // =============================================================================
 // Integration Event Payload Schemas
@@ -168,6 +170,17 @@ export default createBackendPlugin({
 
     // Shared references across init/afterPluginsReady (maintenance-backend pattern)
     let sharedEngine: SloEngine;
+    let gitopsService: SloService | undefined;
+
+    // ─── GitOps Entity Kind Registration ─────────────────────────────
+    const kindRegistry = env.getExtensionPoint(entityKindExtensionPoint);
+    registerSloGitOpsKinds({
+      kindRegistry,
+      getService: () => {
+        if (!gitopsService) throw new Error("SloService not initialized");
+        return gitopsService;
+      },
+    });
 
     env.registerInit({
       schema,
@@ -190,6 +203,7 @@ export default createBackendPlugin({
         logger.debug("🔧 Initializing SLO Backend...");
 
         const service = new SloService(database as SafeDatabase<typeof schema>);
+        gitopsService = service;
         const engine = new SloEngine({
           service,
           signalService,

--- a/core/slo-backend/src/slo-gitops-kinds.test.ts
+++ b/core/slo-backend/src/slo-gitops-kinds.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import {
+  CHECKSTACK_API_VERSION,
+  type ReconcileContext,
+} from "@checkstack/gitops-common";
+import type { SloService } from "./service";
+import type { SloObjective } from "@checkstack/slo-common";
+import { buildSloKind } from "./slo-gitops-kinds";
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const buildContext = (
+  overrides: Partial<ReconcileContext> = {},
+): ReconcileContext =>
+  ({
+    logger: noopLogger,
+    resolveEntityRef: async () => undefined,
+    resolveSecretsBySchema: async ({ value }) => ({
+      resolved: value,
+      warnings: [],
+    }),
+    ...overrides,
+  }) as ReconcileContext;
+
+const stubService = () => {
+  const created: SloObjective = {
+    id: "slo-1",
+    systemId: "sys-1",
+    healthCheckConfigurationId: null,
+    target: 99.9,
+    windowDays: 30,
+    dependencyExclusion: "strict",
+    excludedDependencyIds: [],
+    burnRateThresholds: {
+      warningPercent: 50,
+      criticalPercent: 80,
+      fastBurnMultiplier: 5,
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  const createObjective = mock(async () => created);
+  const updateObjective = mock(async () => created);
+  const deleteObjective = mock(async () => true);
+  return {
+    created,
+    createObjective,
+    updateObjective,
+    deleteObjective,
+    service: {
+      createObjective,
+      updateObjective,
+      deleteObjective,
+    } as unknown as SloService,
+  };
+};
+
+const refResolver =
+  (table: Record<string, string>) =>
+  async ({ entityName }: { kind: string; entityName: string }) =>
+    table[entityName];
+
+const mkEntity = <TSpec>(name: string, spec: TSpec) => ({
+  apiVersion: CHECKSTACK_API_VERSION,
+  kind: "SLO",
+  metadata: { name },
+  spec,
+});
+
+describe("buildSloKind", () => {
+  let stub: ReturnType<typeof stubService>;
+  let kind: ReturnType<typeof buildSloKind>;
+
+  beforeEach(() => {
+    stub = stubService();
+    kind = buildSloKind({ getService: () => stub.service });
+  });
+
+  it("registers under SLO kind", () => {
+    expect(kind.kind).toBe("SLO");
+  });
+
+  it("creates an objective when no existing entity id is supplied", async () => {
+    const result = await kind.reconcile({
+      entity: mkEntity("payments-availability", {
+        systemRef: { kind: "System", name: "payments-api" },
+        target: 99.9,
+        windowDays: 30,
+      }),
+      context: buildContext({
+        resolveEntityRef: refResolver({ "payments-api": "sys-1" }),
+      }),
+    });
+
+    expect(result.entityId).toBe("slo-1");
+    expect(stub.createObjective).toHaveBeenCalledTimes(1);
+    expect(stub.createObjective).toHaveBeenCalledWith({
+      input: {
+        systemId: "sys-1",
+        healthCheckConfigurationId: undefined,
+        target: 99.9,
+        windowDays: 30,
+        dependencyExclusion: "strict",
+        excludedDependencyIds: [],
+        burnRateThresholds: {
+          warningPercent: 50,
+          criticalPercent: 80,
+          fastBurnMultiplier: 5,
+        },
+      },
+    });
+  });
+
+  it("resolves an optional healthcheck ref into healthCheckConfigurationId", async () => {
+    await kind.reconcile({
+      entity: mkEntity("payments-http-availability", {
+        systemRef: { kind: "System", name: "payments-api" },
+        healthcheckRef: { kind: "Healthcheck", name: "payments-http" },
+        target: 99.95,
+        windowDays: 7,
+      }),
+      context: buildContext({
+        resolveEntityRef: refResolver({
+          "payments-api": "sys-1",
+          "payments-http": "hc-1",
+        }),
+      }),
+    });
+
+    expect(stub.createObjective).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        systemId: "sys-1",
+        healthCheckConfigurationId: "hc-1",
+      }),
+    });
+  });
+
+  it("resolves excluded dependency refs to system ids", async () => {
+    await kind.reconcile({
+      entity: mkEntity("core", {
+        systemRef: { kind: "System", name: "core" },
+        target: 99.9,
+        windowDays: 30,
+        dependencyExclusion: "self-only",
+        excludedDependencyRefs: [
+          { kind: "System", name: "third-party-payments" },
+          { kind: "System", name: "third-party-email" },
+        ],
+      }),
+      context: buildContext({
+        resolveEntityRef: refResolver({
+          core: "sys-core",
+          "third-party-payments": "sys-pay",
+          "third-party-email": "sys-mail",
+        }),
+      }),
+    });
+
+    expect(stub.createObjective).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        excludedDependencyIds: ["sys-pay", "sys-mail"],
+        dependencyExclusion: "self-only",
+      }),
+    });
+  });
+
+  it("updates an existing objective when existingEntityId is supplied", async () => {
+    await kind.reconcile({
+      entity: mkEntity("payments", {
+        systemRef: { kind: "System", name: "payments-api" },
+        target: 99.95,
+        windowDays: 30,
+      }),
+      existingEntityId: "slo-existing",
+      context: buildContext({
+        resolveEntityRef: refResolver({ "payments-api": "sys-1" }),
+      }),
+    });
+
+    expect(stub.createObjective).not.toHaveBeenCalled();
+    expect(stub.updateObjective).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        id: "slo-existing",
+        target: 99.95,
+        windowDays: 30,
+      }),
+    });
+  });
+
+  it("treats pending-* entityIds as fresh creates", async () => {
+    await kind.reconcile({
+      entity: mkEntity("payments", {
+        systemRef: { kind: "System", name: "payments-api" },
+        target: 99.9,
+        windowDays: 30,
+      }),
+      existingEntityId: "pending-abc",
+      context: buildContext({
+        resolveEntityRef: refResolver({ "payments-api": "sys-1" }),
+      }),
+    });
+
+    expect(stub.createObjective).toHaveBeenCalledTimes(1);
+    expect(stub.updateObjective).not.toHaveBeenCalled();
+  });
+
+  it("throws when systemRef cannot be resolved", async () => {
+    await expect(
+      kind.reconcile({
+        entity: mkEntity("broken", {
+          systemRef: { kind: "System", name: "nope" },
+          target: 99.9,
+          windowDays: 30,
+        }),
+        context: buildContext({ resolveEntityRef: async () => undefined }),
+      }),
+    ).rejects.toThrow(/Cannot resolve system ref "nope"/);
+  });
+
+  it("delegates delete to the service", async () => {
+    await kind.delete!({
+      entityName: "payments",
+      entityId: "slo-1",
+      context: buildContext(),
+    });
+    expect(stub.deleteObjective).toHaveBeenCalledWith({ id: "slo-1" });
+  });
+
+  it("delete is a no-op when entityId is missing", async () => {
+    await kind.delete!({ entityName: "x", context: buildContext() });
+    expect(stub.deleteObjective).not.toHaveBeenCalled();
+  });
+});

--- a/core/slo-backend/src/slo-gitops-kinds.ts
+++ b/core/slo-backend/src/slo-gitops-kinds.ts
@@ -1,0 +1,174 @@
+import { z } from "zod";
+import {
+  CHECKSTACK_API_VERSION,
+  entityRefSchema,
+  type EntityKindDefinition,
+  type EntityKindRegistry,
+  type ReconcileContext,
+} from "@checkstack/gitops-common";
+import {
+  DependencyExclusionModeSchema,
+  BurnRateThresholdsSchema,
+} from "@checkstack/slo-common";
+import type { SloService } from "./service";
+
+interface SloGitOpsKindsDeps {
+  /** Lazy accessor — populated during init(), invoked at reconcile time. */
+  getService: () => SloService;
+}
+
+// ─── SLO Spec Schema ───────────────────────────────────────────────────────
+
+/**
+ * GitOps spec for `kind: SLO`.
+ *
+ * An SLO targets a specific system (required) and may optionally narrow to a
+ * single healthcheck on that system. When `healthcheckRef` is omitted the SLO
+ * covers the system's aggregate availability across all of its healthchecks.
+ */
+const sloSpecSchema = z.object({
+  systemRef: entityRefSchema,
+  healthcheckRef: entityRefSchema.optional(),
+  target: z.number().min(0).max(100),
+  windowDays: z.number().int().positive(),
+  dependencyExclusion: DependencyExclusionModeSchema.optional(),
+  excludedDependencyRefs: z.array(entityRefSchema).optional(),
+  burnRateThresholds: BurnRateThresholdsSchema.optional(),
+});
+
+type SloSpec = z.infer<typeof sloSpecSchema>;
+
+// ─── Kind builder ───────────────────────────────────────────────────────────
+
+const resolveRequiredRef = async ({
+  context,
+  ref,
+  refKindLabel,
+}: {
+  context: ReconcileContext;
+  ref: { kind: string; name: string };
+  refKindLabel: string;
+}): Promise<string> => {
+  const id = await context.resolveEntityRef({
+    kind: ref.kind,
+    entityName: ref.name,
+  });
+  if (!id) {
+    throw new Error(
+      `Cannot resolve ${refKindLabel} ref "${ref.name}" (kind: ${ref.kind}) — ensure the entity exists`,
+    );
+  }
+  return id;
+};
+
+export function buildSloKind(
+  deps: SloGitOpsKindsDeps,
+): EntityKindDefinition<SloSpec> {
+  return {
+    apiVersion: CHECKSTACK_API_VERSION,
+    kind: "SLO",
+    specSchema: sloSpecSchema,
+
+    reconcile: async ({
+      entity,
+      existingEntityId,
+      context,
+    }: {
+      entity: {
+        metadata: { name: string; title?: string; description?: string };
+        spec: SloSpec;
+      };
+      existingEntityId?: string;
+      context: ReconcileContext;
+    }) => {
+      const { spec } = entity;
+      const service = deps.getService();
+
+      const systemId = await resolveRequiredRef({
+        context,
+        ref: spec.systemRef,
+        refKindLabel: "system",
+      });
+
+      let healthCheckConfigurationId: string | undefined;
+      if (spec.healthcheckRef) {
+        healthCheckConfigurationId = await resolveRequiredRef({
+          context,
+          ref: spec.healthcheckRef,
+          refKindLabel: "healthcheck",
+        });
+      }
+
+      const excludedDependencyIds = spec.excludedDependencyRefs
+        ? await Promise.all(
+            spec.excludedDependencyRefs.map((ref) =>
+              resolveRequiredRef({
+                context,
+                ref,
+                refKindLabel: "excluded dependency",
+              }),
+            ),
+          )
+        : [];
+
+      if (existingEntityId && !existingEntityId.startsWith("pending-")) {
+        await service.updateObjective({
+          input: {
+            id: existingEntityId,
+            target: spec.target,
+            windowDays: spec.windowDays,
+            dependencyExclusion: spec.dependencyExclusion,
+            excludedDependencyIds,
+            burnRateThresholds: spec.burnRateThresholds,
+          },
+        });
+        context.logger.info(
+          `GitOps: updated SLO "${entity.metadata.name}" (id: ${existingEntityId})`,
+        );
+        return { entityId: existingEntityId };
+      }
+
+      const created = await service.createObjective({
+        input: {
+          systemId,
+          healthCheckConfigurationId,
+          target: spec.target,
+          windowDays: spec.windowDays,
+          dependencyExclusion: spec.dependencyExclusion ?? "strict",
+          excludedDependencyIds,
+          burnRateThresholds: spec.burnRateThresholds ?? {
+            warningPercent: 50,
+            criticalPercent: 80,
+            fastBurnMultiplier: 5,
+          },
+        },
+      });
+      context.logger.info(
+        `GitOps: created SLO "${entity.metadata.name}" (id: ${created.id})`,
+      );
+      return { entityId: created.id };
+    },
+
+    delete: async ({
+      entityId,
+      context,
+    }: {
+      entityName: string;
+      entityId?: string;
+      context: ReconcileContext;
+    }) => {
+      if (!entityId) return;
+      await deps.getService().deleteObjective({ id: entityId });
+      context.logger.info(`GitOps: deleted SLO (id: ${entityId})`);
+    },
+  };
+}
+
+export function registerSloGitOpsKinds({
+  kindRegistry,
+  ...deps
+}: SloGitOpsKindsDeps & {
+  kindRegistry: EntityKindRegistry;
+}): void {
+  kindRegistry.registerKind(buildSloKind(deps));
+}

--- a/core/slo-backend/tsconfig.json
+++ b/core/slo-backend/tsconfig.json
@@ -32,6 +32,12 @@
       "path": "../drizzle-helper"
     },
     {
+      "path": "../gitops-backend"
+    },
+    {
+      "path": "../gitops-common"
+    },
+    {
       "path": "../healthcheck-backend"
     },
     {

--- a/docs/backend/gitops-entity-kinds.md
+++ b/docs/backend/gitops-entity-kinds.md
@@ -463,6 +463,125 @@ spec:
     password: "${{ secrets.payment-db-password }}"
 ```
 
+## Other Built-In Kinds and Extensions
+
+Beyond `System` and `Healthcheck`, the following kinds and extensions
+are registered by their owning plugins:
+
+### `kind: SLO` (slo-backend)
+
+Reliability targets bound to a system, optionally narrowed to a single
+healthcheck. The objective UUID is the entity ID in provenance, so
+renames preserve identity.
+
+```yaml
+apiVersion: checkstack.io/v1alpha1
+kind: SLO
+metadata:
+  name: payments-availability
+spec:
+  systemRef: { kind: System, name: payments-api }
+  healthcheckRef: { kind: Healthcheck, name: payments-http } # optional
+  target: 99.9
+  windowDays: 30
+  dependencyExclusion: strict # or "self-only"
+  excludedDependencyRefs: # optional
+    - { kind: System, name: third-party-payments }
+  burnRateThresholds: # optional
+    warningPercent: 50
+    criticalPercent: 80
+    fastBurnMultiplier: 5
+```
+
+### `kind: Satellite` (satellite-backend)
+
+Metadata-only declaration of remote execution nodes. The bcrypt token
+is **never** expressed in YAML — the reconciler discards the random
+token issued at creation. Operators retrieve a working token via the
+"Reset token" button on the Satellites page. Runtime tags use the
+envelope's `metadata.labels` (`Record<string, string>`), so there is no
+duplicate `tags` field on the spec.
+
+```yaml
+apiVersion: checkstack.io/v1alpha1
+kind: Satellite
+metadata:
+  name: eu-west-1
+  labels:
+    tier: prod
+    region-group: emea
+spec:
+  region: eu-west-1
+```
+
+The reconciler adopts pre-existing satellites by `metadata.name` on
+first sync, so manually-created satellites are absorbed safely.
+
+### Extension: `Healthcheck.anomaly` (anomaly-backend)
+
+Per-healthcheck anomaly defaults. Replaces the full template-level
+`AnomalySettings` record on every reconcile (GitOps is the source of
+truth; UI edits to managed entities are blocked).
+
+```yaml
+apiVersion: checkstack.io/v1alpha1
+kind: Healthcheck
+metadata: { name: payment-db-check }
+spec:
+  # …strategy / intervalSeconds / config…
+  anomaly:
+    enabled: true
+    sensitivity: 1
+    confirmationWindow: 3
+    baselineWindow: "7d"
+    notify: true
+    driftEnabled: true
+    driftThreshold: 2
+    fieldOverrides: # keyed by result field path
+      latencyMs: { sensitivity: 0.5, driftThreshold: 4 }
+```
+
+### Extension: `System.dependencies` (dependency-backend)
+
+Declares upstream system dependencies for a system. The reconciler diffs
+the declared edges against the persisted ones where this system is the
+source, then applies create / update / delete to converge. Refs that
+resolve to the source system itself are rejected.
+
+```yaml
+apiVersion: checkstack.io/v1alpha1
+kind: System
+metadata: { name: payments-api }
+spec:
+  dependencies:
+    - targetRef: { kind: System, name: payments-db }
+      impactType: critical # informational | degraded | critical
+      transitive: false # follow multi-hop chains?
+      label: "primary store" # optional
+```
+
+The matching UI (system editor drawer + Dependency Map) disables
+Add/Edit/Delete for the source system's upstream edges; downstream
+edges are gated per-row by the *other* system's lock.
+
+### Extension: `System.anomaly` (anomaly-backend)
+
+Per-assignment anomaly overrides ("exceptions"), keyed by
+`healthcheckRef`. Each entry maps to one System ↔ Healthcheck
+assignment and its `AnomalySettings` partial.
+
+```yaml
+apiVersion: checkstack.io/v1alpha1
+kind: System
+metadata: { name: payment-api }
+spec:
+  anomaly:
+    - healthcheckRef: { kind: Healthcheck, name: payment-db-check }
+      enabled: false
+      fieldOverrides:
+        latencyMs: { sensitivity: 0.3 }
+```
+
 ## Troubleshooting
 
 ### Kind Not Appearing in Registry


### PR DESCRIPTION
## Summary

Surface the source repository for GitOps-managed entities, gate catalog UI on lock state, and add four new GitOps kinds/extensions.

**Source URL & UI affordances**

- \`provenanceSchema\` now carries a \`sourceUrl\` field, derived on the backend from the provider type, base URL, repository, and file path. URLs are constructed for github.com / gitlab.com and self-hosted GitHub/GitLab where the API base ends in \`/api/v3\` or \`/api/v4\`. Other base URLs fall back to \`null\` so the UI keeps showing the raw path.
- New \`useProvenanceLocks\` (bulk variant of \`useProvenanceLock\`) for views that render many entities.
- New \`<GitOpsSourceBadge>\` popover replaces the bare \`GitBranch\` icon on system and group catalog cards. The popover surfaces the repo, file path, and a "View in source provider" deep link.
- \`<GitOpsLockBanner>\` repo line is now a real link when a \`sourceUrl\` is available.
- The system→group remove button in the catalog disables itself when the system is GitOps-managed.

**Anomaly extensions** (\`Healthcheck.anomaly\` + \`System.anomaly\`)

- \`Healthcheck.anomaly\` accepts the full \`AnomalySettings\` shape and applies it via \`updateAnomalyConfig\`.
- \`System.anomaly\` accepts an array of per-healthcheck overrides, each scoped via \`healthcheckRef: { kind: Healthcheck, name: ... }\`, applied with \`updateAnomalyAssignmentConfig\`. UI edits to managed entries are blocked by the existing assignment-level lock.
- Spec schema documentation for \`Healthcheck.anomaly.fieldOverrides\` is registered **per collector field**, conditioned on the selected \`collectors[].config\` variant — same pattern \`collectors[].assertions\` uses. The System extension's \`fieldOverrides\` falls back to a generic variant since the collector lives on the referenced Healthcheck.

**Satellite kind**

- GitOps owns satellite metadata only — \`metadata.name\`, \`spec.region\`, and \`metadata.labels\`. The bcrypt token is intentionally never expressed in YAML; on first reconcile a satellite is created with a random token that is discarded, and operators must use the Satellites page to retrieve a working credential.
- New service methods: \`updateSatelliteMetadata\`, \`rotateSatelliteToken\`, \`getSatelliteByName\`.
- New RPC procs: \`updateSatellite\`, \`rotateSatelliteToken\`.
- New \`RotateSatelliteTokenDialog\` + "Reset token" key icon on the Satellites list (reuses the one-time-reveal layout from \`CreateSatelliteDialog\`).
- Satellites list shows a \`GitOpsSourceBadge\` next to managed satellites, disables the delete button, leaves the token-reset enabled.
- Reconciler adopts pre-existing satellites by name on first sync.

**SLO kind**

References target via \`systemRef\` and may narrow to a single healthcheck via \`healthcheckRef\`. Excluded dependencies are resolved at reconcile time. Reconcile maps to \`SloService.createObjective\` / \`updateObjective\` / \`deleteObjective\`; provenance stores the SLO objective UUID so YAML renames preserve identity.

**\`System.dependencies\` extension**

Each entry references an upstream system by ref and tunes impact (\`impactType\`, \`transitive\`, \`label\`). The reconciler diffs the YAML-declared edges against persisted ones where this system is the source and converges via create / update / delete — edges no longer listed are removed. Refs that resolve to the source system itself are rejected; refs that fail to resolve abort the diff before any mutation.

UI gates:
- \`DependencyEditor\` (system editor drawer) hides Add and disables Edit/Delete on upstream rows when the source system is GitOps-managed. Downstream rows are gated per-row by the *other* system's lock.
- \`DependencyMap\` blocks \`onConnect\` when the source is locked, surfaces a "Managed by GitOps" notice in the edge editor panel, and disables Save/Delete there.

## Test plan

- [ ] Manual: GitHub/GitLab cloud and self-hosted (\`/api/v3\`, \`/api/v4\`) provenance produces working source URLs; other base URLs render the raw path
- [ ] Manual: catalog cards show the \`<GitOpsSourceBadge>\` popover; \`<GitOpsLockBanner>\` repo line links when sourceUrl is present
- [ ] Manual: declare a Healthcheck with \`anomaly\` extension and a System with \`anomaly\` array; verify reconcile applies and UI is locked for managed entries
- [ ] Manual: declare a Satellite, verify token-reset works post-reconcile, delete is disabled, adoption-by-name works for pre-existing
- [ ] Manual: declare an SLO, rename in YAML — provenance preserves identity (no orphan create/delete)
- [ ] Manual: declare \`System.dependencies\`, verify edges converge on update; ref to self is rejected; unresolvable ref aborts before mutation
- [ ] CI: \`bun run typecheck\` and \`bun run lint\` pass
- [ ] CI: \`*-gitops-kinds.test.ts\` passes for anomaly, SLO, satellite, dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)