### PR TITLE
feat: Automation Platform

### DIFF
--- a/.changeset/automation-trigger-actor.md
+++ b/.changeset/automation-trigger-actor.md
@@ -1,0 +1,49 @@
+---
+"@checkstack/common": minor
+"@checkstack/backend-api": minor
+"@checkstack/backend": minor
+"@checkstack/automation-backend": minor
+"@checkstack/automation-common": minor
+"@checkstack/automation-frontend": minor
+---
+
+feat(automation): expose `trigger.actor` so automations can filter on who/what caused an event
+
+Every platform event now carries an **actor** - the user, application (API
+client), service (backend-to-backend), or `system` (background /
+unauthenticated) that caused it - and the automation engine surfaces it to
+automations as `trigger.actor`. This lets a trigger filter gate on the
+origin of the event it reacts to:
+
+```text
+{{ trigger.actor.type == "system" }}      # auto-created by the platform
+{{ trigger.actor.type == "user" }}         # a human
+{{ trigger.actor.id == "app-deploybot" }}  # a specific application
+```
+
+`trigger.actor` is available on **every** trigger - it is injected by the
+platform, not declared per trigger - and editor autocomplete + Run Script
+context types include `trigger.actor.{type,id,name}`.
+
+How it works:
+
+- **`@checkstack/common`** adds the canonical `Actor` type / `ActorSchema`
+  and `SYSTEM_ACTOR`.
+- **`@checkstack/backend-api`** adds `resolveActor(user)` and a
+  `HookEventMeta` envelope. The hook listener / `onHook` signature gains an
+  optional second `meta` argument (additive, backward compatible).
+- **`@checkstack/backend`** wraps emitted hooks in an envelope so the actor
+  travels with the payload through the distributed queue, unwrapping it
+  before delivery. The RPC emit path captures the authenticated caller;
+  background emits default to the system actor. Raw/legacy queue data is
+  treated as a system-actor payload, so delivery stays backward compatible.
+- **`@checkstack/automation-backend`** threads the actor into the dispatch
+  scope (`trigger.actor`), available to trigger filters, top-level
+  conditions, and all run templates, and persisted in the run's scope
+  snapshot. Manual runs are attributed to the invoking user.
+- **`@checkstack/automation-common`** / **`@checkstack/automation-frontend`**
+  expose `trigger.actor` in the editor variable scope and the generated
+  Run Script `context.trigger.actor` types.
+
+No database migration and no per-trigger schema changes: the actor rides as
+event-envelope metadata and in the run scope snapshot.

--- a/.changeset/automation-trigger-id.md
+++ b/.changeset/automation-trigger-id.md
@@ -1,0 +1,37 @@
+---
+"@checkstack/automation-backend": minor
+"@checkstack/automation-common": minor
+"@checkstack/automation-frontend": minor
+"@checkstack/integration-script-backend": minor
+---
+
+feat(automation): expose `trigger.id` and reconcile the trigger scope so multiple triggers are distinguishable
+
+Automations with more than one trigger could not tell which trigger fired:
+the trigger id wasn't queryable, and scripts only received `trigger.event`
+(so two triggers on the same event were indistinguishable). This exposes a
+consistent trigger contract everywhere - `trigger.id`, `trigger.event`,
+`trigger.actor`, `trigger.payload` - in templates, shell, and TypeScript
+scripts.
+
+- **`trigger.id` is now available** in templates (`{{ trigger.id }}`) and in
+  the script context (`context.trigger.id`). It is typed as the **literal
+  union** of the automation's trigger ids, so it discriminates triggers -
+  including two subscribed to the same `event`.
+- **Auto-generated trigger ids.** The editor now assigns a unique, log-
+  friendly id to every trigger (derived from its event, e.g.
+  `incident_created`, deduped as `incident_created_2`), mirroring action ids:
+  seeded on the starter automation, assigned on add, and re-filled on blur.
+- **Scripts now receive `trigger.id` and `trigger.actor`.** The
+  `ActionRunScope` projection previously dropped both (it only forwarded
+  `event` + `payload`), so `context.trigger.actor` was typed but never
+  populated - that gap is fixed.
+- **Scope key reconciled.** The internal dispatch scope now exposes
+  `trigger.event` as the canonical key (matching the editor and script
+  contract) instead of leaking `trigger.eventId`; `trigger.eventId` is kept
+  as a back-compat alias, so `{{ trigger.event }}` now resolves in template
+  fields where it previously returned `undefined`.
+
+No database migration: the actor and id ride in the run scope snapshot. A
+shared `deriveTriggerId` is exported from `@checkstack/automation-common` so
+the editor, generated script types, and the runtime all agree on derived ids.

--- a/core/automation-backend/src/action-types.ts
+++ b/core/automation-backend/src/action-types.ts
@@ -14,7 +14,7 @@ import type {
   ServiceRef,
   Versioned,
 } from "@checkstack/backend-api";
-import type { LucideIconName } from "@checkstack/common";
+import type { Actor, LucideIconName } from "@checkstack/common";
 
 // ─── Artifact types ────────────────────────────────────────────────────────
 
