### PR TITLE
fix: chown _site before Storybook merge in deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Merge Storybook into Pages artifact
         run: |
+          sudo chown -R "$(id -u):$(id -g)" ./_site
           mkdir -p ./_site/storybook
           cp -r ./core/ui/storybook-static/. ./_site/storybook/
 


### PR DESCRIPTION
## Summary

The deploy run on `818399bc` failed at the **Merge Storybook into Pages artifact** step:

```
mkdir: cannot create directory '/_site/storybook': Permission denied
```

`actions/jekyll-build-pages@v1` runs inside a Docker container that writes `_site/` as a non-root user, so when the subsequent `mkdir` runs on the runner host with the regular runner uid, it can't write into the directory. Fix is a single `sudo chown` to the runner uid before the merge step.

## Test plan

- [ ] Workflow re-runs on merge and reaches `Deploy to GitHub Pages`
- [ ] Storybook is reachable at `https://enyineer.github.io/checkstack/storybook/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)