### PR TITLE
chore(security): resolve open CodeQL code-scanning findings

### DIFF
--- a/.changeset/codeql-security-findings.md
+++ b/.changeset/codeql-security-findings.md
@@ -1,0 +1,20 @@
+---
+"@checkstack/ui": patch
+"@checkstack/backend-api": patch
+"@checkstack/backend": patch
+---
+
+Address open CodeQL code-scanning findings:
+
+- **`@checkstack/ui` (`LinksEditor`)**: validate URL scheme on render and on
+  add; only `http:` / `https:` URLs are accepted, defeating stored XSS via
+  `javascript:` / `data:` schemes in user-supplied hotlinks
+  (`js/xss-through-dom`).
+- **`@checkstack/backend-api` (`markdownToPlainText`)**: decode HTML entities
+  before stripping tags, then strip tags in a loop until the output
+  stabilizes. Decoding `&amp;` last avoids reintroducing tag delimiters
+  via `&amp;lt;` round-trips (`js/double-escaping`,
+  `js/incomplete-multi-character-sanitization`).
+- **`@checkstack/backend` (`createScopedWsRegistry`)**: drop the
+  identity-replacement on the path suffix; the leading-slash invariant
+  is documented on `WebSocketRouteRegistry` (`js/identity-replacement`).

--- a/.github/workflows/changeset-reminder.yml
+++ b/.github/workflows/changeset-reminder.yml
@@ -29,6 +29,12 @@ jobs:
         contains(github.event.comment.body, '###  ⚠️  No Changeset found')
       )
     runs-on: ubuntu-latest
+    # NOTE: We intentionally do NOT `actions/checkout` the PR ref here. This
+    # workflow runs in a privileged context (pull-requests: write) and, when
+    # triggered by issue_comment, would otherwise satisfy the classic
+    # "pwn-request" pattern (CodeQL: actions/untrusted-checkout/high). All
+    # source data is fetched via the GitHub API instead — JSON config and
+    # changeset frontmatter are pure data, not executed code.
     steps:
       - name: Resolve PR metadata
         id: pr-meta
@@ -40,11 +46,11 @@ jobs:
               ? context.payload.pull_request.number
               : context.issue.number;
 
-            let headRef;
+            let headSha;
             let isInternalPr;
 
             if (isPullRequest) {
-              headRef = context.payload.pull_request.head.ref;
+              headSha = context.payload.pull_request.head.sha;
               isInternalPr = context.payload.pull_request.head.repo.full_name === context.payload.repository.full_name;
             } else {
               const pr = await github.rest.pulls.get({
@@ -52,11 +58,11 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: prNumber,
               });
-              headRef = pr.data.head.ref;
+              headSha = pr.data.head.sha;
               isInternalPr = pr.data.head.repo.full_name === context.payload.repository.full_name;
             }
 
-            // Check if we already posted a changeset-reminder comment (dedup for issue_comment trigger)
+            // Dedup for issue_comment trigger: skip if we've already analyzed.
             if (!isPullRequest) {
               const comments = await github.paginate(
                 github.rest.issues.listComments,
@@ -80,15 +86,9 @@ jobs:
 
             core.setOutput('skip', 'false');
             core.setOutput('pr_number', prNumber.toString());
-            core.setOutput('head_ref', headRef);
+            core.setOutput('head_sha', headSha);
             core.setOutput('is_internal', isInternalPr.toString());
-            core.info(`PR #${prNumber}, branch: ${headRef}, internal: ${isInternalPr}`);
-
-      - name: Checkout PR branch
-        if: steps.pr-meta.outputs.skip != 'true'
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ steps.pr-meta.outputs.head_ref }}
+            core.info(`PR #${prNumber}, head: ${headSha}, internal: ${isInternalPr}`);
 
       - name: Analyze changeset coverage
         if: steps.pr-meta.outputs.skip != 'true'
@@ -96,19 +96,58 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const fs = require('fs');
-            const path = require('path');
-
             const prNumber = parseInt('${{ steps.pr-meta.outputs.pr_number }}', 10);
+            const headSha = '${{ steps.pr-meta.outputs.head_sha }}';
 
