### PR TITLE
feat: add /rest mount + REST method conventions for oRPC contracts

### DIFF
--- a/.changeset/rest-api-mount.md
+++ b/.changeset/rest-api-mount.md
@@ -1,0 +1,67 @@
+---
+"@checkstack/backend": minor
+"@checkstack/common": minor
+"@checkstack/auth-common": minor
+"@checkstack/catalog-common": minor
+"@checkstack/healthcheck-common": minor
+"@checkstack/incident-common": minor
+"@checkstack/maintenance-common": minor
+"@checkstack/notification-common": minor
+"@checkstack/dependency-common": minor
+"@checkstack/slo-common": minor
+"@checkstack/anomaly-common": minor
+"@checkstack/announcement-common": minor
+"@checkstack/cache-common": minor
+"@checkstack/gitops-common": minor
+"@checkstack/integration-common": minor
+"@checkstack/queue-common": minor
+"@checkstack/satellite-common": minor
+---
+
+Add a `/rest/:pluginId/*` HTTP mount that serves every plugin's oRPC contract
+through the REST/OpenAPI shape described by `/api/openapi.json`. Queries are
+`GET` with query parameters, mutations are `POST` with the input as the raw
+JSON body. The existing `/api/:pluginId/*` mount continues to serve oRPC's
+native wire protocol unchanged, so existing clients are not affected.
+
+The OpenAPI spec at `/api/openapi.json` now reflects the real mount: every
+`paths` entry is prefixed with `/rest` instead of `/api`.
+
+Also fixes a SPA-fallback bug: the backend's `/api-docs` route previously
+returned 404 on production deployments because the static-file middleware
+skipped any path starting with `/api`, capturing `/api-docs` along with real
+API routes. The skip now requires a trailing slash (`/api/`, `/rest/`).
+
+Required access rules are now visible in the API Docs UI. The OpenAPI spec
+generator was reading a non-existent `accessRules` field on procedure
+metadata; the real field is `access: AccessRule[]`. Each procedure's access
+rules are now flattened to fully-qualified IDs (e.g. `catalog.system.read`)
+and emitted under `x-orpc-meta.accessRules`, which the existing
+`Required Access Rules` section in the docs UI already knew how to render.
+
+The API Docs schema renderer now handles record types (zod `z.record`),
+`$ref`s into `components.schemas`, `oneOf`/`anyOf`/`allOf`, nullable union
+types (`type: ["string", "null"]`), and `format` qualifiers. Previously
+record outputs like `{ statuses: object }` masked the actual value type;
+they now render as `{ [key]: <ResolvedType> { ... } }` with the inner
+schema expanded, capped at 12 levels with cycle detection.
+
+**REST method conventions.** `proc()` now defaults to `GET` for queries and
+`POST` for mutations on the `/rest` mount, using bracket-notation query
+params (`?filter[status]=active&ids[0]=a`) for GET inputs. Existing
+procedures were updated to follow REST semantics:
+
+- `update*` mutations → `PATCH`
+- `delete*` / `remove*` mutations → `DELETE`
+- `getBulk*` queries and any query taking a large array input → `POST`
+  (because `@orpc/openapi@1.13.x` has no GET→POST URL-length fallback)
+
+GET endpoints require an `object` input — bare scalars like
+`.input(z.string())` are not valid on GET. `getSystemConfigurations` was
+refactored from `.input(z.string())` to `.input(z.object({ systemId: ... }))`
+to fit the GET shape; the only call-site update was the in-process router
+unpacking `input.systemId` instead of passing `input` directly.
+
+The API Docs UI now renders query parameters (path/query/header/cookie) in a
+dedicated table for GET endpoints, and the fetch example shows them in the
+URL with `<required>` / `<optional>` placeholders.

--- a/bun.lock
+++ b/bun.lock
@@ -5080,9 +5080,9 @@
 
     "@checkstack/anomaly-frontend/react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
 
-    "@checkstack/backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@checkstack/backend/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@checkstack/backend-api/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@checkstack/backend-api/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@checkstack/cache-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
@@ -5108,7 +5108,7 @@
 
     "@checkstack/frontend/vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
-    "@checkstack/frontend-api/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@checkstack/frontend-api/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@checkstack/gitops-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
@@ -5180,11 +5180,11 @@
 
     "@checkstack/satellite-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@checkstack/signal-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@checkstack/signal-backend/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@checkstack/slo-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@checkstack/test-utils-backend/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@checkstack/test-utils-backend/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@checkstack/ui/@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
@@ -5410,9 +5410,9 @@
 
     "@checkstack/anomaly-frontend/react-router-dom/react-router": ["react-router@7.14.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw=="],
 
-    "@checkstack/backend-api/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@checkstack/backend-api/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "@checkstack/backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@checkstack/backend/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@checkstack/cache-memory-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
@@ -5428,7 +5428,7 @@
 
     "@checkstack/dependency-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@checkstack/frontend-api/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@checkstack/frontend-api/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@checkstack/frontend/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
@@ -5496,11 +5496,11 @@
 
     "@checkstack/satellite/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@checkstack/signal-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@checkstack/signal-backend/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@checkstack/slo-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@checkstack/test-utils-backend/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@checkstack/test-utils-backend/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@checkstack/ui/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
@@ -5730,6 +5730,16 @@
 
     "@astrojs/mdx/remark-gfm/micromark-extension-gfm/micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
 
+    "@checkstack/backend-api/@types/bun/bun-types/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@checkstack/backend/@types/bun/bun-types/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@checkstack/frontend-api/@types/bun/bun-types/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@checkstack/signal-backend/@types/bun/bun-types/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@checkstack/test-utils-backend/@types/bun/bun-types/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
     "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -5893,6 +5903,16 @@
     "@astrojs/mdx/remark-gfm/mdast-util-gfm/mdast-util-gfm-autolink-literal/mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "@astrojs/mdx/remark-gfm/mdast-util-gfm/mdast-util-gfm-table/markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "@checkstack/backend-api/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@checkstack/backend/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@checkstack/frontend-api/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@checkstack/signal-backend/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@checkstack/test-utils-backend/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 

