### PR TITLE
fix: install Node 22 + bump all GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/changeset-reminder.yml
+++ b/.github/workflows/changeset-reminder.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Resolve PR metadata
         id: pr-meta
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const isPullRequest = context.eventName === 'pull_request';
@@ -86,14 +86,14 @@ jobs:
 
       - name: Checkout PR branch
         if: steps.pr-meta.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr-meta.outputs.head_ref }}
 
       - name: Analyze changeset coverage
         if: steps.pr-meta.outputs.skip != 'true'
         id: analyze
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,6 +37,16 @@ jobs:
         with:
           bun-version: latest
 
+      # Astro 6 hard-requires Node ≥ 22.12 at runtime. `bun run` defers to
+      # the system `node` binary for shebang-based CLIs like astro, so the
+      # runner's default (Node 20) makes the build fail with
+      # "Node.js v20.20.2 is not supported by Astro!". Install Node 22 on
+      # PATH so bun finds a compatible interpreter for the docs build.
+      - name: Setup Node 22 (required by Astro)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -43,7 +43,7 @@ jobs:
       # "Node.js v20.20.2 is not supported by Astro!". Install Node 22 on
       # PATH so bun finds a compatible interpreter for the docs build.
       - name: Setup Node 22 (required by Astro)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -64,8 +64,8 @@ jobs:
           cp -r ./core/ui/storybook-static/. ./_site/storybook/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -10,7 +10,7 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'bug')
     steps:
       - name: Add criticality label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issueBody = context.payload.issue.body;

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -42,7 +42,7 @@ jobs:
       # workflow. Workspace layout is fixed (`core/*` and `plugins/*`),
       # so glob explicitly.
       - name: Restore tsgo build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             core/*/.tsbuild
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload Output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: typecheck-output
           path: /tmp/typecheck-output.txt
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload Output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lint-output
           path: /tmp/lint-output.txt
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload Output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-output
           path: /tmp/test-output.txt
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build Production Image
         run: docker build -t checkstack-prod:latest .
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload Output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: security-output
           path: /tmp/security-output.txt
@@ -211,7 +211,7 @@ jobs:
     steps:
       - name: Download Typecheck Output
         if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: typecheck-output
           path: /tmp/artifacts/typecheck
@@ -219,7 +219,7 @@ jobs:
 
       - name: Download Lint Output
         if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: lint-output
           path: /tmp/artifacts/lint
@@ -227,7 +227,7 @@ jobs:
 
       - name: Download Test Output
         if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: test-output
           path: /tmp/artifacts/test
@@ -235,7 +235,7 @@ jobs:
 
       - name: Download Security Output
         if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: security-output
           path: /tmp/artifacts/security
@@ -243,7 +243,7 @@ jobs:
 
       - name: Count previous failure comments
         id: count-failures
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const comments = await github.paginate(
@@ -264,7 +264,7 @@ jobs:
 
       - name: Build and post report
         id: report
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       releasePublished: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -68,15 +68,15 @@ jobs:
             dockerfile: Dockerfile.satellite
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -89,7 +89,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build and Push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -150,7 +150,7 @@ jobs:
           bun run scripts/aggregate-changelog.ts >> /tmp/changelog.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: Checkstack v${{ steps.version.outputs.version }}

--- a/core/scripts/src/templates.test.ts
+++ b/core/scripts/src/templates.test.ts
@@ -23,6 +23,12 @@ describe("CLI Template Scaffolding", () => {
   const rootDir = path.resolve(__dirname, "../../..");
   const scaffoldsDir = path.join(rootDir, TEST_SCAFFOLDS_DIR);
 
+  // bun:test gives each hook a 5s default timeout. Both `beforeAll` and
+  // `afterAll` shell out to `bun install` (which dwarfs that on a cold
+  // CI runner), so we extend the hook timeout to match the inner
+  // execSync ceiling. Without this the hook is aborted while the
+  // subprocess is still running and every `it` in the suite shows up as
+  // `(unnamed) [5006.01ms]` — the source of past CI flakes.
   beforeAll(() => {
     registerHelpers();
 
@@ -59,7 +65,7 @@ describe("CLI Template Scaffolding", () => {
       stdio: "pipe",
       timeout: 120_000,
     });
-  });
+  }, 180_000);
 
   afterAll(() => {
     // Cleanup all test packages
@@ -73,7 +79,7 @@ describe("CLI Template Scaffolding", () => {
       stdio: "pipe",
       timeout: 60_000,
     });
-  });
+  }, 120_000);
 
   for (const pluginType of PLUGIN_TYPES) {
     const pluginName = `${TEST_BASE_NAME}-${pluginType}`;


### PR DESCRIPTION
## Summary

The post-merge deploy run on `a3c34790` failed with:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

Astro 6 hard-requires Node ≥ 22.12 at runtime. `bun run` of a shebang-based CLI like `astro` defers to the system `node`, so the runner's default Node 20.20.2 made the build bail. Adding `actions/setup-node@v4` with `node-version: "22"` ahead of the install + build steps so Bun finds a compatible interpreter on PATH.

## Test plan

- [ ] After merge, deploy-docs run reaches "Deploy to GitHub Pages"
- [ ] https://enyineer.github.io/checkstack/ serves the new Astro Starlight site
- [ ] https://enyineer.github.io/checkstack/storybook/ still serves Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)