-            // ── 1. Load coverage config ──
-            const configPath = path.join(process.env.GITHUB_WORKSPACE, '.changeset', 'coverage-config.json');
+            // ── Helpers: fetch file / list directory contents via API ──
+            async function fetchFileText(filePath, ref) {
+              try {
+                const res = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: filePath,
+                  ref,
+                });
+                if (Array.isArray(res.data) || res.data.type !== 'file' || !res.data.content) {
+                  return null;
+                }
+                return Buffer.from(res.data.content, 'base64').toString('utf8');
+              } catch (err) {
+                if (err.status === 404) return null;
+                throw err;
+              }
+            }
+
+            async function listDir(dirPath, ref) {
+              try {
+                const res = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: dirPath,
+                  ref,
+                });
+                return Array.isArray(res.data) ? res.data : [];
+              } catch (err) {
+                if (err.status === 404) return [];
+                throw err;
+              }
+            }
+
+            // ── 1. Coverage config (read from default branch — trusted) ──
             let config = { ignoredFiles: [], ignoredPackages: [] };
-            try {
-              config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-              core.info(`Loaded coverage config: ${config.ignoredFiles.length} ignored file patterns, ${config.ignoredPackages.length} ignored packages`);
-            } catch (err) {
-              core.warning(`Could not load coverage config: ${err.message}. Using defaults.`);
+            const configText = await fetchFileText('.changeset/coverage-config.json');
+            if (configText) {
+              try {
+                config = JSON.parse(configText);
+                core.info(
+                  `Loaded coverage config: ${config.ignoredFiles.length} ignored file patterns, ` +
+                    `${config.ignoredPackages.length} ignored packages`
+                );
+              } catch (err) {
+                core.warning(`Could not parse coverage config: ${err.message}. Using defaults.`);
+              }
+            } else {
+              core.warning('No coverage-config.json found on default branch. Using defaults.');
             }
 
             // ── 2. Convert glob patterns to RegExp matchers ──
@@ -128,31 +167,7 @@ jobs:
               return ignoredFilePatterns.some((re) => re.test(relativePath));
             }
 
-            // ── 3. Discover workspace packages ──
-            const workspaceDirs = ['core', 'plugins'];
-            const packageMap = new Map(); // dir (relative to repo root) → package name
-
-            for (const wsDir of workspaceDirs) {
-              const wsPath = path.join(process.env.GITHUB_WORKSPACE, wsDir);
-              if (!fs.existsSync(wsPath)) continue;
-
-              for (const entry of fs.readdirSync(wsPath, { withFileTypes: true })) {
-                if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-                const pkgJsonPath = path.join(wsPath, entry.name, 'package.json');
-                try {
-                  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-                  if (pkgJson.name && !pkgJson.private) {
-                    packageMap.set(`${wsDir}/${entry.name}`, pkgJson.name);
-                  }
-                } catch {
-                  // Skip directories without valid package.json
-                }
-              }
-            }
-
-            core.info(`Discovered ${packageMap.size} public workspace packages`);
-
-            // ── 4. Get changed files in this PR ──
+            // ── 3. Get changed files in this PR ──
             const changedFiles = await github.paginate(
               github.rest.pulls.listFiles,
               {
@@ -163,6 +178,32 @@ jobs:
             );
 
             core.info(`PR has ${changedFiles.length} changed files`);
+
+            // ── 4. Discover only the workspace packages touched by this PR ──
+            // Avoid fetching all 100+ package.json files; just fetch ones whose
+            // directory has a changed file.
+            const workspaceRe = /^(core|plugins)\/([^/]+)\//;
+            const touchedDirs = new Set();
+            for (const file of changedFiles) {
+              const m = workspaceRe.exec(file.filename);
+              if (m) touchedDirs.add(`${m[1]}/${m[2]}`);
+            }
+
+            const packageMap = new Map(); // dir → package name
+            for (const dir of touchedDirs) {
+              const pkgJsonText = await fetchFileText(`${dir}/package.json`, headSha);
+              if (!pkgJsonText) continue;
+              try {
+                const pkgJson = JSON.parse(pkgJsonText);
+                if (pkgJson.name && !pkgJson.private) {
+                  packageMap.set(dir, pkgJson.name);
+                }
+              } catch (err) {
+                core.warning(`Could not parse ${dir}/package.json: ${err.message}`);
+              }
+            }
+
+            core.info(`Touched ${packageMap.size} public workspace package(s)`);
 
             // ── 5. Map changed files to packages, filtering ignored files ──
             const packagesWithCodeChanges = new Set();
@@ -187,13 +228,15 @@ jobs:
               return;
             }
 