--- a/core/announcement-common/src/rpc-contract.ts
+++ b/core/announcement-common/src/rpc-contract.ts
@@ -75,6 +75,7 @@ export const announcementContract = {
     userType: "authenticated",
     access: [announcementAccess.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateAnnouncementInputSchema)
     .output(AnnouncementSchema),
 
@@ -84,6 +85,7 @@ export const announcementContract = {
     userType: "authenticated",
     access: [announcementAccess.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
 };

--- a/core/anomaly-common/src/rpc-contract.ts
+++ b/core/anomaly-common/src/rpc-contract.ts
@@ -132,6 +132,7 @@ export const anomalyContract = {
     userType: "authenticated",
     access: [anomalyAccess.feed.manage],
   })
+    .route({ method: "PATCH" })
     .input(z.object({
       configurationId: z.string(),
       config: AnomalySettingsSchema,
@@ -156,6 +157,7 @@ export const anomalyContract = {
     access: [anomalyAccess.feed.manage],
     instanceAccess: { idParam: "systemId" },
   })
+    .route({ method: "PATCH" })
     .input(z.object({
       systemId: z.string(),
       configurationId: z.string(),

--- a/core/api-docs-frontend/src/ApiDocsPage.tsx
+++ b/core/api-docs-frontend/src/ApiDocsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import {
   Card,
   CardContent,
@@ -29,6 +29,17 @@ interface OpenApiSpec {
     description?: string;
   };
   paths: Record<string, Record<string, OperationObject>>;
+  components?: {
+    schemas?: Record<string, SchemaObject>;
+  };
+}
+
+interface ParameterObject {
+  name: string;
+  in: "query" | "path" | "header" | "cookie";
+  required?: boolean;
+  description?: string;
+  schema?: SchemaObject;
 }
 
 interface OperationObject {
@@ -36,6 +47,7 @@ interface OperationObject {
   description?: string;
   operationId?: string;
   tags?: string[];
+  parameters?: ParameterObject[];
   requestBody?: {
     content?: {
       "application/json"?: {
@@ -57,31 +69,37 @@ interface OperationObject {
 }
 
 interface SchemaObject {
-  type?: string;
+  type?: string | string[];
   properties?: Record<string, SchemaObject>;
   items?: SchemaObject;
   required?: string[];
   description?: string;
-  enum?: string[];
+  enum?: (string | number | boolean | null)[];
+  format?: string;
+  nullable?: boolean;
   $ref?: string;
+  additionalProperties?: SchemaObject | boolean;
+  oneOf?: SchemaObject[];
+  anyOf?: SchemaObject[];
+  allOf?: SchemaObject[];
 }
 
 function getUserTypeIcon(userType?: string) {
   switch (userType) {
     case "public": {
-      return <Globe className="h-4 w-4 text-green-500" />;
+      return <Globe className="w-4 h-4 text-green-500" />;
     }
     case "user": {
-      return <User className="h-4 w-4 text-blue-500" />;
+      return <User className="w-4 h-4 text-blue-500" />;
     }
     case "service": {
-      return <Server className="h-4 w-4 text-purple-500" />;
+      return <Server className="w-4 h-4 text-purple-500" />;
     }
     case "authenticated": {
-      return <Lock className="h-4 w-4 text-amber-500" />;
+      return <Lock className="w-4 h-4 text-amber-500" />;
     }
     default: {
-      return <Lock className="h-4 w-4 text-gray-500" />;
+      return <Lock className="w-4 h-4 text-gray-500" />;
     }
   }
 }
@@ -120,7 +138,7 @@ function CopyButton({ text }: { text: string }) {
 
   return (
     <Button variant="ghost" size="sm" onClick={handleCopy}>
-      {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+      {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
     </Button>
   );
 }
@@ -131,19 +149,30 @@ function generateFetchExample(
   operation: OperationObject,
 ): string {
   const baseUrl = "http://localhost:3000";
+  const upperMethod = method.toUpperCase();
   const hasBody = operation.requestBody?.content?.["application/json"]?.schema;
 
-  let example = `const response = await fetch("${baseUrl}${path}", {
-  method: "${method.toUpperCase()}",
+  const queryParams =
+    operation.parameters?.filter((p) => p.in === "query") ?? [];
+  const queryString =
+    queryParams.length > 0
+      ? "?" +
+        queryParams
+          .map((p) => `${p.name}=<${p.required ? "required" : "optional"}>`)
+          .join("&")
+      : "";
+
+  const includeContentType = hasBody;
+  let example = `const response = await fetch("${baseUrl}${path}${queryString}", {
+  method: "${upperMethod}",
   headers: {
-    "Content-Type": "application/json",
-    "Authorization": "Bearer ck_<application-id>_<secret>"
+${includeContentType ? '    "Content-Type": "application/json",\n' : ""}    "Authorization": "Bearer ck_<application-id>_<secret>"
   }`;
 
   if (hasBody) {
     example += `,
   body: JSON.stringify({
-    // Request body - see schema below
+    // Request body - see schema above
   })`;
   }
 
@@ -155,45 +184,118 @@ const data = await response.json();`;
   return example;
 }
 
+const SchemasContext = createContext<Record<string, SchemaObject>>({});
+
+const PRIMITIVE_COLORS: Record<string, string> = {
+  string: "text-green-600 dark:text-green-400",
+  number: "text-amber-600 dark:text-amber-400",
+  boolean: "text-red-600 dark:text-red-400",
+  integer: "text-amber-600 dark:text-amber-400",
+  null: "text-gray-500",
+};
+
+function PrimitiveType({ type, format }: { type: string; format?: string }) {
+  const className = PRIMITIVE_COLORS[type] ?? "text-gray-600";
+  return (
+    <span className={className}>
+      {type}
+      {format ? (
+        <span className="text-muted-foreground"> &lt;{format}&gt;</span>
+      ) : null}
+    </span>
+  );
+}
+
+const MAX_DEPTH = 12;
+
 function SchemaDisplay({
   schema,
   depth = 0,
+  refStack = [],
 }: {
   schema?: SchemaObject;
   depth?: number;
+  /** Tracks $refs already in the current chain to halt cycles. */
+  refStack?: string[];
 }) {
+  const schemas = useContext(SchemasContext);
+
   if (!schema) return <span className="text-muted-foreground">unknown</span>;
+  if (depth > MAX_DEPTH) {
+    return <span className="text-muted-foreground">…</span>;
+  }
 
+  // Resolve $ref via the spec's components.schemas registry, guarding against
+  // cycles. If the ref can't be resolved we show its name as a leaf.
   if (schema.$ref) {
-    const refName = schema.$ref.split("/").pop();
-    return (
-      <span className="text-purple-600 dark:text-purple-400">{refName}</span>
-    );
-  }
-
-  if (schema.type === "object" && schema.properties) {
-    return (
-      <div className="font-mono text-sm" style={{ marginLeft: depth * 16 }}>
-        {"{"}
-        {Object.entries(schema.properties).map(([key, value]) => (
-          <div key={key} className="ml-4">
-            <span className="text-blue-600 dark:text-blue-400">{key}</span>
-            {schema.required?.includes(key) && (
-              <span className="text-red-500">*</span>
-            )}
-            : <SchemaDisplay schema={value} depth={depth + 1} />
-          </div>
-        ))}
-        {"}"}
-      </div>
-    );
-  }
-
-  if (schema.type === "array" && schema.items) {
+    const refName = schema.$ref.split("/").pop() ?? schema.$ref;
+    if (refStack.includes(schema.$ref)) {
+      return (
+        <span
+          className="text-purple-600 dark:text-purple-400"
+          title="recursive reference"
+        >
+          {refName} ↻
+        </span>
+      );
+    }
+    const resolved = schemas[refName];
+    if (!resolved) {
+      return (
+        <span className="text-purple-600 dark:text-purple-400">{refName}</span>
+      );
+    }
     return (
       <span>
-        <SchemaDisplay schema={schema.items} depth={depth} />
-        []
+        <span className="mr-1 text-purple-600 dark:text-purple-400">
+          {refName}
+        </span>
+        <SchemaDisplay
+          schema={resolved}
+          depth={depth}
+          refStack={[...refStack, schema.$ref]}
+        />
+      </span>
+    );
+  }
+
+  // Union / intersection — render variants separated by | or & .
+  const variants = schema.oneOf ?? schema.anyOf;
+  if (variants && variants.length > 0) {
+    return (
+      <span>
+        {variants.map((v, i) => (
+          <span key={i}>
+            {i > 0 && <span className="text-muted-foreground"> | </span>}
+            <SchemaDisplay schema={v} depth={depth} refStack={refStack} />
+          </span>
+        ))}
+      </span>
+    );
+  }
+  if (schema.allOf && schema.allOf.length > 0) {
+    return (
+      <span>
+        {schema.allOf.map((v, i) => (
+          <span key={i}>
+            {i > 0 && <span className="text-muted-foreground"> &amp; </span>}
+            <SchemaDisplay schema={v} depth={depth} refStack={refStack} />
+          </span>
+        ))}
+      </span>
+    );
+  }
+
+  // Treat type: ["string", "null"] as a nullable union.
+  if (Array.isArray(schema.type)) {
+    return (
+      <span>
+        {schema.type.map((t, i) => (
+          <span key={i}>
+            {i > 0 && <span className="text-muted-foreground"> | </span>}
+            <PrimitiveType type={t} format={schema.format} />
+          </span>
+        ))}
       </span>
     );
   }
@@ -201,22 +303,167 @@ function SchemaDisplay({
   if (schema.enum) {
     return (
       <span className="text-green-600 dark:text-green-400">
-        {schema.enum.map((e) => `"${e}"`).join(" | ")}
+        {schema.enum
+          .map((e) => (typeof e === "string" ? `"${e}"` : String(e)))
+          .join(" | ")}
       </span>
     );
   }
 
-  const typeColors: Record<string, string> = {
-    string: "text-green-600 dark:text-green-400",
-    number: "text-amber-600 dark:text-amber-400",
-    boolean: "text-red-600 dark:text-red-400",
-    integer: "text-amber-600 dark:text-amber-400",
+  if (
+    schema.type === "object" ||
+    schema.properties ||
+    schema.additionalProperties !== undefined
+  ) {
+    const props = schema.properties;
+    const ap = schema.additionalProperties;
+
+    // zod `z.record(K, V)` → no `properties`, just `additionalProperties: V`.
+    // Render as `{ [key]: V }` so the value type is visible.
+    if (!props && ap !== undefined && ap !== false) {
+      return (
+        <div
+          className="inline-block font-mono text-sm align-top"
+          style={{ marginLeft: depth * 16 }}
+        >
+          {"{ "}
+          <span className="text-muted-foreground">[key]</span>:{" "}
+          {ap === true ? (
+            <span className="text-gray-600">any</span>
+          ) : (
+            <SchemaDisplay schema={ap} depth={depth + 1} refStack={refStack} />
+          )}
+          {" }"}
+        </div>
+      );
+    }
+
+    if (props) {
+      return (
+        <div
+          className="inline-block font-mono text-sm align-top"
+          style={{ marginLeft: depth * 16 }}
+        >
+          {"{"}
+          {Object.entries(props).map(([key, value]) => (
+            <div key={key} className="ml-4">
+              <span className="text-blue-600 dark:text-blue-400">{key}</span>
+              {schema.required?.includes(key) && (
+                <span className="text-red-500">*</span>
+              )}
+              :{" "}
+              <SchemaDisplay
+                schema={value}
+                depth={depth + 1}
+                refStack={refStack}
+              />
+            </div>
+          ))}
+          {ap !== undefined && ap !== false && (
+            <div className="ml-4">
+              <span className="text-muted-foreground">[key]</span>:{" "}
+              {ap === true ? (
+                <span className="text-gray-600">any</span>
+              ) : (
+                <SchemaDisplay
+                  schema={ap}
+                  depth={depth + 1}
+                  refStack={refStack}
+                />
+              )}
+            </div>
+          )}
+          {"}"}
+        </div>
+      );
+    }
+
+    return <PrimitiveType type="object" />;
+  }
+
+  if (schema.type === "array" && schema.items) {
+    return (
+      <span>
+        <SchemaDisplay
+          schema={schema.items}
+          depth={depth}
+          refStack={refStack}
+        />
+        []
+      </span>
+    );
+  }
+
+  if (typeof schema.type === "string") {
+    return <PrimitiveType type={schema.type} format={schema.format} />;
+  }
+
+  return <span className="text-gray-600">unknown</span>;
+}
+
+function ParametersTable({
+  parameters,
+}: {
+  parameters: ParameterObject[];
+}) {
+  const byLocation: Record<string, ParameterObject[]> = {};
+  for (const p of parameters) {
+    (byLocation[p.in] ??= []).push(p);
+  }
+
+  const sectionTitle: Record<string, string> = {
+    query: "Query Parameters",
+    path: "Path Parameters",
+    header: "Header Parameters",
+    cookie: "Cookie Parameters",
   };
 
   return (
-    <span className={typeColors[schema.type ?? ""] ?? "text-gray-600"}>
-      {schema.type ?? "unknown"}
-    </span>
+    <div className="space-y-3">
+      {(["path", "query", "header", "cookie"] as const).map((loc) => {
+        const items = byLocation[loc];
+        if (!items || items.length === 0) return null;
+        return (
+          <div key={loc}>
+            <h4 className="mb-2 text-sm font-medium">{sectionTitle[loc]}</h4>
+            <div className="overflow-x-auto rounded-md bg-muted">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left border-b border-border/50">
+                    <th className="px-3 py-2 font-medium">Name</th>
+                    <th className="px-3 py-2 font-medium">Type</th>
+                    <th className="px-3 py-2 font-medium">Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((p) => (
+                    <tr
+                      key={`${p.in}:${p.name}`}
+                      className="align-top border-t border-border/30"
+                    >
+                      <td className="px-3 py-2 font-mono">
+                        <span className="text-blue-600 dark:text-blue-400">
+                          {p.name}
+                        </span>
+                        {p.required && (
+                          <span className="text-red-500">*</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        <SchemaDisplay schema={p.schema} />
+                      </td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {p.description ?? ""}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -248,21 +495,21 @@ function EndpointCard({
   return (
     <Card className="mb-2">
       <CardHeader
-        className="cursor-pointer hover:bg-accent/50 transition-colors py-3"
+        className="py-3 transition-colors cursor-pointer hover:bg-accent/50"
         onClick={() => setIsOpen(!isOpen)}
       >
         <div className="flex items-center gap-3">
           {isOpen ? (
-            <ChevronDown className="h-4 w-4" />
+            <ChevronDown className="w-4 h-4" />
           ) : (
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight className="w-4 h-4" />
           )}
           <Badge
             className={`${methodColors[method]} text-white uppercase text-xs font-mono`}
           >
             {method}
           </Badge>
-          <code className="font-mono text-sm flex-1 text-left">{path}</code>
+          <code className="flex-1 font-mono text-sm text-left">{path}</code>
           <div className="flex items-center gap-2">
             {getUserTypeIcon(meta?.userType)}
             <Badge
@@ -295,7 +542,7 @@ function EndpointCard({
 
           {meta?.accessRules && meta.accessRules.length > 0 && (
             <div>
-              <h4 className="text-sm font-medium mb-2">
+              <h4 className="mb-2 text-sm font-medium">
                 Required Access Rules
               </h4>
               <div className="flex flex-wrap gap-2">
@@ -308,11 +555,19 @@ function EndpointCard({
             </div>
           )}
 
+          {operation.parameters && operation.parameters.length > 0 && (
+            <ParametersTable parameters={operation.parameters} />
+          )}
+
           <div className="grid gap-4 md:grid-cols-2">
             {inputSchema && (
               <div>
-                <h4 className="text-sm font-medium mb-2">Input Schema</h4>
-                <div className="bg-muted rounded-md p-3 overflow-x-auto">
+                <h4 className="mb-2 text-sm font-medium">
+                  {method.toLowerCase() === "get"
+                    ? "Input Schema (encoded as query params)"
+                    : "Input Schema"}
+                </h4>
+                <div className="p-3 overflow-x-auto rounded-md bg-muted">
                   <SchemaDisplay schema={inputSchema} />
                 </div>
               </div>
@@ -320,8 +575,8 @@ function EndpointCard({
 
             {outputSchema && (
               <div>
-                <h4 className="text-sm font-medium mb-2">Output Schema</h4>
-                <div className="bg-muted rounded-md p-3 overflow-x-auto">
+                <h4 className="mb-2 text-sm font-medium">Output Schema</h4>
+                <div className="p-3 overflow-x-auto rounded-md bg-muted">
                   <SchemaDisplay schema={outputSchema} />
                 </div>
               </div>
@@ -335,7 +590,7 @@ function EndpointCard({
                 text={generateFetchExample(path, method, operation)}
               />
             </div>
-            <pre className="bg-muted rounded-md p-3 overflow-x-auto text-sm">
+            <pre className="p-3 overflow-x-auto text-sm rounded-md bg-muted">
               <code>{generateFetchExample(path, method, operation)}</code>
             </pre>
           </div>
@@ -419,9 +674,10 @@ export function ApiDocsPage() {
         continue;
       }
 
-      // Extract plugin name from path (e.g., /catalog/getEntities -> catalog)
-      // Path can be /api/plugin/... or /plugin/... depending on OpenAPI prefix setting
-      const pluginMatch = path.match(/^\/?(?:api\/)?([^/]+)/);
+      // Extract plugin name from path (e.g. /rest/catalog/getEntities -> catalog).
+      // Paths in the generated spec are prefixed with /rest (the REST mount); a
+      // bare /plugin/... fallback is kept in case the prefix is ever stripped.
+      const pluginMatch = path.match(/^\/?(?:rest\/)?([^/]+)/);
       const pluginName = pluginMatch?.[1] ?? "other";
 
       if (!endpointsByPlugin[pluginName]) {
@@ -432,91 +688,95 @@ export function ApiDocsPage() {
   }
 
   return (
-    <PageLayout
-      title={spec.info.title}
-      subtitle={spec.info.description}
-      icon={FileCode}
-      loading={loading}
-      maxWidth="full"
-    >
-      <Badge variant="secondary">v{spec.info.version}</Badge>
+    <SchemasContext.Provider value={spec.components?.schemas ?? {}}>
+      <PageLayout
+        title={spec.info.title}
+        subtitle={spec.info.description}
+        icon={FileCode}
+        loading={loading}
+        maxWidth="full"
+      >
+        <Badge variant="secondary">v{spec.info.version}</Badge>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="text-sm text-muted-foreground">Filter by access:</span>
-        <Button
-          variant={selectedTypes.size === 0 ? "primary" : "outline"}
-          size="sm"
-          onClick={showAll}
-        >
-          All
-        </Button>
-        <Button
-          variant={selectedTypes.has("authenticated") ? "primary" : "outline"}
-          size="sm"
-          onClick={() => toggleType("authenticated")}
-        >
-          Authenticated
-        </Button>
-        <Button
-          variant={selectedTypes.has("public") ? "primary" : "outline"}
-          size="sm"
-          onClick={() => toggleType("public")}
-        >
-          Public
-        </Button>
-        <Button
-          variant={selectedTypes.has("user") ? "primary" : "outline"}
-          size="sm"
-          onClick={() => toggleType("user")}
-        >
-          User Only
-        </Button>
-        <Button
-          variant={selectedTypes.has("service") ? "primary" : "outline"}
-          size="sm"
-          onClick={() => toggleType("service")}
-        >
-          Service Only
-        </Button>
-      </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-muted-foreground">
+            Filter by access:
+          </span>
+          <Button
+            variant={selectedTypes.size === 0 ? "primary" : "outline"}
+            size="sm"
+            onClick={showAll}
+          >
+            All
+          </Button>
+          <Button
+            variant={selectedTypes.has("authenticated") ? "primary" : "outline"}
+            size="sm"
+            onClick={() => toggleType("authenticated")}
+          >
+            Authenticated
+          </Button>
+          <Button
+            variant={selectedTypes.has("public") ? "primary" : "outline"}
+            size="sm"
+            onClick={() => toggleType("public")}
+          >
+            Public
+          </Button>
+          <Button
+            variant={selectedTypes.has("user") ? "primary" : "outline"}
+            size="sm"
+            onClick={() => toggleType("user")}
+          >
+            User Only
+          </Button>
+          <Button
+            variant={selectedTypes.has("service") ? "primary" : "outline"}
+            size="sm"
+            onClick={() => toggleType("service")}
+          >
+            Service Only
+          </Button>
+        </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Authentication</CardTitle>
-          <CardDescription>
-            Endpoints marked as <strong>authenticated</strong> or{" "}
-            <strong>public</strong> can be accessed using an application token.
-            Other endpoints are for internal use only.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <pre className="bg-muted rounded-md p-3 overflow-x-auto text-sm">
-            <code>
-              Authorization: Bearer ck_{"<application-id>"}_{"<secret>"}
-            </code>
-          </pre>
-        </CardContent>
-      </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Authentication</CardTitle>
+            <CardDescription>
+              Endpoints marked as <strong>authenticated</strong> or{" "}
+              <strong>public</strong> can be accessed using an application
+              token. Other endpoints are for internal use only.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <pre className="p-3 overflow-x-auto text-sm rounded-md bg-muted">
+              <code>
+                Authorization: Bearer ck_{"<application-id>"}_{"<secret>"}
+              </code>
+            </pre>
+          </CardContent>
+        </Card>
 
-      <div className="space-y-8">
-        {Object.entries(endpointsByPlugin)
-          .toSorted(([a], [b]) => a.localeCompare(b))
-          .map(([pluginName, endpoints]) => (
-            <div key={pluginName}>
-              <h2 className="text-xl font-semibold mb-4 capitalize">
-                {pluginName}
-              </h2>
-              {endpoints.map(({ path, method, operation }) => (
-                <EndpointCard
-                  key={`${method}-${path}`}
-                  path={path}
-                  method={method}
-                  operation={operation}
-                />
-              ))}
-            </div>
-          ))}
-      </div>
-    </PageLayout>
+        <div className="space-y-8">
+          {Object.entries(endpointsByPlugin)
+            .toSorted(([a], [b]) => a.localeCompare(b))
+            .map(([pluginName, endpoints]) => (
+              <div key={pluginName}>
+                <h2 className="mb-4 text-xl font-semibold capitalize">
+                  {pluginName}
+                </h2>
+                {endpoints.map(({ path, method, operation }) => (
+                  <EndpointCard
+                    key={`${method}-${path}`}
+                    path={path}
+                    method={method}
+                    operation={operation}
+                  />
+                ))}
+              </div>
+            ))}
+        </div>
+      </PageLayout>
+    </SchemasContext.Provider>
   );
 }

--- a/core/auth-common/src/rpc-contract.ts
+++ b/core/auth-common/src/rpc-contract.ts
@@ -193,6 +193,7 @@ export const authContract = {
     userType: "user",
     access: [],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         name: z.string().min(1).optional(),
@@ -216,6 +217,7 @@ export const authContract = {
     userType: "user",
     access: [authAccess.users.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.string())
     .output(z.void()),
 
@@ -232,6 +234,7 @@ export const authContract = {
     userType: "user",
     access: [authAccess.users.manage],
   })
+    .route({ method: "PATCH" })
     .input(z.object({ userId: z.string(), roles: z.array(z.string()) }))
     .output(z.void()),
 
@@ -270,6 +273,7 @@ export const authContract = {
     userType: "user",
     access: [authAccess.roles.update],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         id: z.string(),
@@ -285,6 +289,7 @@ export const authContract = {
     userType: "user",
     access: [authAccess.roles.delete],
   })
+    .route({ method: "DELETE" })
     .input(z.string())
     .output(z.void()),
 
@@ -303,6 +308,7 @@ export const authContract = {
     userType: "user",
     access: [authAccess.strategies],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         id: z.string(),
@@ -452,6 +458,7 @@ export const authContract = {
     userType: "user",
     access: [authAccess.applications],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         id: z.string(),
@@ -467,6 +474,7 @@ export const authContract = {
     userType: "user",
     access: [authAccess.applications],
   })
+    .route({ method: "DELETE" })
     .input(z.string())
     .output(z.void()),
 
@@ -538,6 +546,7 @@ export const authContract = {
     userType: "authenticated",
     access: [authAccess.teams.read],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         id: z.string(),
@@ -552,6 +561,7 @@ export const authContract = {
     userType: "authenticated",
     access: [authAccess.teams.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.string())
     .output(z.void()),
 
@@ -568,6 +578,7 @@ export const authContract = {
     userType: "authenticated",
     access: [authAccess.teams.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ teamId: z.string(), userId: z.string() }))
     .output(z.void()),
 
@@ -584,6 +595,7 @@ export const authContract = {
     userType: "authenticated",
     access: [authAccess.teams.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ teamId: z.string(), userId: z.string() }))
     .output(z.void()),
 
@@ -625,6 +637,7 @@ export const authContract = {
     userType: "authenticated",
     access: [authAccess.teams.manage],
   })
+    .route({ method: "DELETE" })
     .input(
       z.object({
         resourceType: z.string(),
@@ -699,6 +712,7 @@ export const authContract = {
     userType: "service",
     access: [],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ resourceType: z.string(), resourceId: z.string() }))
     .output(z.void()),
 

--- a/core/backend/src/index.ts
+++ b/core/backend/src/index.ts
@@ -335,8 +335,13 @@ if (frontendDistPath && fs.existsSync(frontendDistPath)) {
   // Serve root-level static files (e.g., /favicon.svg) from the dist directory
   // before the SPA fallback, so they don't get caught by the index.html handler
   app.get("*", async (c, next) => {
-    // Skip API and WebSocket routes - let them pass through to actual handlers
-    if (c.req.path.startsWith("/api")) {
+    // Skip API and WebSocket routes - let them pass through to actual handlers.
+    // The trailing slash matters: `/api-docs` is a frontend route and must hit
+    // the SPA fallback below, while `/api/...` and `/rest/...` go to backend
+    // handlers (oRPC RPC + OpenAPI REST mounts).
+    const apiPath =
+      c.req.path.startsWith("/api/") || c.req.path.startsWith("/rest/");
+    if (apiPath) {
       return next();
     }
 

--- a/core/backend/src/openapi-router.ts
+++ b/core/backend/src/openapi-router.ts
@@ -10,6 +10,7 @@ import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import type { AnyContractRouter } from "@orpc/contract";
 import type { PluginManager } from "./plugin-manager";
 import type { AuthService } from "@checkstack/backend-api";
+import type { AccessRule } from "@checkstack/common";
 
 /**
  * Check if a user has a specific access rule.
@@ -26,39 +27,56 @@ function hasAccess(
 }
 
 /**
- * Extract procedure metadata from a contract using oRPC internal structure.
+ * Shape of the metadata we surface in the OpenAPI spec as `x-orpc-meta`.
+ * `accessRules` are the fully-qualified access rule IDs (e.g.
+ * `"catalog.system.read"`), flattened from each procedure's `access`
+ * AccessRule[] so doc consumers don't need to know the AccessRule shape.
  */
-function extractProcedureMetadata(
+interface ExposedProcedureMeta {
+  userType?: string;
+  accessRules?: string[];
+}
+
+/**
+ * Extract procedure metadata from a contract using oRPC internal structure.
+ * Returns the raw `meta` block stored on the contract procedure builder.
+ */
+function extractRawProcedureMeta(
   contract: unknown
-): { userType?: string; accessRules?: string[] } | undefined {
+): { userType?: string; access?: AccessRule[] } | undefined {
   const orpcData = (contract as Record<string, unknown>)?.["~orpc"] as
-    | { meta?: { userType?: string; accessRules?: string[] } }
+    | { meta?: { userType?: string; access?: AccessRule[] } }
     | undefined;
   return orpcData?.meta;
 }
 
 /**
- * Build a lookup map of operationId -> metadata from all contracts.
- * operationId format: "pluginId.procedureName"
+ * Build a lookup map of operationId -> exposed metadata from all contracts.
+ * operationId format: "pluginId.procedureName".
+ *
+ * The procedure metadata stores `access` as AccessRule[]; we flatten it to
+ * `accessRules: string[]` of qualified IDs (`{pluginId}.{ruleId}`) so the
+ * OpenAPI consumer (API docs UI, third-party clients) gets a plain list.
  */
 function buildMetadataLookup(
   contracts: Map<string, AnyContractRouter>
-): Map<string, { userType?: string; accessRules?: string[] }> {
-  const lookup = new Map<
-    string,
-    { userType?: string; accessRules?: string[] }
-  >();
+): Map<string, ExposedProcedureMeta> {
+  const lookup = new Map<string, ExposedProcedureMeta>();
 
   for (const [pluginId, contract] of contracts) {
-    // Contract is an object with procedure names as keys
     for (const [procedureName, procedure] of Object.entries(
       contract as Record<string, unknown>
     )) {
-      const meta = extractProcedureMetadata(procedure);
-      if (meta) {
-        const operationId = `${pluginId}.${procedureName}`;
-        lookup.set(operationId, meta);
-      }
+      const raw = extractRawProcedureMeta(procedure);
+      if (!raw) continue;
+
+      const accessRules = raw.access?.map((rule) => `${pluginId}.${rule.id}`);
+
+      const operationId = `${pluginId}.${procedureName}`;
+      lookup.set(operationId, {
+        userType: raw.userType,
+        ...(accessRules && accessRules.length > 0 ? { accessRules } : {}),
+      });
     }
   }
 
@@ -107,13 +125,14 @@ export async function generateOpenApiSpec({
     >;
   };
 
-  // Post-process: Add x-orpc-meta to each operation and prefix paths with /api
+  // Post-process: Add x-orpc-meta to each operation and prefix paths with /rest.
+  // The REST handler is mounted at /rest/:pluginId/* (see api-router.ts);
+  // /api/:pluginId/* serves oRPC's native wire protocol, not REST.
   if (spec.paths) {
     const prefixedPaths: typeof spec.paths = {};
 
     for (const [path, methods] of Object.entries(spec.paths)) {
-      // Prefix path with /api
-      const prefixedPath = `/api${path.startsWith("/") ? path : `/${path}`}`;
+      const prefixedPath = `/rest${path.startsWith("/") ? path : `/${path}`}`;
       prefixedPaths[prefixedPath] = methods;
 
       // Add metadata to each operation

--- a/core/backend/src/plugin-manager/api-router.ts
+++ b/core/backend/src/plugin-manager/api-router.ts
@@ -1,6 +1,7 @@
 import type { Hono, Context } from "hono";
 import type { SafeDatabase } from "@checkstack/backend-api";
 import { RPCHandler } from "@orpc/server/fetch";
+import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import {
   coreServices,
   AuthService,
@@ -23,9 +24,182 @@ import type { PluginMetadata } from "@checkstack/common";
 import { rootLogger } from "../logger";
 import { extractErrorMessage } from "@checkstack/common";
 
+interface RouteHandlerDeps {
+  registry: ServiceRegistry;
+  pluginRpcRouters: Map<string, unknown>;
+  pluginMetadataRegistry: Map<string, PluginMetadata>;
+}
+
+interface ResolvedRequestContext {
+  context: RpcContext;
+  logger: Logger;
+}
+
+type ContextResult =
+  | { ok: true; resolved: ResolvedRequestContext }
+  | { ok: false; response: Response };
+
+function createServiceGetter(registry: ServiceRegistry) {
+  return async function getService<T>(ref: {
+    id: string;
+    T: T;
+  }): Promise<T | undefined> {
+    try {
+      return await registry.get(ref, { pluginId: "core" });
+    } catch {
+      return undefined;
+    }
+  };
+}
+
+/**
+ * Resolve auth + core services and build the per-request RpcContext.
+ * Shared between the oRPC `/api/*` handler and the REST `/rest/*` handler.
+ */
+async function resolveRequestContext({
+  c,
+  pluginId,
+  deps,
+}: {
+  c: Context;
+  pluginId: string;
+  deps: RouteHandlerDeps;
+}): Promise<ContextResult> {
+  const getService = createServiceGetter(deps.registry);
+  const pathname = new URL(c.req.raw.url).pathname;
+
+  const logger = await getService(coreServices.logger);
+  const auth = await getService(coreServices.auth);
+  const db = await getService(coreServices.database);
+  const fetch = await getService(coreServices.fetch);
+  const healthCheckRegistry = await getService(
+    coreServices.healthCheckRegistry,
+  );
+  const collectorRegistry = await getService(coreServices.collectorRegistry);
+  const queuePluginRegistry = await getService(
+    coreServices.queuePluginRegistry,
+  );
+  const queueManager = await getService(coreServices.queueManager);
+  const cachePluginRegistry = await getService(
+    coreServices.cachePluginRegistry,
+  );
+  const cacheManager = await getService(coreServices.cacheManager);
+  const eventBus = await getService(coreServices.eventBus);
+
+  if (
+    !auth ||
+    !logger ||
+    !db ||
+    !fetch ||
+    !healthCheckRegistry ||
+    !collectorRegistry ||
+    !queuePluginRegistry ||
+    !queueManager ||
+    !cachePluginRegistry ||
+    !cacheManager ||
+    !eventBus
+  ) {
+    const missing = [
+      !auth && "auth",
+      !logger && "logger",
+      !db && "db",
+      !fetch && "fetch",
+      !healthCheckRegistry && "healthCheckRegistry",
+      !collectorRegistry && "collectorRegistry",
+      !queuePluginRegistry && "queuePluginRegistry",
+      !queueManager && "queueManager",
+      !cachePluginRegistry && "cachePluginRegistry",
+      !cacheManager && "cacheManager",
+      !eventBus && "eventBus",
+    ]
+      .filter(Boolean)
+      .join(", ");
+    (logger ?? rootLogger).error(
+      `${pathname}: core services not initialized — missing: ${missing}`,
+    );
+    return {
+      ok: false,
+      response: c.json({ error: "Core services not initialized" }, 500),
+    };
+  }
+
+  const user = await (auth as AuthService).authenticate(c.req.raw);
+
+  const emitHook: EmitHookFn = async <T>(hook: Hook<T>, payload: T) => {
+    await (eventBus as EventBus).emit(hook, payload);
+  };
+
+  const pluginMetadata: PluginMetadata | undefined =
+    deps.pluginMetadataRegistry.get(pluginId);
+
+  if (!pluginMetadata) {
+    (logger as Logger).error(
+      `${pathname}: no plugin metadata registered for pluginId='${pluginId}'. ` +
+        `Regular plugins populate this during register(); core routers must call ` +
+        `pluginManager.registerCorePluginMetadata().`,
+    );
+    return {
+      ok: false,
+      response: c.json({ error: "Plugin metadata not found in registry" }, 500),
+    };
+  }
+
+  const context: RpcContext = {
+    pluginMetadata,
+    auth: auth as AuthService,
+    logger: logger as Logger,
+    db: db as SafeDatabase<Record<string, unknown>>,
+    fetch: fetch as Fetch,
+    healthCheckRegistry: healthCheckRegistry as HealthCheckRegistry,
+    collectorRegistry: collectorRegistry as CollectorRegistry,
+    queuePluginRegistry: queuePluginRegistry as QueuePluginRegistry,
+    queueManager: queueManager as QueueManager,
+    cachePluginRegistry: cachePluginRegistry as CachePluginRegistry,
+    cacheManager: cacheManager as CacheManager,
+    user,
+    emitHook,
+  };
+
+  return { ok: true, resolved: { context, logger: logger as Logger } };
+}
+
+function buildRpcRouter(
+  pluginRpcRouters: Map<string, unknown>,
+): Record<string, unknown> {
+  const rootRpcRouter: Record<string, unknown> = {};
+  for (const [pluginId, router] of pluginRpcRouters.entries()) {
+    rootRpcRouter[pluginId] = router;
+  }
+  return rootRpcRouter;
+}
+
+function logHandlerError({
+  error,
+  pathname,
+  logger,
+  protocolLabel,
+}: {
+  error: unknown;
+  pathname: string;
+  logger: Logger | undefined;
+  protocolLabel: string;
+}) {
+  const target = (logger ?? rootLogger) as Logger;
+  target.error(
+    `${protocolLabel} ${pathname} failed: ${extractErrorMessage(error)}`,
+  );
+  const stack =
+    error !== null && typeof error === "object" && "stack" in error
+      ? (error as { stack: string }).stack
+      : undefined;
+  if (stack) {
+    target.error(`Stack trace: ${stack}`);
+  }
+}
+
 /**
  * Creates the API route handler for Hono.
- * Extracted from PluginManager for better organization.
+ * Serves oRPC's native RPC wire protocol at /api/:pluginId/*.
  */
 export function createApiRouteHandler({
   registry,
@@ -38,54 +212,36 @@ export function createApiRouteHandler({
   pluginHttpHandlers: Map<string, (req: Request) => Promise<Response>>;
   pluginMetadataRegistry: Map<string, PluginMetadata>;
 }) {
-  // Helper to get service from registry
-  async function getService<T>(ref: {
-    id: string;
-    T: T;
-  }): Promise<T | undefined> {
-    try {
-      return await registry.get(ref, { pluginId: "core" });
-    } catch {
-      return undefined;
-    }
-  }
+  const deps: RouteHandlerDeps = {
+    registry,
+    pluginRpcRouters,
+    pluginMetadataRegistry,
+  };
 
   return async function handleApiRequest(c: Context) {
-    // Extract pluginId from Hono path parameter (/api/:pluginId/*)
     const pluginId = c.req.param("pluginId") || "";
     const pathname = new URL(c.req.raw.url).pathname;
 
-    // Build RPC handler lazily at request time
-    // This ensures all plugins registered during init are included
-    const rootRpcRouter: Record<string, unknown> = {};
-    for (const [pluginId, router] of pluginRpcRouters.entries()) {
-      rootRpcRouter[pluginId] = router;
-    }
-
-    // Resolve logger first for use in interceptor
-    const logger = await getService(coreServices.logger);
+    const result = await resolveRequestContext({ c, pluginId, deps });
+    if (!result.ok) return result.response;
+    const { context, logger } = result.resolved;
 
     const rpcHandler = new RPCHandler(
-      rootRpcRouter as ConstructorParameters<typeof RPCHandler>[0],
+      buildRpcRouter(pluginRpcRouters) as ConstructorParameters<
+        typeof RPCHandler
+      >[0],
       {
         interceptors: [
           async ({ next, ...rest }) => {
             try {
               return await next(rest);
             } catch (error) {
-              const target = (logger ?? rootLogger) as Logger;
-              target.error(
-                `RPC ${pathname} failed: ${extractErrorMessage(error)}`,
-              );
-              const stack =
-                error !== null &&
-                typeof error === "object" &&
-                "stack" in error
-                  ? (error as { stack: string }).stack
-                  : undefined;
-              if (stack) {
-                target.error(`Stack trace: ${stack}`);
-              }
+              logHandlerError({
+                error,
+                pathname,
+                logger,
+                protocolLabel: "RPC",
+              });
               throw error;
             }
           },
@@ -93,93 +249,6 @@ export function createApiRouteHandler({
       },
     );
 
-    // Resolve core services for RPC context
-    const auth = await getService(coreServices.auth);
-    const db = await getService(coreServices.database);
-    const fetch = await getService(coreServices.fetch);
-    const healthCheckRegistry = await getService(
-      coreServices.healthCheckRegistry,
-    );
-    const collectorRegistry = await getService(coreServices.collectorRegistry);
-    const queuePluginRegistry = await getService(
-      coreServices.queuePluginRegistry,
-    );
-    const queueManager = await getService(coreServices.queueManager);
-    const cachePluginRegistry = await getService(
-      coreServices.cachePluginRegistry,
-    );
-    const cacheManager = await getService(coreServices.cacheManager);
-    const eventBus = await getService(coreServices.eventBus);
-
-    if (
-      !auth ||
-      !logger ||
-      !db ||
-      !fetch ||
-      !healthCheckRegistry ||
-      !collectorRegistry ||
-      !queuePluginRegistry ||
-      !queueManager ||
-      !cachePluginRegistry ||
-      !cacheManager ||
-      !eventBus
-    ) {
-      const missing = [
-        !auth && "auth",
-        !logger && "logger",
-        !db && "db",
-        !fetch && "fetch",
-        !healthCheckRegistry && "healthCheckRegistry",
-        !collectorRegistry && "collectorRegistry",
-        !queuePluginRegistry && "queuePluginRegistry",
-        !queueManager && "queueManager",
-        !cachePluginRegistry && "cachePluginRegistry",
-        !cacheManager && "cacheManager",
-        !eventBus && "eventBus",
-      ].filter(Boolean).join(", ");
-      (logger ?? rootLogger).error(
-        `${pathname}: core services not initialized — missing: ${missing}`,
-      );
-      return c.json({ error: "Core services not initialized" }, 500);
-    }
-
-    const user = await (auth as AuthService).authenticate(c.req.raw);
-
-    // Create emitHook function using eventBus
-    const emitHook: EmitHookFn = async <T>(hook: Hook<T>, payload: T) => {
-      await (eventBus as EventBus).emit(hook, payload);
-    };
-
-    // Lookup plugin metadata from registry
-    const pluginMetadata: PluginMetadata | undefined =
-      pluginMetadataRegistry.get(pluginId);
-
-    if (!pluginMetadata) {
-      (logger as Logger).error(
-        `${pathname}: no plugin metadata registered for pluginId='${pluginId}'. ` +
-          `Regular plugins populate this during register(); core routers must call ` +
-          `pluginManager.registerCorePluginMetadata().`,
-      );
-      return c.json({ error: "Plugin metadata not found in registry" }, 500);
-    }
-
-    const context: RpcContext = {
-      pluginMetadata,
-      auth: auth as AuthService,
-      logger: logger as Logger,
-      db: db as SafeDatabase<Record<string, unknown>>,
-      fetch: fetch as Fetch,
-      healthCheckRegistry: healthCheckRegistry as HealthCheckRegistry,
-      collectorRegistry: collectorRegistry as CollectorRegistry,
-      queuePluginRegistry: queuePluginRegistry as QueuePluginRegistry,
-      queueManager: queueManager as QueueManager,
-      cachePluginRegistry: cachePluginRegistry as CachePluginRegistry,
-      cacheManager: cacheManager as CacheManager,
-      user,
-      emitHook,
-    };
-
-    // 1. Try oRPC first
     const { matched, response } = await rpcHandler.handle(c.req.raw, {
       prefix: "/api",
       context,
@@ -191,8 +260,7 @@ export function createApiRouteHandler({
 
     logger.debug(`RPC mismatch for: ${c.req.method} ${pathname}`);
 
-    // 2. Try native handlers
-    // Sort by path length (descending) to ensure more specific paths are tried first
+    // Fall through to native plugin HTTP handlers (sorted longest-prefix first)
     const sortedHandlers = [...pluginHttpHandlers.entries()].toSorted(
       function (a, b) {
         return b[0].length - a[0].length;
@@ -210,6 +278,71 @@ export function createApiRouteHandler({
 }
 
 /**
+ * Creates the REST route handler for Hono.
+ * Serves the REST/OpenAPI shape of the same oRPC contract at /rest/:pluginId/*.
+ * Standard JSON bodies / query params work here — matches /api/openapi.json.
+ */
+export function createRestRouteHandler({
+  registry,
+  pluginRpcRouters,
+  pluginMetadataRegistry,
+}: {
+  registry: ServiceRegistry;
+  pluginRpcRouters: Map<string, unknown>;
+  pluginMetadataRegistry: Map<string, PluginMetadata>;
+}) {
+  const deps: RouteHandlerDeps = {
+    registry,
+    pluginRpcRouters,
+    pluginMetadataRegistry,
+  };
+
+  return async function handleRestRequest(c: Context) {
+    const pluginId = c.req.param("pluginId") || "";
+    const pathname = new URL(c.req.raw.url).pathname;
+
+    const result = await resolveRequestContext({ c, pluginId, deps });
+    if (!result.ok) return result.response;
+    const { context, logger } = result.resolved;
+
+    const restHandler = new OpenAPIHandler(
+      buildRpcRouter(pluginRpcRouters) as ConstructorParameters<
+        typeof OpenAPIHandler
+      >[0],
+      {
+        interceptors: [
+          async ({ next, ...rest }) => {
+            try {
+              return await next(rest);
+            } catch (error) {
+              logHandlerError({
+                error,
+                pathname,
+                logger,
+                protocolLabel: "REST",
+              });
+              throw error;
+            }
+          },
+        ],
+      },
+    );
+
+    const { matched, response } = await restHandler.handle(c.req.raw, {
+      prefix: "/rest",
+      context,
+    });
+
+    if (matched) {
+      return c.newResponse(response.body, response);
+    }
+
+    logger.debug(`REST mismatch for: ${c.req.method} ${pathname}`);
+    return c.json({ error: "Not Found" }, 404);
+  };
+}
+
+/**
  * Registers the /api/:pluginId/* route with Hono.
  */
 export function registerApiRoute(
@@ -217,4 +350,14 @@ export function registerApiRoute(
   handler: ReturnType<typeof createApiRouteHandler>,
 ) {
   rootRouter.all("/api/:pluginId/*", handler);
+}
+
+/**
+ * Registers the /rest/:pluginId/* route with Hono.
+ */
+export function registerRestRoute(
+  rootRouter: Hono,
+  handler: ReturnType<typeof createRestRouteHandler>,
+) {
+  rootRouter.all("/rest/:pluginId/*", handler);
 }

--- a/core/backend/src/plugin-manager/plugin-loader.ts
+++ b/core/backend/src/plugin-manager/plugin-loader.ts
@@ -29,7 +29,12 @@ import {
 } from "../utils/plugin-discovery";
 import type { InitCallback, PendingInit } from "./types";
 import { sortPlugins } from "./dependency-sorter";
-import { createApiRouteHandler, registerApiRoute } from "./api-router";
+import {
+  createApiRouteHandler,
+  createRestRouteHandler,
+  registerApiRoute,
+  registerRestRoute,
+} from "./api-router";
 import type { ExtensionPointManager } from "./extension-points";
 import { Router } from "@orpc/server";
 import { AnyContractRouter } from "@orpc/contract";
@@ -302,7 +307,10 @@ export async function loadPlugins({
   const sortedIds = sortPlugins({ pendingInits, providedBy, logger });
   rootLogger.debug(`✅ Initialization Order: ${sortedIds.join(" -> ")}`);
 
-  // Register /api/* route BEFORE plugin initialization
+  // Register /api/* (oRPC wire format) and /rest/* (REST/OpenAPI shape) routes
+  // BEFORE plugin initialization. Both routes share the same plugin RPC routers
+  // and per-request context; they differ only in how the handler decodes the
+  // request and matches it to a procedure.
   const apiHandler = createApiRouteHandler({
     registry: deps.registry,
     pluginRpcRouters: deps.pluginRpcRouters,
@@ -310,6 +318,13 @@ export async function loadPlugins({
     pluginMetadataRegistry: deps.pluginMetadataRegistry,
   });
   registerApiRoute(rootRouter, apiHandler);
+
+  const restHandler = createRestRouteHandler({
+    registry: deps.registry,
+    pluginRpcRouters: deps.pluginRpcRouters,
+    pluginMetadataRegistry: deps.pluginMetadataRegistry,
+  });
+  registerRestRoute(rootRouter, restHandler);
 
   // Routes are now registered on the root router. Signal readiness so the
   // server can stop blocking incoming requests in `waitForInit()`. We open

--- a/core/cache-common/src/rpc-contract.ts
+++ b/core/cache-common/src/rpc-contract.ts
@@ -35,6 +35,7 @@ export const cacheContract = {
     userType: "authenticated",
     access: [cacheAccess.settings.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateCacheConfigurationSchema)
     .output(CacheConfigurationDtoSchema),
 

--- a/core/catalog-common/src/rpc-contract.ts
+++ b/core/catalog-common/src/rpc-contract.ts
@@ -116,6 +116,7 @@ export const catalogContract = {
     userType: "authenticated",
     access: [catalogAccess.system.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateSystemInputSchema)
     .output(SystemSchema),
 
@@ -124,6 +125,7 @@ export const catalogContract = {
     userType: "authenticated",
     access: [catalogAccess.system.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.string())
     .output(z.object({ success: z.boolean() })),
 
@@ -162,6 +164,7 @@ export const catalogContract = {
     userType: "authenticated",
     access: [catalogAccess.system.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.string())
     .output(z.object({ success: z.boolean() })),
 
@@ -199,6 +202,7 @@ export const catalogContract = {
     userType: "authenticated",
     access: [catalogAccess.system.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.string())
     .output(z.object({ success: z.boolean() })),
 
@@ -219,6 +223,7 @@ export const catalogContract = {
     userType: "authenticated",
     access: [catalogAccess.group.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateGroupInputSchema)
     .output(GroupSchema),
 
@@ -227,6 +232,7 @@ export const catalogContract = {
     userType: "authenticated",
     access: [catalogAccess.group.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.string())
     .output(z.object({ success: z.boolean() })),
 
@@ -252,6 +258,7 @@ export const catalogContract = {
     userType: "authenticated",
     access: [catalogAccess.system.manage],
   })
+    .route({ method: "DELETE" })
     .input(
       z.object({
         groupId: z.string(),

--- a/core/common/src/procedure-builder.ts
+++ b/core/common/src/procedure-builder.ts
@@ -22,19 +22,40 @@ export type TypedContractProcedureBuilder<TMeta extends ProcedureMetadata> =
  * The return type preserves the operationType in the generic parameter,
  * enabling type-safe hook selection (useQuery vs useMutation) in usePluginClient.
  *
+ * REST shape (via `/rest/:pluginId/*` mounted with oRPC's OpenAPIHandler):
+ * queries default to HTTP `GET` (input encoded into the URL as bracket-notation
+ * query params, e.g. `?ids[0]=a&ids[1]=b`); mutations default to `POST` with the
+ * input as the JSON body.
+ *
+ * Override the method by chaining `.route({ method: "..." })` after
+ * `proc({...})`. The repo convention is:
+ *   - `create*` / `add*`              → `POST`   (default for mutations)
+ *   - `update*`                       → `PATCH`  (partial updates)
+ *   - `delete*` / `remove*`           → `DELETE`
+ *   - `getBulk*` and any query with   → `POST`   (avoid URL-length limits;
+ *     a large array input                         no automatic GET→POST fallback
+ *                                                 in `@orpc/openapi@1.13.x`)
+ *
+ * Constraint to know about: when method is `GET` (the default for queries),
+ * the input schema must be an `object`, `any`, or `unknown` — never a bare
+ * scalar like `z.string()`. GET has no field name to attach a top-level scalar
+ * to in a query string, so oRPC's OpenAPI generator throws at boot. Wrap the
+ * input in an object (`z.object({ id: z.string() })`) or, if the existing call
+ * sites can't be migrated, override the method to `POST`.
+ *
  * @example
  * ```typescript
  * import { proc } from "@checkstack/common";
  *
  * export const myContract = {
- *   // Returns TypedContractProcedureBuilder<{ operationType: "query", ... }>
+ *   // GET /rest/myplugin/getItems
  *   getItems: proc({
  *     operationType: "query",
  *     userType: "public",
  *     access: [myAccess.items.read],
  *   }).output(z.array(ItemSchema)),
  *
- *   // Returns TypedContractProcedureBuilder<{ operationType: "mutation", ... }>
+ *   // POST /rest/myplugin/createItem
  *   createItem: proc({
  *     operationType: "mutation",
  *     userType: "authenticated",
@@ -42,11 +63,24 @@ export type TypedContractProcedureBuilder<TMeta extends ProcedureMetadata> =
  *   })
  *     .input(CreateItemSchema)
  *     .output(ItemSchema),
+ *
+ *   // POST /rest/myplugin/getBulkItems — bulk query overrides default GET
+ *   // because `ids` can be too long for a query string.
+ *   getBulkItems: proc({
+ *     operationType: "query",
+ *     userType: "public",
+ *     access: [myAccess.items.read],
+ *   })
+ *     .route({ method: "POST" })
+ *     .input(z.object({ ids: z.array(z.string()) })),
  * };
  * ```
  */
 export function proc<TMeta extends ProcedureMetadata>(
   meta: TMeta
 ): TypedContractProcedureBuilder<TMeta> {
-  return oc.$meta<TMeta>(meta) as TypedContractProcedureBuilder<TMeta>;
+  const defaultMethod = meta.operationType === "query" ? "GET" : "POST";
+  return oc
+    .$meta<TMeta>(meta)
+    .route({ method: defaultMethod }) as TypedContractProcedureBuilder<TMeta>;
 }

--- a/core/dependency-common/src/rpc-contract.ts
+++ b/core/dependency-common/src/rpc-contract.ts
@@ -46,6 +46,7 @@ export const dependencyContract = {
     userType: "public",
     access: [dependencyAccess.dependency.read],
   })
+    .route({ method: "POST" })
     .input(z.object({ systemIds: z.array(z.string()) }))
     .output(
       z.object({
@@ -83,6 +84,7 @@ export const dependencyContract = {
     access: [dependencyAccess.dependency.manage],
     instanceAccess: { idParam: "systemId" },
   })
+    .route({ method: "PATCH" })
     .input(UpdateDependencyInputSchema)
     .output(DependencySchema),
 
@@ -93,6 +95,7 @@ export const dependencyContract = {
     access: [dependencyAccess.dependency.manage],
     instanceAccess: { idParam: "systemId" },
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string(), systemId: z.string() }))
     .output(z.object({ success: z.boolean() })),
 

--- a/core/frontend/vite.config.ts
+++ b/core/frontend/vite.config.ts
@@ -21,6 +21,10 @@ export default defineConfig(() => {
           target: backendUrl,
           ws: true, // Enable WebSocket proxy
         },
+        // REST mount served by oRPC's OpenAPIHandler on the backend (see
+        // core/backend/src/plugin-manager/api-router.ts). Proxied so external
+        // REST clients pointing at the Vite dev port still resolve.
+        "^/rest/": backendUrl,
         "/assets": backendUrl,
         // Platform endpoints (probes etc.) under /.checkstack/* — proxied
         // here for dev convenience so e.g.

--- a/core/gitops-common/src/rpc-contract.ts
+++ b/core/gitops-common/src/rpc-contract.ts
@@ -96,6 +96,7 @@ export const gitopsContract = {
     userType: "authenticated",
     access: [gitopsAccess.provider.manage],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         id: z.string(),
@@ -117,6 +118,7 @@ export const gitopsContract = {
     userType: "authenticated",
     access: [gitopsAccess.provider.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
 
@@ -203,6 +205,7 @@ export const gitopsContract = {
     userType: "authenticated",
     access: [gitopsAccess.secret.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
 

--- a/core/healthcheck-backend/src/router.ts
+++ b/core/healthcheck-backend/src/router.ts
@@ -155,7 +155,7 @@ export const createHealthCheckRouter = (opts: {
 
     getSystemConfigurations: os.getSystemConfigurations.handler(
       async ({ input }) => {
-        return service.getSystemConfigurations(input);
+        return service.getSystemConfigurations(input.systemId);
       },
     ),
 

--- a/core/healthcheck-common/src/rpc-contract.ts
+++ b/core/healthcheck-common/src/rpc-contract.ts
@@ -92,6 +92,7 @@ export const healthCheckContract = {
     userType: "authenticated",
     access: [healthCheckAccess.configuration.manage],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         id: z.string(),
@@ -105,6 +106,7 @@ export const healthCheckContract = {
     userType: "authenticated",
     access: [healthCheckAccess.configuration.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.string())
     .output(z.void()),
 
@@ -133,7 +135,7 @@ export const healthCheckContract = {
     userType: "authenticated",
     access: [healthCheckAccess.configuration.read],
   })
-    .input(z.string())
+    .input(z.object({ systemId: z.string() }))
     .output(z.array(HealthCheckConfigurationSchema)),
 
   getSystemAssociations: proc({
@@ -209,6 +211,7 @@ export const healthCheckContract = {
     userType: "authenticated",
     access: [healthCheckAccess.configuration.manage],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         systemId: z.string(),
@@ -346,6 +349,7 @@ export const healthCheckContract = {
     access: [healthCheckAccess.status],
     instanceAccess: { recordKey: "statuses" },
   })
+    .route({ method: "POST" })
     .input(z.object({ systemIds: z.array(z.string()) }))
     .output(
       z.object({

--- a/core/incident-common/src/rpc-contract.ts
+++ b/core/incident-common/src/rpc-contract.ts
@@ -59,6 +59,7 @@ export const incidentContract = {
     access: [incidentAccess.incident.read],
     instanceAccess: { recordKey: "incidents" },
   })
+    .route({ method: "POST" })
     .input(z.object({ systemIds: z.array(z.string()) }))
     .output(
       z.object({
@@ -81,6 +82,7 @@ export const incidentContract = {
     userType: "authenticated",
     access: [incidentAccess.incident.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateIncidentInputSchema)
     .output(IncidentWithSystemsSchema),
 
@@ -117,6 +119,7 @@ export const incidentContract = {
     userType: "authenticated",
     access: [incidentAccess.incident.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
 
@@ -126,6 +129,7 @@ export const incidentContract = {
     userType: "authenticated",
     access: [incidentAccess.incident.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
 

--- a/core/integration-common/src/rpc-contract.ts
+++ b/core/integration-common/src/rpc-contract.ts
@@ -71,6 +71,7 @@ export const integrationContract = {
     userType: "authenticated",
     access: [integrationAccess.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateSubscriptionInputSchema)
     .output(WebhookSubscriptionSchema),
 
@@ -80,6 +81,7 @@ export const integrationContract = {
     userType: "authenticated",
     access: [integrationAccess.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
 
@@ -155,6 +157,7 @@ export const integrationContract = {
     userType: "authenticated",
     access: [integrationAccess.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateConnectionInputSchema)
     .output(ProviderConnectionRedactedSchema),
 
@@ -164,6 +167,7 @@ export const integrationContract = {
     userType: "authenticated",
     access: [integrationAccess.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ connectionId: z.string() }))
     .output(z.object({ success: z.boolean() })),
 

--- a/core/maintenance-common/src/rpc-contract.ts
+++ b/core/maintenance-common/src/rpc-contract.ts
@@ -58,6 +58,7 @@ export const maintenanceContract = {
     access: [maintenanceAccess.maintenance.read],
     instanceAccess: { recordKey: "maintenances" },
   })
+    .route({ method: "POST" })
     .input(z.object({ systemIds: z.array(z.string()) }))
     .output(
       z.object({
@@ -83,6 +84,7 @@ export const maintenanceContract = {
     userType: "authenticated",
     access: [maintenanceAccess.maintenance.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateMaintenanceInputSchema)
     .output(MaintenanceWithSystemsSchema),
 
@@ -119,6 +121,7 @@ export const maintenanceContract = {
     userType: "authenticated",
     access: [maintenanceAccess.maintenance.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
 
@@ -128,6 +131,7 @@ export const maintenanceContract = {
     userType: "authenticated",
     access: [maintenanceAccess.maintenance.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
 

--- a/core/notification-common/src/rpc-contract.ts
+++ b/core/notification-common/src/rpc-contract.ts
@@ -112,6 +112,7 @@ export const notificationContract = {
     userType: "user",
     access: [],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ notificationId: z.string().uuid() }))
     .output(z.void()),
 
@@ -164,6 +165,7 @@ export const notificationContract = {
     userType: "user",
     access: [],
   })
+    .route({ method: "POST" })
     .input(z.object({ groupIds: z.array(z.string()) }))
     .output(z.record(z.string(), z.boolean())),
 
@@ -226,6 +228,7 @@ export const notificationContract = {
     userType: "service",
     access: [],
   })
+    .route({ method: "DELETE" })
     .input(
       z.object({
         groupId: z.string().describe("Full namespaced group ID to delete"),
@@ -337,6 +340,7 @@ export const notificationContract = {
     userType: "service",
     access: [],
   })
+    .route({ method: "DELETE" })
     .input(
       z.object({
         targetTypeId: z.string(),
@@ -530,6 +534,7 @@ export const notificationContract = {
     userType: "user",
     access: [notificationAccess.admin],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         strategyId: z.string().describe("Qualified strategy ID"),

--- a/core/queue-common/src/rpc-contract.ts
+++ b/core/queue-common/src/rpc-contract.ts
@@ -34,6 +34,7 @@ export const queueContract = {
     userType: "authenticated",
     access: [queueAccess.settings.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateQueueConfigurationSchema)
     .output(QueueConfigurationDtoSchema),
 
@@ -57,6 +58,7 @@ export const queueContract = {
     userType: "authenticated",
     access: [queueAccess.settings.manage],
   })
+    .route({ method: "PATCH" })
     .input(QueueLagThresholdsSchema)
     .output(QueueLagThresholdsSchema),
 

--- a/core/satellite-common/src/rpc-contract.ts
+++ b/core/satellite-common/src/rpc-contract.ts
@@ -52,6 +52,7 @@ export const satelliteContract = {
     userType: "authenticated",
     access: [satelliteAccess.satellite.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.void()),
 
@@ -64,6 +65,7 @@ export const satelliteContract = {
     userType: "authenticated",
     access: [satelliteAccess.satellite.manage],
   })
+    .route({ method: "PATCH" })
     .input(
       z.object({
         id: z.string(),

--- a/core/slo-common/src/rpc-contract.ts
+++ b/core/slo-common/src/rpc-contract.ts
@@ -73,6 +73,7 @@ export const sloContract = {
     access: [sloAccess.slo.read],
     instanceAccess: { recordKey: "systems" },
   })
+    .route({ method: "POST" })
     .input(z.object({ systemIds: z.array(z.string()) }))
     .output(
       z.object({
@@ -103,6 +104,7 @@ export const sloContract = {
     userType: "authenticated",
     access: [sloAccess.slo.manage],
   })
+    .route({ method: "PATCH" })
     .input(UpdateSloObjectiveInputSchema)
     .output(SloObjectiveSchema),
 
@@ -112,6 +114,7 @@ export const sloContract = {
     userType: "authenticated",
     access: [sloAccess.slo.manage],
   })
+    .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
 

--- a/docs/src/content/docs/backend/plugins.md
+++ b/docs/src/content/docs/backend/plugins.md
@@ -643,17 +643,77 @@ export const incidentContract = {
     .input(z.object({ systemId: z.string() }))
     .output(z.array(IncidentSchema)),
 
-  // Bulk endpoint - overrides to use recordKey
+  // Bulk endpoint - overrides to use recordKey AND switches to POST so the
+  // potentially-large systemIds array doesn't blow past URL-length limits.
   getBulkIncidentsForSystems: proc({
     operationType: "query",
     userType: "public",
     access: [incidentAccess.incident.read],  // Same access rule
     instanceAccess: { recordKey: "incidents" },  // Override for bulk
   })
+    .route({ method: "POST" })                   // ← override default GET
     .input(z.object({ systemIds: z.array(z.string()) }))
     .output(z.object({ incidents: z.record(z.string(), z.array(IncidentSchema)) })),
 };
 ```
+
+## REST method conventions
+
+Procedures are exposed both at `/api/{pluginId}/` (oRPC's native wire format)
+and at `/rest/{pluginId}/{procedure}` (REST/OpenAPI, suitable for external
+clients). The HTTP method on the REST mount is derived from `operationType`
+by the `proc()` builder:
+
+| `operationType` | Default method |
+|-----------------|----------------|
+| `"query"`       | `GET`          |
+| `"mutation"`    | `POST`         |
+
+For idiomatic REST semantics, override the method by chaining
+`.route({ method: "..." })` on mutations after the `proc({...})` call:
+
+| Procedure name pattern        | Convention |
+|-------------------------------|------------|
+| `update*` mutation            | `.route({ method: "PATCH" })` |
+| `delete*` / `remove*` mutation| `.route({ method: "DELETE" })` |
+| `getBulk*` query              | `.route({ method: "POST" })` (see below) |
+| Any query taking a large array input | `.route({ method: "POST" })` |
+
+### Why bulk queries are POST
+
+`@orpc/openapi@1.13.x` has no automatic GET→POST fallback when the URL
+would exceed length limits. Bracket-notation encoding of a `string[]` of
+IDs blows past the typical 8 KB cap quickly, so any query that takes a
+potentially-large array input must opt out of the GET default.
+
+### GET input-shape constraint
+
+When a procedure is `GET`, the **top-level input schema must be an
+`object`** (or `any` / `unknown`). A bare scalar like `.input(z.string())`
+will cause the OpenAPI generator to throw at boot:
+
+```
+[OpenAPIGenerator] Error occurred while generating OpenAPI for procedure
+at path: <plugin>.<procedure>
+When method is "GET", input schema must satisfy: object | any | unknown
+```
+
+This isn't a serializer limitation — it's that a query string needs a
+field name to attach each value to, and a top-level scalar has no key.
+Fix it by wrapping the input:
+
+```typescript
+// ❌ Won't generate as GET
+.input(z.string())
+
+// ✅ Idiomatic
+.input(z.object({ id: z.string() }))
+```
+
+Nested objects, arrays, and `z.date()` inside the object input are all
+fine — they're serialized as bracket-notation params
+(`?filter[status]=active&ids[0]=a`) and `z.date()` becomes an ISO 8601
+string.
 
 
 **Benefits:**

--- a/docs/src/content/docs/security/external-applications.md
+++ b/docs/src/content/docs/security/external-applications.md
@@ -46,6 +46,100 @@ Use the `Authorization` header with the Bearer scheme:
 Authorization: Bearer ck_{applicationId}_{secret}
 ```
 
+## Two API surfaces
+
+The same contracts are exposed through two HTTP shapes, and you can pick
+whichever suits your client:
+
+| Mount | Shape | Body / params |
+|-------|-------|----------------|
+| `/api/{pluginId}/` | oRPC native wire protocol — POST a `{procedure: input}` envelope. Supports batching multiple procedures per request. | `{"getSystems": {}}` |
+| `/rest/{pluginId}/{procedure}` | REST / OpenAPI — one procedure per request. Method depends on the procedure (see table below). | varies |
+
+The machine-readable schema for the REST surface is published at
+`/api/openapi.json` (paths listed there are under `/rest/...`). The method
+for each endpoint comes directly from the contract definition — always
+trust the spec over this page.
+
+## Calling REST Endpoints (recommended for ad-hoc clients)
+
+The HTTP method follows REST conventions, derived from the procedure name and
+`operationType` in the contract:
+
+| Procedure shape | HTTP method | Input goes to |
+|-----------------|-------------|---------------|
+| Query (read)                     | `GET`    | URL query params, bracket-notation encoded |
+| `create*` / `add*` mutation      | `POST`   | JSON body |
+| `update*` mutation               | `PATCH`  | JSON body |
+| `delete*` / `remove*` mutation   | `DELETE` | JSON body |
+| Bulk query (`getBulk*`, or any query taking a large array) | `POST` | JSON body |
+
+> [!NOTE]
+> The "bulk query is POST" exception exists because `@orpc/openapi@1.13.x`
+> has no automatic GET→POST fallback when the URL would exceed length limits
+> (browsers / proxies typically cap around 8 KB), and bracket-encoding a
+> large `string[]` blows past that quickly. The OpenAPI spec at
+> `/api/openapi.json` lists the real method for every endpoint.
+
+### Examples
+
+**Query (`GET`, bracket-notation params):**
+
+```bash
+curl "https://your-checkstack-instance.com/rest/healthcheck/getSystemHealthStatus?systemId=YOUR_SYSTEM_ID" \
+  -H "Authorization: Bearer ck_YOUR_APP_ID_YOUR_SECRET"
+```
+
+Nested object inputs and arrays use bracket notation:
+
+```bash
+# Input: { filter: { status: "active" }, ids: ["a", "b"] }
+curl "https://your-checkstack-instance.com/rest/foo/getItems?filter[status]=active&ids[0]=a&ids[1]=b" \
+  -H "Authorization: Bearer ck_YOUR_APP_ID_YOUR_SECRET"
+```
+
+**Create (`POST`):**
+
+```bash
+curl -X POST https://your-checkstack-instance.com/rest/incident/createIncident \
+  -H "Authorization: Bearer ck_YOUR_APP_ID_YOUR_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Database down", "severity": "high"}'
+```
+
+**Update (`PATCH`):**
+
+```bash
+curl -X PATCH https://your-checkstack-instance.com/rest/incident/updateIncident \
+  -H "Authorization: Bearer ck_YOUR_APP_ID_YOUR_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "inc_123", "status": "resolved"}'
+```
+
+**Delete (`DELETE`):**
+
+```bash
+curl -X DELETE https://your-checkstack-instance.com/rest/incident/deleteIncident \
+  -H "Authorization: Bearer ck_YOUR_APP_ID_YOUR_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "inc_123"}'
+```
+
+**Bulk query (`POST` despite being read-only):**
+
+```bash
+curl -X POST https://your-checkstack-instance.com/rest/healthcheck/getBulkSystemHealthStatus \
+  -H "Authorization: Bearer ck_YOUR_APP_ID_YOUR_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"systemIds": ["sys_1", "sys_2", "sys_3"]}'
+```
+
+> [!NOTE]
+> If you POST a raw JSON body to `/api/{pluginId}/{procedure}` and get
+> `"Invalid input: expected object, received undefined"`, you're hitting the
+> oRPC wire-protocol mount — use the `/rest/...` path described above instead,
+> or wrap the body in `{procedure: input}` and POST to `/api/{pluginId}/`.
+
 ## Calling oRPC Endpoints
 
 All oRPC endpoints are available at `/api/{pluginId}/` and accept JSON POST requests.
@@ -140,14 +234,15 @@ systems = call_rpc("catalog", "getSystems")
 
 ## Available Endpoints
 
-Each plugin exposes its procedures at `/api/{pluginId}/`. Common endpoints include:
+Each plugin exposes its procedures at both `/api/{pluginId}/` (oRPC wire format)
+and `/rest/{pluginId}/{procedure}` (REST). Common plugins include:
 
-| Plugin | Endpoint | Example Procedures |
-|--------|----------|-------------------|
-| `catalog` | `/api/catalog/` | `getSystems`, `getGroups` |
-| `healthcheck` | `/api/healthcheck/` | `getHealthChecks`, `getHistory` |
-| `maintenance` | `/api/maintenance/` | `getWindows`, `scheduleWindow` |
-| `incident` | `/api/incident/` | `getIncidents`, `createIncident` |
+| Plugin | oRPC mount | REST mount | Example Procedures |
+|--------|------------|------------|-------------------|
+| `catalog` | `/api/catalog/` | `/rest/catalog/...` | `getSystems`, `getGroups` |
+| `healthcheck` | `/api/healthcheck/` | `/rest/healthcheck/...` | `getHealthChecks`, `getHistory` |
+| `maintenance` | `/api/maintenance/` | `/rest/maintenance/...` | `getWindows`, `scheduleWindow` |
+| `incident` | `/api/incident/` | `/rest/incident/...` | `getIncidents`, `createIncident` |
 
 > **Note**: Available procedures depend on your application's assigned access. Check each plugin's contract definition for the full procedure list and required accesss.
 


### PR DESCRIPTION
## Summary

- Add a `/rest/:pluginId/*` HTTP mount on the backend that serves every plugin's oRPC contract through oRPC's `OpenAPIHandler`, alongside the existing `/api/:pluginId/*` wire-protocol mount. The OpenAPI spec at `/api/openapi.json` now prefixes paths with `/rest` so the doc reflects the real mount.
- Make `proc()` default to `GET` for queries and `POST` for mutations on the REST mount; bulk-apply REST-idiomatic overrides across all 16 plugin contracts (`update*` → PATCH, `delete*`/`remove*` → DELETE, `getBulk*` and large-array queries → POST). Refactor the one query with a bare `.input(z.string())` to use an object input so it fits GET.
- Surface required access rules in the API Docs UI (the OpenAPI generator was reading a non-existent `accessRules` metadata field; the real one is `access: AccessRule[]`). Render path/query/header/cookie parameters in a dedicated table for GET endpoints with a query-string fetch example.
- Rewrite the API Docs schema renderer to handle zod records (`additionalProperties`), `$refs` into `components.schemas` (with cycle detection), `oneOf`/`anyOf`/`allOf`, nullable union types, and `format` qualifiers — fixes bulk endpoints that previously rendered as `{ statuses: object }`.
- Fix two side-effect bugs: `/api-docs` returning 404 on production deployments (SPA-fallback middleware was skipping any `/api*` path, capturing `/api-docs`), and Vite dev-server proxying for `/rest/*` so external REST clients pointing at `localhost:5173` resolve.
- Document the REST conventions in [docs/backend/plugins.md](docs/src/content/docs/backend/plugins.md) (for contract authors) and [docs/security/external-applications.md](docs/src/content/docs/security/external-applications.md) (for external API consumers), including the GET-input-must-be-an-object constraint and why `getBulk*` queries are POST (`@orpc/openapi@1.13.x` has no GET→POST URL-length fallback).

## Test plan

- [ ] `bun run lint && bun run typecheck` — clean
- [ ] `curl "http://localhost:3000/rest/healthcheck/getSystemHealthStatus?systemId=<id>" -H "Authorization: Bearer ck_..."` → 200 with health status
- [ ] `curl -X POST http://localhost:3000/rest/healthcheck/getBulkSystemHealthStatus -d '{"systemIds":["..."]}' -H "Authorization: Bearer ck_..." -H "Content-Type: application/json"` → 200
- [ ] `curl http://localhost:3000/api/openapi.json -H "Authorization: Bearer ..."` returns a spec where every `paths` entry starts with `/rest`, queries are `GET`, mutations are `POST`/`PATCH`/`DELETE` per convention, and operations carry `x-orpc-meta.accessRules`
- [ ] Open `/api-docs` in the browser: each endpoint shows the right method badge, required access rules, query-parameter table for GETs, and `getBulkSystemHealthStatus` output renders the full `SystemHealthStatusResponse` schema (not `{ statuses: object }`)
- [ ] Open `/api-docs` on a prod-style deploy (with `CHECKSTACK_FRONTEND_DIST` set) — SPA fallback serves the page instead of returning 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)