### PR TITLE
fix: stop a single transient health check failure from escalating to "unhealthy"

### DIFF
--- a/.changeset/fix-transient-failure-escalation.md
+++ b/.changeset/fix-transient-failure-escalation.md
@@ -1,0 +1,18 @@
+---
+"@checkstack/healthcheck-backend": minor
+---
+
+fix: stop a single transient health check failure from escalating to "unhealthy"
+
+In consecutive threshold mode, when a run failed but the failure streak had
+not yet reached the configured degraded threshold (and there were not yet
+enough successes to confirm healthy), the evaluator fell back to the raw
+status of the latest run. A single failing run (e.g. a check timeout) that
+recovered on the next run therefore flipped the system to "unhealthy" and
+fired a spurious "System health critical" notification before the configured
+consecutive-failure count (default 2 for degraded, 5 for unhealthy) was
+reached.
+
+The evaluator now falls back to "healthy" in this case, matching window mode's
+behaviour and the intent of the thresholds: a transient blip below the
+degraded threshold no longer escalates the system status.

--- a/core/healthcheck-backend/src/state-evaluator.test.ts
+++ b/core/healthcheck-backend/src/state-evaluator.test.ts
@@ -176,9 +176,51 @@ describe("evaluateHealthStatus", () => {
     });
   });
 
+  describe("transient failure (single blip) does not escalate", () => {
+    test("default thresholds: one failure then recovery never leaves healthy", () => {
+      // Reproduces the real-world bug: an assignment fails once (e.g. a check
+      // timeout) and recovers on the next run. Default degraded threshold is 2
+      // consecutive failures, so a single failure must NOT escalate to
+      // degraded/unhealthy (which would fire a "System health critical"
+      // notification).
+
+      // After the single failing run (only one run recorded so far).
+      expect(evaluateHealthStatus({ runs: createRuns(["unhealthy"]) })).toBe(
+        "healthy"
+      );
+
+      // After the next run succeeds.
+      expect(
+        evaluateHealthStatus({ runs: createRuns(["healthy", "unhealthy"]) })
+      ).toBe("healthy");
+    });
+
+    test("single leading failure below degraded threshold stays healthy", () => {
+      const thresholds: ConsecutiveThresholds = {
+        mode: "consecutive",
+        healthy: { minSuccessCount: 1 },
+        degraded: { minFailureCount: 2 },
+        unhealthy: { minFailureCount: 3 },
+      };
+      // Most recent run failed once, then a flicker of success, then failures.
+      // The leading failure streak is only 1 (< degraded threshold of 2), so
+      // consecutive mode must NOT report unhealthy off the single latest
+      // failure.
+      const runs = createRuns([
+        "unhealthy",
+        "healthy",
+        "unhealthy",
+        "unhealthy",
+        "unhealthy",
+      ]);
+      expect(evaluateHealthStatus({ runs, thresholds })).toBe("healthy");
+    });
+  });
+
   describe("flickering scenarios", () => {
-    test("window mode handles flickering better than consecutive", () => {
-      // System that is mostly failing but occasionally succeeds
+    test("window mode catches a mostly-failing system consecutive mode ignores", () => {
+      // System that is mostly failing but occasionally succeeds, with the most
+      // recent run a single failure after a flicker of success.
       const runs = createRuns([
         "unhealthy",
         "healthy", // Flicker
@@ -201,12 +243,15 @@ describe("evaluateHealthStatus", () => {
         unhealthy: { minFailureCount: 4 },
       };
 
-      // Consecutive: sees only 1 failure at start, returns unhealthy (just the first)
+      // Consecutive: only the leading streak counts (1 failure, below the
+      // degraded threshold), so it stays healthy and does not over-react to the
+      // single most-recent failure.
       expect(
         evaluateHealthStatus({ runs, thresholds: consecutiveThresholds })
-      ).toBe("unhealthy");
+      ).toBe("healthy");
 
-      // Window: sees 4 failures in window of 5, returns unhealthy
+      // Window: sees 4 failures in window of 5, returns unhealthy. This is why
+      // window mode is preferable for intermittently-failing systems.
       expect(evaluateHealthStatus({ runs, thresholds: windowThresholds })).toBe(
         "unhealthy"
       );

--- a/core/healthcheck-backend/src/state-evaluator.ts
+++ b/core/healthcheck-backend/src/state-evaluator.ts
@@ -75,8 +75,15 @@ function evaluateConsecutive(props: {
     return "healthy";
   }
 
-  // Edge case: not enough history to determine - use latest individual status
-  return runs[0].status;
+  // Not enough consecutive failures to reach the degraded threshold (and not
+  // enough successes to confirm healthy). The thresholds exist precisely so a
+  // transient blip (e.g. a single failing run that recovers on the next run)
+  // does NOT escalate the system status. Returning the raw latest run status
+  // here would let one failure flip the system to "degraded"/"unhealthy" and
+  // fire a spurious "System health critical" notification before the
+  // configured failure count is reached. Fall back to "healthy" — the same
+  // baseline window mode uses when no threshold is met.
+  return "healthy";
 }
 
 /**


### PR DESCRIPTION
## Problem

In consecutive-threshold mode, when a run failed but the failure streak had not yet reached the configured degraded threshold (and there were not yet enough successes to confirm healthy), the evaluator fell back to the **raw status of the latest run**. A single failing run (e.g. a check timeout) that recovered on the next run therefore flipped the system to "unhealthy" and fired a spurious "System health critical" notification before the configured consecutive-failure count (default 2 for degraded, 5 for unhealthy) was reached.

## Fix

The evaluator now falls back to "healthy" in this case, matching window mode's behaviour and the intent of the thresholds: a transient blip below the degraded threshold no longer escalates the system status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