-            // ── 6. Read existing changeset entries ──
-            const changesetDir = path.join(process.env.GITHUB_WORKSPACE, '.changeset');
+            // ── 6. Read existing changeset entries at PR head ──
             const coveredPackages = new Set();
-
-            for (const entry of fs.readdirSync(changesetDir)) {
-              if (!entry.endsWith('.md') || entry === 'README.md') continue;
-              const content = fs.readFileSync(path.join(changesetDir, entry), 'utf8');
+            const changesetEntries = await listDir('.changeset', headSha);
+            for (const entry of changesetEntries) {
+              if (entry.type !== 'file' || !entry.name.endsWith('.md') || entry.name === 'README.md') {
+                continue;
+              }
+              const content = await fetchFileText(`.changeset/${entry.name}`, headSha);
+              if (!content) continue;
               const match = content.match(/^---\n([\s\S]*?)\n---/);
               if (!match) continue;
               for (const line of match[1].split('\n')) {
@@ -243,9 +286,6 @@ jobs:
             core.setOutput('has_missing', 'true');
             core.setOutput('missing_list', missingPackages.join(', '));
 
-            const exampleFrontmatter = missingPackages.map((pkg) => `"${pkg}": patch`).join('\n');
-
-
             // ── 9. Post or update informational comment ──
             const packageList = missingPackages.map((pkg) => `- \`${pkg}\``).join('\n');
 
@@ -290,4 +330,3 @@ jobs:
               });
               core.info('Created new changeset coverage comment.');
             }
-

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   add-criticality-label:
     runs-on: ubuntu-latest

--- a/core/backend-api/src/markdown.test.ts
+++ b/core/backend-api/src/markdown.test.ts
@@ -76,6 +76,21 @@ describe("markdownToPlainText", () => {
     const result = markdownToPlainText("A &amp; B");
     expect(result).toBe("A & B");
   });
