### PR TITLE
fix(backend): dedicated connection pool for advisory locks to prevent pool-starvation deadlock

### DIFF
--- a/.changeset/fix-advisory-lock-pool-deadlock.md
+++ b/.changeset/fix-advisory-lock-pool-deadlock.md
@@ -1,0 +1,52 @@
+---
+"@checkstack/backend": minor
+"@checkstack/backend-api": minor
+"@checkstack/incident-backend": minor
+"@checkstack/healthcheck-backend": minor
+"@checkstack/automation-backend": minor
+---
+
+fix(backend): give advisory locks a dedicated connection pool to prevent pool-starvation deadlock
+
+Both the session-lock service and `withXactLock` HOLD a Postgres connection for
+the lock's whole lifetime while the gated work runs on a *different* connection.
+Both lock and work were drawing from the single shared `adminPool` (which, with
+no explicit config, defaulted to `max: 10` and `connectionTimeoutMillis: 0` -
+wait forever). Under concurrency >= pool size, every slot became a lock-holding
+connection waiting for a work connection that could never free up: a permanent
+deadlock. It surfaced as all connections stuck `idle in transaction` on
+`pg_advisory_xact_lock` and every API request hanging into an upstream 502,
+only after the server had been running long enough to hit that concurrency
+(e.g. a burst of health-check evaluations or incident dedups).
+
+Advisory locks now run on a dedicated `lockPool`, separate from `adminPool`, so
+the acquire graph is acyclic (`lockPool -> adminPool`, never back) and the
+deadlock class is impossible. `AdvisoryLockService` gains a pooled
+`withXactLock({ key, fn })` method (lock on the lock pool, work on the admin
+pool); healthcheck's per-system serializer, incident's dedup-create, and the
+automation single-mode concurrency lock now use it. The deadlock-prone
+standalone `withXactLock({ db, ... })` helper is REMOVED.
+
+Both pools are explicitly configured with `connectionTimeoutMillis` so any
+future exhaustion fails fast and self-heals instead of hanging, and both get a
+pool-level `error` handler (an idle pooled client whose backend dies otherwise
+crashes the pod). The lock pool additionally sets
+`idle_in_transaction_session_timeout` and `lock_timeout` so a stalled critical
+section is reaped server-side (auto-releasing the lock) rather than stranding a
+key forever. The advisory-lock service also now removes its per-client error
+listener on release (it previously leaked one listener per acquisition on each
+reused pooled connection - an unbounded `MaxListenersExceeded` leak).
+
+New env vars (all optional): `DATABASE_POOL_MAX` (default 20),
+`DATABASE_LOCK_POOL_MAX` (default 10), `DATABASE_POOL_CONNECTION_TIMEOUT_MS`
+(default 10000), `DATABASE_POOL_IDLE_TIMEOUT_MS` (default 30000),
+`DATABASE_LOCK_IDLE_TX_TIMEOUT_MS` (default 30000), `DATABASE_LOCK_TIMEOUT_MS`
+(default 30000). Size pools off
+`N_pods * (DATABASE_POOL_MAX + DATABASE_LOCK_POOL_MAX) <= max_connections`.
+
+BREAKING CHANGE: the standalone `withXactLock({ db, key, fn })` export is
+removed - use `coreServices.advisoryLock.withXactLock({ key, fn })` instead.
+`IncidentService`'s constructor now requires an `AdvisoryLockService` as its
+second argument, and the healthcheck `createHealthEntitySerializer` /
+`executeHealthCheckJob` / `setupHealthCheckWorker` helpers take `advisoryLock`
+instead of `db` for the serializer.

