### PR TITLE
feat: add Storybook for @checkstack/ui

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "docs/**"
+      - "core/ui/**"
+      - ".github/workflows/deploy-docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -30,11 +32,27 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Build with Jekyll
+      - name: Build Jekyll site
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./_site
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Storybook
+        run: bun run --filter '@checkstack/ui' storybook:build
+
+      - name: Merge Storybook into Pages artifact
+        run: |
+          mkdir -p ./_site/storybook
+          cp -r ./core/ui/storybook-static/. ./_site/storybook/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ runtime_plugins/
 .dev/
 plugins/_test-scaffolds/
 reports/
+storybook-static/

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "core/about-common": {
       "name": "@checkstack/about-common",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -37,7 +37,7 @@
     },
     "core/about-frontend": {
       "name": "@checkstack/about-frontend",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@checkstack/about-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -56,7 +56,7 @@
     },
     "core/announcement-backend": {
       "name": "@checkstack/announcement-backend",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-backend": "workspace:*",
@@ -82,7 +82,7 @@
     },
     "core/announcement-common": {
       "name": "@checkstack/announcement-common",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -97,7 +97,7 @@
     },
     "core/announcement-frontend": {
       "name": "@checkstack/announcement-frontend",
-      "version": "0.2.16",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -120,7 +120,7 @@
     },
     "core/anomaly-backend": {
       "name": "@checkstack/anomaly-backend",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -154,7 +154,7 @@
     },
     "core/anomaly-common": {
       "name": "@checkstack/anomaly-common",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -170,7 +170,7 @@
     },
     "core/anomaly-frontend": {
       "name": "@checkstack/anomaly-frontend",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -197,7 +197,7 @@
     },
     "core/api-docs-common": {
       "name": "@checkstack/api-docs-common",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -209,7 +209,7 @@
     },
     "core/api-docs-frontend": {
       "name": "@checkstack/api-docs-frontend",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -228,7 +228,7 @@
     },
     "core/auth-backend": {
       "name": "@checkstack/auth-backend",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -253,7 +253,7 @@
     },
     "core/auth-common": {
       "name": "@checkstack/auth-common",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -267,7 +267,7 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.5.33",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -289,7 +289,7 @@
     },
     "core/backend": {
       "name": "@checkstack/backend",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -329,7 +329,7 @@
     },
     "core/backend-api": {
       "name": "@checkstack/backend-api",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@checkstack/cache-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -358,7 +358,7 @@
     },
     "core/cache-api": {
       "name": "@checkstack/cache-api",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -370,7 +370,7 @@
     },
     "core/cache-backend": {
       "name": "@checkstack/cache-backend",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -387,7 +387,7 @@
     },
     "core/cache-common": {
       "name": "@checkstack/cache-common",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -401,7 +401,7 @@
     },
     "core/cache-frontend": {
       "name": "@checkstack/cache-frontend",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/cache-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -420,7 +420,7 @@
     },
     "core/cache-utils": {
       "name": "@checkstack/cache-utils",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@checkstack/cache-api": "workspace:*",
       },