+
+  it("does not double-unescape &amp;lt; back into a tag delimiter", () => {
+    // Without ordering the &amp; decode last, `&amp;lt;` would become `<`
+    // after entity decoding, reintroducing a control character.
+    const result = markdownToPlainText("A &amp;lt; B");
+    expect(result).toBe("A &lt; B");
+  });
+
+  it("strips nested tag attempts in raw HTML", () => {
+    // marked passes raw HTML through; the tag stripper must loop until
+    // stable so nested constructs cannot leak through.
+    const result = markdownToPlainText("<<script>script>alert(1)</script>");
+    expect(result).not.toContain("<script");
+    expect(result).not.toContain("</script");
+  });
 });
 
 describe("markdownToSlackMrkdwn", () => {

--- a/core/backend-api/src/markdown.ts
+++ b/core/backend-api/src/markdown.ts
@@ -47,17 +47,26 @@ export function markdownToPlainText(markdown: string): string {
   // Convert to HTML first, then strip tags
   const html = markdownToHtml(markdown);
 
-  // Strip HTML tags
-  let text = html.replaceAll(/<[^>]*>/g, "");
-
-  // Decode common HTML entities
-  text = text
-    .replaceAll("&amp;", "&")
+  // Decode HTML entities FIRST so any escaped markup like `&lt;script&gt;`
+  // is exposed to the tag stripper in the next pass. `&amp;` must be
+  // decoded last; otherwise `&amp;lt;` would round-trip to `<` and
+  // reintroduce a control character (CodeQL js/double-escaping).
+  let text = html
     .replaceAll("&lt;", "<")
     .replaceAll("&gt;", ">")
     .replaceAll("&quot;", '"')
     .replaceAll("&#39;", "'")
-    .replaceAll("&nbsp;", " ");
+    .replaceAll("&nbsp;", " ")
+    .replaceAll("&amp;", "&");
+
+  // Strip HTML tags. Loop until the output stabilizes so adversarial inputs
+  // like `<scr<script>ipt>` cannot leave a residual `<script>` substring
+  // after a single pass (CodeQL js/incomplete-multi-character-sanitization).
+  let previous: string;
+  do {
+    previous = text;
+    text = text.replaceAll(/<[^>]*>/g, "");
+  } while (text !== previous);
 
   // Collapse multiple whitespace/newlines
   text = text.replaceAll(/\n\s*\n/g, "\n").trim();

--- a/core/backend/src/services/ws-route-registry.ts
+++ b/core/backend/src/services/ws-route-registry.ts
@@ -37,8 +37,9 @@ export function createScopedWsRegistry(
 ): WebSocketRouteRegistry {
   return {
     register(path: string, handler: WebSocketRouteHandler): void {
-      // Normalize: "/" maps to just the pluginId, "/foo" maps to "pluginId/foo"
-      const suffix = path === "/" ? "" : path.replace(/^\//, "/");
+      // Normalize: "/" maps to just the pluginId, "/foo" maps to "pluginId/foo".
+      // Paths are documented to start with `/` (see WebSocketRouteRegistry).
+      const suffix = path === "/" ? "" : path;
       const fullPath = `${pluginId}${suffix}`;
       store.registerHandler(fullPath, handler);
     },

--- a/core/ui/src/components/LinksEditor.tsx
+++ b/core/ui/src/components/LinksEditor.tsx
@@ -10,16 +10,21 @@ export interface HotLink {
   url: string;
 }
 
-// Block `javascript:`, `data:`, `vbscript:` etc. on render to defeat stored
-// XSS via maliciously crafted links — see CodeQL js/xss-through-dom.
-function safeHref(raw: string): string {
+// Parse a user-supplied URL and return its canonicalized form ONLY when the
+// scheme is `http:` / `https:`. Returns `undefined` for any other scheme
+// (`javascript:`, `data:`, `vbscript:`, etc.) so callers can refuse to
+// render an anchor at all. The returned string is `URL.toString()` — i.e.
+// a re-serialized URL — so taint analysis sees a fresh, sanitized value
+// rather than the raw input flowing through. CodeQL js/xss-through-dom.
+function safeHref(raw: string): string | undefined {
   try {
     const parsed = new URL(raw);
-    return parsed.protocol === "http:" || parsed.protocol === "https:"
-      ? raw
-      : "#";
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+    return undefined;
   } catch {
-    return "#";
+    return undefined;
   }
 }
 
@@ -95,42 +100,54 @@ export function LinksEditor<T extends HotLink>({
 
       {links.length > 0 ? (
         <div className="border rounded-lg divide-y">
-          {links.map((link) => (
-            <div
-              key={link.id}
-              className="flex items-center justify-between p-3 gap-2"
-            >
-              <div className="flex items-center gap-2 min-w-0 flex-1">
-                <ExternalLink className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div className="min-w-0">
-                  <a
-                    href={safeHref(link.url)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-primary hover:underline truncate block"
-                  >
-                    {link.label ?? link.url}
-                  </a>
-                  {link.label && (
-                    <span className="text-xs text-muted-foreground truncate block">
-                      {link.url}
-                    </span>
-                  )}
+          {links.map((link) => {
+            const href = safeHref(link.url);
+            return (
+              <div
+                key={link.id}
+                className="flex items-center justify-between p-3 gap-2"
+              >
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <ExternalLink className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div className="min-w-0">
+                    {href ? (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-primary hover:underline truncate block"
+                      >
+                        {link.label ?? link.url}
+                      </a>
+                    ) : (
+                      <span
+                        className="text-sm text-muted-foreground truncate block"
+                        title="Unsafe URL scheme — link disabled"
+                      >
+                        {link.label ?? link.url}
+                      </span>
+                    )}
+                    {link.label && (
+                      <span className="text-xs text-muted-foreground truncate block">
+                        {link.url}
+                      </span>
+                    )}
+                  </div>
                 </div>
+                {canManage && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void onRemove(link)}
+                    disabled={busy}
+                    aria-label="Remove link"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
               </div>
-              {canManage && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => void onRemove(link)}
-                  disabled={busy}
-                  aria-label="Remove link"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
-              )}
-            </div>
-          ))}
+            );
+          })}
         </div>
       ) : (
         <p className="text-sm text-muted-foreground">No links attached</p>

--- a/core/ui/src/components/LinksEditor.tsx
+++ b/core/ui/src/components/LinksEditor.tsx
@@ -10,6 +10,19 @@ export interface HotLink {
   url: string;
 }
 
+// Block `javascript:`, `data:`, `vbscript:` etc. on render to defeat stored
+// XSS via maliciously crafted links — see CodeQL js/xss-through-dom.
+function safeHref(raw: string): string {
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? raw
+      : "#";
+  } catch {
+    return "#";
+  }
+}
+
 export interface LinksEditorProps<T extends HotLink> {
   /** Currently attached links. */
   links: T[];
@@ -60,6 +73,11 @@ export function LinksEditor<T extends HotLink>({
       setError("Must be a valid URL (include http:// or https://)");
       return;
     }
+    const parsed = new URL(trimmedUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      setError("Only http:// and https:// URLs are allowed");
+      return;
+    }
     setError(undefined);
     await onAdd({ label: label.trim() || undefined, url: trimmedUrl });
     setLabel("");
@@ -86,7 +104,7 @@ export function LinksEditor<T extends HotLink>({
                 <ExternalLink className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div className="min-w-0">
                   <a
-                    href={link.url}
+                    href={safeHref(link.url)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-sm text-primary hover:underline truncate block"


### PR DESCRIPTION
## Summary

Resolves all 6 open CodeQL alerts on `main` (commit e3b324c) in a single PR.

| # | Severity | Rule | Location |
|---|---|---|---|
| 1 | High | `actions/untrusted-checkout/high` | `.github/workflows/changeset-reminder.yml` |
| 2 | Medium | `actions/missing-workflow-permissions` | `.github/workflows/issue-labeler.yml` |
| 3 | High | `js/xss-through-dom` | `core/ui/src/components/LinksEditor.tsx` |
| 4 | High | `js/double-escaping` | `core/backend-api/src/markdown.ts` |
| 5 | High | `js/incomplete-multi-character-sanitization` | `core/backend-api/src/markdown.ts` |
| 6 | Medium | `js/identity-replacement` | `core/backend/src/services/ws-route-registry.ts` |

## Changes

- **#3 — `LinksEditor`**: validate URL scheme on render and on add — only `http:` / `https:` URLs are accepted, defeating stored XSS via `javascript:` / `data:` schemes in user-supplied hotlinks.
- **#4 / #5 — `markdownToPlainText`**: decode HTML entities BEFORE tag stripping, then loop the tag stripper until output stabilizes. `&amp;` is decoded last so `&amp;lt;` cannot round-trip into a `<`. Regression tests added.
- **#6 — `ws-route-registry`**: drop dead identity-replacement (`path.replace(/^\//, "/")`) on the path suffix; the leading-slash invariant is already documented on `WebSocketRouteRegistry`.
- **#2 — `issue-labeler.yml`**: add explicit least-privilege permissions block (`contents: read`, `issues: write`).
- **#1 — `changeset-reminder.yml`**: remove the `actions/checkout` of the PR head ref. The workflow runs in a privileged context (`issue_comment` trigger + `pull-requests: write`) and previously satisfied the classic "pwn-request" pattern. All source data is now fetched via the GitHub API — JSON config and changeset frontmatter are pure data, never executed. Workspace package discovery is scoped to directories with changed files, so we never need to scan all 100+ packages per run.

## Test plan

- [x] `bun run lint` (clean)
- [x] `bun run typecheck` (clean)
- [x] `bun test core/backend-api/src/markdown.test.ts` — 20/20 pass, includes new regression tests for double-unescape and nested-tag sanitization
- [x] `bun test core/backend/src/services/ws-route-registry.test.ts` — 7/7 pass
- [ ] CI: `Lint`, `Test`, `Build`, `Trivy`, CodeQL re-scan
- [ ] Manual: verify `changeset-reminder` workflow still detects missing changesets on a follow-up commit (the workflow refactor is the largest behavior change and is best verified by watching this PR's own check run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)