### PR TITLE
fix: deploy-docs LFS checkout + env→dotenv lang alias

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Required: SVG/PNG/etc. assets (logo, favicons) are stored
+          # in Git LFS — see .gitattributes. Without this the runner
+          # gets pointer files and Astro fails with NoImageMetadata.
+          lfs: true
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -16,6 +16,18 @@ export default defineConfig({
     starlight({
       title: "Checkstack",
       description: "Plugin-based application platform with extensible architecture.",
+      // expressive-code (Starlight's syntax-highlighting layer) bundles
+      // Shiki's standard languages but does not include `env`. Several
+      // pages use ```env fences for .env-style examples, so alias them
+      // to `dotenv` (which Shiki ships) instead of falling back to
+      // `txt` with a build-time warning.
+      expressiveCode: {
+        shiki: {
+          langAlias: {
+            env: "dotenv",
+          },
+        },
+      },
       logo: {
         src: "./src/assets/logo.svg",
         replacesTitle: false,


### PR DESCRIPTION
## Summary

Fixes the post-merge deploy-docs failure on \`a3b302a2\`:

\`\`\`
[NoImageMetadata] [astro:assets:esm] Could not load …/docs/src/assets/logo.svg
\`\`\`

\`*.svg\` (and other binary assets) are stored in Git LFS per [.gitattributes](.gitattributes); without \`lfs: true\` on \`actions/checkout@v6\` the runner gets a 130-byte pointer file that Astro can't extract image metadata from.

Also clears the build warning:

\`\`\`
[WARN] [astro-expressive-code] Error while highlighting code block using language "env"
\`\`\`

by aliasing \`env\` → \`dotenv\` in the Shiki config so \`\`\`env fences render with proper highlighting instead of falling back to plain text.

## Test plan

- [x] Local \`bun run --filter '@checkstack/docs' build\` clean (no warnings)
- [ ] After merge, deploy-docs run reaches \`Deploy to GitHub Pages\`
- [ ] https://enyineer.github.io/checkstack/ shows the logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)