### PR TITLE
fix: allow create-github-release to run on workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
   create-github-release:
     name: Create GitHub Release
     needs: [release, docker]
-    if: needs.release.outputs.releasePublished == 'true'
+    if: needs.release.outputs.releasePublished == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary

- Adds `|| github.event_name == 'workflow_dispatch'` to the `create-github-release` job's `if`, mirroring the existing fallback on the `docker` job.
- This makes `workflow_dispatch` a proper recovery path when the prior automatic Release run published npm packages (or built docker images) but failed before reaching the GitHub release step.

## Why

When the Release workflow runs on `push` and `changesets/action` finds nothing new to publish (because a previous run already published, or because there are no changesets), `outputs.published` is `false`. The `docker` job has a `workflow_dispatch` fallback so manual re-runs rebuild images, but `create-github-release` did not — leaving no way to create the missing GitHub release without doing it by hand.

This bit us today: v0.82.0 packages and docker images shipped, but the `v0.82.0` GitHub release was never created, and re-running the workflow couldn't fix it.

CI/workflow-only change, no changeset required (per `.agent/rules/changesets.md`).

## Test plan

- [ ] After merge, dispatch the Release workflow manually on a commit where `core/release/package.json` is already at the published version → confirm `create-github-release` job runs (it will fail loudly on a duplicate tag, which is the intended safety net) instead of being skipped.
- [ ] On a normal `push` to `main` with new changesets, confirm the job still runs end-to-end as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)