--- a/core/automation-backend/src/dispatch/run-state-masking.test.ts
+++ b/core/automation-backend/src/dispatch/run-state-masking.test.ts
@@ -294,6 +294,9 @@ describe("L2 cross-pod masking — resume on a fresh pod re-seeds the mask set",
     // The scope-snapshot choke point (run-state) is masked too.
     const noopAdvisoryLock: AdvisoryLockService = {
       tryAcquire: async () => ({ release: async () => {} }),
+      withXactLock<T>({ fn }: { key: string; fn: () => Promise<T> }): Promise<T> {
+        return fn();
+      },
     };
     const stateCaptured: Captured = { inserts: [], updates: [] };
     const stateStore = createRunStateStore(

--- a/core/automation-backend/src/dispatch/scope-artifact-masking.test.ts
+++ b/core/automation-backend/src/dispatch/scope-artifact-masking.test.ts
@@ -45,6 +45,9 @@ function capturingDb(captured: Captured) {
 
 const noopAdvisoryLock: AdvisoryLockService = {
   tryAcquire: async () => ({ release: async () => {} }),
+  withXactLock<T>({ fn }: { key: string; fn: () => Promise<T> }): Promise<T> {
+    return fn();
+  },
 };
 
 describe("H2 — scope snapshot masking (run-state choke point)", () => {

--- a/core/automation-backend/src/index.ts
+++ b/core/automation-backend/src/index.ts
@@ -1,7 +1,6 @@
 import {
   createBackendPlugin,
   coreServices,
-  withXactLock,
   type SafeDatabase,
 } from "@checkstack/backend-api";
 import {
@@ -431,9 +430,10 @@ export default createBackendPlugin({
           // Serialize the concurrency-mode check-then-create with a
           // transaction-scoped advisory lock (blocks until granted,
           // auto-releases at COMMIT) so racing fires can't double-run a
-          // single-mode automation.
+          // single-mode automation. Runs on the dedicated lock pool (lock held
+          // there, work on the admin pool) so it can't starve the admin pool.
           withConcurrencyLock: <T>(key: string, fn: () => Promise<T>) =>
-            withXactLock({ db: database, key, fn: () => fn() }),
+            advisoryLock.withXactLock({ key, fn }),
         };
 
         const stash = env as unknown as EnvStash;

--- a/core/backend-api/src/advisory-lock-pool.it.test.ts
+++ b/core/backend-api/src/advisory-lock-pool.it.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Integration test (real Postgres) for the advisory-lock CONNECTION-POOL
+ * contract — the behaviour that silently wedged production and that fakes
+ * cannot model: a held advisory lock keeps its connection checked out while the
+ * gated work runs on a *different* connection, so lock-pool / work-pool sizing
+ * decides whether the system makes progress or deadlocks.
+ *
+ * It pins three things against a live server:
+ *
+ *   1. REPRODUCE THE BUG: when the lock and its work share ONE pool, concurrency
+ *      at the pool size deadlocks (every slot is a lock-holder waiting for a
+ *      work connection that can never free up). This is a guard — if a refactor
+ *      makes this stop deadlocking, the throughput test below is no longer
+ *      proving anything.
+ *   2. THE FIX: with the lock on a DEDICATED pool, the same (and much higher)
+ *      concurrency completes with zero failures.
+ *   3. CORRECTNESS ACROSS INSTANCES: independent service instances with their
+ *      OWN pools (simulating N pods on one database) serialize a find-then-
+ *      create on a shared key down to exactly ONE row — with a no-lock control
+ *      proving the lock is what enforces it.
+ *
+ * Gated behind `CHECKSTACK_IT=1`; the integration CI job provides the Postgres
+ * service container. Connection from `CHECKSTACK_IT_PG_URL`.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { createAdvisoryLockService } from "./advisory-lock";
+
+const PG_URL =
+  process.env.CHECKSTACK_IT_PG_URL ??
+  "postgres://postgres:postgres@localhost:5432/postgres";
+
+const DEDUP_TABLE = "it_advisory_dedup";
+
+describe.skipIf(!process.env.CHECKSTACK_IT)(
+  "advisory-lock pool contract (real Postgres)",
+  () => {
+    /** Pools created during a test; ended in afterEach-style cleanup helpers. */
+    const tracked: Pool[] = [];
+    function makePool(max: number, connectionTimeoutMillis = 5000): Pool {
+      const pool = new Pool({
+        connectionString: PG_URL,
+        max,
+        connectionTimeoutMillis,
+        idleTimeoutMillis: 1000,
+      });
+      // A held-lock client can error asynchronously (timeout / termination);
+      // swallow so it never surfaces as an unhandled error and fails the file.
+      pool.on("error", () => {});
+      tracked.push(pool);
+      return pool;
+    }
+    async function endTrackedPools(): Promise<void> {
+      await Promise.all(tracked.splice(0).map((p) => p.end().catch(() => {})));
+    }
+
+    let setupPool: Pool;
+    beforeAll(async () => {
+      setupPool = new Pool({ connectionString: PG_URL });
+      await setupPool.query(
+        `CREATE TABLE IF NOT EXISTS ${DEDUP_TABLE} (lock_key text NOT NULL, id text NOT NULL)`,
+      );
+    });
+    afterAll(async () => {
+      await setupPool.query(`DROP TABLE IF EXISTS ${DEDUP_TABLE}`);
+      await setupPool.end();
+      await endTrackedPools();
+    });
+
+    /**
+     * Find-then-create on `workPool`: insert exactly once per key. The 15ms gap
+     * between the read and the write widens the race window so an UNSERIALIZED
+     * run reliably double-inserts — making the lock's effect observable.
+     */
+    async function dedupCreate(workPool: Pool, key: string): Promise<boolean> {
+      const client = await workPool.connect();
+      try {
+        const { rows } = await client.query(
+          `SELECT id FROM ${DEDUP_TABLE} WHERE lock_key = $1 LIMIT 1`,
+          [key],
+        );
+        if (rows.length > 0) return false;
+        await new Promise((r) => setTimeout(r, 15));
+        await client.query(
+          `INSERT INTO ${DEDUP_TABLE} (lock_key, id) VALUES ($1, $2)`,
+          [key, crypto.randomUUID()],
+        );
+        return true;
+      } finally {
+        client.release();
+      }
+    }
+
+    async function countFor(key: string): Promise<number> {
+      const { rows } = await setupPool.query<{ n: string }>(
+        `SELECT count(*)::text AS n FROM ${DEDUP_TABLE} WHERE lock_key = $1`,
+        [key],
+      );
+      return Number(rows[0]?.n ?? "0");
+    }
+
+    it(
+      "REPRODUCES the deadlock when lock + work share one pool (the bug)",
+      async () => {
+        const POOL_MAX = 4;
+        // Single shared pool — the pre-fix wiring. The lock client AND the work
+        // client both come from here. Short connect timeout so the deadlock
+        // surfaces as a fast rejection rather than a long hang.
+        const pool = makePool(POOL_MAX, 1500);
+        const svc = createAdvisoryLockService(pool);
+        const runId = crypto.randomUUID();
+
+        // Exactly POOL_MAX concurrent ops, each on a DISTINCT key (so there is
+        // NO lock contention — the only thing that can stall is connection
+        // accounting). Each holds a lock client, then asks the same pool for a
+        // work client that will never come.
+        const results = await Promise.allSettled(
+          Array.from({ length: POOL_MAX }, (_, i) =>
+            svc.withXactLock({
+              key: `deadlock:${runId}:${i}`,
+              fn: async () => {
+                const c = await pool.connect();
+                try {
+                  await c.query("SELECT 1");
+                } finally {
+                  c.release();
+                }
+              },
+            }),
+          ),
+        );
+
+        const rejected = results.filter((r) => r.status === "rejected").length;
+        // The deadlock manifests as connection-acquire timeouts on the work
+        // checkout. If this ever becomes 0, the single-pool design no longer
+        // deadlocks and the throughput proof below must be re-examined.
+        expect(rejected).toBeGreaterThan(0);
+
+        await endTrackedPools();
+      },
+      30_000,
+    );
+
+    it(
+      "does NOT deadlock under high throughput with a dedicated lock pool (the fix)",
+      async () => {
+        // Deliberately TINY pools so any deadlock would be hit immediately; the
+        // fix is that lock and work draw from different pools.
+        const lockPool = makePool(4);
+        const workPool = makePool(4);
+        const svc = createAdvisoryLockService(lockPool);
+        const runId = crypto.randomUUID();
+
+        const CONCURRENCY = 200;
+        const results = await Promise.allSettled(
+          Array.from({ length: CONCURRENCY }, (_, i) =>
+            svc.withXactLock({
+              key: `throughput:${runId}:${i}`,
+              fn: async () => {
+                const c = await workPool.connect();
+                try {
+                  await c.query("SELECT 1");
+                } finally {
+                  c.release();
+                }
+              },
+            }),
+          ),
+        );
+
+        const rejected = results.filter((r) => r.status === "rejected");
+        // Every single operation must complete: no deadlock, no timeout.
+        expect(rejected).toHaveLength(0);
+
+        await endTrackedPools();
+      },
+      30_000,
+    );
+
+    it(
+      "serializes find-then-create across INSTANCES to exactly one row",
+      async () => {
+        // Each "pod" is an independent service instance with its OWN pools, all
+        // pointing at the same database — the real multi-instance topology. The
+        // advisory lock space is global to the server, so they must serialize.
+        const PODS = 6;
+        const ATTEMPTS_PER_POD = 5;
+        const key = `dedupe:${crypto.randomUUID()}`;
+
+        const pods = Array.from({ length: PODS }, () => {
+          const workPool = makePool(2);
+          const svc = createAdvisoryLockService(makePool(2));
+          return { workPool, svc };
+        });
+
+        const attempts = pods.flatMap((pod) =>
+          Array.from({ length: ATTEMPTS_PER_POD }, () =>
+            pod.svc.withXactLock({
+              key,
+              fn: () => dedupCreate(pod.workPool, key),
+            }),
+          ),
+        );
+
+        const settled = await Promise.allSettled(attempts);
+        const created = settled.filter(
+          (r) => r.status === "fulfilled" && r.value === true,
+        ).length;
+
+        // Exactly one attempt created the row; the rest observed it and no-oped.
+        expect(await countFor(key)).toBe(1);
+        expect(created).toBe(1);
+
+        await endTrackedPools();
+      },
+      30_000,
+    );
+
+    it(
+      "a STALLED critical section is reaped by idle_in_transaction_session_timeout, freeing the key",
+      async () => {
+        // The lock pool sets a short idle-in-transaction timeout. A held lock
+        // sits "idle in transaction" for the whole time `fn` runs, so a hung
+        // `fn` trips it: Postgres aborts the session, auto-releasing the lock -
+        // proving a stall self-heals instead of stranding the key forever.
+        const lockPool = new Pool({
+          connectionString: PG_URL,
+          max: 4,
+          connectionTimeoutMillis: 5000,
+          idle_in_transaction_session_timeout: 1000,
+        });
+        lockPool.on("error", () => {});
+        tracked.push(lockPool);
+        const svc = createAdvisoryLockService(lockPool);
+        const key = `stall:${crypto.randomUUID()}`;
+
+        let releaseHang!: () => void;
+        const hang = new Promise<void>((r) => (releaseHang = r));
+
+        // Holder whose critical section hangs (never issues another query).
+        const stalled = svc
+          .withXactLock({ key, fn: () => hang })
+          .catch(() => "rejected-as-expected");
+
+        // Wait past the 1s idle timeout so the server reaps the stalled holder.
+        await new Promise((r) => setTimeout(r, 1800));
+
+        // The key must be acquirable again now that the stalled session was
+        // aborted server-side.
+        const t0 = Date.now();
+        const got = await svc.withXactLock({ key, fn: async () => "ok" });
+        expect(got).toBe("ok");
+        expect(Date.now() - t0).toBeLessThan(3000);
+
+        releaseHang();
+        await stalled; // let the stalled call unwind (COMMIT fails on dead conn)
+        await endTrackedPools();
+      },
+      30_000,
+    );
+
+    it(
+      "CONTROL: the same workload WITHOUT the lock races into duplicates",
+      async () => {
+        // Proves the lock — not some incidental ordering — is what enforces
+        // single-creation above. Same widened-window find-then-create, run
+        // concurrently with NO advisory lock, must double-insert.
+        const workPool = makePool(8);
+        const key = `dedupe-nolock:${crypto.randomUUID()}`;
+
+        await Promise.all(
+          Array.from({ length: 8 }, () => dedupCreate(workPool, key)),
+        );
+
+        expect(await countFor(key)).toBeGreaterThan(1);
+
+        await endTrackedPools();
+      },
+      30_000,
+    );
+  },
+);

--- a/core/backend-api/src/advisory-lock.test.ts
+++ b/core/backend-api/src/advisory-lock.test.ts
@@ -7,8 +7,9 @@ import {
 
 /**
  * Faithful fake of a `pg.Pool` that models Postgres' per-connection
- * SESSION advisory-lock semantics:
+ * advisory-lock semantics for BOTH lock flavours:
  *
+ * SESSION locks (`tryAcquire`):
  *   - A key can be held by at most one connection at a time.
  *   - `pg_try_advisory_lock` succeeds only if the key is free; it then
  *     binds the key to the acquiring connection.
@@ -16,8 +17,15 @@ import {
  *     (a no-op otherwise) — exactly the bug we are guarding against: an
  *     unlock issued on a different connection does nothing.
  *
- * This lets the test prove the service keeps acquire + release on ONE
- * client.
+ * TRANSACTION locks (`withXactLock`):
+ *   - `pg_advisory_xact_lock` BLOCKS until the key is free, then binds it to
+ *     the acquiring connection's transaction.
+ *   - `COMMIT` / `ROLLBACK` release every xact lock held by that connection
+ *     and wake the next blocked waiter (FIFO) — modelling auto-release and
+ *     the serialization guarantee.
+ *
+ * This lets the tests prove the service keeps acquire + release on ONE
+ * client and that concurrent `withXactLock` callers serialize.
  */
 interface FakePool extends AdvisoryLockPool {
   checkedOut: number;
@@ -27,6 +35,9 @@ interface FakePool extends AdvisoryLockPool {
 function makeFakePool(): FakePool {
   // key -> owning connection id (or absent if free)
   const heldBy = new Map<string, number>();
+  // xact key -> owning connection id; waiters queued FIFO per key.
+  const xactHeldBy = new Map<string, number>();
+  const xactWaiters = new Map<string, Array<() => void>>();
   let nextConnId = 0;
   const counters = { checkedOut: 0, released: 0 };
 
@@ -46,14 +57,43 @@ function makeFakePool(): FakePool {
     async connect(): Promise<AdvisoryLockPoolClient> {
       const connId = nextConnId++;
       counters.checkedOut++;
+      const releaseXactLocks = () => {
+        for (const [key, owner] of [...xactHeldBy.entries()]) {
+          if (owner !== connId) continue;
+          xactHeldBy.delete(key);
+          const next = xactWaiters.get(key)?.shift();
+          if (next) next();
+        }
+      };
       return {
         async query<T>(queryText: string, values?: unknown[]) {
+          if (queryText === "BEGIN") return { rows: [] };
+          if (queryText === "COMMIT" || queryText === "ROLLBACK") {
+            releaseXactLocks();
+            return { rows: [] };
+          }
           const key = keyOf(values);
           if (queryText.includes("pg_try_advisory_lock")) {
             const owner = heldBy.get(key);
             const ok = owner === undefined;
             if (ok) heldBy.set(key, connId);
             return { rows: [{ ok } as unknown as T] };
+          }
+          if (queryText.includes("pg_advisory_xact_lock")) {
+            if (!xactHeldBy.has(key)) {
+              xactHeldBy.set(key, connId);
+              return { rows: [] };
+            }
+            // Blocked: enqueue and wait until a holder commits/rolls back.
+            await new Promise<void>((resolve) => {
+              const q = xactWaiters.get(key) ?? [];
+              q.push(() => {
+                xactHeldBy.set(key, connId);
+                resolve();
+              });
+              xactWaiters.set(key, q);
+            });
+            return { rows: [] };
           }
           if (queryText.includes("pg_advisory_unlock")) {
             // Only the owning connection can release — model the leak bug.
@@ -69,6 +109,10 @@ function makeFakePool(): FakePool {
           // The fake never emits async client errors; the real client's
           // `on('error')` hardening is exercised by the IT against real
           // Postgres (killing the holding connection).
+        },
+        off() {
+          // Counterpart to `on`; the service detaches its error listener on
+          // release. No-op here since the fake never attaches one.
         },
       };
     },
@@ -128,5 +172,102 @@ describe("createAdvisoryLockService", () => {
     expect(b).not.toBeNull();
     await a!.release();
     await b!.release();
+  });
+});
+
+describe("createAdvisoryLockService.withXactLock", () => {
+  const tick = (ms = 5) => new Promise((r) => setTimeout(r, ms));
+
+  it("runs fn, returns its value, and releases the client", async () => {
+    const pool = makeFakePool();
+    const svc = createAdvisoryLockService(pool);
+    const result = await svc.withXactLock({ key: "k", fn: async () => 42 });
+    expect(result).toBe(42);
+    expect(pool.checkedOut).toBe(1);
+    expect(pool.released).toBe(1);
+  });
+
+  it("serializes concurrent calls on the same key (second fn waits for first to commit)", async () => {
+    const pool = makeFakePool();
+    const svc = createAdvisoryLockService(pool);
+    const order: string[] = [];
+
+    let releaseFirst!: () => void;
+    const firstHeld = new Promise<void>((r) => (releaseFirst = r));
+
+    const p1 = svc.withXactLock({
+      key: "k",
+      fn: async () => {
+        order.push("1-start");
+        await firstHeld;
+        order.push("1-end");
+      },
+    });
+
+    // Let p1 acquire the lock before p2 attempts it.
+    await tick();
+    const p2 = svc.withXactLock({
+      key: "k",
+      fn: async () => {
+        order.push("2-start");
+      },
+    });
+
+    // While p1 holds the lock, p2's fn must NOT have started.
+    await tick();
+    expect(order).toEqual(["1-start"]);
+
+    releaseFirst();
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(["1-start", "1-end", "2-start"]);
+    expect(pool.released).toBe(2);
+  });
+
+  it("rolls back and releases the client when fn throws, freeing the lock", async () => {
+    const pool = makeFakePool();
+    const svc = createAdvisoryLockService(pool);
+
+    await expect(
+      svc.withXactLock({
+        key: "k",
+        fn: async () => {
+          throw new Error("boom");
+        },
+      }),
+    ).rejects.toThrow("boom");
+
+    // Lock was released on rollback: a subsequent acquire succeeds promptly.
+    const after = await svc.withXactLock({ key: "k", fn: async () => "ok" });
+    expect(after).toBe("ok");
+    expect(pool.released).toBe(2);
+  });
+
+  it("different keys do not serialize", async () => {
+    const pool = makeFakePool();
+    const svc = createAdvisoryLockService(pool);
+    const started: string[] = [];
+
+    let release!: () => void;
+    const held = new Promise<void>((r) => (release = r));
+
+    const pA = svc.withXactLock({
+      key: "a",
+      fn: async () => {
+        started.push("a");
+        await held;
+      },
+    });
+    await tick();
+    // Key "b" must run even while "a" is still held.
+    await svc.withXactLock({
+      key: "b",
+      fn: async () => {
+        started.push("b");
+      },
+    });
+    expect(started).toContain("b");
+
+    release();
+    await pA;
   });
 });

--- a/core/backend-api/src/advisory-lock.ts
+++ b/core/backend-api/src/advisory-lock.ts
@@ -18,19 +18,25 @@
  *     (e.g. an installer election held across a minutes-long `bun install`)
  *     where a long-open transaction would be unacceptable.
  *
- *   - {@link withXactLock} wraps acquire + work + release in a single
- *     transaction using `pg_advisory_xact_lock`, which auto-releases at
- *     COMMIT/ROLLBACK. Use this for SHORT critical sections (e.g. a
- *     find-then-create dedup) where holding a transaction for the duration
- *     is fine and the auto-release removes any chance of a leak.
+ *   - {@link AdvisoryLockService.withXactLock} wraps acquire + work + release
+ *     in a single transaction using `pg_advisory_xact_lock`, which auto-
+ *     releases at COMMIT/ROLLBACK. Use this for SHORT critical sections (e.g. a
+ *     find-then-create dedup) where holding a transaction for the duration is
+ *     fine and the auto-release removes any chance of a leak.
+ *
+ * BOTH run on the service's pool, which MUST be a pool dedicated to advisory
+ * locks (separate from the pool the locked work runs on). A held lock keeps its
+ * connection checked out for the lock's lifetime; if lock and work shared one
+ * pool, concurrency >= pool size would deadlock (every slot a lock-holder
+ * waiting for a work connection). The backend wires this to a dedicated
+ * `lockPool`; that pool also sets `idle_in_transaction_session_timeout` /
+ * `lock_timeout` so a stalled critical section cannot strand a lock forever.
  *
  * Keys are arbitrary strings hashed to Postgres' 64-bit lock space via
  * `hashtextextended(key, 0)`. Callers SHOULD namespace keys (e.g.
  * `"script-packages.installer"`, `"incident.dedupe:<systemId>"`) since the
  * advisory-lock space is global to the database server, not schema-scoped.
  */
-import { sql } from "drizzle-orm";
-import type { SafeDatabase } from "./plugin-system";
 
 /**
  * Minimal pool surface this module needs. Modelled on `pg.Pool` /
@@ -45,13 +51,22 @@ export interface AdvisoryLockPoolClient {
   /** Return the client to the pool. */
   release(): void;
   /**
-   * Subscribe to async client errors. A session-lock client is held for a long
-   * time; if its backend dies (admin termination, failover, network drop) `pg`
-   * emits `'error'` on the client, and an `'error'` with no listener is
-   * re-thrown by the EventEmitter and would crash the pod. We attach a listener
-   * so that loss degrades gracefully instead. Modelled on `pg.Client.on`.
+   * Subscribe to async client errors. A held client (session lock, or an open
+   * xact-lock transaction) is checked out for a while; if its backend dies
+   * (admin termination, failover, network drop) `pg` emits `'error'` on the
+   * client, and an `'error'` with no listener is re-thrown by the EventEmitter
+   * and would crash the pod. We attach a listener so that loss degrades
+   * gracefully instead. Modelled on `pg.Client.on`.
    */
   on(event: "error", listener: (err: Error) => void): void;
+  /**
+   * Detach a previously-attached error listener. MUST be called before
+   * returning the client to the pool: pooled clients are reused, so attaching a
+   * fresh listener on every checkout WITHOUT removing it on release leaks one
+   * listener per acquisition on each long-lived physical connection (an
+   * unbounded `MaxListenersExceeded` leak). Modelled on `pg.Client.off`.
+   */
+  off(event: "error", listener: (err: Error) => void): void;
 }
 
 export interface AdvisoryLockPool {
@@ -76,7 +91,29 @@ export interface AdvisoryLockService {
    * `finally`.
    */
   tryAcquire(key: string): Promise<AdvisoryLockHandle | null>;
+  /**
+   * Run `fn` while holding a transaction-scoped advisory lock for `key`,
+   * acquired with `pg_advisory_xact_lock` (which BLOCKS until granted) on a
+   * dedicated client from THIS service's pool, and auto-released when that
+   * transaction commits/rolls back after `fn` settles.
+   *
+   * The lock transaction runs on this service's (dedicated lock) pool, while
+   * `fn` does its real work on whatever database it already holds (typically
+   * the shared admin pool). Because the held lock connection and the work
+   * connection come from DIFFERENT pools, the nested acquisition can never
+   * deadlock the work pool. Use this for SHORT critical sections that gate a
+   * read-then-write on another connection.
+   */
+  withXactLock<T>(args: { key: string; fn: () => Promise<T> }): Promise<T>;
 }
+
+/**
+ * Shared no-op `'error'` listener for held clients. A single module-level
+ * reference (rather than a fresh closure per acquisition) is what lets `off`
+ * detach exactly the listener `on` attached, and avoids allocating one per
+ * lock. It captures nothing, so sharing it is safe.
+ */
+const swallowClientError = (): void => {};
 
 /**
  * Build an {@link AdvisoryLockService} backed by a pool. The backend
@@ -95,8 +132,13 @@ export function createAdvisoryLockService(
       // here; without a listener the process crashes. Swallow it - the session
       // lock is auto-released server-side when the backend dies, and a stale
       // `release()` is already a no-op-safe `finally`, so the loss surfaces as
-      // the key simply becoming acquirable again.
-      client.on("error", () => {});
+      // the key simply becoming acquirable again. The listener is removed on
+      // release so it does not accumulate on the reused pooled connection.
+      client.on("error", swallowClientError);
+      const releaseClient = () => {
+        client.off("error", swallowClientError);
+        client.release();
+      };
       let acquired = false;
       try {
         const result = await client.query<{ ok: boolean }>(
@@ -105,14 +147,14 @@ export function createAdvisoryLockService(
         );
         acquired = Boolean(result.rows[0]?.ok);
       } catch (error) {
-        client.release();
+        releaseClient();
         throw error;
       }
       if (!acquired) {
         // Did not get the lock — return the client immediately. (A failed
         // pg_try_advisory_lock acquires nothing, so there is nothing to
         // unlock.)
-        client.release();
+        releaseClient();
         return null;
       }
 
@@ -127,48 +169,48 @@ export function createAdvisoryLockService(
               [key],
             );
           } finally {
-            client.release();
+            releaseClient();
           }
         },
       };
     },
-  };
-}
 
-/**
- * Run `fn` while holding a transaction-scoped advisory lock for `key`. The
- * lock is acquired with `pg_advisory_xact_lock` (which BLOCKS until granted)
- * inside a transaction and auto-released at COMMIT/ROLLBACK, so there is no
- * unlock to leak. Use only for SHORT critical sections — the lock is held
- * for the whole transaction.
- *
- * Because the scoped DB runs an entire `transaction()` callback on a single
- * dedicated connection, the lock + the work + the implicit release all share
- * one session, which is exactly the affinity session locks require.
- *
- * `fn` receives the transaction handle `tx` and MUST run its
- * read-then-write critical section on it (not on the outer pool). Running
- * the work on the pool would put it on a DIFFERENT connection than the one
- * holding the lock — so two concurrent callers' critical sections could
- * interleave even though both "hold" the lock. Using `tx` keeps the
- * read-check + write atomic with respect to the lock.
- */
-export async function withXactLock<
-  S extends Record<string, unknown>,
-  T,
->({
-  db,
-  key,
-  fn,
-}: {
-  db: SafeDatabase<S>;
-  key: string;
-  fn: (tx: Parameters<Parameters<SafeDatabase<S>["transaction"]>[0]>[0]) => Promise<T>;
-}): Promise<T> {
-  return db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))`,
-    );
-    return fn(tx);
-  });
+    async withXactLock({ key, fn }) {
+      const client = await pool.connect();
+      // Same rationale as tryAcquire: the lock transaction keeps this client
+      // checked out (idle in transaction) while `fn` runs, so attach an error
+      // listener to survive a backend termination instead of crashing the pod.
+      // Removed in the finally so it does not accumulate on the reused client.
+      client.on("error", swallowClientError);
+      try {
+        await client.query("BEGIN");
+        try {
+          // BLOCKS on this dedicated client until the lock is granted; auto-
+          // released by the COMMIT/ROLLBACK below. `fn`'s own work runs on a
+          // DIFFERENT pool, so no same-pool nested-acquisition deadlock.
+          await client.query(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            [key],
+          );
+          const result = await fn();
+          await client.query("COMMIT");
+          return result;
+        } catch (error) {
+          // Roll back so the xact lock releases and nothing partial lingers on
+          // this connection before it returns to the pool. Best-effort: if the
+          // backend already died, ROLLBACK throws but release() still frees the
+          // slot and the lock is auto-released server-side.
+          try {
+            await client.query("ROLLBACK");
+          } catch (rollbackError) {
+            void rollbackError;
+          }
+          throw error;
+        }
+      } finally {
+        client.off("error", swallowClientError);
+        client.release();
+      }
+    },
+  };
 }

--- a/core/backend/src/db.ts
+++ b/core/backend/src/db.ts
@@ -1,6 +1,7 @@
 import { drizzle } from "drizzle-orm/node-postgres";
-import { Pool } from "pg";
+import { Pool, type PoolConfig } from "pg";
 import * as schema from "./schema";
+import { rootLogger } from "./logger";
 
 // Basic connection string sometimes fails with Bun + pg + docker SASL
 // parsing manually or relying on pg to pick up ENV variables if we don't pass anything
@@ -13,8 +14,114 @@ if (!connectionString) {
   throw new Error("DATABASE_URL is not defined");
 }
 
-export const adminPool = new Pool({
+/** Parse a positive-integer env var, falling back to `fallback` when unset/invalid. */
+function intFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * ## Connection budget (read this before bumping the defaults)
+ *
+ * The platform runs as N horizontally-scaled pods sharing ONE Postgres. The
+ * server-wide ceiling is `max_connections`, so the real budget is:
+ *
+ *   N_pods * (adminPool.max + lockPool.max) <= max_connections - headroom
+ *
+ * Size the pools off that budget (via the env vars below), NOT off the number
+ * of plugins: connections are never pinned per-plugin. The scoped-db proxy sets
+ * `SET LOCAL search_path` per transaction on a borrowed-then-returned
+ * connection, so a connection is occupied only for one transaction (or one
+ * held advisory lock), never for a plugin's lifetime.
+ *
+ * ## Why two pools
+ *
+ * Session/transaction advisory locks (see `advisory-lock.ts`) HOLD a connection
+ * for the lock's whole lifetime while the locked work runs on a *different*
+ * connection. If both came from one pool, then under concurrency >= pool size
+ * every slot becomes a lock-holding connection waiting for a work connection
+ * that can never free up - a self-inflicted deadlock (observed: 10 connections
+ * all `idle in transaction` on `pg_advisory_xact_lock`). Giving advisory locks
+ * their own `lockPool` makes the acquire graph acyclic (lockPool -> adminPool,
+ * never back), so that deadlock class is impossible.
+ *
+ * `connectionTimeoutMillis` is the universal safety net: a pg Pool defaults to
+ * waiting FOREVER for a free connection, which turns any future exhaustion into
+ * a permanent hang (and an upstream 502). With a finite timeout, an exhausted
+ * acquire throws, its holder unwinds and releases, and the pool self-heals.
+ */
+const COMMON_POOL_CONFIG = {
   connectionString,
+  connectionTimeoutMillis: intFromEnv(
+    "DATABASE_POOL_CONNECTION_TIMEOUT_MS",
+    10_000,
+  ),
+  idleTimeoutMillis: intFromEnv("DATABASE_POOL_IDLE_TIMEOUT_MS", 30_000),
+} satisfies PoolConfig;
+
+/**
+ * The main pool: serves every plugin query and all API request work. Never used
+ * to hold an advisory lock open (that is `lockPool`'s job).
+ */
+export const adminPool = new Pool({
+  ...COMMON_POOL_CONFIG,
+  max: intFromEnv("DATABASE_POOL_MAX", 20),
+});
+
+/**
+ * Dedicated pool for advisory locks ONLY (the session-lock service and
+ * `withXactLock`). Kept separate from `adminPool` so a held lock connection
+ * and the work it gates draw from different pools - see the deadlock note
+ * above. Sized for peak concurrent held locks INCLUDING nesting: one logical
+ * operation can hold up to two locks at once (an automation run lock wrapping
+ * an `incident.dedupe-open-for-system` lock), so this needs headroom above the
+ * raw concurrent-operation count.
+ *
+ * ## Stall backstops (server-enforced, can't be skipped by a hung process)
+ *
+ * Advisory locks lock no rows or tables - only other callers of the SAME key
+ * block. But a critical section whose `fn` hangs (e.g. an unbounded await)
+ * would hold its key + this connection open indefinitely, blocking same-key
+ * callers. Two connection-level timeouts bound that, set ONLY on this pool
+ * (where every transaction is a short lock critical section, so the limits are
+ * safe; the admin pool runs arbitrary plugin work and must NOT inherit them):
+ *
+ *   - `idle_in_transaction_session_timeout`: the lock transaction sits "idle in
+ *     transaction" for the whole time `fn` runs (it only issued BEGIN + the
+ *     lock). If `fn` hangs past this, Postgres ABORTS the session, which
+ *     auto-releases the advisory lock and frees the connection - so a stall
+ *     self-heals instead of stranding the lock forever.
+ *   - `lock_timeout`: a caller BLOCKED waiting to acquire a contended/stalled
+ *     key aborts after this (verified to apply to `pg_advisory_xact_lock`),
+ *     surfacing as a retryable error rather than an indefinite block that also
+ *     ties up a lock-pool connection.
+ *
+ * Both default high enough that a healthy short critical section never trips
+ * them; tune via env if your critical sections are unusually long.
+ */
+export const lockPool = new Pool({
+  ...COMMON_POOL_CONFIG,
+  max: intFromEnv("DATABASE_LOCK_POOL_MAX", 10),
+  idle_in_transaction_session_timeout: intFromEnv(
+    "DATABASE_LOCK_IDLE_TX_TIMEOUT_MS",
+    30_000,
+  ),
+  lock_timeout: intFromEnv("DATABASE_LOCK_TIMEOUT_MS", 30_000),
+});
+
+// A pg Pool emits 'error' on behalf of IDLE clients whose backend dies (admin
+// termination, failover, network drop). With no listener, that 'error' is
+// unhandled and CRASHES the process. Log and swallow: the pool discards the
+// dead client and hands out a fresh one on the next checkout. (Checked-out
+// clients are covered separately - the scoped-db transaction wrapper and the
+// advisory-lock service attach their own per-client handlers while held.)
+adminPool.on("error", (error) => {
+  rootLogger.warn("adminPool idle client error (recovered)", error);
+});
+lockPool.on("error", (error) => {
+  rootLogger.warn("lockPool idle client error (recovered)", error);
 });
 
 export const db = drizzle({ client: adminPool, schema });

--- a/core/backend/src/plugin-manager/core-services.ts
+++ b/core/backend/src/plugin-manager/core-services.ts
@@ -14,7 +14,7 @@ import {
 import { AuthApi } from "@checkstack/auth-common";
 import type { ServiceRegistry } from "../services/service-registry";
 import { rootLogger } from "../logger";
-import { db } from "../db";
+import { db, lockPool } from "../db";
 import { jwtService } from "../services/jwt";
 import {
   CoreHealthCheckRegistry,
@@ -98,11 +98,14 @@ export function registerCoreServices({
     return createScopedDb(db, assignedSchema);
   });
 
-  // 1b. Advisory Lock Factory (server-global, backed by the shared admin
-  // pool). Session locks need connection affinity, so the service checks
-  // out a dedicated client per acquired lock and releases on the SAME
-  // client — the scoped per-query DB proxy can't provide that.
-  const advisoryLockService = createAdvisoryLockService(adminPool);
+  // 1b. Advisory Lock Factory (server-global, backed by the DEDICATED
+  // `lockPool`, NOT `adminPool`). Both session locks (`tryAcquire`) and the
+  // transaction-scoped `withXactLock` HOLD a connection for the lock's whole
+  // lifetime while the locked work runs on `adminPool`. Drawing the lock
+  // connection from a separate pool keeps the acquire graph acyclic
+  // (lockPool -> adminPool, never back), so a held lock can never starve the
+  // work pool into the `idle in transaction` deadlock. See `db.ts`.
+  const advisoryLockService = createAdvisoryLockService(lockPool);
   registry.registerFactory(
     coreServices.advisoryLock,
     () => advisoryLockService,

--- a/core/healthcheck-backend/src/health-entity.test.ts
+++ b/core/healthcheck-backend/src/health-entity.test.ts
@@ -663,36 +663,32 @@ describe("per-system serialization (Defect 2 regression)", () => {
     expect(emitted[0].next.status).toBe("unhealthy");
   });
 
-  it("createHealthEntitySerializer keys the advisory lock `health:<systemId>` and runs work in a transaction", async () => {
-    // Intercept `db.transaction` + the advisory-lock SQL the serializer's
-    // `withXactLock` issues. The fake runs `fn(tx)` inline (single connection),
-    // mirroring `withXactLock`'s single-session contract. We assert the
-    // namespaced key flows into `pg_advisory_xact_lock(...)`.
-    const executedKeys: string[] = [];
-    let transactionRan = false;
-    const fakeDb = {
-      transaction: async (
-        cb: (tx: { execute: (q: unknown) => Promise<void> }) => Promise<unknown>,
-      ) => {
-        transactionRan = true;
-        return cb({
-          execute: async (q) => {
-            // The bound key is a plain string chunk in the drizzle template.
-            const chunks = (q as { queryChunks?: unknown[] }).queryChunks ?? [];
-            for (const c of chunks) {
-              if (typeof c === "string") executedKeys.push(c);
-            }
-          },
-        });
+  it("createHealthEntitySerializer routes work through the advisory lock keyed `health:<systemId>`", async () => {
+    // The serializer now delegates to the shared AdvisoryLockService's
+    // `withXactLock` (lock held on the dedicated lock pool, work on the admin
+    // pool). Assert the per-system namespaced key flows through and `fn` runs.
+    const keys: string[] = [];
+    const advisoryLock = {
+      tryAcquire: async () => ({ release: async () => {} }),
+      withXactLock<T>({
+        key,
+        fn,
+      }: {
+        key: string;
+        fn: () => Promise<T>;
+      }): Promise<T> {
+        keys.push(key);
+        return fn();
       },
-    } as unknown as Parameters<typeof createHealthEntitySerializer>[0]["db"];
+    } satisfies Parameters<
+      typeof createHealthEntitySerializer
+    >[0]["advisoryLock"];
 
-    const serializer = createHealthEntitySerializer({ db: fakeDb });
+    const serializer = createHealthEntitySerializer({ advisoryLock });
     const result = await serializer("sys-42")(async () => "ok");
 
     expect(result).toBe("ok");
-    expect(transactionRan).toBe(true);
     // The advisory lock was acquired with the per-system namespaced key.
-    expect(executedKeys).toContain("health:sys-42");
+    expect(keys).toContain("health:sys-42");
   });
 });

--- a/core/healthcheck-backend/src/health-entity.ts
+++ b/core/healthcheck-backend/src/health-entity.ts
@@ -23,7 +23,7 @@
  */
 import { z } from "zod";
 import { HealthCheckStatusSchema } from "@checkstack/healthcheck-common";
-import { withXactLock, type SafeDatabase } from "@checkstack/backend-api";
+import type { AdvisoryLockService } from "@checkstack/backend-api";
 import type {
   EntityChangeDeriver,
   EntityChangePayloadMapper,
@@ -31,11 +31,6 @@ import type {
   EntityRead,
 } from "@checkstack/automation-backend";
 import type { HealthCheckService } from "./service";
-import * as schema from "./schema";
-// Re-export the change type through automation-backend's barrel (it
-// re-exports it from automation-common) so this domain needs no extra dep.
-
-type Db = SafeDatabase<typeof schema>;
 
 /** Entity kind id for the per-system aggregated health. */
 export const HEALTH_ENTITY_KIND = "health";
@@ -360,10 +355,13 @@ export function healthSystemLockKey(systemId: string): string {
  * commits.
  */
 export function createHealthEntitySerializer(deps: {
-  db: Db;
+  advisoryLock: AdvisoryLockService;
 }): (systemId: string) => <T>(fn: () => Promise<T>) => Promise<T> {
-  const { db } = deps;
+  const { advisoryLock } = deps;
   return (systemId) =>
     <T>(fn: () => Promise<T>) =>
-      withXactLock({ db, key: healthSystemLockKey(systemId), fn: () => fn() });
+      advisoryLock.withXactLock({
+        key: healthSystemLockKey(systemId),
+        fn: () => fn(),
+      });
 }

--- a/core/healthcheck-backend/src/index.ts
+++ b/core/healthcheck-backend/src/index.ts
@@ -198,6 +198,7 @@ export default createBackendPlugin({
         cacheManager: coreServices.cacheManager,
         config: coreServices.config,
         secretResolver: secretResolverRef,
+        advisoryLock: coreServices.advisoryLock,
       },
       // Phase 2: Register router and setup worker
       init: async ({
@@ -212,6 +213,7 @@ export default createBackendPlugin({
         cacheManager,
         config,
         secretResolver,
+        advisoryLock,
       }) => {
         logger.debug("🏥 Initializing Health Check Backend...");
 
@@ -258,6 +260,7 @@ export default createBackendPlugin({
         await setupHealthCheckWorker({
           notificationClient,
           db: database,
+          advisoryLock,
           registry: healthCheckRegistry,
           collectorRegistry,
           logger,

--- a/core/healthcheck-backend/src/queue-executor.test.ts
+++ b/core/healthcheck-backend/src/queue-executor.test.ts
@@ -13,6 +13,16 @@ const passthroughCache: HealthCheckCache = {
   invalidateAllSystems: async () => 0,
   scope: {} as HealthCheckCache["scope"],
 };
+
+// Pass-through advisory lock: these tests don't exercise cross-pod
+// serialization, so run the critical section directly.
+const mockAdvisoryLock: Parameters<
+  typeof setupHealthCheckWorker
+>[0]["advisoryLock"] = {
+  tryAcquire: async () => ({ release: async () => {} }),
+  withXactLock: <T>({ fn }: { key: string; fn: () => Promise<T> }): Promise<T> =>
+    fn(),
+};
 import {
   createMockLogger,
   createMockQueueManager,
@@ -179,6 +189,7 @@ describe("Queue-Based Health Check Executor", () => {
         db: mockDb as unknown as Parameters<
           typeof setupHealthCheckWorker
         >[0]["db"],
+        advisoryLock: mockAdvisoryLock,
         registry: mockRegistry,
         collectorRegistry:
           createMockCollectorRegistry() as unknown as Parameters<
@@ -376,6 +387,7 @@ describe("Queue-Based Health Check Executor", () => {
         db: mockDb as unknown as Parameters<
           typeof setupHealthCheckWorker
         >[0]["db"],
+        advisoryLock: mockAdvisoryLock,
         registry: mockRegistry,
         collectorRegistry:
           createMockCollectorRegistry() as unknown as Parameters<
@@ -510,6 +522,7 @@ describe("Queue-Based Health Check Executor", () => {
         db: mockDb as unknown as Parameters<
           typeof setupHealthCheckWorker
         >[0]["db"],
+        advisoryLock: mockAdvisoryLock,
         registry: mockRegistry,
         collectorRegistry: mockCollectorRegistry as unknown as Parameters<
           typeof setupHealthCheckWorker

--- a/core/healthcheck-backend/src/queue-executor.ts
+++ b/core/healthcheck-backend/src/queue-executor.ts
@@ -9,6 +9,7 @@ import {
   type ConnectedClient,
   type TransportClient,
   type CollectorRunContext,
+  type AdvisoryLockService,
 } from "@checkstack/backend-api";
 import { QueueManager } from "@checkstack/queue-api";
 import {
@@ -375,6 +376,7 @@ async function notifyStateChange(props: {
 async function executeHealthCheckJob(props: {
   payload: HealthCheckJobPayload;
   db: Db;
+  advisoryLock: AdvisoryLockService;
   registry: HealthCheckRegistry;
   collectorRegistry: CollectorRegistry;
   logger: Logger;
@@ -404,6 +406,7 @@ async function executeHealthCheckJob(props: {
   const {
     payload,
     db,
+    advisoryLock,
     registry,
     collectorRegistry,
     logger,
@@ -428,7 +431,9 @@ async function executeHealthCheckJob(props: {
   // system (multiple per-config jobs across pods, or at-least-once
   // redelivery) can't double-emit a single logical transition. Bound to this
   // job's systemId below at every `writeHealthEntity` call.
-  const serializeHealthWrite = createHealthEntitySerializer({ db })(systemId);
+  const serializeHealthWrite = createHealthEntitySerializer({ advisoryLock })(
+    systemId,
+  );
 
   // Capture aggregated state BEFORE this run for comparison
   const previousState = await service.getSystemHealthStatus(systemId);
@@ -1073,6 +1078,7 @@ async function executeHealthCheckJob(props: {
 
 export async function setupHealthCheckWorker(props: {
   db: Db;
+  advisoryLock: AdvisoryLockService;
   registry: HealthCheckRegistry;
   collectorRegistry: CollectorRegistry;
   logger: Logger;
@@ -1089,6 +1095,7 @@ export async function setupHealthCheckWorker(props: {
 }): Promise<void> {
   const {
     db,
+    advisoryLock,
     registry,
     collectorRegistry,
     logger,
@@ -1113,6 +1120,7 @@ export async function setupHealthCheckWorker(props: {
       await executeHealthCheckJob({
         payload: job.data,
         db,
+        advisoryLock,
         registry,
         collectorRegistry,
         logger,

--- a/core/incident-backend/src/index.ts
+++ b/core/incident-backend/src/index.ts
@@ -127,6 +127,7 @@ export default createBackendPlugin({
         rpcClient: coreServices.rpcClient,
         signalService: coreServices.signalService,
         cacheManager: coreServices.cacheManager,
+        advisoryLock: coreServices.advisoryLock,
       },
       init: async ({
         logger,
@@ -135,6 +136,7 @@ export default createBackendPlugin({
         rpcClient,
         signalService,
         cacheManager,
+        advisoryLock,
       }) => {
         logger.debug("🔧 Initializing Incident Backend...");
 
@@ -144,6 +146,7 @@ export default createBackendPlugin({
 
         const service = new IncidentService(
           database as SafeDatabase<typeof schema>,
+          advisoryLock,
         );
         // Publish the service for the PLUGIN-BACKED entity `read` accessor
         // (defined in register()). Mutations only run from here onward.
@@ -208,9 +211,14 @@ export default createBackendPlugin({
       // associations) + register subscription specs. Per-system /
       // per-group notification group lifecycle is fully owned by
       // notification-backend now — incident never touches it.
-      afterPluginsReady: async ({ database, logger, rpcClient }) => {
+      afterPluginsReady: async ({
+        database,
+        logger,
+        rpcClient,
+        advisoryLock,
+      }) => {
         const typedDb = database as SafeDatabase<typeof schema>;
-        const service = new IncidentService(typedDb);
+        const service = new IncidentService(typedDb, advisoryLock);
         const notificationClient = rpcClient.forPlugin(NotificationApi);
 
         await Promise.all([

--- a/core/incident-backend/src/service.test.ts
+++ b/core/incident-backend/src/service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { AdvisoryLockService } from "@checkstack/backend-api";
 import { IncidentService } from "./service";
 import {
   incidents,
@@ -6,6 +7,40 @@ import {
   incidentUpdates,
   incidentLinks,
 } from "./schema";
+
+/**
+ * In-memory {@link AdvisoryLockService} that faithfully serializes
+ * `withXactLock` calls per key (a racing call on the same key cannot run its
+ * `fn` until the prior call's `fn` settles) — modelling `pg_advisory_xact_lock`
+ * without a real connection. Different keys are independent.
+ */
+function makeFakeAdvisoryLock(): AdvisoryLockService {
+  const tails = new Map<string, Promise<unknown>>();
+  return {
+    tryAcquire: async () => ({ release: async () => {} }),
+    withXactLock<T>({
+      key,
+      fn,
+    }: {
+      key: string;
+      fn: () => Promise<T>;
+    }): Promise<T> {
+      const prior = tails.get(key) ?? Promise.resolve();
+      const result = prior.then(
+        () => fn(),
+        () => fn(),
+      );
+      tails.set(
+        key,
+        result.then(
+          () => undefined,
+          () => undefined,
+        ),
+      );
+      return result;
+    },
+  };
+}
 
 /**
  * Programmable mock DB that records each `select(...).from(...).where(...)`
@@ -48,7 +83,7 @@ describe("IncidentService.hasActiveIncidentWithSuppression", () => {
 
   const setup = (resultsByCall: unknown[][]) => {
     dbHelper = createProgrammableSelectDb(resultsByCall);
-    service = new IncidentService(dbHelper.db as never);
+    service = new IncidentService(dbHelper.db as never, makeFakeAdvisoryLock());
   };
 
   beforeEach(() => {
@@ -134,7 +169,7 @@ describe("IncidentService.hasActiveIncidentWithSuppression", () => {
 describe("IncidentService.getManyEntityStates (plugin-backed entity read)", () => {
   it("returns {} for an empty id set without querying", async () => {
     const dbHelper = createProgrammableSelectDb([]);
-    const service = new IncidentService(dbHelper.db as never);
+    const service = new IncidentService(dbHelper.db as never, makeFakeAdvisoryLock());
     expect(await service.getManyEntityStates([])).toEqual({});
     expect(dbHelper.getCallCount()).toBe(0);
   });
@@ -153,7 +188,7 @@ describe("IncidentService.getManyEntityStates (plugin-backed entity read)", () =
         { incidentId: "inc-2", systemId: "sys-c" },
       ],
     ]);
-    const service = new IncidentService(dbHelper.db as never);
+    const service = new IncidentService(dbHelper.db as never, makeFakeAdvisoryLock());
     const out = await service.getManyEntityStates(["inc-1", "inc-2", "inc-x"]);
     expect(out).toEqual({
       "inc-1": {
@@ -172,7 +207,7 @@ describe("IncidentService.getManyEntityStates (plugin-backed entity read)", () =
       // incidents query returns nothing → no second query.
       [],
     ]);
-    const service = new IncidentService(dbHelper.db as never);
+    const service = new IncidentService(dbHelper.db as never, makeFakeAdvisoryLock());
     expect(await service.getManyEntityStates(["ghost"])).toEqual({});
     expect(dbHelper.getCallCount()).toBe(1);
   });
@@ -182,7 +217,7 @@ describe("IncidentService.getManyEntityStates (plugin-backed entity read)", () =
       [{ id: "inc-1", status: "monitoring", severity: "critical" }],
       [], // no junction rows
     ]);
-    const service = new IncidentService(dbHelper.db as never);
+    const service = new IncidentService(dbHelper.db as never, makeFakeAdvisoryLock());
     const out = await service.getManyEntityStates(["inc-1"]);
     expect(out["inc-1"]).toEqual({
       status: "monitoring",
@@ -300,7 +335,7 @@ function createDedupFakeDb() {
 describe("IncidentService.createIncidentDedupedForSystem (M3)", () => {
   it("two concurrent dedupe creates for one system open exactly ONE incident", async () => {
     const { db, store } = createDedupFakeDb();
-    const service = new IncidentService(db as never);
+    const service = new IncidentService(db as never, makeFakeAdvisoryLock());
 
     const input = {
       title: "Down",

--- a/core/incident-backend/src/service.ts
+++ b/core/incident-backend/src/service.ts
@@ -1,5 +1,5 @@
 import { eq, and, inArray, ne } from "drizzle-orm";
-import { withXactLock, type SafeDatabase } from "@checkstack/backend-api";
+import type { AdvisoryLockService, SafeDatabase } from "@checkstack/backend-api";
 import * as schema from "./schema";
 import {
   incidents,
@@ -27,7 +27,10 @@ function generateId(): string {
 }
 
 export class IncidentService {
-  constructor(private db: Db) {}
+  constructor(
+    private db: Db,
+    private advisoryLock: AdvisoryLockService,
+  ) {}
 
   /**
    * List incidents with optional filters
@@ -528,15 +531,16 @@ export class IncidentService {
       create: () => Promise<IncidentWithSystems>,
     ) => Promise<IncidentWithSystems> = (create) => create(),
   ): Promise<{ incident: IncidentWithSystems; reused: boolean }> {
-    return withXactLock({
-      db: this.db,
+    return this.advisoryLock.withXactLock({
       key: `incident.dedupe-open-for-system:${dedupeSystemId}`,
-      // The find + create run on `this.db` (the pool), NOT on `tx`. That is
-      // safe here because `pg_advisory_xact_lock` BLOCKS every other holder
-      // of this key until this transaction commits: a racing caller waits
-      // at lock-acquire, so its find can't observe "no open incident" until
-      // ours has already committed the insert. The critical section is thus
-      // serialized by the lock window even though it doesn't ride `tx`.
+      // The find + create deliberately run on `this.db` (the admin pool), NOT
+      // on the lock connection. That is safe because `pg_advisory_xact_lock`
+      // BLOCKS every other holder of this key until this lock transaction
+      // commits: a racing caller waits at lock-acquire, so its find can't
+      // observe "no open incident" until ours has already committed the
+      // insert. Crucially, the lock transaction lives on the DEDICATED lock
+      // pool (see `createAdvisoryLockService(lockPool)`), so holding it open
+      // while the work runs on the admin pool cannot starve the admin pool.
       fn: async () => {
         const existing = await this.findActiveIncidentForSystem(dedupeSystemId);
         if (existing) {

--- a/docs/src/content/docs/developer-guide/backend/drizzle-schema.md
+++ b/docs/src/content/docs/developer-guide/backend/drizzle-schema.md
@@ -178,11 +178,11 @@ the lock leaks. Do NOT call the session-lock functions through the scoped
 `db`.
 
 Use the `coreServices.advisoryLock` service instead. It checks out one
-dedicated client from the pool, acquires the session lock on it, and returns
-a handle whose `release()` runs the unlock on the SAME client before
-returning it to the pool. Use it for locks held for a long time (e.g. an
-election held across a slow background job), where a long-open transaction
-would be unacceptable:
+dedicated client from a **separate lock pool** (NOT the shared admin pool),
+acquires the session lock on it, and returns a handle whose `release()` runs
+the unlock on the SAME client before returning it to the pool. Use it for
+locks held for a long time (e.g. an election held across a slow background
+job), where a long-open transaction would be unacceptable:
 
 ```typescript
 import { coreServices } from "@checkstack/backend-api";
@@ -204,23 +204,68 @@ env.registerInit({
 Keys are arbitrary strings hashed into Postgres' global 64-bit lock space, so
 namespace them per plugin (e.g. `"my-plugin.<purpose>"`).
 
-For a SHORT critical section, prefer `withXactLock`, which wraps acquire +
-work + release in a single transaction using `pg_advisory_xact_lock` (it
-auto-releases at COMMIT, so a leak is impossible). Because the scoped DB runs
-a whole `transaction()` callback on one connection, the lock and the work
-share a session:
+For a SHORT critical section, prefer `advisoryLock.withXactLock`, which wraps
+acquire + work + release using `pg_advisory_xact_lock` (it auto-releases at
+COMMIT, so a leak is impossible). The lock transaction runs on the **dedicated
+lock pool**, while `fn` does its work on the admin pool as usual:
 
 ```typescript
-import { withXactLock } from "@checkstack/backend-api";
-
-await withXactLock({
-  db,
+await advisoryLock.withXactLock({
   key: `my-plugin.dedupe:${someId}`,
   fn: async () => {
-    // find-then-create, serialized per key
+    // find-then-create, serialized per key (runs on the admin-pool `db`)
   },
 });
 ```
+
+> [!CAUTION]
+> Why two pools? A held advisory lock keeps its connection checked out for the
+> lock's whole lifetime while the gated work runs on a *different* connection.
+> If both came from one pool, then at concurrency >= pool size every slot
+> becomes a lock-holder waiting for a work connection that can never free up -
+> a self-inflicted deadlock that surfaces as connections stuck `idle in
+> transaction` on `pg_advisory_xact_lock` and every request hanging into a 502.
+> Drawing lock connections from a separate pool makes the acquire graph acyclic
+> (`lockPool -> adminPool`, never back), so that class of deadlock is
+> impossible. Always go through `coreServices.advisoryLock`; never run an
+> advisory lock through a plugin's scoped `db`.
+
+### What if a critical section stalls?
+
+Advisory locks lock **no rows or tables** - other queries against the same
+tables run untouched. Only other callers of the **same key** block. But a
+critical section whose `fn` hangs (an unbounded await) would otherwise hold its
+key, and its lock-pool connection, open forever. Two server-enforced backstops
+on the lock pool bound that (they can't be skipped by a stuck process):
+
+- `idle_in_transaction_session_timeout` (`DATABASE_LOCK_IDLE_TX_TIMEOUT_MS`,
+  default 30s): the lock transaction sits idle-in-transaction for the whole
+  time `fn` runs, so a hang past this aborts the session - auto-releasing the
+  lock and freeing the connection. The stall self-heals.
+- `lock_timeout` (`DATABASE_LOCK_TIMEOUT_MS`, default 30s): a caller blocked
+  waiting on a contended or stalled key aborts with a retryable error instead
+  of blocking (and tying up a connection) indefinitely.
+
+A crash or pod restart also ends the holding transaction, which auto-releases
+the lock - so a stalled lock can never survive the process that held it. Keep
+critical sections SHORT (a read-then-write); never do unbounded external work
+(HTTP, etc.) inside one.
+
+### Connection budget
+
+The platform runs as N pods sharing one Postgres, so size both pools off
+`max_connections`, NOT the plugin count (connections are never pinned
+per-plugin - the scoped proxy borrows and returns one per transaction):
+
+```text
+N_pods * (DATABASE_POOL_MAX + DATABASE_LOCK_POOL_MAX) <= max_connections - headroom
+```
+
+Both pools also set `connectionTimeoutMillis` (`DATABASE_POOL_CONNECTION_TIMEOUT_MS`,
+default 10s) so an exhausted pool fails fast and self-heals instead of hanging
+forever. Tunable env vars: `DATABASE_POOL_MAX` (default 20),
+`DATABASE_LOCK_POOL_MAX` (default 10), `DATABASE_POOL_IDLE_TIMEOUT_MS`
+(default 30s).
 
 ## See Also
 


### PR DESCRIPTION
## Problem

The session-lock service and `withXactLock` HOLD a Postgres connection for the lock's whole lifetime while the gated work runs on a *different* connection. Both drew from the single shared `adminPool` (default `max: 10`, `connectionTimeoutMillis: 0` = wait forever). At concurrency ≥ pool size, every slot became a lock-holder waiting for a work connection that could never free up — a permanent **deadlock**, surfacing as connections stuck `idle in transaction` on `pg_advisory_xact_lock` and every API request hanging into an upstream 502. It only triggered after enough concurrent health-check evaluations / incident dedups built up.

## Fix

- Dedicated `lockPool` separate from `adminPool` → acquire graph is acyclic (`lockPool → adminPool`), so the deadlock class is impossible.
- `AdvisoryLockService.withXactLock({ key, fn })` (lock on lock pool, work on admin pool); healthcheck per-system serializer, incident dedup-create, and the automation single-mode concurrency lock routed through it.
- **Removed** the deadlock-prone standalone `withXactLock({ db, ... })` helper.
- Both pools configured (`max`, `connectionTimeoutMillis`, `idleTimeoutMillis`) + pool-level `error` handlers; lock pool also sets `idle_in_transaction_session_timeout` and `lock_timeout` so a stalled critical section is reaped server-side rather than stranding a key.
- Fixed a per-acquire error-listener leak in the advisory-lock service (`MaxListenersExceeded`).

## Verification

New real-Postgres integration test (`advisory-lock-pool.it.test.ts`): reproduces the old single-pool deadlock, proves no deadlock at high throughput, proves exactly-once dedup across simulated multi-instance pods, proves a stalled critical section is reaped, plus a no-lock control. Typecheck, lint, and all unit + integration tests pass.

> [!WARNING]
> Each pod now opens up to `DATABASE_POOL_MAX + DATABASE_LOCK_POOL_MAX` (default 20 + 10 = 30) connections. Size pools so `N_pods × 30 ≤ max_connections`.

**BREAKING CHANGE:** standalone `withXactLock` removed (use `coreServices.advisoryLock.withXactLock`); `IncidentService` constructor and the healthcheck serializer/worker helpers now take `advisoryLock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