@@ -182,10 +182,18 @@ export interface ActionResult<TArtifact = unknown> {
  * is the narrow, explicitly-declared `consumes` subset.
  */
 export interface ActionRunScope {
-  /** The trigger event that started this run, plus its raw payload. */
+  /** The trigger that started this run, plus its raw payload. */
   trigger: {
+    /**
+     * The id of the specific trigger declaration that fired. Distinguishes
+     * triggers within an automation - including two triggers on the same
+     * `event` - so scripts/templates can branch on which one fired.
+     */
+    id: string;
     /** Fully-qualified trigger event id (e.g. `incident.created`). */
     event: string;
+    /** Who/what caused the event (system, user, application, or service). */
+    actor: Actor;
     /** Trigger payload exactly as emitted. */
     payload: Record<string, unknown>;
   };

--- a/core/automation-backend/src/dispatch/engine.ts
+++ b/core/automation-backend/src/dispatch/engine.ts
@@ -59,6 +59,7 @@ import type {
   VariablesInput,
   WaitForTriggerInput,
 } from "@checkstack/automation-common";
+import { SYSTEM_ACTOR, type Actor } from "@checkstack/common";
 import type {
   TemplateContext,
 } from "@checkstack/template-engine";
@@ -108,6 +109,12 @@ export interface DispatchTriggerArgs {
   triggerId: string;
   triggerEventId: string;
   payload: Record<string, unknown>;
+  /**
+   * Who/what caused the originating event. Persisted as part of the run's
+   * scope snapshot and exposed to the automation as `trigger.actor`. Defaults
+   * to the system actor when the caller has none.
+   */
+  actor?: Actor;
   contextKey: string | null;
 }
 
@@ -149,6 +156,7 @@ export async function dispatchTrigger(
       triggerId: args.triggerId,
       triggerEventId: args.triggerEventId,
       payload: args.payload,
+      actor: args.actor,
       startedAt,
     }),
     resuming: false,
@@ -589,22 +597,39 @@ function templateContext(ctx: DispatchContext): TemplateContext {
 
 /**
  * Project the dispatch scope into the {@link ActionRunScope} handed to an
- * action's `execute`. The internal scope keys (`trigger.eventId`,
- * `variables`) are normalised to the public contract names
- * (`trigger.event`, `vars`).
+ * action's `execute`. The internal `variables` key is normalised to the
+ * public contract name `vars`, and the trigger identity (`id`, `event`,
+ * `actor`) is projected so scripts can branch on which trigger fired and who
+ * caused it.
  */
 function actionRunScope(ctx: DispatchContext): ActionRunScope {
   const scope = ctx.scope as {
-    trigger?: { eventId?: unknown; payload?: unknown };
+    trigger?: {
+      id?: unknown;
+      event?: unknown;
+      eventId?: unknown;
+      actor?: unknown;
+      payload?: unknown;
+    };
     artifacts?: unknown;
     variables?: unknown;
     repeat?: { index?: unknown; item?: unknown };
   };
+  const trigger = scope.trigger;
+  // `event` is canonical; fall back to the legacy `eventId` alias for older
+  // scope snapshots persisted before the rename.
+  const event =
+    typeof trigger?.event === "string"
+      ? trigger.event
+      : typeof trigger?.eventId === "string"
+        ? trigger.eventId
+        : "";
   const result: ActionRunScope = {
     trigger: {
-      event:
-        typeof scope.trigger?.eventId === "string" ? scope.trigger.eventId : "",
-      payload: coerceRecord(scope.trigger?.payload),
+      id: typeof trigger?.id === "string" ? trigger.id : "",
+      event,
+      actor: isActor(trigger?.actor) ? trigger.actor : SYSTEM_ACTOR,
+      payload: coerceRecord(trigger?.payload),
     },
     artifacts: coerceRecord(scope.artifacts),
     vars: coerceRecord(scope.variables),
@@ -620,6 +645,15 @@ function coerceRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+/** Structural check that a scope value is a usable {@link Actor}. */
+function isActor(value: unknown): value is Actor {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.type === "string" && typeof candidate.id === "string"
+  );
 }
 
 async function recordSkipStep(

--- a/core/automation-backend/src/dispatch/scope.test.ts
+++ b/core/automation-backend/src/dispatch/scope.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "bun:test";
+import { SYSTEM_ACTOR } from "@checkstack/common";
+import { buildInitialScope } from "./scope";
+
+describe("buildInitialScope — trigger.actor", () => {
+  const base = {
+    triggerId: "t1",
+    triggerEventId: "incident.created",
+    payload: { incidentId: "i1" },
+    startedAt: new Date("2026-05-30T00:00:00.000Z"),
+  };
+
+  it("defaults trigger.actor to the system actor when none is supplied", () => {
+    const scope = buildInitialScope(base);
+    const trigger = scope.trigger as { actor: unknown };
+    expect(trigger.actor).toEqual(SYSTEM_ACTOR);
+  });
+
+  it("exposes the supplied actor under trigger.actor alongside the payload", () => {
+    const actor = { type: "user", id: "user-1", name: "Nico" } as const;
+    const scope = buildInitialScope({ ...base, actor });
+    const trigger = scope.trigger as { actor: unknown; payload: unknown };
+    expect(trigger.actor).toEqual(actor);
+    expect(trigger.payload).toEqual({ incidentId: "i1" });
+  });
+
+  it("exposes trigger.id and the canonical trigger.event (with eventId alias)", () => {
+    const scope = buildInitialScope(base);
+    const trigger = scope.trigger as {
+      id: unknown;
+      event: unknown;
+      eventId: unknown;
+    };
+    expect(trigger.id).toBe("t1");
+    // `event` is canonical (matches the editor + script contract); `eventId`
+    // stays as a back-compat alias.
+    expect(trigger.event).toBe("incident.created");
+    expect(trigger.eventId).toBe("incident.created");
+  });
+});

--- a/core/automation-backend/src/dispatch/scope.ts
+++ b/core/automation-backend/src/dispatch/scope.ts
@@ -3,7 +3,8 @@
  *
  * The shape exposed to templates is:
  *
- *   trigger.id, trigger.eventId, trigger.payload.*
+ *   trigger.id, trigger.event, trigger.payload.*
+ *   trigger.actor.{type,id,name}                 (who/what caused the event)
  *   variables.*                                  (from `variables` blocks)
  *   artifacts.<actionId>.<localArtifactName>.*  (set when an action produces)
  *   repeat.item, repeat.index                    (only inside a repeat)
@@ -11,23 +12,34 @@
  *
  * Keep this shape stable — the editor's intellisense reads it.
  */
+import { SYSTEM_ACTOR, type Actor } from "@checkstack/common";
 import type { DispatchContext } from "./types";
 
 /**
  * Build the initial scope at run start. Subsequent blocks (variables,
  * repeat) clone-and-extend this scope rather than mutating it, so a
  * variable defined inside a nested block does not leak to siblings.
+ *
+ * `actor` carries who/what caused the originating event (a user, an
+ * application/API client, a service, or the system). It defaults to the
+ * system actor so callers that don't have one still produce a complete scope.
  */
 export function buildInitialScope(args: {
   triggerId: string;
   triggerEventId: string;
   payload: Record<string, unknown>;
+  actor?: Actor;
   startedAt: Date;
 }): Record<string, unknown> {
   return {
     trigger: {
       id: args.triggerId,
+      event: args.triggerEventId,
+      // Back-compat alias for the former internal key. Templates and the
+      // editor use `trigger.event`; `eventId` stays so older saved scope
+      // snapshots / automations referencing it keep resolving.
       eventId: args.triggerEventId,
+      actor: args.actor ?? SYSTEM_ACTOR,
       payload: args.payload,
     },
     variables: {},

--- a/core/automation-backend/src/dispatch/trigger-subscriber.ts
+++ b/core/automation-backend/src/dispatch/trigger-subscriber.ts
@@ -13,7 +13,12 @@ import type {
   AutomationMode,
   Trigger,
 } from "@checkstack/automation-common";
-import type { HookSubscribeOptions, Logger } from "@checkstack/backend-api";
+import type {
+  HookEventMeta,
+  HookSubscribeOptions,
+  Logger,
+} from "@checkstack/backend-api";
+import { SYSTEM_ACTOR, type Actor } from "@checkstack/common";
 
 import type { AutomationStore } from "../automation-store";
 import { dispatchTrigger, resumeRun } from "./engine";
@@ -42,7 +47,7 @@ export interface TriggerSubscriptions {
  */
 export type OnHookFn = <T>(
   hook: { id: string; _type?: T },
-  listener: (payload: T) => Promise<void>,
+  listener: (payload: T, meta?: HookEventMeta) => Promise<void>,
   options?: HookSubscribeOptions,
 ) => () => Promise<void>;
 
@@ -67,12 +72,13 @@ export async function setupTriggerSubscriptions(
     if (trigger.hook) {
       const teardown = args.onHook(
         trigger.hook,
-        async (payload) => {
+        async (payload, meta) => {
           await handleTriggerFiring({
             deps: args.deps,
             automationStore: args.automationStore,
             qualifiedEventId: trigger.qualifiedId,
             triggerPayload: payload as Record<string, unknown>,
+            actor: meta?.actor ?? SYSTEM_ACTOR,
             contextKey:
               (trigger.contextKey?.(payload) ?? null),
           });
@@ -111,6 +117,9 @@ export async function setupTriggerSubscriptions(
                 automationStore: args.automationStore,
                 qualifiedEventId: trigger.qualifiedId,
                 triggerPayload: payload as Record<string, unknown>,
+                // Setup-backed triggers (cron / interval / template) fire on a
+                // schedule with no acting caller — the system is the actor.
+                actor: SYSTEM_ACTOR,
                 contextKey:
                   trigger.contextKey?.(payload) ?? null,
               });
@@ -143,6 +152,7 @@ interface HandleTriggerFiringArgs {
   automationStore: AutomationStore;
   qualifiedEventId: string;
   triggerPayload: Record<string, unknown>;
+  actor: Actor;
   contextKey: string | null;
 }
 
@@ -166,6 +176,7 @@ async function handleTriggerFiring(
         automation,
         trigger,
         triggerPayload: args.triggerPayload,
+        actor: args.actor,
         contextKey: args.contextKey,
         eventId: args.qualifiedEventId,
       });
@@ -188,6 +199,7 @@ async function wakeWaitingRuns(args: HandleTriggerFiringArgs): Promise<void> {
           triggerId: "wait",
           triggerEventId: args.qualifiedEventId,
           payload: args.triggerPayload,
+          actor: args.actor,
           startedAt: new Date(),
         });
         const pass = evaluateCondition(
@@ -230,6 +242,7 @@ interface MaybeStartRunArgs {
   automation: LoadedAutomation;
   trigger: Trigger;
   triggerPayload: Record<string, unknown>;
+  actor: Actor;
   contextKey: string | null;
   eventId: string;
 }
@@ -241,6 +254,7 @@ async function maybeStartRun(args: MaybeStartRunArgs): Promise<void> {
       triggerId: args.trigger.id ?? deriveTriggerId(args.trigger),
       triggerEventId: args.eventId,
       payload: args.triggerPayload,
+      actor: args.actor,
       startedAt: new Date(),
     });
     let pass: boolean;
@@ -265,6 +279,7 @@ async function maybeStartRun(args: MaybeStartRunArgs): Promise<void> {
       triggerId: args.trigger.id ?? deriveTriggerId(args.trigger),
       triggerEventId: args.eventId,
       payload: args.triggerPayload,
+      actor: args.actor,
       startedAt: new Date(),
     });
     for (const condition of args.automation.definition.conditions) {
@@ -289,6 +304,7 @@ async function maybeStartRun(args: MaybeStartRunArgs): Promise<void> {
     triggerId: args.trigger.id ?? deriveTriggerId(args.trigger),
     triggerEventId: args.eventId,
     triggerPayload: args.triggerPayload,
+    actor: args.actor,
     contextKey: args.contextKey,
     automation: args.automation,
   });
@@ -303,6 +319,7 @@ interface RespectConcurrencyArgs {
   triggerId: string;
   triggerEventId: string;
   triggerPayload: Record<string, unknown>;
+  actor: Actor;
   contextKey: string | null;
 }
 
@@ -358,6 +375,7 @@ async function respectConcurrencyMode(
     triggerId: args.triggerId,
     triggerEventId: args.triggerEventId,
     payload: args.triggerPayload,
+    actor: args.actor,
     contextKey: args.contextKey,
   });
 }

--- a/core/automation-backend/src/router.ts
+++ b/core/automation-backend/src/router.ts
@@ -12,6 +12,7 @@ import type { SafeDatabase, Logger } from "@checkstack/backend-api";
 import {
   autoAuthMiddleware,
   correlationMiddleware,
+  resolveActor,
   type RpcContext,
 } from "@checkstack/backend-api";
 import type { SignalService } from "@checkstack/signal-common";
@@ -254,7 +255,7 @@ export function createAutomationRouter(deps: RouterDeps) {
 
     // ─── Manual run ──────────────────────────────────────────────────────
 
-    manualRun: os.manualRun.handler(async ({ input }) => {
+    manualRun: os.manualRun.handler(async ({ input, context }) => {
       const automation = await automationStore.getById(input.automationId);
       if (!automation) {
         throw new ORPCError("NOT_FOUND", {
@@ -288,6 +289,8 @@ export function createAutomationRouter(deps: RouterDeps) {
         triggerId: selectedTrigger.id ?? selectedTrigger.event,
         triggerEventId: selectedTrigger.event,
         payload: input.payload,
+        // Attribute the manual run to whoever invoked it.
+        actor: resolveActor(context.user),
         contextKey,
       });
 

--- a/core/automation-common/src/variable-scope.test.ts
+++ b/core/automation-common/src/variable-scope.test.ts
@@ -198,6 +198,83 @@ describe("resolveVariableScope", () => {
     expect(flat).toContain("trigger.payload.severity");
   });
 
+  it("exposes trigger.actor.* on every automation (independent of triggers)", () => {
+    // With a matched trigger.
+    const matched = flattenScope(
+      resolveVariableScope({
+        definition: basicDefinition(),
+        triggers: [triggerInfo],
+        actions: [],
+        artifactTypes: [],
+        path: [{ slot: "root", index: 0 }],
+      }),
+    );
+    const byPath = new Map(matched.map((e) => [e.path, e]));
+    expect(byPath.has("trigger.actor")).toBe(true);
+    expect(byPath.has("trigger.actor.type")).toBe(true);
+    expect(byPath.has("trigger.actor.id")).toBe(true);
+    expect(byPath.has("trigger.actor.name")).toBe(true);
+    // actor is universal — never gated on a subset of triggers.
+    expect(byPath.get("trigger.actor.type")?.conditionalOnTriggers).toBeUndefined();
+    expect(byPath.get("trigger.actor.type")?.type).toBe(
+      '"system" | "user" | "application" | "service"',
+    );
+
+    // Still present when no trigger matches the registry (no payload schema).
+    const unmatched = flattenScope(
+      resolveVariableScope({
+        definition: basicDefinition({
+          triggers: [{ event: "does.not.exist" }],
+          actions: [],
+        }),
+        triggers: [],
+        actions: [],
+        artifactTypes: [],
+        path: [{ slot: "root", index: 0 }],
+      }),
+    ).map((e) => e.path);
+    expect(unmatched).toContain("trigger.actor");
+    expect(unmatched).toContain("trigger.actor.type");
+  });
+
+  it("exposes trigger.id typed as the literal union of the automation's trigger ids", () => {
+    const definition = basicDefinition({
+      // Two triggers on the SAME event, distinguished by explicit ids.
+      triggers: [
+        { event: "incident.created", id: "majors" },
+        { event: "incident.created", id: "minors" },
+      ],
+      actions: [],
+    });
+    const flat = flattenScope(
+      resolveVariableScope({
+        definition,
+        triggers: [triggerInfo],
+        actions: [],
+        artifactTypes: [],
+        path: [{ slot: "root", index: 0 }],
+      }),
+    );
+    const idEntry = flat.find((e) => e.path === "trigger.id");
+    expect(idEntry).toBeDefined();
+    expect(idEntry?.type).toBe('"majors" | "minors"');
+    expect(idEntry?.conditionalOnTriggers).toBeUndefined();
+  });
+
+  it("derives trigger.id from the event when no explicit id is set", () => {
+    const flat = flattenScope(
+      resolveVariableScope({
+        definition: basicDefinition(),
+        triggers: [triggerInfo],
+        actions: [],
+        artifactTypes: [],
+        path: [{ slot: "root", index: 0 }],
+      }),
+    );
+    const idEntry = flat.find((e) => e.path === "trigger.id");
+    expect(idEntry?.type).toBe('"incident_created"');
+  });
+
   it("unions payload fields across multiple subscribed triggers and annotates conditional entries", () => {
     const definition = basicDefinition({
       triggers: [{ event: "incident.created" }, { event: "incident.resolved" }],

--- a/core/automation-common/src/variable-scope.ts
+++ b/core/automation-common/src/variable-scope.ts
@@ -462,6 +462,102 @@ function entryFromSchemaNode(
  * shape so Monaco narrows correctly inside `{{#if trigger.event === "A"}}`
  * branches.
  */
+/**
+ * Static `trigger.actor` subtree. Every trigger carries an actor (who/what
+ * caused the event), injected by the platform as event metadata, so this is
+ * offered unconditionally on every automation - independent of which triggers
+ * are subscribed - to drive filters like
+ * `{{ trigger.actor.type == "system" }}`.
+ */
+function buildActorEntry(): VariableEntry {
+  return {
+    path: "trigger.actor",
+    templateRef: "trigger.actor",
+    type: "object",
+    description:
+      "Who or what caused the event (system, user, application, or service).",
+    jsonSchema: {
+      type: "object",
+      properties: {
+        type: {
+          type: "string",
+          enum: ["system", "user", "application", "service"],
+        },
+        id: { type: "string" },
+        name: { type: "string" },
+      },
+      required: ["type", "id"],
+    },
+    children: [
+      {
+        path: "trigger.actor.type",
+        templateRef: "trigger.actor.type",
+        type: '"system" | "user" | "application" | "service"',
+        description:
+          "Actor kind. Filter e.g. system-created vs user-created events.",
+        jsonSchema: {
+          type: "string",
+          enum: ["system", "user", "application", "service"],
+        },
+      },
+      {
+        path: "trigger.actor.id",
+        templateRef: "trigger.actor.id",
+        type: "string",
+        description:
+          'Stable id: user id, application id, plugin id (service), or "system".',
+        jsonSchema: { type: "string" },
+      },
+      {
+        path: "trigger.actor.name",
+        templateRef: "trigger.actor.name",
+        type: "string",
+        description: "Human-readable actor name when known.",
+        jsonSchema: { type: "string" },
+      },
+    ],
+  };
+}
+
+/**
+ * Derive a stable, identifier-safe id for a trigger from its event id, used
+ * when the operator hasn't assigned an explicit `id`. Mirrors the backend
+ * dispatcher's derivation so editor autocomplete, the generated script types,
+ * and the runtime `trigger.id` all agree.
+ */
+export function deriveTriggerId(event: string): string {
+  return event.replaceAll(/[^a-z0-9]+/gi, "_").toLowerCase();
+}
+
+/**
+ * Build the `trigger.id` entry — the id of the specific trigger declaration
+ * that fired. Typed as the literal union of the automation's trigger ids
+ * (explicit `id` or derived from the event), so it discriminates triggers
+ * even when two subscribe to the same `event`.
+ */
+function buildTriggerIdEntry(triggers: Trigger[]): VariableEntry {
+  const effectiveIds = [
+    ...new Set(triggers.map((t) => t.id ?? deriveTriggerId(t.event))),
+  ];
+  const idType =
+    effectiveIds.length > 0
+      ? effectiveIds.map((id) => JSON.stringify(id)).join(" | ")
+      : "string";
+  return {
+    path: "trigger.id",
+    templateRef: "trigger.id",
+    type: idType,
+    description:
+      effectiveIds.length <= 1
+        ? "Id of the trigger declaration that fired."
+        : "Id of the trigger that fired — distinguishes triggers, including two on the same event.",
+    jsonSchema:
+      effectiveIds.length > 0
+        ? { type: "string", enum: effectiveIds }
+        : { type: "string" },
+  };
+}
+
 function buildTriggerEntries(args: {
   triggers: Trigger[];
   registeredTriggers: TriggerInfo[];
@@ -477,6 +573,7 @@ function buildTriggerEntries(args: {
       ? allEventIds.map((id) => JSON.stringify(id)).join(" | ")
       : "string";
 
+  const idEntry = buildTriggerIdEntry(triggers);
   const eventEntry: VariableEntry = {
     path: "trigger.event",
     templateRef: "trigger.event",
@@ -499,7 +596,9 @@ function buildTriggerEntries(args: {
         type: "object",
         description: "Trigger that fired this run.",
         children: [
+          idEntry,
           eventEntry,
+          buildActorEntry(),
           {
             path: "trigger.payload",
             templateRef: "trigger.payload",
@@ -520,7 +619,7 @@ function buildTriggerEntries(args: {
       templateRef: "trigger",
       type: "object",
       description: "Trigger that fired this run.",
-      children: [eventEntry, payloadEntry],
+      children: [idEntry, eventEntry, buildActorEntry(), payloadEntry],
     },
   ];
 }

--- a/core/automation-frontend/src/editor/TriggersEditor.tsx
+++ b/core/automation-frontend/src/editor/TriggersEditor.tsx
@@ -19,6 +19,7 @@ import type {
 import { useAutomationRegistry, useVariableScope } from "./registry-context";
 import { ItemPicker } from "./ItemPicker";
 import { useTriggerIssues } from "./editor-validation";
+import { collectTriggerIds, defaultTriggerId } from "./trigger-helpers";
 
 /**
  * Build a minimal `AutomationDefinition` that only subscribes to the
@@ -81,7 +82,12 @@ export const TriggersEditor: React.FC<TriggersEditorProps> = ({
   );
 
   const handleAdd = () => {
-    onChange([...value, { event: triggers[0]?.qualifiedId ?? "" }]);
+    // Assign a unique default id up front (deduped against existing triggers)
+    // so the new trigger is immediately referenceable as `trigger.id` and the
+    // field shows a value rather than appearing blank.
+    const fresh: Trigger = { event: triggers[0]?.qualifiedId ?? "" };
+    const id = defaultTriggerId(fresh, collectTriggerIds(value));
+    onChange([...value, { ...fresh, id }]);
   };
 
   return (
@@ -120,6 +126,9 @@ export const TriggersEditor: React.FC<TriggersEditorProps> = ({
             onRemove={() => onChange(value.filter((_, i) => i !== index))}
             disabled={disabled}
             pickerItems={pickerItems}
+            // Ids of the other triggers — used to keep this trigger's
+            // auto-filled id unique when the operator clears the field.
+            siblingIds={collectTriggerIds(value.filter((_, i) => i !== index))}
           />
         ))}
       </CardContent>
@@ -134,7 +143,8 @@ const TriggerCard: React.FC<{
   onRemove: () => void;
   disabled?: boolean;
   pickerItems: Array<{ id: string; label: string; description?: string; category?: string }>;
-}> = ({ index, value, onChange, onRemove, disabled, pickerItems }) => {
+  siblingIds: Set<string>;
+}> = ({ index, value, onChange, onRemove, disabled, pickerItems, siblingIds }) => {
   const { triggers } = useAutomationRegistry();
   const selected = triggers.find((t) => t.qualifiedId === value.event);
   const issues = useTriggerIssues(index);
@@ -191,11 +201,11 @@ const TriggerCard: React.FC<{
             </div>
             <div className="grid gap-2 sm:grid-cols-2">
               <div className="space-y-1">
-                <Label className="text-xs" htmlFor={`trigger-id-${value.event}`}>
-                  ID (optional)
+                <Label className="text-xs" htmlFor={`trigger-id-${index}`}>
+                  ID
                 </Label>
                 <Input
-                  id={`trigger-id-${value.event}`}
+                  id={`trigger-id-${index}`}
                   value={value.id ?? ""}
                   onChange={(event) =>
                     onChange({
@@ -203,7 +213,14 @@ const TriggerCard: React.FC<{
                       id: event.target.value || undefined,
                     })
                   }
-                  placeholder="e.g. major-incident"
+                  onBlur={() => {
+                    // Never leave the id blank: re-fill a unique default so the
+                    // trigger stays referenceable as `trigger.id` and is
+                    // distinguishable from sibling triggers.
+                    if (value.id) return;
+                    onChange({ ...value, id: defaultTriggerId(value, siblingIds) });
+                  }}
+                  placeholder="Generated on blur"
                   disabled={disabled}
                   className="font-mono text-xs"
                 />

--- a/core/automation-frontend/src/editor/trigger-helpers.test.ts
+++ b/core/automation-frontend/src/editor/trigger-helpers.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "bun:test";
+import type { Trigger } from "@checkstack/automation-common";
+import {
+  assignDefaultTriggerIds,
+  collectTriggerIds,
+  defaultTriggerId,
+} from "./trigger-helpers";
+
+describe("trigger-helpers", () => {
+  it("derives a default id from the event when none is set", () => {
+    expect(defaultTriggerId({ event: "incident.created" }, new Set())).toBe(
+      "incident_created",
+    );
+  });
+
+  it("dedupes against taken ids with numeric suffixes", () => {
+    const trigger: Trigger = { event: "incident.created" };
+    expect(defaultTriggerId(trigger, new Set(["incident_created"]))).toBe(
+      "incident_created_2",
+    );
+    expect(
+      defaultTriggerId(
+        trigger,
+        new Set(["incident_created", "incident_created_2"]),
+      ),
+    ).toBe("incident_created_3");
+  });
+
+  it("collects only non-empty ids", () => {
+    const triggers: Trigger[] = [
+      { event: "a", id: "x" },
+      { event: "b" },
+      { event: "c", id: "" },
+    ];
+    expect([...collectTriggerIds(triggers)]).toEqual(["x"]);
+  });
+
+  it("assigns unique ids to triggers missing them, preserving existing", () => {
+    const out = assignDefaultTriggerIds([
+      { event: "incident.created", id: "primary" },
+      { event: "incident.created" },
+      { event: "maintenance.created" },
+    ]);
+    expect(out[0]!.id).toBe("primary");
+    expect(out[1]!.id).toBe("incident_created");
+    expect(out[2]!.id).toBe("maintenance_created");
+    expect(new Set(out.map((t) => t.id)).size).toBe(3);
+  });
+
+  it("makes two triggers on the same event distinguishable", () => {
+    const out = assignDefaultTriggerIds([
+      { event: "incident.created" },
+      { event: "incident.created" },
+    ]);
+    expect(out[0]!.id).toBe("incident_created");
+    expect(out[1]!.id).toBe("incident_created_2");
+  });
+});

--- a/core/automation-frontend/src/editor/trigger-helpers.ts
+++ b/core/automation-frontend/src/editor/trigger-helpers.ts
@@ -1,0 +1,67 @@
+import type { Trigger } from "@checkstack/automation-common";
+import { deriveTriggerId } from "@checkstack/automation-common";
+
+/**
+ * Auto-id helpers for triggers, mirroring `action-helpers` for actions.
+ *
+ * A trigger's `id` is what `trigger.id` resolves to at runtime and the
+ * discriminator that distinguishes triggers in templates / scripts - including
+ * two triggers subscribed to the same `event`. The editor assigns a unique,
+ * log-friendly default so the operator never has to, but can rename it.
+ */
+
+/** Base id for a trigger: derived from its event id, falling back to `trigger`. */
+function suggestTriggerIdBase(trigger: Trigger): string {
+  return deriveTriggerId(trigger.event) || "trigger";
+}
+
+/** Collect every assigned (non-empty) trigger id into a set. */
+export function collectTriggerIds(
+  triggers: Trigger[],
+  into: Set<string> = new Set(),
+): Set<string> {
+  for (const trigger of triggers) {
+    if (typeof trigger.id === "string" && trigger.id.length > 0) {
+      into.add(trigger.id);
+    }
+  }
+  return into;
+}
+
+/** Make `base` unique against `taken`, appending `_2`, `_3`, ... as needed. */
+function uniqueTriggerId(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  let n = 2;
+  while (taken.has(`${base}_${n}`)) n += 1;
+  return `${base}_${n}`;
+}
+
+/**
+ * A single identifier-safe, unique default id for `trigger`, deduped against
+ * `taken`. Used to seed a new trigger and to re-fill the Id field when the
+ * operator clears it.
+ */
+export function defaultTriggerId(
+  trigger: Trigger,
+  taken: Set<string>,
+): string {
+  return uniqueTriggerId(suggestTriggerIdBase(trigger), taken);
+}
+
+/**
+ * Return a copy of `triggers` with a stable, unique id assigned to every
+ * trigger that does not already have one. Existing ids are preserved and seed
+ * the uniqueness set. Used when seeding the starter automation so the id is
+ * shown immediately rather than appearing blank.
+ */
+export function assignDefaultTriggerIds(
+  triggers: Trigger[],
+  taken: Set<string> = collectTriggerIds(triggers),
+): Trigger[] {
+  return triggers.map((trigger) => {
+    if (typeof trigger.id === "string" && trigger.id.length > 0) return trigger;
+    const id = uniqueTriggerId(suggestTriggerIdBase(trigger), taken);
+    taken.add(id);
+    return { ...trigger, id };
+  });
+}

--- a/core/automation-frontend/src/pages/AutomationEditPage.tsx
+++ b/core/automation-frontend/src/pages/AutomationEditPage.tsx
@@ -49,6 +49,7 @@ import { extractErrorMessage, resolveRoute } from "@checkstack/common";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { AutomationDefinitionEditor } from "../editor/AutomationDefinitionEditor";
 import { assignDefaultIds } from "../editor/action-helpers";
+import { assignDefaultTriggerIds } from "../editor/trigger-helpers";
 import { computeYamlMarkers } from "../editor/yaml-markers";
 import {
   ValidationProvider,
@@ -57,7 +58,9 @@ import {
 
 const STARTER_DEFINITION: AutomationDefinition = {
   name: "New Automation",
-  triggers: [{ event: "incident.created" }],
+  // Seed the starter trigger's id the same way actions are seeded, so it is
+  // shown (and referenceable as `trigger.id`) immediately.
+  triggers: assignDefaultTriggerIds([{ event: "incident.created" }]),
   conditions: [],
   // Run the seeded starter action through the same default-id assignment the
   // "Add step" path uses, so its `id` is filled in (and shown) immediately
@@ -137,13 +140,23 @@ const AutomationEditContent: React.FC = () => {
     Array<{ path: Array<string | number>; message: string }>
   >([]);
 
-  useInitOnceForKey(loadQuery.data, loadQuery.data?.id, (a) => {
-    setName(a.name);
-    setDescription(a.description ?? "");
-    setStatusEnabled(a.status === "enabled");
-    setDefinition(a.definition);
-    setYamlText(stringifyYaml(a.definition));
-  });
+  // Seed local form state from the loaded automation, once per record.
+  // `useInitOnceForKey` seeds during render (not in an effect), so it survives
+  // StrictMode's double-mount even when the query resolves from a warm cache on
+  // reopen, and ignores background refetches of the same record so in-progress
+  // edits are not clobbered. `isFetchedAfterMount` keeps it to genuinely fresh
+  // data rather than a stale cache entry served instantly on mount.
+  useInitOnceForKey(
+    loadQuery.isFetchedAfterMount ? loadQuery.data : undefined,
+    loadQuery.data?.id,
+    (a) => {
+      setName(a.name);
+      setDescription(a.description ?? "");
+      setStatusEnabled(a.status === "enabled");
+      setDefinition(a.definition);
+      setYamlText(stringifyYaml(a.definition));
+    },
+  );
 
   // Keep the YAML mirror in sync with definition while the visual editor
   // is active — the YAML tab needs a non-stale starting point when the

--- a/core/automation-frontend/src/pages/RunsPage.tsx
+++ b/core/automation-frontend/src/pages/RunsPage.tsx
@@ -66,7 +66,10 @@ const RunsPageContent: React.FC = () => {
 
   const automationQuery = client.getAutomation.useQuery(
     { id: automationId ?? "" },
-    { enabled: Boolean(automationId) },
+    // Drop the cache entry as soon as this page unmounts: the editor seeds its
+    // form from this same `getAutomation` cache key once, and a lingering entry
+    // here would let it seed pre-edit (stale) data. See AutomationEditPage.
+    { enabled: Boolean(automationId), gcTime: 0 },
   );
 
   const runsQuery = client.listRuns.useQuery(

--- a/core/automation-frontend/src/script-context.test.ts
+++ b/core/automation-frontend/src/script-context.test.ts
@@ -88,6 +88,37 @@ describe("generateAutomationContextTypes", () => {
     expect(typeDefinitions).not.toContain('readonly event: "incident.resolved"');
   });
 
+  it("carries trigger.id (derived) and a shared actor on the trigger union", () => {
+    const { typeDefinitions } = generateAutomationContextTypes({
+      definition: baseDef(),
+      triggers: [incidentCreated, incidentResolved],
+      artifactTypes: [],
+      path: [{ slot: "root", index: 0 }],
+    });
+    // id is a literal, derived from the event when no explicit id is set.
+    expect(typeDefinitions).toContain('readonly id: "incident_created"');
+    // actor is shared across every variant (intersected onto the union).
+    expect(typeDefinitions).toContain("type AutomationActor =");
+    expect(typeDefinitions).toContain("readonly actor: AutomationActor");
+  });
+
+  it("uses explicit trigger ids to discriminate two triggers on the same event", () => {
+    const def = baseDef({
+      triggers: [
+        { event: "incident.created", id: "majors" },
+        { event: "incident.created", id: "minors" },
+      ],
+    });
+    const { typeDefinitions } = generateAutomationContextTypes({
+      definition: def,
+      triggers: [incidentCreated],
+      artifactTypes: [],
+      path: [{ slot: "root", index: 0 }],
+    });
+    expect(typeDefinitions).toContain('readonly id: "majors"');
+    expect(typeDefinitions).toContain('readonly id: "minors"');
+  });
+
   it("emits a multi-variant discriminated union when multiple triggers are subscribed", () => {
     const def = baseDef({
       triggers: [{ event: "incident.created" }, { event: "incident.resolved" }],

--- a/core/automation-frontend/src/script-context.ts
+++ b/core/automation-frontend/src/script-context.ts
@@ -33,7 +33,7 @@ import type {
   TriggerInfo,
   VariableScope,
 } from "@checkstack/automation-common";
-import { resolveVariableScope } from "@checkstack/automation-common";
+import { deriveTriggerId, resolveVariableScope } from "@checkstack/automation-common";
 // Deep-import the standalone helper rather than going through the
 // `@checkstack/ui` barrel — the barrel pulls in MonacoEditor which
 // side-effect imports Vite-only `?worker` modules, which break bun's
@@ -103,19 +103,24 @@ export function generateAutomationContextTypes(
   });
 
   // ─── Trigger union ─────────────────────────────────────────────────────
-  const subscribed = definition.triggers
-    .map((t) => triggers.find((r) => r.qualifiedId === t.event))
-    .filter((r): r is TriggerInfo => r !== undefined);
-
+  // Each variant carries the trigger's `id` (explicit or derived) and `event`,
+  // both literal types, so a script can discriminate on either - including two
+  // triggers that share the same event but have distinct ids.
   const triggerUnion =
-    subscribed.length === 0
-      ? "{ readonly event: string; readonly payload: Record<string, unknown> }"
-      : subscribed
-          .map((trig) => {
-            const payloadType = jsonSchemaToTypeScript(
-              trig.payloadSchema as Parameters<typeof jsonSchemaToTypeScript>[0],
-            );
-            return `{ readonly event: ${JSON.stringify(trig.qualifiedId)}; readonly payload: ${payloadType} }`;
+    definition.triggers.length === 0
+      ? "{ readonly id: string; readonly event: string; readonly payload: Record<string, unknown> }"
+      : definition.triggers
+          .map((t) => {
+            const info = triggers.find((r) => r.qualifiedId === t.event);
+            const id = t.id ?? deriveTriggerId(t.event);
+            const payloadType = info
+              ? jsonSchemaToTypeScript(
+                  info.payloadSchema as Parameters<
+                    typeof jsonSchemaToTypeScript
+                  >[0],
+                )
+              : "Record<string, unknown>";
+            return `{ readonly id: ${JSON.stringify(id)}; readonly event: ${JSON.stringify(t.event)}; readonly payload: ${payloadType} }`;
           })
           .join("\n  | ");
 
@@ -184,8 +189,11 @@ export function generateAutomationContextTypes(
     " * scope at the action position being edited.",
     " */",
     "",
+    "/** Who or what caused the event (present on every trigger). */",
+    'type AutomationActor = { readonly type: "system" | "user" | "application" | "service"; readonly id: string; readonly name?: string };',
+    "",
     "/** Trigger that fired this run. */",
-    `type AutomationTrigger =\n  | ${triggerUnion};`,
+    `type AutomationTrigger = (\n  | ${triggerUnion}\n) & { readonly actor: AutomationActor };`,
     "",
     "declare const context: {",
     "  readonly trigger: AutomationTrigger;",

--- a/core/backend-api/src/actor.test.ts
+++ b/core/backend-api/src/actor.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { SYSTEM_ACTOR } from "@checkstack/common";
+import { resolveActor } from "./actor";
+
+describe("resolveActor", () => {
+  it("falls back to the system actor when there is no caller", () => {
+    expect(resolveActor(undefined)).toEqual(SYSTEM_ACTOR);
+  });
+
+  it("maps a real (human) user", () => {
+    expect(
+      resolveActor({ type: "user", id: "user-1", name: "Nico" }),
+    ).toEqual({ type: "user", id: "user-1", name: "Nico" });
+  });
+
+  it("maps an application (API client)", () => {
+    expect(
+      resolveActor({ type: "application", id: "app-deploybot", name: "Deploy Bot" }),
+    ).toEqual({ type: "application", id: "app-deploybot", name: "Deploy Bot" });
+  });
+
+  it("maps a service to its originating plugin id", () => {
+    expect(resolveActor({ type: "service", pluginId: "healthcheck" })).toEqual({
+      type: "service",
+      id: "healthcheck",
+      name: "healthcheck",
+    });
+  });
+});

--- a/core/backend-api/src/actor.ts
+++ b/core/backend-api/src/actor.ts
@@ -1,0 +1,27 @@
+import { SYSTEM_ACTOR, type Actor } from "@checkstack/common";
+import type { AuthUser } from "./types";
+
+/**
+ * Resolve the canonical platform {@link Actor} for an event from the
+ * authenticated caller. Background / unauthenticated emits (no `user`)
+ * resolve to the system actor, so every emitted event carries an actor.
+ *
+ * - {@link RealUser}        -> `{ type: "user" }`
+ * - {@link ApplicationUser} -> `{ type: "application" }`
+ * - {@link ServiceUser}     -> `{ type: "service", id: pluginId }`
+ * - `undefined`             -> {@link SYSTEM_ACTOR}
+ */
+export function resolveActor(user?: AuthUser): Actor {
+  if (!user) return SYSTEM_ACTOR;
+  switch (user.type) {
+    case "user": {
+      return { type: "user", id: user.id, name: user.name };
+    }
+    case "application": {
+      return { type: "application", id: user.id, name: user.name };
+    }
+    case "service": {
+      return { type: "service", id: user.pluginId, name: user.pluginId };
+    }
+  }
+}

--- a/core/backend-api/src/event-bus-types.ts
+++ b/core/backend-api/src/event-bus-types.ts
@@ -1,4 +1,9 @@
-import type { Hook, HookSubscribeOptions, HookUnsubscribe } from "./hooks";
+import type {
+  Hook,
+  HookEventMeta,
+  HookSubscribeOptions,
+  HookUnsubscribe,
+} from "./hooks";
 
 /**
  * EventBus interface for dependency injection
@@ -7,22 +12,26 @@ export interface EventBus {
   subscribe<T>(
     pluginId: string,
     hook: Hook<T>,
-    listener: (payload: T) => Promise<void>,
+    listener: (payload: T, meta?: HookEventMeta) => Promise<void>,
     options?: HookSubscribeOptions
   ): Promise<HookUnsubscribe>;
 
   /**
    * Emit a hook through the distributed queue system.
    * All instances receive broadcast hooks; one instance handles work-queue hooks.
+   *
+   * `meta` carries event-envelope metadata (the acting `actor`). When omitted,
+   * the bus defaults to the system actor, so every emitted hook carries an
+   * actor even when emitted from a background/unauthenticated context.
    */
-  emit<T>(hook: Hook<T>, payload: T): Promise<void>;
+  emit<T>(hook: Hook<T>, payload: T, meta?: HookEventMeta): Promise<void>;
 
   /**
    * Emit a hook locally only (not distributed).
    * Use for instance-local hooks that should only run on THIS instance.
    * Uses Promise.allSettled to ensure one listener error doesn't block others.
    */
-  emitLocal<T>(hook: Hook<T>, payload: T): Promise<void>;
+  emitLocal<T>(hook: Hook<T>, payload: T, meta?: HookEventMeta): Promise<void>;
 
   shutdown(): Promise<void>;
 }

--- a/core/backend-api/src/hooks.ts
+++ b/core/backend-api/src/hooks.ts
@@ -1,4 +1,4 @@
-import type { AccessRule } from "@checkstack/common";
+import type { AccessRule, Actor } from "@checkstack/common";
 
 /**
  * Hook definition for type-safe event emission and subscription
@@ -6,6 +6,19 @@ import type { AccessRule } from "@checkstack/common";
 export interface Hook<T = unknown> {
   id: string;
   _type?: T; // Phantom type for TypeScript inference
+}
+
+/**
+ * Envelope metadata that travels alongside every emitted hook payload,
+ * independent of the hook's typed payload. Injected centrally at emit time
+ * (from the request context, defaulting to the system actor) and delivered to
+ * subscribers as the optional second listener argument.
+ *
+ * The automation engine reads `actor` and exposes it to automations as
+ * `trigger.actor`, so a trigger filter can gate on who/what caused the event.
+ */
+export interface HookEventMeta {
+  actor: Actor;
 }
 
 /**

--- a/core/backend-api/src/index.ts
+++ b/core/backend-api/src/index.ts
@@ -17,6 +17,7 @@ export * from "./rpc";
 export * from "./test-utils";
 export * from "./hooks";
 export * from "./event-bus-types";
+export * from "./actor";
 export * from "./plugin-source";
 export * from "./plugin-artifact-store";
 export * from "./notification-strategy";

--- a/core/backend-api/src/plugin-system.ts
+++ b/core/backend-api/src/plugin-system.ts
@@ -2,7 +2,12 @@ import { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { ServiceRef } from "./service-ref";
 import { ExtensionPoint } from "./extension-point";
 import type { AccessRule, PluginMetadata } from "@checkstack/common";
-import type { Hook, HookSubscribeOptions, HookUnsubscribe } from "./hooks";
+import type {
+  Hook,
+  HookEventMeta,
+  HookSubscribeOptions,
+  HookUnsubscribe,
+} from "./hooks";
 import { Router } from "@orpc/server";
 import { RpcContext } from "./rpc";
 import { AnyContractRouter } from "@orpc/contract";
@@ -48,7 +53,7 @@ export type AfterPluginsReadyContext = {
    */
   onHook: <T>(
     hook: Hook<T>,
-    listener: (payload: T) => Promise<void>,
+    listener: (payload: T, meta?: HookEventMeta) => Promise<void>,
     options?: HookSubscribeOptions,
   ) => HookUnsubscribe;
   /**

--- a/core/backend/src/plugin-manager/api-router.ts
+++ b/core/backend/src/plugin-manager/api-router.ts
@@ -10,6 +10,7 @@ import {
   Fetch,
   HealthCheckRegistry,
   CollectorRegistry,
+  resolveActor,
   type EmitHookFn,
   type Hook,
 } from "@checkstack/backend-api";
@@ -126,7 +127,12 @@ async function resolveRequestContext({
   const user = await (auth as AuthService).authenticate(c.req.raw);
 
   const emitHook: EmitHookFn = async <T>(hook: Hook<T>, payload: T) => {
-    await (eventBus as EventBus).emit(hook, payload);
+    // Capture the authenticated caller as the event actor so automations can
+    // filter on who/what caused the event (falls back to the system actor for
+    // unauthenticated callers).
+    await (eventBus as EventBus).emit(hook, payload, {
+      actor: resolveActor(user),
+    });
   };
 
   const pluginMetadata: PluginMetadata | undefined =

--- a/core/backend/src/services/event-bus.test.ts
+++ b/core/backend/src/services/event-bus.test.ts
@@ -3,6 +3,7 @@ import { EventBus } from "./event-bus";
 import type { QueueManager } from "@checkstack/queue-api";
 import type { Logger, Hook } from "@checkstack/backend-api";
 import { createHook } from "@checkstack/backend-api";
+import { SYSTEM_ACTOR } from "@checkstack/common";
 import {
   createMockLogger,
   createMockQueueManager,
@@ -269,6 +270,63 @@ describe("EventBus", () => {
 
       expect(received).toContain(10);
       expect(received).toContain(20);
+    });
+  });
+
+  describe("Actor metadata", () => {
+    it("delivers the system actor by default when no meta is provided", async () => {
+      const testHook = createHook<{ value: number }>("test.actor.hook");
+      let receivedActor: unknown;
+
+      await eventBus.subscribe("plugin-1", testHook, async (_payload, meta) => {
+        receivedActor = meta?.actor;
+      });
+
+      await eventBus.emit(testHook, { value: 1 });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(receivedActor).toEqual(SYSTEM_ACTOR);
+    });
+
+    it("delivers the provided actor alongside the payload", async () => {
+      const testHook = createHook<{ value: number }>("test.actor.hook");
+      let received: { value: number } | undefined;
+      let receivedActor: unknown;
+
+      await eventBus.subscribe("plugin-1", testHook, async (payload, meta) => {
+        received = payload;
+        receivedActor = meta?.actor;
+      });
+
+      const actor = { type: "user", id: "user-1", name: "Nico" } as const;
+      await eventBus.emit(testHook, { value: 7 }, { actor });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(received).toEqual({ value: 7 });
+      expect(receivedActor).toEqual(actor);
+    });
+
+    it("delivers actor meta on instance-local emit", async () => {
+      const testHook = createHook<{ value: number }>("test.actor.local");
+      let receivedActor: unknown;
+
+      await eventBus.subscribe(
+        "plugin-1",
+        testHook,
+        async (_payload, meta) => {
+          receivedActor = meta?.actor;
+        },
+        { mode: "instance-local" },
+      );
+
+      const actor = {
+        type: "application",
+        id: "app-deploybot",
+        name: "Deploy Bot",
+      } as const;
+      await eventBus.emitLocal(testHook, { value: 1 }, { actor });
+
+      expect(receivedActor).toEqual(actor);
     });
   });
 

--- a/core/backend/src/services/event-bus.ts
+++ b/core/backend/src/services/event-bus.ts
@@ -1,13 +1,55 @@
 import type { Queue, QueueManager } from "@checkstack/queue-api";
 import type {
   Hook,
+  HookEventMeta,
   HookSubscribeOptions,
   HookUnsubscribe,
   Logger,
 } from "@checkstack/backend-api";
 import type { EventBus as IEventBus } from "@checkstack/backend-api";
+import { SYSTEM_ACTOR } from "@checkstack/common";
 
-export type HookListener<T> = (payload: T) => Promise<void>;
+export type HookListener<T> = (
+  payload: T,
+  meta?: HookEventMeta,
+) => Promise<void>;
+
+/**
+ * Internal queue envelope. Hooks are enqueued wrapped so event metadata (the
+ * acting `actor`) rides alongside the typed payload through the distributed
+ * queue. `invokeListener` unwraps it before calling listeners, so subscribers
+ * still receive the payload as their first argument (plus optional `meta`).
+ */
+const HOOK_ENVELOPE_MARKER = "__checkstackHookEnvelope" as const;
+
+interface HookEnvelope<T> {
+  [HOOK_ENVELOPE_MARKER]: 1;
+  payload: T;
+  meta: HookEventMeta;
+}
+
+function isHookEnvelope(data: unknown): data is HookEnvelope<unknown> {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    (data as Record<string, unknown>)[HOOK_ENVELOPE_MARKER] === 1
+  );
+}
+
+/**
+ * Unwrap queued hook data into `{ payload, meta }`. Data emitted before the
+ * envelope existed (or enqueued by other producers) is treated as a raw
+ * payload with the system actor, so delivery stays backward compatible.
+ */
+function unwrapHookData(data: unknown): {
+  payload: unknown;
+  meta: HookEventMeta;
+} {
+  if (isHookEnvelope(data)) {
+    return { payload: data.payload, meta: data.meta };
+  }
+  return { payload: data, meta: { actor: SYSTEM_ACTOR } };
+}
 
 interface ListenerRegistration {
   id: string;
@@ -201,7 +243,11 @@ export class EventBus implements IEventBus {
    * need cross-process delivery must therefore ensure at least one
    * listener registers on every replica that should receive the hook.
    */
-  async emit<T>(hook: Hook<T>, payload: T): Promise<void> {
+  async emit<T>(
+    hook: Hook<T>,
+    payload: T,
+    meta?: HookEventMeta,
+  ): Promise<void> {
     const hasDistributedListeners =
       (this.listeners.get(hook.id)?.length ?? 0) > 0;
     const hasLocalListeners =
@@ -218,11 +264,18 @@ export class EventBus implements IEventBus {
 
     // Create channel lazily if not exists
     if (!channel) {
-      channel = this.queueManager.getQueue<T>(hook.id);
+      channel = this.queueManager.getQueue<unknown>(hook.id);
       this.queueChannels.set(hook.id, channel);
     }
 
-    await channel.enqueue(payload);
+    // Enqueue the payload wrapped in an envelope so the acting actor (defaulting
+    // to the system actor for background/unauthenticated emits) travels with it.
+    const envelope: HookEnvelope<T> = {
+      [HOOK_ENVELOPE_MARKER]: 1,
+      payload,
+      meta: meta ?? { actor: SYSTEM_ACTOR },
+    };
+    await channel.enqueue(envelope);
     this.logger.debug(`Emitted hook: ${hook.id}`);
   }
 
@@ -231,7 +284,11 @@ export class EventBus implements IEventBus {
    * Use this for instance-local hooks like pluginDeregistering.
    * Uses Promise.allSettled to ensure one listener error doesn't block others.
    */
-  async emitLocal<T>(hook: Hook<T>, payload: T): Promise<void> {
+  async emitLocal<T>(
+    hook: Hook<T>,
+    payload: T,
+    meta?: HookEventMeta,
+  ): Promise<void> {
     const registrations = this.localListeners.get(hook.id) || [];
 
     if (registrations.length === 0) {
@@ -239,10 +296,13 @@ export class EventBus implements IEventBus {
       return;
     }
 
+    // Local hooks bypass the queue, so deliver `meta` straight to listeners
+    // (defaulting to the system actor when none was provided).
+    const resolvedMeta: HookEventMeta = meta ?? { actor: SYSTEM_ACTOR };
     const results = await Promise.allSettled(
       registrations.map(async (reg) => {
         try {
-          await reg.listener(payload);
+          await reg.listener(payload, resolvedMeta);
           this.logger.debug(
             `Local listener ${reg.id} (${reg.pluginId}) processed successfully`
           );
@@ -315,10 +375,11 @@ export class EventBus implements IEventBus {
    */
   private async invokeListener(
     registration: ListenerRegistration,
-    payload: unknown
+    data: unknown
   ): Promise<void> {
+    const { payload, meta } = unwrapHookData(data);
     try {
-      await registration.listener(payload);
+      await registration.listener(payload, meta);
       this.logger.debug(
         `Listener ${registration.id} (${registration.consumerGroup}) processed successfully`
       );

--- a/core/common/src/actor.ts
+++ b/core/common/src/actor.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+/**
+ * Who (or what) caused a platform event. Travels as event-envelope metadata
+ * on every emitted hook and is surfaced to automations as `trigger.actor`, so
+ * an automation can filter on the origin of the event it reacts to - e.g.
+ * "only incidents auto-created by the system" or "systems created by a
+ * specific application/API client".
+ *
+ * - `system`      - no authenticated caller (platform-internal / background /
+ *                   automatic events such as healthcheck or SLO triggers).
+ * - `user`        - a human user (session/token authenticated).
+ * - `application` - an external application authenticated via API key.
+ * - `service`     - a trusted backend-to-backend (plugin) call; `id` is the
+ *                   originating plugin id.
+ */
+export const ACTOR_TYPES = ["system", "user", "application", "service"] as const;
+
+export type ActorType = (typeof ACTOR_TYPES)[number];
+
+export const ActorSchema = z.object({
+  type: z.enum(ACTOR_TYPES),
+  /**
+   * Stable identifier for the actor: the user id, application id, originating
+   * plugin id for services, or the literal `"system"`.
+   */
+  id: z.string(),
+  /** Human-readable display name when known (absent for system/service). */
+  name: z.string().optional(),
+});
+
+export type Actor = z.infer<typeof ActorSchema>;
+
+/** Canonical actor for platform-internal / unauthenticated events. */
+export const SYSTEM_ACTOR: Actor = {
+  type: "system",
+  id: "system",
+  name: "System",
+};

--- a/core/common/src/index.ts
+++ b/core/common/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./actor";
 export * from "./pagination";
 export * from "./routes";
 export * from "./plugin-metadata";

--- a/core/ui/src/hooks/useInitOnceForKey.test.ts
+++ b/core/ui/src/hooks/useInitOnceForKey.test.ts
@@ -124,4 +124,31 @@ describe("shouldInitForKey", () => {
       shouldInitForKey({ value: "any", key: "1", initialisedKey: 1 }),
     ).toBe(true);
   });
+
+  it("does not seed from a stale cache entry served on mount, only from a post-mount fetch", () => {
+    // Regression for the automation editor: another page observes the same
+    // `getAutomation` cache key without `gcTime: 0`, so a stale (pre-edit)
+    // entry can be served instantly on reopen. The call site gates `value` on
+    // `isFetchedAfterMount`, so until a fresh fetch lands it passes `undefined`
+    // and we must NOT seed the stale value (which would revert edits such as a
+    // renamed trigger id back to its auto-generated default).
+    const staleCacheBeforeFreshFetch = undefined; // isFetchedAfterMount === false
+    expect(
+      shouldInitForKey({
+        value: staleCacheBeforeFreshFetch,
+        key: "auto-1",
+        initialisedKey: undefined,
+      }),
+    ).toBe(false);
+
+    // Once the post-mount fetch resolves, the caller passes the fresh value and
+    // the one-shot init fires with server-truth data.
+    expect(
+      shouldInitForKey({
+        value: { name: "A", definition: { triggers: [{ id: "majors" }] } },
+        key: "auto-1",
+        initialisedKey: undefined,
+      }),
+    ).toBe(true);
+  });
 });

--- a/core/ui/src/hooks/useInitOnceForKey.ts
+++ b/core/ui/src/hooks/useInitOnceForKey.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useState } from "react";
 
 /**
  * Pure decision function powering {@link useInitOnceForKey}. Extracted so
@@ -52,8 +52,15 @@ export function shouldInitForKey({
  *  - Skips initialisation entirely while either `value` or `key` is
  *    `undefined`/`null`.
  *
- * `onInit` is read from a ref so callers can safely pass a fresh closure
- * each render without re-firing the effect.
+ * Seeding runs **during render** (not in a `useEffect`). This is deliberate:
+ * the app is wrapped in `<StrictMode>`, which double-mounts components and
+ * **discards a `setState` scheduled from an effect** when the source query
+ * resolves synchronously — e.g. a warm react-query cache on reopen. That made
+ * the one-shot init silently no-op, reverting seeded form state (a renamed id
+ * snapping back to its default, etc.) while a cold-cache first open worked.
+ * Seeding during render with a state guard is React's recommended
+ * "adjust state when data changes" pattern and is immune to that race. `onInit`
+ * must therefore be pure aside from calling this component's state setters.
  *
  * @example
  *   useInitOnceForKey(existingConfig, existingConfig?.id, (config) => {
@@ -68,20 +75,16 @@ export function useInitOnceForKey<T>(
   key: string | number | null | undefined,
   onInit: (value: T) => void,
 ): void {
-  const initialisedKeyRef = useRef<string | number | null | undefined>(undefined);
-  const onInitRef = useRef(onInit);
+  const [initialisedKey, setInitialisedKey] =
+    useState<string | number | null | undefined>();
 
-  // Keep the latest callback in a ref so a fresh closure each render doesn't
-  // re-trigger the effect; only `value` and `key` should drive it.
-  useEffect(() => {
-    onInitRef.current = onInit;
-  });
-
-  useEffect(() => {
-    if (!shouldInitForKey({ value, key, initialisedKey: initialisedKeyRef.current })) {
-      return;
-    }
-    initialisedKeyRef.current = key;
-    onInitRef.current(value as T);
-  }, [value, key]);
+  if (shouldInitForKey({ value, key, initialisedKey })) {
+    // Setting state + invoking `onInit` (which sets this component's state)
+    // during render is the supported "store info from previous renders"
+    // pattern: React restarts this component's render with the new state
+    // before committing, and the `initialisedKey` guard makes it idempotent
+    // (no loop; background refetches of the same key are ignored).
+    setInitialisedKey(key);
+    onInit(value as T);
+  }
 }

--- a/docs/src/content/docs/developer-guide/backend/plugins.md
+++ b/docs/src/content/docs/developer-guide/backend/plugins.md
@@ -359,6 +359,60 @@ afterPluginsReady: async ({ emitHook }) => {
 }
 ```
 
+### Event actor metadata
+
+Every emitted hook carries envelope metadata describing the **actor** that
+caused the event - a human `user`, an `application` (API client), a
+`service` (backend-to-backend call), or the `system` (background /
+unauthenticated). You do not set this yourself: the platform captures it
+automatically from the request context when a hook is emitted from an RPC
+handler, and defaults to the system actor for background emits.
+
+Listeners receive it as an optional second argument:
+
+```typescript
+onHook(incidentHooks.incidentCreated, async (payload, meta) => {
+  // meta?.actor -> { type: "user" | "application" | "service" | "system"; id; name? }
+  logger.info(`Incident ${payload.incidentId} created by ${meta?.actor.type}`);
+});
+```
+
+The actor is surfaced to automations as `trigger.actor`, so a trigger filter
+can gate on it - for example, only react to incidents that were
+auto-created by the system:
+
+```text
+{{ trigger.actor.type == "system" }}
+{{ trigger.actor.type == "user" }}
+{{ trigger.actor.id == "app-deploybot" }}
+```
+
+> [!NOTE]
+> `trigger.actor` is available on **every** trigger (it is injected by the
+> platform, not declared per trigger). Purely automatic events - cron,
+> healthcheck, SLO, etc. - report `trigger.actor.type == "system"`.
+
+### Differentiating triggers (`trigger.id`)
+
+When an automation subscribes to several triggers, the run scope exposes the
+**id of the trigger that fired** as `trigger.id` (and `context.trigger.id` in
+scripts). The editor auto-assigns a unique id to every trigger (derived from
+its event, e.g. `incident_created`), so two triggers on the *same* event are
+still distinguishable:
+
+```text
+{{ trigger.id == "majors" }}          # template / filter
+```
+
+```typescript
+// inline-script action — `id` and `event` are both literal-typed, so either
+// can discriminate the union:
+if (context.trigger.id === "majors") { /* … */ }
+```
+
+The full trigger contract available to templates and scripts is
+`trigger.id`, `trigger.event`, `trigger.actor`, and `trigger.payload`.
+
 ### Core Hooks Reference
 
 | Hook | Payload | Description |

--- a/plugins/integration-script-backend/src/automations.test.ts
+++ b/plugins/integration-script-backend/src/automations.test.ts
@@ -20,6 +20,7 @@ import type {
   ShellScriptRunResult,
 } from "@checkstack/backend-api";
 import { createMockLogger } from "@checkstack/test-utils-backend";
+import { SYSTEM_ACTOR } from "@checkstack/common";
 
 import {
   createScriptRunAction,
@@ -38,7 +39,12 @@ const ctxBase = {
   contextKey: null,
   logger,
   scope: {
-    trigger: { event: "incident.created", payload: {} },
+    trigger: {
+      id: "incident_created",
+      event: "incident.created",
+      actor: SYSTEM_ACTOR,
+      payload: {},
+    },
     artifacts: {},
     vars: {},
   },
@@ -153,7 +159,12 @@ describe("integration-script.run_shell", () => {
       ...ctxBase,
       consumedArtifacts: {},
       scope: {
-        trigger: { event: "incident.created", payload: { title: "Outage" } },
+        trigger: {
+          id: "incident_created",
+          event: "incident.created",
+          actor: SYSTEM_ACTOR,
+          payload: { title: "Outage" },
+        },
         artifacts: {},
         vars: {},
       },
@@ -377,7 +388,12 @@ describe("integration-script.run_script", () => {
       ...ctxBase,
       consumedArtifacts: {},
       scope: {
-        trigger: { event: "incident.created", payload: { title: "Outage" } },
+        trigger: {
+          id: "incident_created",
+          event: "incident.created",
+          actor: SYSTEM_ACTOR,
+          payload: { title: "Outage" },
+        },
         artifacts: { "jira.issue": { key: "OPS-1" } },
         vars: { region: "eu" },
       },

--- a/plugins/integration-script-backend/src/automations.ts
+++ b/plugins/integration-script-backend/src/automations.ts
@@ -34,7 +34,7 @@ import type {
   ActionDefinition,
   ActionRunScope,
 } from "@checkstack/automation-backend";
-import { extractErrorMessage } from "@checkstack/common";
+import { extractErrorMessage, SYSTEM_ACTOR } from "@checkstack/common";
 import { flattenScopeToShellEnv } from "./script-env";
 
 /**
@@ -43,7 +43,7 @@ import { flattenScopeToShellEnv } from "./script-env";
  * scope.
  */
 const EMPTY_SCOPE: ActionRunScope = {
-  trigger: { event: "", payload: {} },
+  trigger: { id: "", event: "", actor: SYSTEM_ACTOR, payload: {} },
   artifacts: {},
   vars: {},
 };

--- a/plugins/integration-script-backend/src/script-env.test.ts
+++ b/plugins/integration-script-backend/src/script-env.test.ts
@@ -1,13 +1,25 @@
 import { describe, expect, it } from "bun:test";
 import type { ActionRunScope } from "@checkstack/automation-backend";
+import { SYSTEM_ACTOR } from "@checkstack/common";
 import { flattenScopeToShellEnv } from "./script-env";
 
-function scope(overrides: Partial<ActionRunScope> = {}): ActionRunScope {
+function scope(overrides: {
+  trigger?: Partial<ActionRunScope["trigger"]>;
+  artifacts?: ActionRunScope["artifacts"];
+  vars?: ActionRunScope["vars"];
+  repeat?: ActionRunScope["repeat"];
+} = {}): ActionRunScope {
   return {
-    trigger: { event: "incident.created", payload: {} },
-    artifacts: {},
-    vars: {},
-    ...overrides,
+    trigger: {
+      id: "incident_created",
+      event: "incident.created",
+      actor: SYSTEM_ACTOR,
+      payload: {},
+      ...overrides.trigger,
+    },
+    artifacts: overrides.artifacts ?? {},
+    vars: overrides.vars ?? {},
+    ...(overrides.repeat ? { repeat: overrides.repeat } : {}),
   };
 }
 


### PR DESCRIPTION
Introduces the **Automation Platform** (triggers → conditions → actions), migrating off the legacy webhook-subscription model, plus the editor and a Monaco→Typefox migration. Large branch; grouped below.

## Platform
- Dispatch engine: durable runs, concurrency modes (single/parallel/queued/restart), `wait_for_trigger` resume, delays, repeat/choose/parallel/sequence, artifact store.
- RPC contract + router (`@checkstack/automation-{common,backend}`), run history, manual run, deep + live definition validation.
- One-time migration from legacy `webhook_subscriptions`.

## Triggers & actions (per domain)
- Triggers/actions for incident, maintenance, catalog, dependency, healthcheck, SLO, satellite, notification; integration actions for Jira / Teams / Webex; shell + TypeScript script actions with typed `context`.

## Editor (visual + YAML)
- Visual editor with drag-reorder, YAML mirror, inline validation markers.
- HA-style "Add action" picker (Actions/Blocks tabs); connection picker + cascading dropdowns for integration actions; restored Integrations menu/landing page.
- Action-card polish; explicit + auto-generated action ids; auto-generated trigger ids.
- `{{ }}` template autocomplete + Run Script IntelliSense (typed trigger/artifact/var scope).

## Contracts
- Artifacts referenced by action id.
- `trigger.actor` (system/user/application/service) on every trigger, injected centrally at hook-emit time — filter on who/what caused an event.
- `trigger.id` queryable in templates/scripts (literal-union typed) to distinguish same-event triggers.

## Editor migration
- `CodeEditor` swapped from `monaco-editor` to `@typefox/monaco-editor-react`; legacy Monaco wiring removed.

## Notable fixes
- Form state reverting to defaults when reopening an editor with a warm query cache — `useInitOnceForKey` now seeds during render (StrictMode-safe) instead of in an effect (fixes automation + healthcheck editors).
- Template artifact-ref resolution, connection-store init ordering, save/name validation.

Changesets included per area (beta: minor bumps).