@@ -433,7 +433,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -465,7 +465,7 @@
     },
     "core/catalog-common": {
       "name": "@checkstack/catalog-common",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -482,7 +482,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -509,7 +509,7 @@
     },
     "core/command-backend": {
       "name": "@checkstack/command-backend",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-common": "workspace:*",
@@ -527,7 +527,7 @@
     },
     "core/command-common": {
       "name": "@checkstack/command-common",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -541,7 +541,7 @@
     },
     "core/command-frontend": {
       "name": "@checkstack/command-frontend",
-      "version": "0.2.34",
+      "version": "0.2.35",
       "dependencies": {
         "@checkstack/command-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -560,7 +560,7 @@
     },
     "core/common": {
       "name": "@checkstack/common",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@orpc/contract": "^1.13.14",
         "lucide-react": "0.562.0",
@@ -574,7 +574,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -607,7 +607,7 @@
     },
     "core/dependency-backend": {
       "name": "@checkstack/dependency-backend",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/catalog-backend": "workspace:*",
@@ -638,7 +638,7 @@
     },
     "core/dependency-common": {
       "name": "@checkstack/dependency-common",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -656,7 +656,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -682,7 +682,7 @@
     },
     "core/dev-server": {
       "name": "@checkstack/dev-server",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "bin": {
         "checkstack-dev": "./src/dev-server.ts",
       },
@@ -717,7 +717,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -757,7 +757,7 @@
     },
     "core/frontend-api": {
       "name": "@checkstack/frontend-api",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -780,7 +780,7 @@
     },
     "core/gitops-backend": {
       "name": "@checkstack/gitops-backend",
-      "version": "0.2.8",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -807,7 +807,7 @@
     },
     "core/gitops-common": {
       "name": "@checkstack/gitops-common",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -821,7 +821,7 @@
     },
     "core/gitops-frontend": {
       "name": "@checkstack/gitops-frontend",
-      "version": "0.3.8",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -841,7 +841,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -881,7 +881,7 @@
     },
     "core/healthcheck-common": {
       "name": "@checkstack/healthcheck-common",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -897,7 +897,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.18.2",
+      "version": "0.19.0",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -930,7 +930,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -961,7 +961,7 @@
     },
     "core/incident-common": {
       "name": "@checkstack/incident-common",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -979,7 +979,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -1006,7 +1006,7 @@
     },
     "core/infrastructure-common": {
       "name": "@checkstack/infrastructure-common",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1021,7 +1021,7 @@
     },
     "core/infrastructure-frontend": {
       "name": "@checkstack/infrastructure-frontend",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1040,7 +1040,7 @@
     },
     "core/integration-backend": {
       "name": "@checkstack/integration-backend",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -1064,7 +1064,7 @@
     },
     "core/integration-common": {
       "name": "@checkstack/integration-common",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1079,7 +1079,7 @@
     },
     "core/integration-frontend": {
       "name": "@checkstack/integration-frontend",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1100,7 +1100,7 @@
     },
     "core/maintenance-backend": {
       "name": "@checkstack/maintenance-backend",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1131,7 +1131,7 @@
     },
     "core/maintenance-common": {
       "name": "@checkstack/maintenance-common",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1149,7 +1149,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -1176,7 +1176,7 @@
     },
     "core/notification-backend": {
       "name": "@checkstack/notification-backend",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1203,7 +1203,7 @@
     },
     "core/notification-common": {
       "name": "@checkstack/notification-common",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1218,7 +1218,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1240,7 +1240,7 @@
     },
     "core/pluginmanager-common": {
       "name": "@checkstack/pluginmanager-common",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
@@ -1253,7 +1253,7 @@
     },
     "core/pluginmanager-frontend": {
       "name": "@checkstack/pluginmanager-frontend",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1273,7 +1273,7 @@
     },
     "core/queue-api": {
       "name": "@checkstack/queue-api",
-      "version": "0.2.18",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -1285,7 +1285,7 @@
     },
     "core/queue-backend": {
       "name": "@checkstack/queue-backend",
-      "version": "0.2.22",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1304,7 +1304,7 @@
     },
     "core/queue-common": {
       "name": "@checkstack/queue-common",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1319,7 +1319,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1343,11 +1343,11 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.81.0",
+      "version": "0.82.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1362,7 +1362,7 @@
     },
     "core/satellite-backend": {
       "name": "@checkstack/satellite-backend",
-      "version": "0.2.21",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1389,7 +1389,7 @@
     },
     "core/satellite-common": {
       "name": "@checkstack/satellite-common",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
@@ -1405,7 +1405,7 @@
     },
     "core/satellite-frontend": {
       "name": "@checkstack/satellite-frontend",
-      "version": "0.2.13",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1428,7 +1428,7 @@
     },
     "core/scripts": {
       "name": "@checkstack/scripts",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "bin": {
         "checkstack-scripts": "./src/cli.ts",
       },
@@ -1447,7 +1447,7 @@
     },
     "core/signal-backend": {
       "name": "@checkstack/signal-backend",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1463,7 +1463,7 @@
     },
     "core/signal-common": {
       "name": "@checkstack/signal-common",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
@@ -1476,7 +1476,7 @@
     },
     "core/signal-frontend": {
       "name": "@checkstack/signal-frontend",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@checkstack/signal-common": "workspace:*",
       },
@@ -1492,7 +1492,7 @@
     },
     "core/slo-backend": {
       "name": "@checkstack/slo-backend",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -1527,7 +1527,7 @@
     },
     "core/slo-common": {
       "name": "@checkstack/slo-common",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1543,7 +1543,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.3.10",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1570,7 +1570,7 @@
     },
     "core/test-utils-backend": {
       "name": "@checkstack/test-utils-backend",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1606,7 +1606,7 @@
     },
     "core/theme-backend": {
       "name": "@checkstack/theme-backend",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1628,7 +1628,7 @@
     },
     "core/theme-common": {
       "name": "@checkstack/theme-common",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -1642,7 +1642,7 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1661,7 +1661,7 @@
     },
     "core/tips-backend": {
       "name": "@checkstack/tips-backend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1683,7 +1683,7 @@
     },
     "core/tips-common": {
       "name": "@checkstack/tips-common",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.14",
@@ -1697,7 +1697,7 @@
     },
     "core/tips-frontend": {
       "name": "@checkstack/tips-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1724,7 +1724,7 @@
     },
     "core/ui": {
       "name": "@checkstack/ui",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1744,7 +1744,7 @@
         "monaco-editor": "^0.55.1",
         "react": "^18.2.0",
         "react-day-picker": "^9.13.0",
-        "react-dom": "^19.2.5",
+        "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.20.0",
         "recharts": "^3.6.0",
@@ -1754,15 +1754,27 @@
         "@checkstack/scripts": "workspace:*",
         "@checkstack/test-utils-frontend": "workspace:*",
         "@checkstack/tsconfig": "workspace:*",
+        "@storybook/addon-a11y": "^10.3.6",
+        "@storybook/addon-docs": "^10.3.6",
+        "@storybook/addon-themes": "^10.3.6",
+        "@storybook/react": "^10.3.6",
+        "@storybook/react-vite": "^10.3.6",
         "@testing-library/react": "^16.0.0",
         "@types/react": "^18.2.0",
-        "@types/react-dom": "^19.2.3",
+        "@types/react-dom": "^18.2.0",
+        "@vitejs/plugin-react": "^6.0.1",
+        "autoprefixer": "^10.4.18",
+        "postcss": "^8.4.35",
+        "storybook": "^10.3.6",
+        "tailwindcss": "^3.4.1",
+        "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.0.0",
+        "vite": "^8.0.8",
       },
     },
     "plugins/auth-credential-backend": {
       "name": "@checkstack/auth-credential-backend",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1776,7 +1788,7 @@
     },
     "plugins/auth-github-backend": {
       "name": "@checkstack/auth-github-backend",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1790,7 +1802,7 @@
     },
     "plugins/auth-ldap-backend": {
       "name": "@checkstack/auth-ldap-backend",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1809,7 +1821,7 @@
     },
     "plugins/auth-saml-backend": {
       "name": "@checkstack/auth-saml-backend",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1827,7 +1839,7 @@
     },
     "plugins/cache-memory-backend": {
       "name": "@checkstack/cache-memory-backend",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -1843,7 +1855,7 @@
     },
     "plugins/cache-memory-common": {
       "name": "@checkstack/cache-memory-common",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -1854,7 +1866,7 @@
     },
     "plugins/collector-hardware-backend": {
       "name": "@checkstack/collector-hardware-backend",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1870,7 +1882,7 @@
     },
     "plugins/healthcheck-dns-backend": {
       "name": "@checkstack/healthcheck-dns-backend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1885,7 +1897,7 @@
     },
     "plugins/healthcheck-grpc-backend": {
       "name": "@checkstack/healthcheck-grpc-backend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1901,7 +1913,7 @@
     },
     "plugins/healthcheck-http-backend": {
       "name": "@checkstack/healthcheck-http-backend",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1917,7 +1929,7 @@
     },
     "plugins/healthcheck-jenkins-backend": {
       "name": "@checkstack/healthcheck-jenkins-backend",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1932,7 +1944,7 @@
     },
     "plugins/healthcheck-mysql-backend": {
       "name": "@checkstack/healthcheck-mysql-backend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1948,7 +1960,7 @@
     },
     "plugins/healthcheck-ping-backend": {
       "name": "@checkstack/healthcheck-ping-backend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1963,7 +1975,7 @@
     },
     "plugins/healthcheck-postgres-backend": {
       "name": "@checkstack/healthcheck-postgres-backend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1980,7 +1992,7 @@
     },
     "plugins/healthcheck-rcon-backend": {
       "name": "@checkstack/healthcheck-rcon-backend",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1997,7 +2009,7 @@
     },
     "plugins/healthcheck-rcon-common": {
       "name": "@checkstack/healthcheck-rcon-common",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -2010,7 +2022,7 @@
     },
     "plugins/healthcheck-redis-backend": {
       "name": "@checkstack/healthcheck-redis-backend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2026,7 +2038,7 @@
     },
     "plugins/healthcheck-script-backend": {
       "name": "@checkstack/healthcheck-script-backend",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2041,7 +2053,7 @@
     },
     "plugins/healthcheck-ssh-backend": {
       "name": "@checkstack/healthcheck-ssh-backend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2059,7 +2071,7 @@
     },
     "plugins/healthcheck-ssh-common": {
       "name": "@checkstack/healthcheck-ssh-common",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -2072,7 +2084,7 @@
     },
     "plugins/healthcheck-tcp-backend": {
       "name": "@checkstack/healthcheck-tcp-backend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2087,7 +2099,7 @@
     },
     "plugins/healthcheck-tls-backend": {
       "name": "@checkstack/healthcheck-tls-backend",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2102,7 +2114,7 @@
     },
     "plugins/integration-jira-backend": {
       "name": "@checkstack/integration-jira-backend",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2121,7 +2133,7 @@
     },
     "plugins/integration-jira-common": {
       "name": "@checkstack/integration-jira-common",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/integration-common": "workspace:*",
@@ -2137,7 +2149,7 @@
     },
     "plugins/integration-script-backend": {
       "name": "@checkstack/integration-script-backend",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2154,7 +2166,7 @@
     },
     "plugins/integration-teams-backend": {
       "name": "@checkstack/integration-teams-backend",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2169,7 +2181,7 @@
     },
     "plugins/integration-webex-backend": {
       "name": "@checkstack/integration-webex-backend",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2184,7 +2196,7 @@
     },
     "plugins/integration-webhook-backend": {
       "name": "@checkstack/integration-webhook-backend",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2201,7 +2213,7 @@
     },
     "plugins/notification-backstage-backend": {
       "name": "@checkstack/notification-backstage-backend",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2215,7 +2227,7 @@
     },
     "plugins/notification-discord-backend": {
       "name": "@checkstack/notification-discord-backend",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2229,7 +2241,7 @@
     },
     "plugins/notification-gotify-backend": {
       "name": "@checkstack/notification-gotify-backend",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2243,7 +2255,7 @@
     },
     "plugins/notification-pushover-backend": {
       "name": "@checkstack/notification-pushover-backend",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2257,7 +2269,7 @@
     },
     "plugins/notification-slack-backend": {
       "name": "@checkstack/notification-slack-backend",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2271,7 +2283,7 @@
     },
     "plugins/notification-smtp-backend": {
       "name": "@checkstack/notification-smtp-backend",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2287,7 +2299,7 @@
     },
     "plugins/notification-teams-backend": {
       "name": "@checkstack/notification-teams-backend",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2301,7 +2313,7 @@
     },
     "plugins/notification-telegram-backend": {
       "name": "@checkstack/notification-telegram-backend",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2317,7 +2329,7 @@
     },
     "plugins/notification-webex-backend": {
       "name": "@checkstack/notification-webex-backend",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2331,7 +2343,7 @@
     },
     "plugins/queue-bullmq-backend": {
       "name": "@checkstack/queue-bullmq-backend",
-      "version": "0.2.18",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2349,7 +2361,7 @@
     },
     "plugins/queue-bullmq-common": {
       "name": "@checkstack/queue-bullmq-common",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -2361,7 +2373,7 @@
     },
     "plugins/queue-memory-backend": {
       "name": "@checkstack/queue-memory-backend",
-      "version": "0.3.18",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2378,7 +2390,7 @@
     },
     "plugins/queue-memory-common": {
       "name": "@checkstack/queue-memory-common",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -2898,6 +2910,8 @@
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
+    "@joshwooding/vite-plugin-react-docgen-typescript": ["@joshwooding/vite-plugin-react-docgen-typescript@0.7.0", "", { "dependencies": { "glob": "^13.0.1", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "typescript": ">= 4.3.x", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -2917,6 +2931,8 @@
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
+
+    "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
     "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
 
@@ -3108,6 +3124,8 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
+
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
@@ -3164,6 +3182,26 @@
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
+    "@storybook/addon-a11y": ["@storybook/addon-a11y@10.3.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "axe-core": "^4.2.0" }, "peerDependencies": { "storybook": "^10.3.6" } }, "sha512-cbwXIT5CeHZ9AFbTKQ6YB7Ct6TAl/kKOgALbvzzVtFfRvm51JYygGaiJaB7PbPWn9wgJP2olJcFt+erlEc6cRw=="],
+
+    "@storybook/addon-docs": ["@storybook/addon-docs@10.3.6", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/csf-plugin": "10.3.6", "@storybook/icons": "^2.0.1", "@storybook/react-dom-shim": "10.3.6", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.3.6" } }, "sha512-TvIdADVPtauxW0LzXIpIv7X6GxwetorhyNh+6+7MHC27XSBCWVxxRUwL63YeLlHTuXsIk0quG3b1xgwVRzWOJA=="],
+
+    "@storybook/addon-themes": ["@storybook/addon-themes@10.3.6", "", { "dependencies": { "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.3.6" } }, "sha512-/6lPU36+nDQzoDJqwy5BrAO0zFHOHDXn6hy/aq2aKF/RTS54+KrA0fdv0sxTssaBo5tjqZ4jKs60hB0iRWKkFA=="],
+
+    "@storybook/builder-vite": ["@storybook/builder-vite@10.3.6", "", { "dependencies": { "@storybook/csf-plugin": "10.3.6", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.3.6", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg=="],
+
+    "@storybook/csf-plugin": ["@storybook/csf-plugin@10.3.6", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.3.6", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ=="],
+
+    "@storybook/global": ["@storybook/global@5.0.0", "", {}, "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="],
+
+    "@storybook/icons": ["@storybook/icons@2.0.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg=="],
+
+    "@storybook/react": ["@storybook/react@10.3.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.3.6", "react-docgen": "^8.0.2", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.6", "typescript": ">= 4.9.x" }, "optionalPeers": ["typescript"] }, "sha512-oZQZ6xayWe5IdHmFUTL0TL8rX/gpNNh9gWhT2vzW5eeUvlkVG/RBKdsja6Ndrk2s1D9vcnwiI6r6CNXy3IEEmg=="],
+
+    "@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.3.6", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.6" } }, "sha512-/Tu1gPu+Fw+zOnAGmxRmOD30FX3a04LxcTAKflEtdpmtIMVR5bA3qpjy+f5YhoyDCecbXyKmL1OeIU2FIIZHqQ=="],
+
+    "@storybook/react-vite": ["@storybook/react-vite@10.3.6", "", { "dependencies": { "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0", "@rollup/pluginutils": "^5.0.2", "@storybook/builder-vite": "10.3.6", "@storybook/react": "10.3.6", "empathic": "^2.0.0", "magic-string": "^0.30.0", "react-docgen": "^8.0.0", "resolve": "^1.22.8", "tsconfig-paths": "^4.2.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.6", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-tySQRc+8q7V2NkylQMNJjDV8zXy6tkxb8oDqw/DIhHhI9Xn77MTKVZ8Cihbo5NMm7HYTB6xDKr6wqdSMgdufYQ=="],
+
     "@tabby_ai/hijri-converter": ["@tabby_ai/hijri-converter@1.0.5", "", {}, "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.99.0", "", {}, "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ=="],
@@ -3180,6 +3218,8 @@
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
@@ -3193,6 +3233,8 @@
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
 
@@ -3222,6 +3264,10 @@
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/doctrine": ["@types/doctrine@0.0.9", "", {}, "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -3238,6 +3284,8 @@
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
+    "@types/mdx": ["@types/mdx@2.0.13", "", {}, "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw=="],
+
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
@@ -3251,6 +3299,8 @@
     "@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
 
     "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+
+    "@types/resolve": ["@types/resolve@1.20.6", "", {}, "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ=="],
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
@@ -3314,6 +3364,16 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@webcontainer/env": ["@webcontainer/env@1.1.1", "", {}, "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng=="],
+
     "@xmldom/is-dom-node": ["@xmldom/is-dom-node@1.0.1", "", {}, "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
@@ -3354,11 +3414,17 @@
 
     "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
+
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "autoprefixer": ["autoprefixer@10.5.0", "", { "dependencies": { "browserslist": "^4.28.2", "caniuse-lite": "^1.0.30001787", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong=="],
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
+
+    "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
 
     "bail": ["bail@1.0.5", "", {}, "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="],
 
@@ -3394,6 +3460,8 @@
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
@@ -3401,6 +3469,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -3415,6 +3485,8 @@
     "character-reference-invalid": ["character-reference-invalid@1.1.4", "", {}, "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -3510,7 +3582,15 @@
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
@@ -3532,6 +3612,8 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
+    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
@@ -3543,6 +3625,8 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.336", "", {}, "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
     "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
 
@@ -3583,6 +3667,8 @@
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
@@ -3651,6 +3737,8 @@
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -3724,6 +3812,8 @@
 
     "is-decimal": ["is-decimal@1.0.4", "", {}, "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="],
 
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
@@ -3731,6 +3821,8 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@1.0.4", "", {}, "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -3743,6 +3835,8 @@
     "is-subdir": ["is-subdir@1.2.0", "", { "dependencies": { "better-path-resolve": "1.0.0" } }, "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw=="],
 
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -3830,6 +3924,8 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
@@ -3839,6 +3935,8 @@
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "markdown-table": ["markdown-table@2.0.0", "", { "dependencies": { "repeat-string": "^1.0.0" } }, "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A=="],
 
@@ -3988,6 +4086,8 @@
 
     "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
 
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -4016,7 +4116,11 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
 
@@ -4094,6 +4198,10 @@
 
     "react-day-picker": ["react-day-picker@9.14.0", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "@tabby_ai/hijri-converter": "1.0.5", "date-fns": "^4.1.0", "date-fns-jalali": "4.1.0-0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA=="],
 
+    "react-docgen": ["react-docgen@8.0.3", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/traverse": "^7.28.0", "@babel/types": "^7.28.2", "@types/babel__core": "^7.20.5", "@types/babel__traverse": "^7.20.7", "@types/doctrine": "^0.0.9", "@types/resolve": "^1.20.2", "doctrine": "^3.0.0", "resolve": "^1.22.1", "strip-indent": "^4.0.0" } }, "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w=="],
+
+    "react-docgen-typescript": ["react-docgen-typescript@2.4.0", "", { "peerDependencies": { "typescript": ">= 4.3.x" } }, "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg=="],
+
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
@@ -4123,6 +4231,8 @@
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "readline-sync": ["readline-sync@1.4.10", "", {}, "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="],
+
+    "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
     "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
 
@@ -4171,6 +4281,8 @@
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-async": ["run-async@4.0.6", "", {}, "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ=="],
 
@@ -4224,6 +4336,8 @@
 
     "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
 
+    "storybook": ["storybook@10.3.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.1", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "@webcontainer/env": "^1.1.1", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0", "open": "^10.2.0", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "prettier": "^2 || ^3", "vite-plus": "^0.1.15" }, "optionalPeers": ["prettier", "vite-plus"], "bin": "./dist/bin/dispatcher.js" }, "sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ=="],
+
     "strict-event-emitter-types": ["strict-event-emitter-types@2.0.0", "", {}, "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -4276,6 +4390,10 @@
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
     "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
@@ -4290,7 +4408,11 @@
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
+
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -4326,6 +4448,8 @@
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
+    "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
@@ -4350,6 +4474,8 @@
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
+
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
@@ -4369,6 +4495,8 @@
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
 
@@ -4518,11 +4646,11 @@
 
     "@checkstack/test-utils-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@checkstack/ui/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+    "@checkstack/ui/@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
     "@checkstack/ui/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
-    "@checkstack/ui/react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+    "@checkstack/ui/vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -4565,6 +4693,8 @@
     "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
+
+    "@storybook/addon-docs/react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
@@ -4639,6 +4769,8 @@
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "monaco-editor/marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
+
+    "path-scurry/lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -4776,7 +4908,7 @@
 
     "@checkstack/test-utils-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@checkstack/ui/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+    "@checkstack/ui/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
     "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
@@ -4785,6 +4917,8 @@
     "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "@storybook/addon-docs/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 

--- a/core/ui/.storybook/main.ts
+++ b/core/ui/.storybook/main.ts
@@ -1,0 +1,22 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+  stories: [
+    "../stories/**/*.mdx",
+    "../stories/**/*.stories.@(ts|tsx)",
+  ],
+  addons: [
+    "@storybook/addon-docs",
+    "@storybook/addon-themes",
+    "@storybook/addon-a11y",
+  ],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+  typescript: {
+    reactDocgen: "react-docgen",
+  },
+};
+
+export default config;

--- a/core/ui/.storybook/manager-head.html
+++ b/core/ui/.storybook/manager-head.html
@@ -1,0 +1,2 @@
+<title>Checkstack UI — Component Library</title>
+<meta name="description" content="Component library for Checkstack plugin developers." />

--- a/core/ui/.storybook/mock-access-api.ts
+++ b/core/ui/.storybook/mock-access-api.ts
@@ -1,0 +1,5 @@
+import type { AccessApi } from "@checkstack/frontend-api";
+
+export const mockAccessApi: AccessApi = {
+  useAccess: () => ({ loading: false, allowed: true }),
+};

--- a/core/ui/.storybook/preview.css
+++ b/core/ui/.storybook/preview.css
@@ -1,0 +1,5 @@
+@import "../src/themes.css";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/core/ui/.storybook/preview.tsx
+++ b/core/ui/.storybook/preview.tsx
@@ -1,0 +1,73 @@
+import type { Preview } from "@storybook/react";
+import { withThemeByClassName } from "@storybook/addon-themes";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import {
+  ApiRegistryBuilder,
+  ApiProvider,
+  accessApiRef,
+} from "@checkstack/frontend-api";
+import { ThemeProvider } from "../src/components/ThemeProvider";
+import { ToastProvider } from "../src/components/ToastProvider";
+import { PerformanceProvider } from "../src/components/PerformanceProvider";
+import { mockAccessApi } from "./mock-access-api";
+import "./preview.css";
+
+const apiRegistry = new ApiRegistryBuilder()
+  .register(accessApiRef, mockAccessApi)
+  .build();
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    backgrounds: {
+      default: "app",
+      values: [
+        { name: "app", value: "hsl(0 0% 100%)" },
+        { name: "app-dark", value: "hsl(240 10% 4%)" },
+      ],
+    },
+    layout: "padded",
+    options: {
+      storySort: {
+        order: [
+          "Introduction",
+          "Foundations",
+          "Components",
+          ["Inputs", "Display", "Feedback", "Navigation", "Overlays", "Forms", "Layout", "Data"],
+        ],
+      },
+    },
+  },
+  decorators: [
+    withThemeByClassName({
+      themes: {
+        light: "light",
+        dark: "dark",
+      },
+      defaultTheme: "light",
+    }),
+    (Story) => (
+      <MemoryRouter>
+        <ApiProvider registry={apiRegistry}>
+          <ThemeProvider defaultTheme="light" storageKey="checkstack-storybook-theme">
+            <ToastProvider>
+              <PerformanceProvider>
+                <div className="bg-background text-foreground p-4">
+                  <Story />
+                </div>
+              </PerformanceProvider>
+            </ToastProvider>
+          </ThemeProvider>
+        </ApiProvider>
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default preview;

--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -23,7 +23,7 @@
     "monaco-editor": "^0.55.1",
     "react": "^18.2.0",
     "react-day-picker": "^9.13.0",
-    "react-dom": "^19.2.5",
+    "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.20.0",
     "recharts": "^3.6.0",
@@ -33,16 +33,30 @@
     "@checkstack/scripts": "workspace:*",
     "@checkstack/test-utils-frontend": "workspace:*",
     "@checkstack/tsconfig": "workspace:*",
+    "@storybook/addon-a11y": "^10.3.6",
+    "@storybook/addon-docs": "^10.3.6",
+    "@storybook/addon-themes": "^10.3.6",
+    "@storybook/react": "^10.3.6",
+    "@storybook/react-vite": "^10.3.6",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^18.2.0",
-    "@types/react-dom": "^19.2.3",
-    "typescript": "^5.0.0"
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^6.0.1",
+    "autoprefixer": "^10.4.18",
+    "postcss": "^8.4.35",
+    "storybook": "^10.3.6",
+    "tailwindcss": "^3.4.1",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.0.0",
+    "vite": "^8.0.8"
   },
   "scripts": {
     "typecheck": "tsgo -b",
     "lint": "bun run lint:code",
     "lint:code": "eslint . --max-warnings 0",
-    "test": "bun test"
+    "test": "bun test",
+    "storybook": "storybook dev -p 6006",
+    "storybook:build": "storybook build -o storybook-static"
   },
   "checkstack": {
     "type": "tooling"

--- a/core/ui/postcss.config.js
+++ b/core/ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/core/ui/stories/AccessDenied.stories.tsx
+++ b/core/ui/stories/AccessDenied.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AccessDenied } from "../src/components/AccessDenied";
+
+const meta: Meta<typeof AccessDenied> = {
+  title: "Components/Feedback/AccessDenied",
+  component: AccessDenied,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof AccessDenied>;
+
+export const Default: Story = {};
+
+export const CustomMessage: Story = {
+  args: { message: "You need 'catalog.manage' to view this page." },
+};

--- a/core/ui/stories/AccessGate.stories.tsx
+++ b/core/ui/stories/AccessGate.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AccessGate } from "../src/components/AccessGate";
+
+const allowed = () => ({ loading: false, allowed: true });
+const denied = () => ({ loading: false, allowed: false });
+const loading = () => ({ loading: true, allowed: false });
+
+const meta: Meta<typeof AccessGate> = {
+  title: "Components/Feedback/AccessGate",
+  component: AccessGate,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof AccessGate>;
+
+export const Allowed: Story = {
+  args: {
+    accessRuleId: "demo.read",
+    useAccess: allowed,
+    children: <p className="text-sm">Gated content visible.</p>,
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    accessRuleId: "demo.read",
+    useAccess: denied,
+    children: <p className="text-sm">You should not see this.</p>,
+  },
+};
+
+export const ShowDenied: Story = {
+  args: {
+    accessRuleId: "demo.read",
+    useAccess: denied,
+    showDenied: true,
+    deniedMessage: "Demo access denied.",
+    children: <p>Hidden</p>,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    accessRuleId: "demo.read",
+    useAccess: loading,
+    children: <p>Resolves once access loads.</p>,
+  },
+};

--- a/core/ui/stories/Accordion.stories.tsx
+++ b/core/ui/stories/Accordion.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../src/components/Accordion";
+
+const meta: Meta<typeof Accordion> = {
+  title: "Components/Display/Accordion",
+  component: Accordion,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Accordion>;
+
+export const Single: Story = {
+  render: () => (
+    <Accordion type="single" collapsible className="max-w-md">
+      <AccordionItem value="a">
+        <AccordionTrigger>What is a health check?</AccordionTrigger>
+        <AccordionContent>
+          A periodic probe that asserts a system property and reports a status.
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="b">
+        <AccordionTrigger>What is a strategy?</AccordionTrigger>
+        <AccordionContent>
+          A pluggable provider that defines how a check is executed.
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="c">
+        <AccordionTrigger>What is a satellite?</AccordionTrigger>
+        <AccordionContent>
+          A standalone agent that runs checks from a remote network location.
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  ),
+};
+
+export const Multiple: Story = {
+  render: () => (
+    <Accordion type="multiple" className="max-w-md">
+      <AccordionItem value="a">
+        <AccordionTrigger>Section one</AccordionTrigger>
+        <AccordionContent>Content one.</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="b">
+        <AccordionTrigger>Section two</AccordionTrigger>
+        <AccordionContent>Content two.</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  ),
+};

--- a/core/ui/stories/Alert.stories.tsx
+++ b/core/ui/stories/Alert.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CircleAlert, CircleCheck, Info, TriangleAlert } from "lucide-react";
+import {
+  Alert,
+  AlertContent,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+} from "../src/components/Alert";
+
+const meta: Meta<typeof Alert> = {
+  title: "Components/Feedback/Alert",
+  component: Alert,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "success", "warning", "error", "info"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Alert>;
+
+export const Default: Story = {
+  args: { variant: "default" },
+  render: (args) => (
+    <Alert {...args}>
+      <AlertIcon>
+        <Info className="h-4 w-4" />
+      </AlertIcon>
+      <AlertContent>
+        <AlertTitle>Heads up</AlertTitle>
+        <AlertDescription>
+          This is an informational alert for plugin developers.
+        </AlertDescription>
+      </AlertContent>
+    </Alert>
+  ),
+};
+
+export const Success: Story = {
+  args: { variant: "success" },
+  render: (args) => (
+    <Alert {...args}>
+      <AlertIcon>
+        <CircleCheck className="h-4 w-4" />
+      </AlertIcon>
+      <AlertContent>
+        <AlertTitle>Saved</AlertTitle>
+        <AlertDescription>Plugin configuration was saved.</AlertDescription>
+      </AlertContent>
+    </Alert>
+  ),
+};
+
+export const Warning: Story = {
+  args: { variant: "warning" },
+  render: (args) => (
+    <Alert {...args}>
+      <AlertIcon>
+        <TriangleAlert className="h-4 w-4" />
+      </AlertIcon>
+      <AlertContent>
+        <AlertTitle>Heads up</AlertTitle>
+        <AlertDescription>
+          The satellite token will expire in 24 hours.
+        </AlertDescription>
+      </AlertContent>
+    </Alert>
+  ),
+};
+
+export const Error: Story = {
+  args: { variant: "error" },
+  render: (args) => (
+    <Alert {...args}>
+      <AlertIcon>
+        <CircleAlert className="h-4 w-4" />
+      </AlertIcon>
+      <AlertContent>
+        <AlertTitle>Something went wrong</AlertTitle>
+        <AlertDescription>The health check failed to start.</AlertDescription>
+      </AlertContent>
+    </Alert>
+  ),
+};

--- a/core/ui/stories/AmbientBackground.stories.tsx
+++ b/core/ui/stories/AmbientBackground.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AmbientBackground } from "../src/components/AmbientBackground";
+
+const meta: Meta<typeof AmbientBackground> = {
+  title: "Components/Layout/AmbientBackground",
+  component: AmbientBackground,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AmbientBackground>;
+
+export const Default: Story = {
+  render: () => (
+    <AmbientBackground>
+      <div className="max-w-3xl mx-auto py-24 px-6">
+        <h1 className="text-4xl font-bold tracking-tight">Inverse glow grid</h1>
+        <p className="mt-4 text-muted-foreground">
+          Aurora blobs and a grid mask, with automatic graceful degradation when{" "}
+          <code>usePerformance().isLowPower</code> is true.
+        </p>
+      </div>
+    </AmbientBackground>
+  ),
+};

--- a/core/ui/stories/AnimatedCounter.stories.tsx
+++ b/core/ui/stories/AnimatedCounter.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useState } from "react";
+import { AnimatedCounter } from "../src/components/AnimatedCounter";
+
+const meta: Meta<typeof AnimatedCounter> = {
+  title: "Components/Display/AnimatedCounter",
+  component: AnimatedCounter,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof AnimatedCounter>;
+
+const Demo = () => {
+  const [value, setValue] = useState(0);
+  useEffect(() => {
+    const id = setInterval(
+      () => setValue((v) => (v >= 1000 ? 0 : v + Math.floor(Math.random() * 200))),
+      1500,
+    );
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="text-4xl font-bold">
+      <AnimatedCounter value={value} />
+    </div>
+  );
+};
+
+export const TickingUp: Story = {
+  render: () => <Demo />,
+};
+
+export const StaticValue: Story = {
+  args: { value: 1042 },
+  render: (args) => (
+    <span className="text-3xl font-bold">
+      <AnimatedCounter {...args} />
+    </span>
+  ),
+};

--- a/core/ui/stories/AnimatedNumber.stories.tsx
+++ b/core/ui/stories/AnimatedNumber.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useState } from "react";
+import { AnimatedNumber } from "../src/components/AnimatedNumber";
+
+const meta: Meta<typeof AnimatedNumber> = {
+  title: "Components/Display/AnimatedNumber",
+  component: AnimatedNumber,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof AnimatedNumber>;
+
+const Demo = () => {
+  const [value, setValue] = useState(99.95);
+  useEffect(() => {
+    const id = setInterval(
+      () => setValue(95 + Math.random() * 5),
+      1500,
+    );
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="text-3xl font-bold text-success tabular-nums">
+      <AnimatedNumber value={value} suffix="%" decimals={2} />
+    </div>
+  );
+};
+
+export const Uptime: Story = { render: () => <Demo /> };
+
+export const NA: Story = {
+  args: { value: undefined },
+  render: (args) => (
+    <span className="text-2xl font-bold">
+      <AnimatedNumber {...args} />
+    </span>
+  ),
+};

--- a/core/ui/stories/BackLink.stories.tsx
+++ b/core/ui/stories/BackLink.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { BackLink } from "../src/components/BackLink";
+
+const meta: Meta<typeof BackLink> = {
+  title: "Components/Navigation/BackLink",
+  component: BackLink,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof BackLink>;
+
+export const Default: Story = {
+  args: {
+    onClick: () => {
+      /* navigate back */
+    },
+  },
+};
+
+export const CustomLabel: Story = {
+  args: {
+    children: "Back to systems",
+    onClick: () => {
+      /* navigate back */
+    },
+  },
+};
+
+export const AsLink: Story = {
+  args: { to: "/catalog" },
+};

--- a/core/ui/stories/Badge.stories.tsx
+++ b/core/ui/stories/Badge.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Badge } from "../src/components/Badge";
+
+const meta: Meta<typeof Badge> = {
+  title: "Components/Display/Badge",
+  component: Badge,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "secondary", "destructive", "outline", "success", "warning", "info"],
+    },
+  },
+  args: {
+    children: "Badge",
+    variant: "default",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Badge variant="default">Default</Badge>
+      <Badge variant="secondary">Secondary</Badge>
+      <Badge variant="destructive">Destructive</Badge>
+      <Badge variant="outline">Outline</Badge>
+      <Badge variant="success">Success</Badge>
+      <Badge variant="warning">Warning</Badge>
+      <Badge variant="info">Info</Badge>
+    </div>
+  ),
+};

--- a/core/ui/stories/Button.stories.tsx
+++ b/core/ui/stories/Button.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../src/components/Button";
+
+const meta: Meta<typeof Button> = {
+  title: "Components/Inputs/Button",
+  component: Button,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "secondary", "outline", "ghost", "destructive", "link"],
+    },
+    size: {
+      control: "select",
+      options: ["default", "sm", "lg", "icon"],
+    },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    children: "Click me",
+    variant: "primary",
+    size: "default",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {};
+
+export const Secondary: Story = { args: { variant: "secondary" } };
+
+export const Outline: Story = { args: { variant: "outline" } };
+
+export const Ghost: Story = { args: { variant: "ghost" } };
+
+export const Destructive: Story = { args: { variant: "destructive" } };
+
+export const Link: Story = { args: { variant: "link" } };
+
+export const AllSizes: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-3">
+      <Button {...args} size="sm">
+        Small
+      </Button>
+      <Button {...args} size="default">
+        Default
+      </Button>
+      <Button {...args} size="lg">
+        Large
+      </Button>
+    </div>
+  ),
+};
+
+export const Disabled: Story = { args: { disabled: true } };

--- a/core/ui/stories/Card.stories.tsx
+++ b/core/ui/stories/Card.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../src/components/Button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "../src/components/Card";
+
+const meta: Meta<typeof Card> = {
+  title: "Components/Display/Card",
+  component: Card,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Basic: Story = {
+  render: () => (
+    <Card className="max-w-md">
+      <CardHeader>
+        <CardTitle>HTTP Health Check</CardTitle>
+        <CardDescription>Probe a public endpoint every 60 seconds.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">
+          A card is the standard container for plugin panels.
+        </p>
+      </CardContent>
+      <CardFooter className="justify-end gap-2">
+        <Button variant="ghost">Cancel</Button>
+        <Button>Save</Button>
+      </CardFooter>
+    </Card>
+  ),
+};

--- a/core/ui/stories/Checkbox.stories.tsx
+++ b/core/ui/stories/Checkbox.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Checkbox } from "../src/components/Checkbox";
+import { Label } from "../src/components/Label";
+
+const meta: Meta<typeof Checkbox> = {
+  title: "Components/Inputs/Checkbox",
+  component: Checkbox,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Checkbox>;
+
+const Interactive = () => {
+  const [checked, setChecked] = useState(false);
+  return (
+    <div className="flex items-center gap-2">
+      <Checkbox
+        id="cb"
+        checked={checked}
+        onCheckedChange={setChecked}
+      />
+      <Label htmlFor="cb">I agree</Label>
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Interactive /> };
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Checkbox
+        id="cb-d"
+        checked
+        disabled
+        onChange={() => {
+          /* noop */
+        }}
+      />
+      <Label htmlFor="cb-d">Disabled (checked)</Label>
+    </div>
+  ),
+};

--- a/core/ui/stories/CodeEditor.stories.tsx
+++ b/core/ui/stories/CodeEditor.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { CodeEditor } from "../src/components/CodeEditor";
+
+const meta: Meta<typeof CodeEditor> = {
+  title: "Components/Inputs/CodeEditor",
+  component: CodeEditor,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof CodeEditor>;
+
+const Demo = ({
+  language,
+  initial,
+}: {
+  language: "json" | "yaml" | "javascript";
+  initial: string;
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <CodeEditor
+      value={value}
+      onChange={setValue}
+      language={language}
+      minHeight="280px"
+    />
+  );
+};
+
+export const Json: Story = {
+  render: () => (
+    <Demo
+      language="json"
+      initial={`{
+  "url": "https://api.example.com/health",
+  "timeoutMs": 5000
+}`}
+    />
+  ),
+};
+
+export const Yaml: Story = {
+  render: () => (
+    <Demo
+      language="yaml"
+      initial={`url: https://api.example.com/health
+timeoutMs: 5000
+assertions:
+  - status: 200`}
+    />
+  ),
+};
+
+export const JavaScript: Story = {
+  render: () => (
+    <Demo
+      language="javascript"
+      initial={`// Custom assertion
+export default async function check({ fetch }) {
+  const res = await fetch("https://example.com");
+  return res.status === 200;
+}`}
+    />
+  ),
+};

--- a/core/ui/stories/ColorPicker.stories.tsx
+++ b/core/ui/stories/ColorPicker.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { ColorPicker } from "../src/components/ColorPicker";
+
+const meta: Meta<typeof ColorPicker> = {
+  title: "Components/Inputs/ColorPicker",
+  component: ColorPicker,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof ColorPicker>;
+
+const Demo = () => {
+  const [color, setColor] = useState("#7c3aed");
+  return (
+    <div className="space-y-3 max-w-sm">
+      <ColorPicker value={color} onChange={setColor} />
+      <p className="text-sm text-muted-foreground">Selected: <code>{color}</code></p>
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/CommandPalette.stories.tsx
+++ b/core/ui/stories/CommandPalette.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CommandPalette } from "../src/components/CommandPalette";
+
+const meta: Meta<typeof CommandPalette> = {
+  title: "Components/Navigation/CommandPalette",
+  component: CommandPalette,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof CommandPalette>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="max-w-2xl">
+      <CommandPalette
+        onClick={() => {
+          /* open palette */
+        }}
+      />
+    </div>
+  ),
+};
+
+export const CustomPlaceholder: Story = {
+  render: () => (
+    <div className="max-w-2xl">
+      <CommandPalette
+        placeholder="Find a health check, satellite, or runbook…"
+        onClick={() => {
+          /* open palette */
+        }}
+      />
+    </div>
+  ),
+};

--- a/core/ui/stories/ConfirmationModal.stories.tsx
+++ b/core/ui/stories/ConfirmationModal.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Button } from "../src/components/Button";
+import { ConfirmationModal } from "../src/components/ConfirmationModal";
+
+const meta: Meta<typeof ConfirmationModal> = {
+  title: "Components/Overlays/ConfirmationModal",
+  component: ConfirmationModal,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmationModal>;
+
+const Demo = ({ variant }: { variant: "danger" | "warning" | "info" }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant={variant === "danger" ? "destructive" : "primary"}
+        onClick={() => setOpen(true)}
+      >
+        Open {variant} modal
+      </Button>
+      <ConfirmationModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+        title="Delete satellite?"
+        message="This will revoke its token and delete recorded health-check history."
+        confirmText="Delete"
+        variant={variant}
+      />
+    </>
+  );
+};
+
+export const Danger: Story = { render: () => <Demo variant="danger" /> };
+export const Warning: Story = { render: () => <Demo variant="warning" /> };
+export const Info: Story = { render: () => <Demo variant="info" /> };

--- a/core/ui/stories/DateRangeFilter.stories.tsx
+++ b/core/ui/stories/DateRangeFilter.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import {
+  DateRangeFilter,
+  type DateRange,
+  getDefaultDateRange,
+} from "../src/components/DateRangeFilter";
+
+const meta: Meta<typeof DateRangeFilter> = {
+  title: "Components/Inputs/DateRangeFilter",
+  component: DateRangeFilter,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof DateRangeFilter>;
+
+const Demo = () => {
+  const [range, setRange] = useState<DateRange>(getDefaultDateRange());
+  return (
+    <div className="space-y-3">
+      <DateRangeFilter value={range} onChange={setRange} />
+      <p className="text-xs text-muted-foreground">
+        {range.startDate.toISOString()} → {range.endDate.toISOString()}
+      </p>
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/DateTimePicker.stories.tsx
+++ b/core/ui/stories/DateTimePicker.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { DateTimePicker } from "../src/components/DateTimePicker";
+
+const meta: Meta<typeof DateTimePicker> = {
+  title: "Components/Inputs/DateTimePicker",
+  component: DateTimePicker,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof DateTimePicker>;
+
+const Demo = () => {
+  const [value, setValue] = useState<Date | undefined>(new Date());
+  return (
+    <div className="space-y-3 max-w-md">
+      <DateTimePicker value={value} onChange={setValue} />
+      <p className="text-xs text-muted-foreground">
+        {value ? value.toISOString() : "no date"}
+      </p>
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/Dialog.stories.tsx
+++ b/core/ui/stories/Dialog.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../src/components/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../src/components/Dialog";
+
+const meta: Meta = {
+  title: "Components/Overlays/Dialog",
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Open dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit display name</DialogTitle>
+          <DialogDescription>
+            Renaming a system updates how it appears across all dashboards.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4 text-sm text-muted-foreground">
+          Form contents go here.
+        </div>
+        <DialogFooter>
+          <Button variant="ghost">Cancel</Button>
+          <Button>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+export const LargeSize: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open large dialog</Button>
+      </DialogTrigger>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>Large dialog</DialogTitle>
+          <DialogDescription>
+            Use <code>size=&quot;lg&quot;</code> for forms with many fields.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4 text-sm text-muted-foreground">…</div>
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/core/ui/stories/DynamicForm.stories.tsx
+++ b/core/ui/stories/DynamicForm.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import {
+  DynamicForm,
+  KeyValueEditor,
+  type JsonSchema,
+  type KeyValuePair,
+} from "../src/components/DynamicForm";
+
+const meta: Meta = {
+  title: "Components/Forms/DynamicForm",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const schema: JsonSchema = {
+  type: "object",
+  required: ["url", "method"],
+  properties: {
+    url: { type: "string", title: "URL", format: "uri", description: "Endpoint to probe" },
+    method: {
+      type: "string",
+      title: "Method",
+      enum: ["GET", "POST", "HEAD"],
+      default: "GET",
+    },
+    timeoutMs: {
+      type: "number",
+      title: "Timeout (ms)",
+      default: 5000,
+      minimum: 100,
+      maximum: 60_000,
+    },
+    followRedirects: {
+      type: "boolean",
+      title: "Follow redirects",
+      default: true,
+    },
+    apiKey: {
+      type: "string",
+      title: "API key",
+      "x-secret": true,
+    },
+  },
+};
+
+const Demo = () => {
+  const [value, setValue] = useState<Record<string, unknown>>({});
+  const [valid, setValid] = useState(false);
+  return (
+    <div className="max-w-xl space-y-4">
+      <DynamicForm
+        schema={schema}
+        value={value}
+        onChange={setValue}
+        onValidChange={setValid}
+      />
+      <p className="text-xs text-muted-foreground">
+        Valid: <strong>{String(valid)}</strong>
+      </p>
+      <pre className="text-xs bg-muted/50 rounded p-3 overflow-auto">
+        {JSON.stringify(value, undefined, 2)}
+      </pre>
+    </div>
+  );
+};
+
+export const FromSchema: Story = { render: () => <Demo /> };
+
+const KvDemo = () => {
+  const [pairs, setPairs] = useState<KeyValuePair[]>([
+    { key: "Authorization", value: "Bearer ***" },
+    { key: "X-Trace-Id", value: "abc-123" },
+  ]);
+  return (
+    <div className="max-w-xl">
+      <KeyValueEditor id="headers" value={pairs} onChange={setPairs} />
+    </div>
+  );
+};
+
+export const KeyValue: Story = { render: () => <KvDemo /> };

--- a/core/ui/stories/DynamicIcon.stories.tsx
+++ b/core/ui/stories/DynamicIcon.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DynamicIcon } from "../src/components/DynamicIcon";
+
+const meta: Meta<typeof DynamicIcon> = {
+  title: "Components/Display/DynamicIcon",
+  component: DynamicIcon,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof DynamicIcon>;
+
+export const Named: Story = {
+  args: { name: "HeartPulse", className: "h-8 w-8 text-primary" },
+};
+
+export const Fallback: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <DynamicIcon name={undefined} className="h-6 w-6" />
+      <span className="text-sm text-muted-foreground">
+        Falls back to <code>Settings</code> when no name is given.
+      </span>
+    </div>
+  ),
+};
+
+export const Gallery: Story = {
+  render: () => (
+    <div className="grid grid-cols-6 gap-4">
+      {[
+        "AlertCircle",
+        "Activity",
+        "Bell",
+        "Cloud",
+        "Database",
+        "Heart",
+        "ShieldCheck",
+        "Server",
+        "Terminal",
+        "Settings",
+        "Wrench",
+        "Zap",
+      ].map((name) => (
+        <div key={name} className="flex flex-col items-center gap-2 text-xs">
+          <DynamicIcon name={name as never} className="h-6 w-6" />
+          <span className="text-muted-foreground">{name}</span>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/core/ui/stories/EditableText.stories.tsx
+++ b/core/ui/stories/EditableText.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { EditableText } from "../src/components/EditableText";
+
+const meta: Meta<typeof EditableText> = {
+  title: "Components/Inputs/EditableText",
+  component: EditableText,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof EditableText>;
+
+const Demo = () => {
+  const [value, setValue] = useState("My system");
+  return (
+    <div className="max-w-sm">
+      <EditableText
+        value={value}
+        onSave={async (next) => {
+          await new Promise((r) => setTimeout(r, 300));
+          setValue(next);
+        }}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/Feedback.stories.tsx
+++ b/core/ui/stories/Feedback.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Inbox } from "lucide-react";
+import { Button } from "../src/components/Button";
+import { EmptyState } from "../src/components/EmptyState";
+import { HealthBadge } from "../src/components/HealthBadge";
+import { LoadingSpinner } from "../src/components/LoadingSpinner";
+
+const meta: Meta = {
+  title: "Components/Feedback/Status & Empty",
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const HealthBadges: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-3">
+      <HealthBadge status="healthy" />
+      <HealthBadge status="degraded" />
+      <HealthBadge status="unhealthy" />
+      <HealthBadge status="healthy" variant="compact" />
+    </div>
+  ),
+};
+
+export const Spinner: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <LoadingSpinner />
+      <span className="text-sm text-muted-foreground">Loading…</span>
+    </div>
+  ),
+};
+
+export const Empty: Story = {
+  render: () => (
+    <EmptyState
+      title="No health checks yet"
+      description="Plugins can register checks at runtime. Create one to see it here."
+      icon={<Inbox className="h-10 w-10" />}
+      actions={<Button>Create check</Button>}
+    />
+  ),
+};

--- a/core/ui/stories/IDELayout.stories.tsx
+++ b/core/ui/stories/IDELayout.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { File, Folder } from "lucide-react";
+import {
+  IDELayout,
+  IDETreeNode,
+  IDETreeSection,
+  type ValidationIssue,
+} from "../src/components/IDELayout";
+
+const meta: Meta = {
+  title: "Components/Layout/IDELayout",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const issues: ValidationIssue[] = [
+  { nodeId: "node-2", message: "URL is required" },
+];
+
+const Demo = () => {
+  const [selected, setSelected] = useState("node-1");
+  return (
+    <IDELayout
+      issues={issues}
+      onIssueClick={setSelected}
+      tree={
+        <div className="py-2">
+          <IDETreeSection label="Check items" />
+          <IDETreeNode
+            nodeId="node-1"
+            label="api.checkstack.io"
+            icon={File}
+            selected={selected === "node-1"}
+            onClick={() => setSelected("node-1")}
+            issues={issues}
+          />
+          <IDETreeNode
+            nodeId="node-2"
+            label="db.primary"
+            icon={File}
+            selected={selected === "node-2"}
+            onClick={() => setSelected("node-2")}
+            issues={issues}
+          />
+          <IDETreeSection label="Permissions" />
+          <IDETreeNode
+            nodeId="node-3"
+            label="readers"
+            icon={Folder}
+            selected={selected === "node-3"}
+            onClick={() => setSelected("node-3")}
+          />
+        </div>
+      }
+      panel={
+        <div className="p-6">
+          <h3 className="font-semibold">Editing: {selected}</h3>
+          <p className="text-sm text-muted-foreground mt-2">
+            The right panel renders whatever editor is appropriate for the
+            selected tree node.
+          </p>
+        </div>
+      }
+    />
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/InfoBanner.stories.tsx
+++ b/core/ui/stories/InfoBanner.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Info } from "lucide-react";
+import {
+  InfoBanner,
+  InfoBannerContent,
+  InfoBannerDescription,
+  InfoBannerIcon,
+  InfoBannerTitle,
+} from "../src/components/InfoBanner";
+
+const meta: Meta<typeof InfoBanner> = {
+  title: "Components/Feedback/InfoBanner",
+  component: InfoBanner,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "info", "warning", "success", "error"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InfoBanner>;
+
+export const Default: Story = {
+  args: { variant: "info" },
+  render: (args) => (
+    <InfoBanner {...args}>
+      <InfoBannerIcon>
+        <Info className="h-4 w-4" />
+      </InfoBannerIcon>
+      <InfoBannerContent>
+        <InfoBannerTitle>Heads up</InfoBannerTitle>
+        <InfoBannerDescription>
+          This is a soft, low-emphasis banner used inline within content.
+        </InfoBannerDescription>
+      </InfoBannerContent>
+    </InfoBanner>
+  ),
+};

--- a/core/ui/stories/Input.stories.tsx
+++ b/core/ui/stories/Input.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Input } from "../src/components/Input";
+import { Label } from "../src/components/Label";
+
+const meta: Meta<typeof Input> = {
+  title: "Components/Inputs/Input",
+  component: Input,
+  tags: ["autodocs"],
+  args: {
+    placeholder: "Enter a value",
+    type: "text",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = { args: { disabled: true, value: "Cannot edit" } };
+
+export const WithLabel: Story = {
+  render: (args) => (
+    <div className="space-y-2 max-w-sm">
+      <Label htmlFor="endpoint">API endpoint</Label>
+      <Input id="endpoint" {...args} placeholder="https://api.example.com" />
+    </div>
+  ),
+};

--- a/core/ui/stories/InstanceScopeBanner.stories.tsx
+++ b/core/ui/stories/InstanceScopeBanner.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { InstanceScopeBanner } from "../src/components/InstanceScopeBanner";
+
+const meta: Meta<typeof InstanceScopeBanner> = {
+  title: "Components/Feedback/InstanceScopeBanner",
+  component: InstanceScopeBanner,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof InstanceScopeBanner>;
+
+export const InstanceScope: Story = {
+  args: {
+    scope: "instance",
+    subject: "Queue",
+    recommendation: "Switch to a Redis-backed queue to see cluster-wide totals.",
+  },
+};
+
+export const ClusterScope: Story = {
+  args: {
+    scope: "cluster",
+    subject: "Queue",
+    recommendation: "Banner is hidden when scope is 'cluster'.",
+  },
+  render: (args) => (
+    <div>
+      <InstanceScopeBanner {...args} />
+      <p className="text-sm text-muted-foreground">
+        Renders nothing — confirm by inspecting the DOM.
+      </p>
+    </div>
+  ),
+};

--- a/core/ui/stories/Introduction.mdx
+++ b/core/ui/stories/Introduction.mdx
@@ -1,0 +1,50 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Introduction" />
+
+# Checkstack UI
+
+This is the component library for Checkstack plugin developers. Every primitive
+exported from `@checkstack/ui` is intended to be safe for plugin use — both in
+core plugins shipped in this repo and in third-party plugins published to npm.
+
+## Why this exists
+
+Plugins ship their own React components but render *inside* the host frontend's
+React tree, so they must use the host's design tokens, theme, and spacing scale.
+The `@checkstack/ui` package is the public surface for that. If a primitive
+isn't documented here, treat it as an internal implementation detail.
+
+## How to use
+
+```tsx
+import { Button, Card, CardHeader, CardTitle, CardContent } from "@checkstack/ui";
+
+export function MyPanel() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>My Plugin</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Button variant="primary">Do the thing</Button>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+## Theming
+
+All components consume CSS custom properties defined in `themes.css`. The host
+frontend wraps the entire app in `ThemeProvider`, so plugins automatically
+inherit light/dark mode. Use semantic Tailwind classes (`bg-primary`,
+`text-muted-foreground`, …) — never hardcoded colors.
+
+## Accessibility & performance
+
+- Components are built on Radix primitives where keyboard / focus / ARIA
+  behavior is non-trivial.
+- Animation-heavy components respect the `usePerformance` hook's `isLowPower`
+  flag — see [the performance rule](https://github.com/enyineer/checkstack/blob/main/.agent/rules/performance.md)
+  for the full contract plugins are expected to follow.

--- a/core/ui/stories/Label.stories.tsx
+++ b/core/ui/stories/Label.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Input } from "../src/components/Input";
+import { Label } from "../src/components/Label";
+
+const meta: Meta<typeof Label> = {
+  title: "Components/Inputs/Label",
+  component: Label,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="space-y-2 max-w-sm">
+      <Label htmlFor="email">Email</Label>
+      <Input id="email" type="email" placeholder="you@example.com" />
+    </div>
+  ),
+};

--- a/core/ui/stories/LinksEditor.stories.tsx
+++ b/core/ui/stories/LinksEditor.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { LinksEditor, type HotLink } from "../src/components/LinksEditor";
+
+const meta: Meta = {
+  title: "Components/Inputs/LinksEditor",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const Demo = ({ canManage }: { canManage: boolean }) => {
+  const [links, setLinks] = useState<HotLink[]>([
+    { id: "1", label: "Runbook", url: "https://example.com/runbook" },
+    { id: "2", label: null, url: "https://example.com/dashboards/api" },
+  ]);
+  return (
+    <div className="max-w-md">
+      <LinksEditor
+        links={links}
+        canManage={canManage}
+        onAdd={({ label, url }) => {
+          setLinks((prev) => [
+            ...prev,
+            { id: String(prev.length + 1), label: label ?? null, url },
+          ]);
+        }}
+        onRemove={(link) => {
+          setLinks((prev) => prev.filter((l) => l.id !== link.id));
+        }}
+      />
+    </div>
+  );
+};
+
+export const Editable: Story = { render: () => <Demo canManage /> };
+export const ReadOnly: Story = { render: () => <Demo canManage={false} /> };

--- a/core/ui/stories/Markdown.stories.tsx
+++ b/core/ui/stories/Markdown.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Markdown, MarkdownBlock } from "../src/components/Markdown";
+
+const meta: Meta = {
+  title: "Components/Display/Markdown",
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Inline: Story = {
+  render: () => (
+    <p>
+      <Markdown>
+        {"Build **fast**, ship **safe**. See the [docs](https://example.com)."}
+      </Markdown>
+    </p>
+  ),
+};
+
+export const Block: Story = {
+  render: () => (
+    <MarkdownBlock>
+      {`# Health checks
+
+A *health check* probes a system and asserts an outcome.
+
+- HTTP probes
+- TCP probes
+- Custom strategies
+
+Read more in the [strategies guide](https://example.com).`}
+    </MarkdownBlock>
+  ),
+};

--- a/core/ui/stories/Menu.stories.tsx
+++ b/core/ui/stories/Menu.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LogOut, Settings, User } from "lucide-react";
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "../src/components/Menu";
+
+const meta: Meta = {
+  title: "Components/Overlays/Menu (Dropdown items)",
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Items: Story = {
+  render: () => (
+    <div className="w-64 rounded-md border border-border bg-popover p-1 shadow-md">
+      <DropdownMenuLabel>Account</DropdownMenuLabel>
+      <DropdownMenuItem icon={<User className="h-4 w-4" />}>
+        Profile
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        icon={<Settings className="h-4 w-4" />}
+        description="Theme, notifications, integrations"
+      >
+        Settings
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem icon={<LogOut className="h-4 w-4" />}>
+        Sign out
+      </DropdownMenuItem>
+    </div>
+  ),
+};

--- a/core/ui/stories/MetricTile.stories.tsx
+++ b/core/ui/stories/MetricTile.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Activity, Cpu, MemoryStick, Network } from "lucide-react";
+import { MetricTile } from "../src/components/MetricTile";
+
+const meta: Meta<typeof MetricTile> = {
+  title: "Components/Display/MetricTile",
+  component: MetricTile,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof MetricTile>;
+
+export const Single: Story = {
+  args: {
+    icon: Activity,
+    label: "Throughput",
+    value: "1.2k req/s",
+  },
+};
+
+export const Grid: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-3xl">
+      <MetricTile icon={Cpu} label="CPU" value="42%" subtitle="across 4 cores" />
+      <MetricTile icon={MemoryStick} label="Memory" value="3.1 GB" variant="warning" />
+      <MetricTile icon={Network} label="Network" value="220 Mbps" variant="success" />
+      <MetricTile icon={Activity} label="Errors" value="14" variant="destructive" />
+    </div>
+  ),
+};

--- a/core/ui/stories/NavItem.stories.tsx
+++ b/core/ui/stories/NavItem.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Activity, Bell, Cog } from "lucide-react";
+import { NavItem } from "../src/components/NavItem";
+
+const meta: Meta<typeof NavItem> = {
+  title: "Components/Navigation/NavItem",
+  component: NavItem,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof NavItem>;
+
+export const TopLevel: Story = {
+  args: {
+    to: "/health",
+    label: "Health",
+    icon: <Activity className="h-4 w-4" />,
+  },
+};
+
+export const Nested: Story = {
+  render: () => (
+    <NavItem label="Settings" icon={<Cog className="h-4 w-4" />}>
+      <NavItem to="/settings/notifications" label="Notifications" icon={<Bell className="h-4 w-4" />} />
+      <NavItem to="/settings/general" label="General" icon={<Cog className="h-4 w-4" />} />
+    </NavItem>
+  ),
+};

--- a/core/ui/stories/NotFound.stories.tsx
+++ b/core/ui/stories/NotFound.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { NotFound } from "../src/components/NotFound";
+
+const meta: Meta<typeof NotFound> = {
+  title: "Components/Feedback/NotFound",
+  component: NotFound,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof NotFound>;
+
+export const Default: Story = {};
+
+export const CustomMessage: Story = {
+  args: { message: "We couldn't find the catalog system you requested." },
+};

--- a/core/ui/stories/Page.stories.tsx
+++ b/core/ui/stories/Page.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Activity } from "lucide-react";
+import { Button } from "../src/components/Button";
+import { Page, PageContent, PageHeader } from "../src/components/Page";
+
+const meta: Meta = {
+  title: "Components/Layout/Page",
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <Page className="h-[60vh]">
+      <PageHeader
+        title="Health"
+        subtitle="Live system signals across all environments."
+        icon={Activity}
+        actions={<Button>New check</Button>}
+      />
+      <PageContent>
+        <p className="text-sm text-muted-foreground">
+          Page content scrolls independently of the header.
+        </p>
+      </PageContent>
+    </Page>
+  ),
+};

--- a/core/ui/stories/PageLayout.stories.tsx
+++ b/core/ui/stories/PageLayout.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ShieldCheck } from "lucide-react";
+import { Button } from "../src/components/Button";
+import { PageLayout } from "../src/components/PageLayout";
+
+const meta: Meta<typeof PageLayout> = {
+  title: "Components/Layout/PageLayout",
+  component: PageLayout,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof PageLayout>;
+
+export const Allowed: Story = {
+  render: () => (
+    <div className="h-[60vh]">
+      <PageLayout
+        title="Access rules"
+        subtitle="Define who can do what."
+        icon={ShieldCheck}
+        allowed
+        actions={<Button>New rule</Button>}
+      >
+        <p className="text-sm text-muted-foreground">Rules table…</p>
+      </PageLayout>
+    </div>
+  ),
+};
+
+export const Denied: Story = {
+  render: () => (
+    <div className="h-[60vh]">
+      <PageLayout
+        title="Access rules"
+        subtitle="Define who can do what."
+        icon={ShieldCheck}
+        allowed={false}
+      >
+        <p>(Hidden)</p>
+      </PageLayout>
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <div className="h-[60vh]">
+      <PageLayout
+        title="Access rules"
+        subtitle="Define who can do what."
+        icon={ShieldCheck}
+        loading
+      >
+        <p>(Hidden while loading)</p>
+      </PageLayout>
+    </div>
+  ),
+};

--- a/core/ui/stories/PaginatedList.stories.tsx
+++ b/core/ui/stories/PaginatedList.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useMemo } from "react";
+import { PaginatedList } from "../src/components/PaginatedList";
+import { usePagination } from "../src/hooks/usePagination";
+
+const meta: Meta = {
+  title: "Components/Data/PaginatedList",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const ITEMS = Array.from({ length: 73 }, (_, i) => ({
+  id: String(i + 1),
+  name: `System ${i + 1}`,
+}));
+
+const Demo = () => {
+  const pagination = usePagination({ defaultLimit: 10 });
+  useEffect(() => {
+    pagination.setTotal(ITEMS.length);
+  }, [pagination]);
+  const slice = useMemo(
+    () => ITEMS.slice(pagination.offset, pagination.offset + pagination.limit),
+    [pagination.offset, pagination.limit],
+  );
+  return (
+    <div className="max-w-md">
+      <PaginatedList items={slice} loading={false} pagination={pagination}>
+        {(items) => (
+          <ul className="divide-y rounded-md border border-border">
+            {items.map((item) => (
+              <li key={item.id} className="px-3 py-2 text-sm">
+                {item.name}
+              </li>
+            ))}
+          </ul>
+        )}
+      </PaginatedList>
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/Pagination.stories.tsx
+++ b/core/ui/stories/Pagination.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Pagination } from "../src/components/Pagination";
+
+const meta: Meta<typeof Pagination> = {
+  title: "Components/Navigation/Pagination",
+  component: Pagination,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+const Demo = () => {
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
+  return (
+    <Pagination
+      page={page}
+      totalPages={12}
+      onPageChange={setPage}
+      total={234}
+      limit={limit}
+      onPageSizeChange={setLimit}
+      showPageSize
+      showTotal
+    />
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/PerformanceProvider.stories.tsx
+++ b/core/ui/stories/PerformanceProvider.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../src/components/Button";
+import { usePerformance } from "../src/components/PerformanceProvider";
+
+const meta: Meta = {
+  title: "Foundations/PerformanceProvider",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const Demo = () => {
+  const { isLowPower, manualLowPower, toggleManualLowPower } = usePerformance();
+  return (
+    <div className="space-y-3 max-w-md">
+      <p className="text-sm">
+        <code>isLowPower</code>: <strong>{String(isLowPower)}</strong>
+      </p>
+      <p className="text-sm">
+        <code>manualLowPower</code>: <strong>{String(manualLowPower)}</strong>
+      </p>
+      <Button onClick={toggleManualLowPower}>
+        Toggle low-power mode
+      </Button>
+      <p className="text-xs text-muted-foreground">
+        Plugins should consume <code>usePerformance().isLowPower</code> to
+        disable expensive animations / blurs.
+      </p>
+    </div>
+  );
+};
+
+export const Toggle: Story = { render: () => <Demo /> };

--- a/core/ui/stories/PluginConfigForm.stories.tsx
+++ b/core/ui/stories/PluginConfigForm.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import {
+  PluginConfigForm,
+  type PluginOption,
+} from "../src/components/PluginConfigForm";
+
+const meta: Meta = {
+  title: "Components/Forms/PluginConfigForm",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const plugins: PluginOption[] = [
+  {
+    id: "http-probe",
+    displayName: "HTTP Probe",
+    description: "Probes a public HTTP endpoint and asserts a 2xx response.",
+    configSchema: {
+      type: "object",
+      required: ["url"],
+      properties: {
+        url: { type: "string", title: "URL", format: "uri" },
+        timeoutMs: { type: "number", title: "Timeout (ms)", default: 5000 },
+      },
+    },
+  },
+  {
+    id: "tcp-probe",
+    displayName: "TCP Probe",
+    description: "Opens a TCP connection to verify the port is reachable.",
+    configSchema: {
+      type: "object",
+      required: ["host", "port"],
+      properties: {
+        host: { type: "string", title: "Host" },
+        port: { type: "number", title: "Port" },
+      },
+    },
+  },
+];
+
+const Demo = () => {
+  const [pluginId, setPluginId] = useState("http-probe");
+  const [config, setConfig] = useState<Record<string, unknown>>({});
+  return (
+    <div className="max-w-xl">
+      <PluginConfigForm
+        label="Strategy"
+        plugins={plugins}
+        selectedPluginId={pluginId}
+        onPluginChange={(id) => {
+          setPluginId(id);
+          setConfig({});
+        }}
+        config={config}
+        onConfigChange={setConfig}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/Popover.stories.tsx
+++ b/core/ui/stories/Popover.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../src/components/Button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../src/components/Popover";
+
+const meta: Meta = {
+  title: "Components/Overlays/Popover",
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-4">
+        <h4 className="font-medium leading-none mb-2">Filter</h4>
+        <p className="text-sm text-muted-foreground">
+          Use this for filter chips, info hovers, or quick edits.
+        </p>
+      </PopoverContent>
+    </Popover>
+  ),
+};

--- a/core/ui/stories/SectionHeader.stories.tsx
+++ b/core/ui/stories/SectionHeader.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Activity } from "lucide-react";
+import { SectionHeader } from "../src/components/SectionHeader";
+
+const meta: Meta<typeof SectionHeader> = {
+  title: "Components/Layout/SectionHeader",
+  component: SectionHeader,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof SectionHeader>;
+
+export const Default: Story = {
+  args: {
+    title: "Recent activity",
+    description: "Last 24 hours of health-check transitions.",
+    icon: <Activity className="h-5 w-5" />,
+  },
+};

--- a/core/ui/stories/Select.stories.tsx
+++ b/core/ui/stories/Select.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../src/components/Select";
+
+const meta: Meta = {
+  title: "Components/Inputs/Select",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const Demo = () => {
+  const [value, setValue] = useState("");
+  return (
+    <div className="max-w-xs">
+      <Select value={value} onValueChange={setValue}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick an environment" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="prod">Production</SelectItem>
+          <SelectItem value="staging">Staging</SelectItem>
+          <SelectItem value="dev">Development</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/Sheet.stories.tsx
+++ b/core/ui/stories/Sheet.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../src/components/Button";
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "../src/components/Sheet";
+
+const meta: Meta = {
+  title: "Components/Overlays/Sheet",
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open sheet</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Edit system</SheetTitle>
+          <SheetDescription>
+            Slide-in side panel for secondary tasks.
+          </SheetDescription>
+        </SheetHeader>
+        <SheetBody>
+          <p className="text-sm text-muted-foreground">Form contents…</p>
+        </SheetBody>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const LargeSize: Story = {
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button>Open large sheet</Button>
+      </SheetTrigger>
+      <SheetContent size="lg">
+        <SheetHeader>
+          <SheetTitle>Large sheet</SheetTitle>
+        </SheetHeader>
+        <SheetBody>
+          <p className="text-sm text-muted-foreground">
+            Use <code>size=&quot;lg&quot;</code> for richer side panels.
+          </p>
+        </SheetBody>
+      </SheetContent>
+    </Sheet>
+  ),
+};

--- a/core/ui/stories/Slider.stories.tsx
+++ b/core/ui/stories/Slider.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Slider } from "../src/components/Slider";
+
+const meta: Meta<typeof Slider> = {
+  title: "Components/Inputs/Slider",
+  component: Slider,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Slider>;
+
+const Demo = () => {
+  const [value, setValue] = useState([60]);
+  return (
+    <div className="max-w-md space-y-3">
+      <Slider value={value} onValueChange={setValue} min={0} max={100} step={1} />
+      <p className="text-sm text-muted-foreground">Value: {value[0]}</p>
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/StatusCard.stories.tsx
+++ b/core/ui/stories/StatusCard.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TrendingUp } from "lucide-react";
+import { StatusCard } from "../src/components/StatusCard";
+
+const meta: Meta<typeof StatusCard> = {
+  title: "Components/Display/StatusCard",
+  component: StatusCard,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof StatusCard>;
+
+export const Default: Story = {
+  args: {
+    title: "Uptime",
+    value: "99.95%",
+    description: "Last 30 days",
+    icon: <TrendingUp className="h-5 w-5" />,
+  },
+};
+
+export const Gradient: Story = {
+  args: {
+    title: "Throughput",
+    value: "1.2k req/s",
+    icon: <TrendingUp className="h-5 w-5" />,
+    variant: "gradient",
+  },
+};

--- a/core/ui/stories/StatusUpdateTimeline.stories.tsx
+++ b/core/ui/stories/StatusUpdateTimeline.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Badge } from "../src/components/Badge";
+import {
+  StatusUpdateTimeline,
+  Timeline,
+  type StatusUpdate,
+} from "../src/components/StatusUpdateTimeline";
+
+const meta: Meta = {
+  title: "Components/Display/StatusUpdateTimeline",
+};
+
+export default meta;
+type Story = StoryObj;
+
+type IncidentStatus = "investigating" | "identified" | "monitoring" | "resolved";
+
+const updates: StatusUpdate<IncidentStatus>[] = [
+  {
+    id: "1",
+    message: "We are investigating reports of elevated 5xx on /api.",
+    statusChange: "investigating",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3),
+    createdByName: "On-call",
+  },
+  {
+    id: "2",
+    message: "Identified a misconfigured rate limiter; rolling back.",
+    statusChange: "identified",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2),
+    createdByName: "On-call",
+  },
+  {
+    id: "3",
+    message: "Rollback completed. Monitoring error rate.",
+    statusChange: "monitoring",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60),
+    createdByName: "On-call",
+  },
+  {
+    id: "4",
+    message: "Resolved.",
+    statusChange: "resolved",
+    createdAt: new Date(Date.now() - 1000 * 60 * 30),
+    createdByName: "On-call",
+  },
+];
+
+export const Updates: Story = {
+  render: () => (
+    <div className="max-w-xl">
+      <StatusUpdateTimeline
+        updates={updates}
+        renderStatusBadge={(status) => (
+          <Badge variant={status === "resolved" ? "success" : "secondary"}>
+            {status}
+          </Badge>
+        )}
+      />
+    </div>
+  ),
+};
+
+export const GenericTimeline: Story = {
+  render: () => (
+    <div className="max-w-xl">
+      <Timeline
+        items={updates.map((u) => ({ id: u.id, date: u.createdAt, msg: u.message }))}
+        renderItem={(item) => (
+          <div className="rounded-md border border-border p-3">
+            <p className="text-sm">{item.msg}</p>
+          </div>
+        )}
+      />
+    </div>
+  ),
+};

--- a/core/ui/stories/StrategyConfigCard.stories.tsx
+++ b/core/ui/stories/StrategyConfigCard.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import {
+  StrategyConfigCard,
+  type StrategyConfigCardData,
+} from "../src/components/StrategyConfigCard";
+
+const meta: Meta<typeof StrategyConfigCard> = {
+  title: "Components/Forms/StrategyConfigCard",
+  component: StrategyConfigCard,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof StrategyConfigCard>;
+
+const strategy: StrategyConfigCardData = {
+  id: "http-probe",
+  displayName: "HTTP Probe",
+  description: "Probe a public HTTP endpoint and assert a 2xx response.",
+  icon: "Globe",
+  enabled: true,
+};
+
+const Demo = () => {
+  const [enabled, setEnabled] = useState(true);
+  const [config, setConfig] = useState<Record<string, unknown>>({
+    url: "https://example.com/health",
+    timeoutMs: 5000,
+  });
+  return (
+    <div className="max-w-2xl">
+      <StrategyConfigCard
+        strategy={{ ...strategy, enabled }}
+        onToggle={async (_, next) => setEnabled(next)}
+        configSections={[
+          {
+            id: "main",
+            title: "Configuration",
+            value: config,
+            schema: {
+              type: "object",
+              required: ["url"],
+              properties: {
+                url: { type: "string", title: "URL", format: "uri" },
+                timeoutMs: { type: "number", title: "Timeout (ms)", default: 5000 },
+              },
+            },
+            onSave: async (next) => setConfig(next),
+          },
+        ]}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = { render: () => <Demo /> };

--- a/core/ui/stories/SubscribeButton.stories.tsx
+++ b/core/ui/stories/SubscribeButton.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { SubscribeButton } from "../src/components/SubscribeButton";
+
+const meta: Meta<typeof SubscribeButton> = {
+  title: "Components/Inputs/SubscribeButton",
+  component: SubscribeButton,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof SubscribeButton>;
+
+const Demo = ({ size }: { size: "default" | "sm" | "lg" | "icon" }) => {
+  const [subscribed, setSubscribed] = useState(false);
+  return (
+    <SubscribeButton
+      isSubscribed={subscribed}
+      size={size}
+      onSubscribe={() => setSubscribed(true)}
+      onUnsubscribe={() => setSubscribed(false)}
+    />
+  );
+};
+
+export const IconButton: Story = { render: () => <Demo size="icon" /> };
+export const Default: Story = { render: () => <Demo size="default" /> };

--- a/core/ui/stories/Table.stories.tsx
+++ b/core/ui/stories/Table.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Badge } from "../src/components/Badge";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../src/components/Table";
+
+const meta: Meta = {
+  title: "Components/Data/Table",
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <div className="max-w-2xl">
+      <Table>
+        <TableCaption>Recent health checks</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Strategy</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="text-right">Latency</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>api.checkstack.io</TableCell>
+            <TableCell>HTTP probe</TableCell>
+            <TableCell><Badge variant="success">Healthy</Badge></TableCell>
+            <TableCell className="text-right">42 ms</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>db-primary</TableCell>
+            <TableCell>TCP probe</TableCell>
+            <TableCell><Badge variant="warning">Degraded</Badge></TableCell>
+            <TableCell className="text-right">340 ms</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>cache</TableCell>
+            <TableCell>HTTP probe</TableCell>
+            <TableCell><Badge variant="destructive">Down</Badge></TableCell>
+            <TableCell className="text-right">—</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  ),
+};

--- a/core/ui/stories/Tabs.stories.tsx
+++ b/core/ui/stories/Tabs.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { TabPanel, Tabs, type TabItem } from "../src/components/Tabs";
+
+const meta: Meta<typeof Tabs> = {
+  title: "Components/Navigation/Tabs",
+  component: Tabs,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+const items: TabItem[] = [
+  { id: "overview", label: "Overview" },
+  { id: "history", label: "History" },
+  { id: "config", label: "Configuration" },
+];
+
+const InteractiveTabs = () => {
+  const [active, setActive] = useState("overview");
+  return (
+    <div className="space-y-4">
+      <Tabs items={items} activeTab={active} onTabChange={setActive} />
+      <TabPanel tabId="overview" activeTab={active}>
+        <p className="text-sm text-muted-foreground">Overview content.</p>
+      </TabPanel>
+      <TabPanel tabId="history" activeTab={active}>
+        <p className="text-sm text-muted-foreground">History content.</p>
+      </TabPanel>
+      <TabPanel tabId="config" activeTab={active}>
+        <p className="text-sm text-muted-foreground">Configuration content.</p>
+      </TabPanel>
+    </div>
+  );
+};
+
+export const Basic: Story = {
+  render: () => <InteractiveTabs />,
+};

--- a/core/ui/stories/TerminalFeed.stories.tsx
+++ b/core/ui/stories/TerminalFeed.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TerminalFeed, type TerminalEntry } from "../src/components/TerminalFeed";
+
+const meta: Meta<typeof TerminalFeed> = {
+  title: "Components/Display/TerminalFeed",
+  component: TerminalFeed,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof TerminalFeed>;
+
+const entries: TerminalEntry[] = [
+  {
+    id: "1",
+    timestamp: new Date(),
+    content: "Probe started for api.checkstack.io",
+    variant: "info",
+  },
+  {
+    id: "2",
+    timestamp: new Date(),
+    content: "200 OK in 42ms",
+    variant: "success",
+  },
+  {
+    id: "3",
+    timestamp: new Date(),
+    content: "Latency exceeds SLO threshold",
+    variant: "warning",
+    suffix: "p99 > 300ms",
+  },
+  {
+    id: "4",
+    timestamp: new Date(),
+    content: "Probe failed: connection refused",
+    variant: "error",
+  },
+];
+
+export const Default: Story = {
+  args: {
+    entries,
+    title: "Probe activity",
+    maxHeight: "300px",
+  },
+};

--- a/core/ui/stories/Textarea.stories.tsx
+++ b/core/ui/stories/Textarea.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Label } from "../src/components/Label";
+import { Textarea } from "../src/components/Textarea";
+
+const meta: Meta<typeof Textarea> = {
+  title: "Components/Inputs/Textarea",
+  component: Textarea,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Textarea>;
+
+export const Default: Story = {
+  args: { placeholder: "Describe what changed…", rows: 4 },
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <div className="space-y-2 max-w-md">
+      <Label htmlFor="notes">Notes</Label>
+      <Textarea id="notes" rows={5} placeholder="Optional context…" />
+    </div>
+  ),
+};

--- a/core/ui/stories/ThemeProvider.stories.tsx
+++ b/core/ui/stories/ThemeProvider.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../src/components/Button";
+import { useTheme } from "../src/components/ThemeProvider";
+
+const meta: Meta = {
+  title: "Foundations/ThemeProvider",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const Demo = () => {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  return (
+    <div className="space-y-3">
+      <p className="text-sm">
+        Theme: <strong>{theme}</strong> (resolved: {resolvedTheme})
+      </p>
+      <div className="flex gap-2">
+        <Button variant={theme === "light" ? "primary" : "outline"} onClick={() => setTheme("light")}>
+          Light
+        </Button>
+        <Button variant={theme === "dark" ? "primary" : "outline"} onClick={() => setTheme("dark")}>
+          Dark
+        </Button>
+        <Button variant={theme === "system" ? "primary" : "outline"} onClick={() => setTheme("system")}>
+          System
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        The host frontend wraps the app in <code>ThemeProvider</code>; plugins
+        inherit it for free.
+      </p>
+    </div>
+  );
+};
+
+export const Switcher: Story = { render: () => <Demo /> };

--- a/core/ui/stories/Toast.stories.tsx
+++ b/core/ui/stories/Toast.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../src/components/Button";
+import { useToast } from "../src/components/ToastProvider";
+
+const meta: Meta = {
+  title: "Components/Feedback/Toast",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const Demo = () => {
+  const toast = useToast();
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button onClick={() => toast.success("Saved successfully.")}>
+        Success
+      </Button>
+      <Button variant="outline" onClick={() => toast.info("Reload to see updates.")}>
+        Info
+      </Button>
+      <Button variant="outline" onClick={() => toast.warning("Token expires in 24h.")}>
+        Warning
+      </Button>
+      <Button variant="destructive" onClick={() => toast.error("Probe failed.")}>
+        Error
+      </Button>
+    </div>
+  );
+};
+
+export const Triggers: Story = { render: () => <Demo /> };

--- a/core/ui/stories/Toggle.stories.tsx
+++ b/core/ui/stories/Toggle.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Toggle } from "../src/components/Toggle";
+
+const meta: Meta<typeof Toggle> = {
+  title: "Components/Inputs/Toggle",
+  component: Toggle,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Toggle>;
+
+const InteractiveToggle = () => {
+  const [checked, setChecked] = useState(false);
+  return (
+    <div className="flex items-center gap-3">
+      <Toggle
+        checked={checked}
+        onCheckedChange={setChecked}
+        aria-label="Enable feature"
+      />
+      <span className="text-sm">{checked ? "Enabled" : "Disabled"}</span>
+    </div>
+  );
+};
+
+export const Interactive: Story = {
+  render: () => <InteractiveToggle />,
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <Toggle
+      checked
+      disabled
+      onCheckedChange={() => {
+        /* readonly */
+      }}
+      aria-label="Read-only toggle"
+    />
+  ),
+};

--- a/core/ui/stories/Tooltip.stories.tsx
+++ b/core/ui/stories/Tooltip.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Tooltip } from "../src/components/Tooltip";
+
+const meta: Meta<typeof Tooltip> = {
+  title: "Components/Overlays/Tooltip",
+  component: Tooltip,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Hover: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <span className="text-sm">Probe interval</span>
+      <Tooltip content="How frequently this check runs against its target." />
+    </div>
+  ),
+};

--- a/core/ui/stories/UserMenu.stories.tsx
+++ b/core/ui/stories/UserMenu.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LogOut, Settings } from "lucide-react";
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "../src/components/Menu";
+import { UserMenu } from "../src/components/UserMenu";
+
+const meta: Meta<typeof UserMenu> = {
+  title: "Components/Navigation/UserMenu",
+  component: UserMenu,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof UserMenu>;
+
+export const Default: Story = {
+  args: {
+    user: { name: "Nico", email: "nico@example.com" },
+  },
+  render: (args) => (
+    <UserMenu {...args}>
+      <DropdownMenuLabel>{args.user.email}</DropdownMenuLabel>
+      <DropdownMenuItem icon={<Settings className="h-4 w-4" />}>
+        Settings
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem icon={<LogOut className="h-4 w-4" />}>
+        Sign out
+      </DropdownMenuItem>
+    </UserMenu>
+  ),
+};

--- a/core/ui/tailwind.config.js
+++ b/core/ui/tailwind.config.js
@@ -1,0 +1,74 @@
+import tailwindcssAnimate from "tailwindcss-animate";
+
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ["class"],
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+    "./.storybook/**/*.{js,ts,jsx,tsx,mdx,html}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        chart: {
+          1: "hsl(var(--chart-1))",
+          2: "hsl(var(--chart-2))",
+          3: "hsl(var(--chart-3))",
+          4: "hsl(var(--chart-4))",
+          5: "hsl(var(--chart-5))",
+        },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        info: {
+          DEFAULT: "hsl(var(--info))",
+          foreground: "hsl(var(--info-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
+  },
+  plugins: [tailwindcssAnimate],
+};

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ Building backend plugins and services:
 Building frontend plugins and UI:
 
 - **[Frontend Plugins](./frontend/plugins.md)** - Create UI components, pages, and routing
+- **[Component Library (Storybook)](./storybook/)** - Browse every `@checkstack/ui` primitive plugins can use
 - **[Extension Points](./frontend/extension-points.md)** - UI slots and extension system
 - **[Theming](./frontend/theming.md)** - Design tokens and theme customization
 - **[Config Schemas](./frontend/config-schemas.md)** - Sending configuration schemas to frontend


### PR DESCRIPTION
## Summary

- Adds Storybook 10 (Vite builder) under `core/ui/.storybook/` with stories for every component exported from `@checkstack/ui`, aimed at plugin developers.
- Stories render inside the real `ThemeProvider`, `ToastProvider`, `PerformanceProvider`, `ApiProvider` (mock access API) and `MemoryRouter`, matching how plugins consume the components inside the host frontend.
- The `Deploy Documentation` workflow now also builds Storybook and merges the static output into the GitHub Pages artifact at `/checkstack/storybook/`. Linked from the Frontend Development section of `docs/README.md`.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run --filter '@checkstack/ui' storybook:build` succeeds
- [ ] After merge, verify the deploy-docs workflow runs and Storybook is reachable at `https://enyineer.github.io/checkstack/storybook/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)