### PR TITLE
chore: changeset for packages missed in /rest mount PR

### DIFF
--- a/.changeset/rest-api-mount-missing-packages.md
+++ b/.changeset/rest-api-mount-missing-packages.md
@@ -1,0 +1,20 @@
+---
+"@checkstack/api-docs-frontend": minor
+"@checkstack/frontend": minor
+"@checkstack/healthcheck-backend": minor
+---
+
+Backfill missing package bumps for the `/rest` mount PR — these packages were
+modified in that change but were not declared in its changeset:
+
+- `@checkstack/api-docs-frontend`: schema renderer rewrite (`additionalProperties`,
+  `$ref` resolution, `oneOf`/`anyOf`/`allOf`, nullable unions, `format`
+  qualifiers) and the new path/query/header/cookie parameters table for GET
+  endpoints.
+- `@checkstack/frontend`: Vite dev-server proxy for `/rest/*` so external REST
+  clients pointing at the Vite port resolve to the backend.
+- `@checkstack/healthcheck-backend`: router handler now unpacks `input.systemId`
+  after `getSystemConfigurations` was refactored from `.input(z.string())` to
+  `.input(z.object({ systemId: z.string() }))`.
+
+No behavior change beyond what the original PR already shipped.


### PR DESCRIPTION
## Summary

- Backfills the changeset for #206. Three packages had code changes in that PR but were omitted from its changeset, so they wouldn't have been released:
  - `@checkstack/api-docs-frontend` — schema-renderer rewrite + parameters table
  - `@checkstack/frontend` — Vite dev-server proxy for `/rest/*`
  - `@checkstack/healthcheck-backend` — router unpacks `input.systemId` after the `getSystemConfigurations` input refactor

## Test plan

- [ ] CI changeset check passes (no "missing packages" warning)
- [ ] On the next `changeset version`, the three packages get bumped to the next minor alongside their dependents

🤖 Generated with [Claude Code](https://claude.com/claude-code)