### PR TITLE
docs: fix plugin dev-server command to use @checkstack/dev-server

### DIFF
--- a/docs/src/content/docs/architecture/plugin-distribution.md
+++ b/docs/src/content/docs/architecture/plugin-distribution.md
@@ -16,8 +16,9 @@ bottom is enough.
 
 > **Looking for the dev loop?** This doc covers the *distribution
 > mechanics* (packing, bundles, channels). For local development — add
-> `@checkstack/dev-server` as a devDependency and run `checkstack-dev` —
-> see [Developing Plugins in Isolation](../getting-started/plugin-development.md).
+> `@checkstack/dev-server` as a devDependency, wire `"dev": "checkstack-dev"`
+> into your `package.json` scripts, and run `bun run dev` — see
+> [Developing Plugins in Isolation](../getting-started/plugin-development.md).
 
 > **Distinction:** monorepo-internal plugins (the ones living in `core/` and
 > `plugins/` of this repo) are loaded automatically at boot via filesystem

--- a/docs/src/content/docs/backend/plugins.md
+++ b/docs/src/content/docs/backend/plugins.md
@@ -1045,9 +1045,11 @@ mode, npm / GitHub release / GitHub Enterprise / tarball-upload distribution,
 and a copy-paste GitHub Actions workflow — lives in
 [Plugin Distribution & Packing](../architecture/plugin-distribution.md).
 
-For the dev loop itself, add `@checkstack/dev-server` as a devDependency
-and run `checkstack-dev` from your plugin's repo — it boots a local
-Checkstack with your plugin loaded and auth bypassed. Full guide:
+For the dev loop itself, add `@checkstack/dev-server` as a devDependency,
+wire `"dev": "checkstack-dev"` into your `package.json` scripts, and
+run `bun run dev` from your plugin's repo — it boots a local Checkstack
+with your plugin loaded and auth bypassed. (`bunx @checkstack/dev-server`
+also works as a one-shot before any install.) Full guide:
 [Developing Plugins in Isolation](../getting-started/plugin-development.md).
 
 Quick checklist before your first release:

--- a/docs/src/content/docs/frontend/plugins.md
+++ b/docs/src/content/docs/frontend/plugins.md
@@ -1108,8 +1108,9 @@ how `bunx @checkstack/scripts plugin-pack --bundle` produces a single
 bundle tarball, and the npm / GitHub release / GitHub Enterprise /
 tarball-upload distribution channels operators can install from.
 
-For local development, add `@checkstack/dev-server` as a devDependency
-and run `checkstack-dev` from your plugin's repo — see
+For local development, add `@checkstack/dev-server` as a devDependency,
+wire `"dev": "checkstack-dev"` into your `package.json` scripts, and
+run `bun run dev` from your plugin's repo — see
 [Developing Plugins in Isolation](../getting-started/plugin-development.md).
 
 ## Next Steps

--- a/docs/src/content/docs/getting-started/plugin-development.md
+++ b/docs/src/content/docs/getting-started/plugin-development.md
@@ -8,10 +8,17 @@ Develop a Checkstack plugin from its own repo. No monorepo checkout. No
 upload loop. No Docker bind-mount tricks.
 
 ```bash
-bunx checkstack-dev
+bunx @checkstack/dev-server
 ```
 
-That's it. The command boots the same backend code path Checkstack uses
+`@checkstack/dev-server` is the published npm package that ships the
+dev server; it exposes a `checkstack-dev` binary so once you've added
+it as a devDependency, your `package.json` can wire `"dev":
+"checkstack-dev"` and you run `bun run dev` from then on (see the
+bootstrap section below). The `bunx @checkstack/dev-server` form is for
+a one-shot try before any install.
+
+The command boots the same backend code path Checkstack uses
 in production, with two well-defined dev overrides:
 
 - **Filesystem plugin discovery is skipped.** Only your plugin loads —
@@ -196,8 +203,12 @@ refuses `CHECKSTACK_DEV_AUTH=true` when `NODE_ENV=production` and ignores
 ## Command-line flags
 
 ```
-bunx checkstack-dev --help
+bunx @checkstack/dev-server --help
 ```
+
+(After installing `@checkstack/dev-server` as a devDependency, the
+binary is on the local `node_modules/.bin` path, so `bun run dev --
+--help` or `checkstack-dev --help` both work too.)
 
 | Flag                   | Default                                                                  | Notes                                              |
 |------------------------|--------------------------------------------------------------------------|----------------------------------------------------|


### PR DESCRIPTION
The "Developing Plugins in Isolation" docs instructed users to run `bunx checkstack-dev`, but no `checkstack-dev` package exists on npm — `checkstack-dev` is the bin name exposed by `@checkstack/dev-server`, which only resolves once it's installed locally. Update the hero command and all cross-page references to use `bunx @checkstack/dev-server` for the one-shot form and `bun run dev` (after wiring the script) for the normal loop.