### PR TITLE
perf(frontend): lazy-load Monaco, plugin pages, icons & charts; upgrade lucide-react to v1

### DIFF
--- a/.agent/plans/frontend-bundle-lazy-loading.md
+++ b/.agent/plans/frontend-bundle-lazy-loading.md
@@ -1,8 +1,30 @@
 # Frontend bundle size — Monaco on the login page & eager plugin loading
 
-> **Status:** planned (investigated 2026-05-31, not started)
+> **Status:** Fix 1 + Fix 3 + Fix 2 (Strategy 1) DONE (2026-06-01, verified against prod build). Measured result + remaining levers in the progress log.
 > **Branch:** TBD (off `main`)
 > **Original ask:** Opening Checkstack transfers ~50 MB on initial page load (dev server, Vite on `localhost:5173`, ~123 requests). It loads the Monaco code editor and plugins/components that aren't even visible on the login page. Figure out why lazy-loading isn't working and whether it's only the dev server, then plan fixes.
+
+## Progress log
+
+- **Fix 1 (Monaco off the barrel) — DONE.** All THREE static Monaco edges from the `@checkstack/ui` barrel were cut (the original analysis only spotted two):
+  1. Component path: `TypefoxEditor` is now `React.lazy` + `Suspense` inside `CodeEditor.tsx` (skeleton fallback honoring `usePerformance`).
+  2. Utility path: `validateScripts.ts` now `await import(...)`s the Monaco editor API, the standalone TS worker, and `monacoTsService` in-body.
+  3. **Signal path (missed originally):** the barrel re-exported `onVscodeServicesReady`/`areVscodeServicesReady` from the Monaco-heavy `monacoTsService`, which alone re-shipped the whole stack. Extracted to a new Monaco-free `core/ui/src/components/CodeEditor/vscodeServicesSignal.ts`; updated `monacoTsService.ts`, `TypefoxEditor.tsx`, `validateScripts.ts`, and `CodeEditor/index.ts` to source it from there.
+- **Fix 3 (Vite chunking) — DONE, but Monaco grouping deliberately omitted.** Added a `react-vendor` `manualChunks` split only. A hand-rolled `monaco` chunk was tried and REVERTED: a tiny `@codingame/*` module is an *eager* transitive dep of non-editor code, so folding it into one chunk with the lazy editor body made the whole ~10 MB chunk a static dependency of the entry, re-shipping Monaco to the login page. Rollup's natural splitting already isolates the editor behind the lazy boundaries — leave it alone. This is documented in `core/frontend/vite.config.ts` so nobody re-adds it.
+- **Verified (clean prod build):** initial-load HTML preloads only `index`, `react-vendor`, `browser`, `rolldown-runtime`, `preload-helper` — **zero** Monaco/stdlib/typefox/codingame. The ~10 MB monaco chunk + 3.3 MB `stdlib-types` + `TypefoxEditor` are now lazy chunks fetched only when an editor mounts. `typecheck` + `lint` clean; `core/ui` (126) and `automation-frontend` (128) tests pass. Changeset added (`.changeset/lazy-monaco-editor-bundle.md`).
+- **Fix 2 (Strategy 1 — per-route `React.lazy`) — DONE.** Converted all route-page imports in 18 plugins (auth-frontend kept fully eager per decision) to `lazy(() => import(...).then(m => ({ default: m.X })))`, and wrapped the rendered route element in one shared `<Suspense>` in `App.tsx`. No change to `FrontendPlugin`, `plugin-registry.ts`, `plugin-loader.ts`, or `main.tsx`. Changeset: `.changeset/lazy-load-plugin-route-pages.md`. `typecheck` + `lint` clean; `automation-frontend` tests (128) pass; other edited plugins are config-only (no tests).
+- **Fix 2 measured result (clean prod build):**
+  - Entry chunk `index-*.js`: **2,455 KB → 189 KB** (gzip 655 KB → 52 KB).
+  - **Total initial-load JS (entry + all modulepreloaded chunks): ~810 KB → ~679 KB gzip (~16% / ~130 KB).** 37 route-page chunks (~600 KB raw, e.g. `AutomationEditPage` 83 KB) are now lazy and fetched on navigation. No page bodies and no Monaco in the initial preload set (verified).
+  - **Honest takeaway:** the headline "189 KB entry" overstates the win — the bytes redistributed into ~80 eagerly-preloaded chunks. Strategy 1 deferred *route pages*, which improves post-login navigation TTI, but the initial load is now dominated by **eager plugin registration + extension (slot) components + shared vendor**, not pages.
+- **Next levers — DONE (2026-06-01):**
+  1. **lucide-react v1 migration + icon bloat — DONE.** The eager `src` chunk was dominated by lucide's full `icons` map (~1 MB), imported by `DynamicIcon`. Also unified lucide from 5 drifting versions to `^1.17.0` (major bump; v1 removed brand icons → vendored GitHub/GitLab in `@checkstack/ui`, added `IconName` type in common). `DynamicIcon` now lazy-loads the icon set via a `React.lazy` `iconRegistry` chunk (fetched on first data-driven icon, not initial paint); statically named-imported icons tree-shake normally. Changeset: `.changeset/lucide-v1-and-icon-chart-perf.md`. **Stale-cache gotcha:** the lucide bump's icon-rename/removal errors only surfaced after `bun run typecheck:clean` — incremental `tsgo -b` reported 0 errors against stale `.tsbuild`.
+  2. `react-vendor` 375 KB — left as-is (unavoidable React runtime, its own cached chunk).
+  3. **recharts chart extensions — DONE.** The recharts chunk (~312 KB) + `auto-charts` (~92 KB) were eager via two paths, both now cut: the auto-chart slot extension lazy-loads `AutoChartGrid` (and healthcheck's index imports the extension directly, not via the `./auto-charts` barrel that re-exports chart components), and `HealthCheckSystemOverview` lazy-loads its on-demand `HealthCheckDrawer`.
+  4. **Plugin template — DONE.** `core/scripts/src/templates/frontend/src/index.tsx.hbs` now scaffolds new plugins with a `React.lazy` route page, so generated plugins follow the lazy-loading strategy by default.
+  5. **Strategy 2** (defer entire plugin module eval) — still NOT done; the only lever that removes eager *registration* cost, and still the high-risk app-shell redesign described below. Defer to its own effort.
+
+- **Final measured initial-load JS (gzip), clean prod build:** Fix 1+3 ~810 KB → Fix 2 (route lazy) ~679 KB → lucide+DynamicIcon ~559 KB → chart lazy **~445 KB**. The remaining initial load is shared vendor (date-fns, markdown/ajv, react-day-picker in one ~650 KB-raw `src` chunk), `react-vendor`, and the app shell — no Monaco, no full icon set, no recharts, no route-page bodies.
 
 Self-contained handoff. A future session should be able to pick this up without prior chat context.
 
@@ -71,14 +93,75 @@ There is **no `React.lazy` anywhere** in the frontend, and **no `manualChunks`**
 
 **Verification:** build prod (or inspect the dev network panel) on the login route and confirm no `@codingame`/`ts.worker`/`standaloneServices` chunks load until an editor mounts or TS validation runs.
 
-### Fix 2 — lazy-load plugins (HIGH RISK, architectural)
-**Goal:** plugins load on navigation instead of all 26 up front.
+### Fix 2 — lazy-load plugin route pages (detailed plan, not started)
+**Goal:** stop the ~2.4 MB entry from statically pulling in all 52 plugin route-page component bodies. Defer each page to a per-route chunk fetched on navigation, so the initial load carries only plugin registration + nav/slot widgets.
 
-**The blocker is not imports — it's the shell contract.** Registration is synchronous at module-eval, and the route table + nav are built from all plugins before first render ([main.tsx:9](../../core/frontend/src/main.tsx#L9) → [plugin-loader.ts:26-36](../../core/frontend/src/plugin-loader.ts#L26-L36) → `App.tsx`). Each plugin `index.tsx` exports a `createFrontendPlugin({ routes, extensions, ... })` object literal at eval time (routes/extensions are NOT lazy). Flipping the glob to `eager: false` only parallelizes loading; real deferral requires decoupling "module loaded" from "routes registered" — e.g. per-route `React.lazy` + a manifest of routes/nav metadata known without evaluating each plugin's full module.
+**Verified facts (read 2026-06-01):**
+- `core/frontend/src/main.tsx:9` does `await loadPlugins()` before React renders.
+- `plugin-loader.ts:26-36` eager-globs all 29 `core/*-frontend/src/index.tsx` (`plugins/*-frontend` matches 0 today). Registration is synchronous at module-eval.
+- Each plugin `index.tsx` statically imports its page components and declares `routes: [{ route, element: <SomePage />, title, accessRule }]`. **All 52 route elements across all plugins are bare `<Foo />`** — no props, no provider wrapping, no reuse of a page as an extension component. (Confirmed by grep: zero non-bare elements.)
+- `App.tsx:178-188` renders `pluginRegistry.getAllRoutes()` into `<Route element={<RouteGuard …>{route.element}</RouteGuard>} />`. `RouteGuard` already shows a `<LoadingSpinner/>` while access loads, so a Suspense fallback has a precedent.
+- The `FrontendPlugin` contract (`core/frontend-api/src/plugin.ts`): `routes[].element?: React.ReactNode`, `extensions[].component: React.ComponentType`, `apis[].factory`, `foreignSignals`. The registry stores `element` as-is.
+- Route **metadata** (path, id, accessRule) lives in the `*-common` packages (e.g. `incidentRoutes`, `pluginMetadata` from `@checkstack/incident-common`) — already importable without the frontend module. Nav/slot **components** (UserMenu items, badges, dashboard cards) live in the frontend module and are React components, so they cannot move to `-common`.
 
-**Blast radius:** `plugin-loader.ts` + an `App.tsx` restructure (route table built lazily). The 26 plugin `index.tsx` files likely need a contract change to separate lightweight metadata/nav from heavy route component bodies. **Consumer-import surface is small, but the plugin contract changes — that is the cost.**
+#### Chosen approach: Strategy 1 — per-route `React.lazy`, contract-preserving (RECOMMENDED)
 
-**Risk:** High. Defer until Fix 1 + Fix 3 are measured; may not be needed if Fix 1 + manualChunks get initial load acceptable.
+Keep each plugin module eagerly registered (so routes, nav extensions, API factories, and `foreignSignals` are all known synchronously at startup — no loader/registry/contract change), but make each route's `element` a lazy component so the heavy page **body** moves to its own chunk.
+
+**Per-plugin edit (mechanical, 52 elements across ~25 plugins):**
+```tsx
+// before
+import { IncidentConfigPage } from "./pages/IncidentConfigPage";
+// ...
+{ route: incidentRoutes.routes.config, element: <IncidentConfigPage />, title: "Incidents", accessRule: incidentAccess.incident.manage },
+
+// after
+import { lazy } from "react";
+const IncidentConfigPage = lazy(() =>
+  import("./pages/IncidentConfigPage").then((m) => ({ default: m.IncidentConfigPage })),
+);
+// ...
+{ route: incidentRoutes.routes.config, element: <IncidentConfigPage />, title: "Incidents", accessRule: incidentAccess.incident.manage },
+```
+The `.then((m) => ({ default: m.X }))` shim is needed because pages are **named** exports and `React.lazy` wants a default. The route literal is otherwise unchanged.
+
+**Single shell edit (`App.tsx`):** wrap the rendered route element in one `<Suspense>` so every lazy page shares one fallback:
+```tsx
+element={
+  <RouteGuard accessRule={route.accessRule}>
+    <Suspense fallback={<div className="h-full flex items-center justify-center p-8"><LoadingSpinner /></div>}>
+      {route.element}
+    </Suspense>
+  </RouteGuard>
+}
+```
+(`LoadingSpinner` is already imported and `usePerformance`-aware; matches the existing `RouteGuard` loading look.) The `DashboardSlot` on `/` renders extensions, not lazy pages, so it needs no Suspense unless we also lazy extensions (see optional phase).
+
+**What stays eager (intentionally):** the 29 `index.tsx` modules themselves, their small nav/slot extension components, API factories, and `foreignSignals`. These must be synchronous for nav, slots, command palette, and query-invalidation wiring to work on first paint. They are lightweight relative to the page bodies (tables, editors, charts, forms).
+
+**Decision point — the auth pages.** `LoginPage`/`RegisterPage`/`ForgotPasswordPage`/`ResetPasswordPage` are the *first* thing an unauthenticated user hits. Lazy-loading `LoginPage` adds one extra chunk fetch + a Suspense flash on the most critical path. **Recommendation: leave the auth route pages eager** (they are small) and lazy only the post-login plugin pages. Revisit if the auth chunk turns out heavy.
+
+**Blast radius (Strategy 1):** ~25 plugin `index.tsx` files (swap static page import → `lazy()`), plus 1 `App.tsx` Suspense wrap. **No change to `FrontendPlugin`, `plugin-registry.ts`, `plugin-loader.ts`, or `main.tsx`.** Remote-plugin path untouched.
+
+**Risk (Strategy 1):** Low-medium.
+- Watch for any page that is *also* used as an extension component (grep confirmed none today, but re-check before editing each plugin).
+- A page that reads route/search params still works (lazy only defers the module, not routing).
+- Suspense flash on navigation — acceptable; mirrors `RouteGuard`'s existing access-loading spinner. Optionally add hover/intent preloading later (additive).
+- `gcTime: 0` editor-loader rule (CLAUDE.md) is unaffected — that's query config, not bundling.
+
+#### Escalation: Strategy 2 — full module deferral (HIGH RISK, only if Strategy 1 isn't enough)
+
+If, after Strategy 1 + measurement, the eager graph (29 modules + their extension components + shared deps) is still too large, defer entire plugin modules:
+- Flip the glob to `eager: false`, await the importers in `loadPlugins`, OR introduce a manifest contract: each plugin exports lightweight metadata (route paths + nav declarations as data, not components) consumed synchronously, plus a `() => import()` module loader invoked on navigation.
+- **Cost:** changes the `FrontendPlugin` contract, `plugin-loader.ts`, `plugin-registry.ts`, and `App.tsx`; nav/slot widgets (currently React components in the frontend module) need either a metadata-only nav declaration or to stay eager anyway. This is a genuine app-shell redesign and must ship docs updates (`docs/src/content/docs/frontend/…`) in the same PR.
+- **Do not start Strategy 2 without a fresh plan + measurement showing Strategy 1 was insufficient.**
+
+#### Verification (either strategy)
+1. `bun run build` in `core/frontend`; `rm -rf dist` first (note `emptyOutDir: false` — stale chunks accumulate and will mislead grep).
+2. Confirm `dist/index.html` modulepreloads do NOT include the heavy plugin page chunks; confirm per-page chunks exist and are referenced only via the dynamic-import manifest (`__vite__mapDeps`), not as top-level entry imports.
+3. Smoke-test navigation to several plugin routes; confirm pages load behind the Suspense fallback and render correctly.
+4. `bun run typecheck` + `bun run lint` (root). No workspace dep changes expected, so the references generator should not be needed.
+5. Changeset: perf improvement to `@checkstack/frontend` (and any plugin packages touched) — minor, BETA (no major bumps).
 
 ### Fix 3 — `manualChunks` in Vite config (LOW RISK, additive)
 **Goal:** better splitting/caching of vendor + Monaco + per-plugin chunks in the prod build.
@@ -92,10 +175,10 @@ There is **no `React.lazy` anywhere** in the frontend, and **no `manualChunks`**
 
 ## 3. Recommended order
 
-1. **Fix 1** first — it's the only fix that actually removes Monaco from the login-page load, and it's contained to `@checkstack/ui` with zero consumer-import churn.
-2. **Fix 3** next — cheap, additive, improves caching once chunks are split.
-3. **Measure.** Re-check initial transfer on the login route (prefer a prod build for a realistic number; dev is inflated). If initial load is now acceptable, **stop**.
-4. **Fix 2** only if still needed — it's the expensive, behavior-touching one (plugin contract + app shell).
+1. ~~**Fix 1**~~ — DONE.
+2. ~~**Fix 3**~~ — DONE (react-vendor split only; Monaco grouping intentionally omitted, see progress log).
+3. **Measure.** Re-check initial transfer on the login route with a prod build (`rm -rf dist && bun run build`; dev is inflated). Monaco is already gone; the remaining weight is the ~2.4 MB entry from eager plugin pages. If acceptable, **stop**.
+4. **Fix 2** — start with **Strategy 1** (per-route `React.lazy`, contract-preserving). Measure again. Escalate to **Strategy 2** only if Strategy 1 leaves the eager graph too large.
 
 ---
 

--- a/.changeset/lazy-load-plugin-route-pages.md
+++ b/.changeset/lazy-load-plugin-route-pages.md
@@ -18,6 +18,7 @@
 "@checkstack/script-packages-frontend": minor
 "@checkstack/secrets-frontend": minor
 "@checkstack/slo-frontend": minor
+"@checkstack/scripts": minor
 ---
 
 Lazy-load plugin route pages so their component bodies are fetched on navigation instead of in the initial load.
@@ -25,3 +26,5 @@ Lazy-load plugin route pages so their component bodies are fetched on navigation
 Each plugin's route `element` now references a `React.lazy`-wrapped page component (`const FooPage = lazy(() => import("./pages/FooPage").then((m) => ({ default: m.FooPage })))`) instead of a statically imported one, and `App.tsx` renders every route element inside a shared `<Suspense>` boundary (fallback mirrors `RouteGuard`'s access-loading spinner). The `FrontendPlugin` contract, plugin registry, and plugin loader are unchanged - plugins still register synchronously, so nav, slots, commands, API factories, and `foreignSignals` are all available on first paint.
 
 This moves the 37 route-page chunks (~600 KB raw) out of the entry: the main entry chunk drops from ~2.4 MB to ~190 KB and navigating to a heavy page (e.g. the automation editor) no longer costs that code up front. Auth flow pages (login/register/forgot/reset) are intentionally kept eager so the unauthenticated landing path has no extra chunk fetch.
+
+The `@checkstack/scripts` frontend plugin scaffold template (`bun run create`) now generates its route page as a `React.lazy` component too, so new plugins follow this strategy by default.

--- a/.changeset/lazy-load-plugin-route-pages.md
+++ b/.changeset/lazy-load-plugin-route-pages.md
@@ -1,0 +1,27 @@
+---
+"@checkstack/frontend": minor
+"@checkstack/about-frontend": minor
+"@checkstack/announcement-frontend": minor
+"@checkstack/api-docs-frontend": minor
+"@checkstack/automation-frontend": minor
+"@checkstack/catalog-frontend": minor
+"@checkstack/dependency-frontend": minor
+"@checkstack/gitops-frontend": minor
+"@checkstack/healthcheck-frontend": minor
+"@checkstack/incident-frontend": minor
+"@checkstack/infrastructure-frontend": minor
+"@checkstack/integration-frontend": minor
+"@checkstack/maintenance-frontend": minor
+"@checkstack/notification-frontend": minor
+"@checkstack/pluginmanager-frontend": minor
+"@checkstack/satellite-frontend": minor
+"@checkstack/script-packages-frontend": minor
+"@checkstack/secrets-frontend": minor
+"@checkstack/slo-frontend": minor
+---
+
+Lazy-load plugin route pages so their component bodies are fetched on navigation instead of in the initial load.
+
+Each plugin's route `element` now references a `React.lazy`-wrapped page component (`const FooPage = lazy(() => import("./pages/FooPage").then((m) => ({ default: m.FooPage })))`) instead of a statically imported one, and `App.tsx` renders every route element inside a shared `<Suspense>` boundary (fallback mirrors `RouteGuard`'s access-loading spinner). The `FrontendPlugin` contract, plugin registry, and plugin loader are unchanged - plugins still register synchronously, so nav, slots, commands, API factories, and `foreignSignals` are all available on first paint.
+
+This moves the 37 route-page chunks (~600 KB raw) out of the entry: the main entry chunk drops from ~2.4 MB to ~190 KB and navigating to a heavy page (e.g. the automation editor) no longer costs that code up front. Auth flow pages (login/register/forgot/reset) are intentionally kept eager so the unauthenticated landing path has no extra chunk fetch.

--- a/.changeset/lazy-monaco-editor-bundle.md
+++ b/.changeset/lazy-monaco-editor-bundle.md
@@ -1,0 +1,14 @@
+---
+"@checkstack/ui": minor
+"@checkstack/frontend": minor
+---
+
+Stop shipping the Monaco editor on pages that never mount an editor (e.g. the login page).
+
+The `@checkstack/ui` barrel transitively pulled the entire `@codingame/*` / `monaco-languageclient` stack into the initial load via three static edges from the `CodeEditor` subpackage. All three are now cut, with no change to the public `@checkstack/ui` API:
+
+- `CodeEditor` lazy-loads its Monaco-backed `TypefoxEditor` behind `React.lazy` + an internal `Suspense` (skeleton fallback that respects `usePerformance`).
+- `validateTypeScriptSources` now imports the Monaco editor API, the standalone TS worker, and `monacoTsService` via in-body `await import(...)` instead of at module scope.
+- The "monaco-vscode services ready" signal (`markVscodeServicesReady` / `areVscodeServicesReady` / `onVscodeServicesReady`) moved to a new Monaco-free `vscodeServicesSignal` module, so the barrel re-export no longer drags Monaco in.
+
+The Monaco editor body (~10 MB) now loads on demand only when a `CodeEditor` mounts. A `react-vendor` `manualChunks` split was also added in `@checkstack/frontend` for stable vendor caching.

--- a/.changeset/lucide-v1-and-icon-chart-perf.md
+++ b/.changeset/lucide-v1-and-icon-chart-perf.md
@@ -5,6 +5,14 @@
 "@checkstack/about-frontend": minor
 "@checkstack/gitops-frontend": minor
 "@checkstack/healthcheck-frontend": minor
+"@checkstack/anomaly-frontend": minor
+"@checkstack/auth-frontend": minor
+"@checkstack/cache-frontend": minor
+"@checkstack/command-frontend": minor
+"@checkstack/dashboard-frontend": minor
+"@checkstack/queue-frontend": minor
+"@checkstack/theme-frontend": minor
+"@checkstack/tips-frontend": minor
 ---
 
 Upgrade lucide-react to v1 and stop shipping the full icon set / chart libraries in the initial load.

--- a/.changeset/lucide-v1-and-icon-chart-perf.md
+++ b/.changeset/lucide-v1-and-icon-chart-perf.md
@@ -1,0 +1,18 @@
+---
+"@checkstack/common": minor
+"@checkstack/ui": minor
+"@checkstack/backend-api": minor
+"@checkstack/about-frontend": minor
+"@checkstack/gitops-frontend": minor
+"@checkstack/healthcheck-frontend": minor
+---
+
+Upgrade lucide-react to v1 and stop shipping the full icon set / chart libraries in the initial load.
+
+**lucide-react 1.x (BREAKING for icon consumers).** lucide-react was unified from three drifting ranges (`^0.344`, `^0.468`, `0.562` - five copies in the store) to `^1.17.0` across all frontend packages. lucide v1 removed every brand icon, so the GitHub/GitLab marks are now vendored in `@checkstack/ui` (`GithubIcon`, `GitlabIcon`, `brandIcons`). A new `IconName` type (`LucideIconName | BrandIconName`) in `@checkstack/common` is the canonical icon-name type; `AuthStrategy.icon` and the `@checkstack/ui` card components accept it, so data-driven brand icon names (e.g. `icon: "Github"`) keep working. Renamed v0 alias icons (e.g. `AlertCircle`) still resolve.
+
+  BREAKING: any external consumer importing a brand icon from `lucide-react` (e.g. `import { Github } from "lucide-react"`) must switch to the vendored `@checkstack/ui` brand icons or a custom SVG.
+
+**Icon bundle perf.** `DynamicIcon` no longer eagerly imports lucide's `icons` map (~1600 icons, ~1 MB). The map now lives in a `React.lazy`-loaded `iconRegistry` chunk fetched on first data-driven icon render, while statically named-imported icons (`import { Plus } from "lucide-react"`) tree-shake normally. Brand icons render synchronously.
+
+**Chart bundle perf.** The recharts-backed health-check charts (~300 KB) no longer ship in the initial load: the auto-chart slot extension lazy-loads its chart grid, and `HealthCheckSystemOverview` lazy-loads its drawer (which only opens on demand).

--- a/bun.lock
+++ b/bun.lock
@@ -37,13 +37,13 @@
     },
     "core/about-frontend": {
       "name": "@checkstack/about-frontend",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/about-common": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
       },
@@ -56,7 +56,7 @@
     },
     "core/announcement-backend": {
       "name": "@checkstack/announcement-backend",
-      "version": "0.3.11",
+      "version": "0.3.13",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-backend": "workspace:*",
@@ -97,7 +97,7 @@
     },
     "core/announcement-frontend": {
       "name": "@checkstack/announcement-frontend",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -107,7 +107,7 @@
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.20.0",
       },
@@ -120,7 +120,7 @@
     },
     "core/anomaly-backend": {
       "name": "@checkstack/anomaly-backend",
-      "version": "1.1.7",
+      "version": "1.1.9",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -170,7 +170,7 @@
     },
     "core/anomaly-frontend": {
       "name": "@checkstack/anomaly-frontend",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -183,7 +183,7 @@
         "@checkstack/signal-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^7.14.2",
         "zod": "^4.2.1",
@@ -209,13 +209,13 @@
     },
     "core/api-docs-frontend": {
       "name": "@checkstack/api-docs-frontend",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
       },
@@ -228,7 +228,7 @@
     },
     "core/auth-backend": {
       "name": "@checkstack/auth-backend",
-      "version": "0.4.31",
+      "version": "0.4.33",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -268,14 +268,14 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/ui": "workspace:*",
         "better-auth": "^1.1.8",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
       },
@@ -290,7 +290,7 @@
     },
     "core/automation-backend": {
       "name": "@checkstack/automation-backend",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/automation-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -329,7 +329,7 @@
     },
     "core/automation-common": {
       "name": "@checkstack/automation-common",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -345,7 +345,7 @@
     },
     "core/automation-frontend": {
       "name": "@checkstack/automation-frontend",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/automation-common": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -362,7 +362,7 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
         "yaml": "^2.6.1",
@@ -376,7 +376,7 @@
     },
     "core/backend": {
       "name": "@checkstack/backend",
-      "version": "0.11.0",
+      "version": "0.15.0",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -416,7 +416,7 @@
     },
     "core/backend-api": {
       "name": "@checkstack/backend-api",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "dependencies": {
         "@checkstack/cache-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -447,7 +447,7 @@
     },
     "core/cache-api": {
       "name": "@checkstack/cache-api",
-      "version": "0.3.6",
+      "version": "0.3.8",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -459,7 +459,7 @@
     },
     "core/cache-backend": {
       "name": "@checkstack/cache-backend",
-      "version": "0.3.6",
+      "version": "0.3.8",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -490,14 +490,14 @@
     },
     "core/cache-frontend": {
       "name": "@checkstack/cache-frontend",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@checkstack/cache-common": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/infrastructure-common": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.468.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.3.1",
       },
       "devDependencies": {
@@ -509,7 +509,7 @@
     },
     "core/cache-utils": {
       "name": "@checkstack/cache-utils",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "dependencies": {
         "@checkstack/cache-api": "workspace:*",
       },
@@ -522,7 +522,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -572,7 +572,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -586,7 +586,7 @@
         "@checkstack/ui": "workspace:*",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
       },
@@ -599,7 +599,7 @@
     },
     "core/command-backend": {
       "name": "@checkstack/command-backend",
-      "version": "0.1.31",
+      "version": "0.1.33",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-common": "workspace:*",
@@ -631,13 +631,13 @@
     },
     "core/command-frontend": {
       "name": "@checkstack/command-frontend",
-      "version": "0.2.41",
+      "version": "0.2.42",
       "dependencies": {
         "@checkstack/command-common": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.468.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^7.1.1",
       },
@@ -653,7 +653,7 @@
       "version": "0.12.0",
       "dependencies": {
         "@orpc/contract": "^1.13.14",
-        "lucide-react": "0.562.0",
+        "lucide-react": "^1.17.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -664,7 +664,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -684,7 +684,7 @@
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
       },
@@ -697,7 +697,7 @@
     },
     "core/dependency-backend": {
       "name": "@checkstack/dependency-backend",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -747,7 +747,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -760,7 +760,7 @@
         "@checkstack/signal-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
         "@xyflow/react": "^12.10.2",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.20.0",
       },
@@ -808,7 +808,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -827,7 +827,7 @@
         "better-auth": "^1.1.8",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.0",
@@ -871,7 +871,7 @@
     },
     "core/gitops-backend": {
       "name": "@checkstack/gitops-backend",
-      "version": "0.3.7",
+      "version": "0.4.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -898,7 +898,7 @@
     },
     "core/gitops-common": {
       "name": "@checkstack/gitops-common",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/secrets-common": "workspace:*",
@@ -913,14 +913,14 @@
     },
     "core/gitops-frontend": {
       "name": "@checkstack/gitops-frontend",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/gitops-common": "workspace:*",
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
       },
@@ -933,7 +933,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -977,7 +977,7 @@
     },
     "core/healthcheck-common": {
       "name": "@checkstack/healthcheck-common",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -993,7 +993,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -1012,7 +1012,7 @@
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.20.0",
         "recharts": "^3.6.0",
@@ -1028,7 +1028,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/automation-backend": "workspace:*",
@@ -1079,7 +1079,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -1093,7 +1093,7 @@
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.20.0",
       },
@@ -1121,13 +1121,13 @@
     },
     "core/infrastructure-frontend": {
       "name": "@checkstack/infrastructure-frontend",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/infrastructure-common": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.468.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.3.1",
         "react-router-dom": "^7.1.1",
       },
@@ -1140,7 +1140,7 @@
     },
     "core/integration-backend": {
       "name": "@checkstack/integration-backend",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -1181,7 +1181,7 @@
     },
     "core/integration-frontend": {
       "name": "@checkstack/integration-frontend",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1189,7 +1189,7 @@
         "@checkstack/signal-frontend": "workspace:*",
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
       },
@@ -1202,7 +1202,7 @@
     },
     "core/maintenance-backend": {
       "name": "@checkstack/maintenance-backend",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/automation-backend": "workspace:*",
@@ -1233,7 +1233,7 @@
     },
     "core/maintenance-common": {
       "name": "@checkstack/maintenance-common",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1251,7 +1251,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -1265,7 +1265,7 @@
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.20.0",
       },
@@ -1278,7 +1278,7 @@
     },
     "core/notification-backend": {
       "name": "@checkstack/notification-backend",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1321,7 +1321,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1330,7 +1330,7 @@
         "@checkstack/signal-frontend": "workspace:*",
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
       },
@@ -1356,14 +1356,14 @@
     },
     "core/pluginmanager-frontend": {
       "name": "@checkstack/pluginmanager-frontend",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/pluginmanager-common": "workspace:*",
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.22.0",
       },
@@ -1376,7 +1376,7 @@
     },
     "core/queue-api": {
       "name": "@checkstack/queue-api",
-      "version": "0.3.6",
+      "version": "0.3.8",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -1388,7 +1388,7 @@
     },
     "core/queue-backend": {
       "name": "@checkstack/queue-backend",
-      "version": "0.3.6",
+      "version": "0.3.8",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1422,7 +1422,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1432,7 +1432,7 @@
         "@checkstack/ui": "workspace:*",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
-        "lucide-react": "^0.468.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.3.1",
         "react-router-dom": "^7.1.1",
         "zod": "^4.0.0",
@@ -1446,11 +1446,11 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.89.0",
+      "version": "0.93.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1466,7 +1466,7 @@
     },
     "core/satellite-backend": {
       "name": "@checkstack/satellite-backend",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/automation-common": "workspace:*",
@@ -1501,7 +1501,7 @@
     },
     "core/satellite-common": {
       "name": "@checkstack/satellite-common",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
@@ -1517,7 +1517,7 @@
     },
     "core/satellite-frontend": {
       "name": "@checkstack/satellite-frontend",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1527,7 +1527,7 @@
         "@checkstack/signal-frontend": "workspace:*",
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.20.0",
       },
@@ -1540,7 +1540,7 @@
     },
     "core/script-packages-backend": {
       "name": "@checkstack/script-packages-backend",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1560,7 +1560,7 @@
     },
     "core/script-packages-common": {
       "name": "@checkstack/script-packages-common",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1575,13 +1575,13 @@
     },
     "core/script-packages-frontend": {
       "name": "@checkstack/script-packages-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/script-packages-common": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "0.562.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.3.1",
         "react-router-dom": "^6.20.0",
       },
@@ -1594,7 +1594,7 @@
     },
     "core/script-packages-store-postgres": {
       "name": "@checkstack/script-packages-store-postgres",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1612,7 +1612,7 @@
     },
     "core/script-packages-store-s3": {
       "name": "@checkstack/script-packages-store-s3",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1647,7 +1647,7 @@
     },
     "core/secrets-backend": {
       "name": "@checkstack/secrets-backend",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1672,7 +1672,7 @@
     },
     "core/secrets-backend-local": {
       "name": "@checkstack/secrets-backend-local",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1696,7 +1696,7 @@
     },
     "core/secrets-backend-vault": {
       "name": "@checkstack/secrets-backend-vault",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1721,7 +1721,7 @@
     },
     "core/secrets-common": {
       "name": "@checkstack/secrets-common",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.13.2",
@@ -1736,13 +1736,13 @@
     },
     "core/secrets-frontend": {
       "name": "@checkstack/secrets-frontend",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/secrets-common": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "0.562.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.3.1",
         "react-router-dom": "^6.20.0",
       },
@@ -1755,7 +1755,7 @@
     },
     "core/signal-backend": {
       "name": "@checkstack/signal-backend",
-      "version": "0.2.10",
+      "version": "0.2.12",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1800,7 +1800,7 @@
     },
     "core/slo-backend": {
       "name": "@checkstack/slo-backend",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1850,7 +1850,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1863,7 +1863,7 @@
         "@checkstack/tips-frontend": "workspace:*",
         "@checkstack/ui": "workspace:*",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
         "react-router-dom": "^6.20.0",
         "recharts": "^3.8.1",
@@ -1877,7 +1877,7 @@
     },
     "core/template-engine": {
       "name": "@checkstack/template-engine",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
@@ -1890,7 +1890,7 @@
     },
     "core/test-utils-backend": {
       "name": "@checkstack/test-utils-backend",
-      "version": "0.1.31",
+      "version": "0.1.33",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1926,7 +1926,7 @@
     },
     "core/theme-backend": {
       "name": "@checkstack/theme-backend",
-      "version": "0.1.35",
+      "version": "0.1.37",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1962,14 +1962,14 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/theme-common": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
       },
       "devDependencies": {
@@ -1981,7 +1981,7 @@
     },
     "core/tips-backend": {
       "name": "@checkstack/tips-backend",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2017,14 +2017,14 @@
     },
     "core/tips-frontend": {
       "name": "@checkstack/tips-frontend",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
         "@checkstack/tips-common": "workspace:*",
         "@checkstack/ui": "workspace:*",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.17.0",
         "react": "^18.2.0",
       },
       "devDependencies": {
@@ -2044,7 +2044,7 @@
     },
     "core/ui": {
       "name": "@checkstack/ui",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -2067,7 +2067,7 @@
         "date-fns": "^4.1.0",
         "fast-xml-parser": "^5.8.0",
         "jsonc-parser": "^3.3.1",
-        "lucide-react": "0.562.0",
+        "lucide-react": "^1.17.0",
         "monaco-languageclient": "10.7.0",
         "react": "^18.2.0",
         "react-day-picker": "^9.13.0",
@@ -2117,7 +2117,7 @@
     },
     "plugins/auth-credential-backend": {
       "name": "@checkstack/auth-credential-backend",
-      "version": "0.0.40",
+      "version": "0.0.42",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2131,7 +2131,7 @@
     },
     "plugins/auth-github-backend": {
       "name": "@checkstack/auth-github-backend",
-      "version": "0.0.40",
+      "version": "0.0.42",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2145,7 +2145,7 @@
     },
     "plugins/auth-ldap-backend": {
       "name": "@checkstack/auth-ldap-backend",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -2164,7 +2164,7 @@
     },
     "plugins/auth-saml-backend": {
       "name": "@checkstack/auth-saml-backend",
-      "version": "0.1.31",
+      "version": "0.1.33",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -2182,7 +2182,7 @@
     },
     "plugins/cache-memory-backend": {
       "name": "@checkstack/cache-memory-backend",
-      "version": "0.3.6",
+      "version": "0.3.8",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -2209,7 +2209,7 @@
     },
     "plugins/collector-hardware-backend": {
       "name": "@checkstack/collector-hardware-backend",
-      "version": "0.1.36",
+      "version": "0.1.38",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2225,7 +2225,7 @@
     },
     "plugins/healthcheck-dns-backend": {
       "name": "@checkstack/healthcheck-dns-backend",
-      "version": "0.2.21",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2240,7 +2240,7 @@
     },
     "plugins/healthcheck-grpc-backend": {
       "name": "@checkstack/healthcheck-grpc-backend",
-      "version": "0.2.21",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2256,7 +2256,7 @@
     },
     "plugins/healthcheck-http-backend": {
       "name": "@checkstack/healthcheck-http-backend",
-      "version": "0.3.21",
+      "version": "0.3.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2272,7 +2272,7 @@
     },
     "plugins/healthcheck-jenkins-backend": {
       "name": "@checkstack/healthcheck-jenkins-backend",
-      "version": "0.3.22",
+      "version": "0.3.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2287,7 +2287,7 @@
     },
     "plugins/healthcheck-mysql-backend": {
       "name": "@checkstack/healthcheck-mysql-backend",
-      "version": "0.2.21",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2303,7 +2303,7 @@
     },
     "plugins/healthcheck-ping-backend": {
       "name": "@checkstack/healthcheck-ping-backend",
-      "version": "0.2.21",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2318,7 +2318,7 @@
     },
     "plugins/healthcheck-postgres-backend": {
       "name": "@checkstack/healthcheck-postgres-backend",
-      "version": "0.2.21",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2335,7 +2335,7 @@
     },
     "plugins/healthcheck-rcon-backend": {
       "name": "@checkstack/healthcheck-rcon-backend",
-      "version": "0.3.21",
+      "version": "0.3.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2365,7 +2365,7 @@
     },
     "plugins/healthcheck-redis-backend": {
       "name": "@checkstack/healthcheck-redis-backend",
-      "version": "0.2.21",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2381,7 +2381,7 @@
     },
     "plugins/healthcheck-script-backend": {
       "name": "@checkstack/healthcheck-script-backend",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2398,7 +2398,7 @@
     },
     "plugins/healthcheck-ssh-backend": {
       "name": "@checkstack/healthcheck-ssh-backend",
-      "version": "0.2.21",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2429,7 +2429,7 @@
     },
     "plugins/healthcheck-tcp-backend": {
       "name": "@checkstack/healthcheck-tcp-backend",
-      "version": "0.2.21",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2444,7 +2444,7 @@
     },
     "plugins/healthcheck-tls-backend": {
       "name": "@checkstack/healthcheck-tls-backend",
-      "version": "0.2.21",
+      "version": "0.2.23",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2459,7 +2459,7 @@
     },
     "plugins/integration-jira-backend": {
       "name": "@checkstack/integration-jira-backend",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2494,7 +2494,7 @@
     },
     "plugins/integration-script-backend": {
       "name": "@checkstack/integration-script-backend",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/automation-common": "workspace:*",
@@ -2516,7 +2516,7 @@
     },
     "plugins/integration-teams-backend": {
       "name": "@checkstack/integration-teams-backend",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2533,7 +2533,7 @@
     },
     "plugins/integration-webex-backend": {
       "name": "@checkstack/integration-webex-backend",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2550,7 +2550,7 @@
     },
     "plugins/integration-webhook-backend": {
       "name": "@checkstack/integration-webhook-backend",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2567,7 +2567,7 @@
     },
     "plugins/notification-backstage-backend": {
       "name": "@checkstack/notification-backstage-backend",
-      "version": "0.1.36",
+      "version": "0.1.38",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2581,7 +2581,7 @@
     },
     "plugins/notification-discord-backend": {
       "name": "@checkstack/notification-discord-backend",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2595,7 +2595,7 @@
     },
     "plugins/notification-gotify-backend": {
       "name": "@checkstack/notification-gotify-backend",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2609,7 +2609,7 @@
     },
     "plugins/notification-pushover-backend": {
       "name": "@checkstack/notification-pushover-backend",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2623,7 +2623,7 @@
     },
     "plugins/notification-slack-backend": {
       "name": "@checkstack/notification-slack-backend",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2637,7 +2637,7 @@
     },
     "plugins/notification-smtp-backend": {
       "name": "@checkstack/notification-smtp-backend",
-      "version": "0.0.40",
+      "version": "0.0.42",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2653,7 +2653,7 @@
     },
     "plugins/notification-teams-backend": {
       "name": "@checkstack/notification-teams-backend",
-      "version": "0.0.40",
+      "version": "0.0.42",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2667,7 +2667,7 @@
     },
     "plugins/notification-telegram-backend": {
       "name": "@checkstack/notification-telegram-backend",
-      "version": "0.0.40",
+      "version": "0.0.42",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2683,7 +2683,7 @@
     },
     "plugins/notification-webex-backend": {
       "name": "@checkstack/notification-webex-backend",
-      "version": "0.0.40",
+      "version": "0.0.42",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2697,7 +2697,7 @@
     },
     "plugins/queue-bullmq-backend": {
       "name": "@checkstack/queue-bullmq-backend",
-      "version": "0.3.7",
+      "version": "0.4.1",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2727,7 +2727,7 @@
     },
     "plugins/queue-memory-backend": {
       "name": "@checkstack/queue-memory-backend",
-      "version": "0.4.6",
+      "version": "0.4.8",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -4709,7 +4709,7 @@
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
-    "lucide-react": ["lucide-react@0.344.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0" } }, "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ=="],
+    "lucide-react": ["lucide-react@1.17.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w=="],
 
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
@@ -5557,31 +5557,15 @@
 
     "@checkstack/anomaly-frontend/react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
 
-    "@checkstack/cache-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
-
-    "@checkstack/command-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
-
     "@checkstack/command-frontend/react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
 
-    "@checkstack/common/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
-
     "@checkstack/healthcheck-postgres-backend/pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
-
-    "@checkstack/infrastructure-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
     "@checkstack/infrastructure-frontend/react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
 
     "@checkstack/queue-backend/@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
-    "@checkstack/queue-frontend/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
-
     "@checkstack/queue-frontend/react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
-
-    "@checkstack/script-packages-frontend/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
-
-    "@checkstack/secrets-frontend/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
-
-    "@checkstack/ui/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
     "@codingame/monaco-vscode-api/marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
 

--- a/core/about-frontend/package.json
+++ b/core/about-frontend/package.json
@@ -19,7 +19,7 @@
     "@checkstack/ui": "workspace:*",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0",
-    "lucide-react": "^0.344.0"
+    "lucide-react": "^1.17.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/core/about-frontend/src/AboutPage.tsx
+++ b/core/about-frontend/src/AboutPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Info, Github, Mail, Scale, ExternalLink, Package } from "lucide-react";
+import { Info, Mail, Scale, ExternalLink, Package } from "lucide-react";
 import {
   PageLayout,
   Card,
@@ -9,6 +9,8 @@ import {
   CardContent,
   Badge,
   LoadingSpinner,
+  // Brand marks were removed from lucide v1; use the vendored one.
+  GithubIcon as Github,
 } from "@checkstack/ui";
 import { extractErrorMessage } from "@checkstack/common";
 

--- a/core/about-frontend/src/index.tsx
+++ b/core/about-frontend/src/index.tsx
@@ -4,8 +4,13 @@ import {
 } from "@checkstack/frontend-api";
 import { createRoutes } from "@checkstack/common";
 import { pluginMetadata } from "@checkstack/about-common";
-import { AboutPage } from "./AboutPage";
+import { lazy } from "react";
 import { AboutMenuItem } from "./AboutMenuItem";
+
+// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
+const AboutPage = lazy(() =>
+  import("./AboutPage").then((m) => ({ default: m.AboutPage })),
+);
 
 export const aboutRoutes = createRoutes(pluginMetadata.pluginId, {
   page: "/",

--- a/core/announcement-frontend/package.json
+++ b/core/announcement-frontend/package.json
@@ -21,7 +21,7 @@
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.20.0"
   },

--- a/core/announcement-frontend/src/index.tsx
+++ b/core/announcement-frontend/src/index.tsx
@@ -9,9 +9,16 @@ import {
   pluginMetadata,
   announcementAccess,
 } from "@checkstack/announcement-common";
-import { AnnouncementManagePage } from "./pages/AnnouncementManagePage";
+import { lazy } from "react";
 import { AnnouncementMenuItems } from "./components/AnnouncementMenuItems";
 import { DashboardAnnouncements } from "./components/DashboardAnnouncements";
+
+// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
+const AnnouncementManagePage = lazy(() =>
+  import("./pages/AnnouncementManagePage").then((m) => ({
+    default: m.AnnouncementManagePage,
+  })),
+);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/anomaly-frontend/package.json
+++ b/core/anomaly-frontend/package.json
@@ -24,7 +24,7 @@
     "@checkstack/signal-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^7.14.2",
     "zod": "^4.2.1"

--- a/core/api-docs-frontend/package.json
+++ b/core/api-docs-frontend/package.json
@@ -19,7 +19,7 @@
     "@checkstack/ui": "workspace:*",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0",
-    "lucide-react": "^0.344.0"
+    "lucide-react": "^1.17.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/core/api-docs-frontend/src/index.tsx
+++ b/core/api-docs-frontend/src/index.tsx
@@ -5,8 +5,13 @@ import {
 } from "@checkstack/frontend-api";
 import { createRoutes } from "@checkstack/common";
 import { pluginMetadata, apiDocsAccess } from "@checkstack/api-docs-common";
-import { ApiDocsPage } from "./ApiDocsPage";
+import { lazy } from "react";
 import { ApiDocsMenuItem } from "./ApiDocsMenuItem";
+
+// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
+const ApiDocsPage = lazy(() =>
+  import("./ApiDocsPage").then((m) => ({ default: m.ApiDocsPage })),
+);
 
 export const apiDocsRoutes = createRoutes(pluginMetadata.pluginId, {
   docs: "/",

--- a/core/auth-frontend/package.json
+++ b/core/auth-frontend/package.json
@@ -23,7 +23,7 @@
     "@checkstack/ui": "workspace:*",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "better-auth": "^1.1.8",
     "@checkstack/auth-common": "workspace:*"
   },

--- a/core/auth-frontend/src/components/AuthStrategyCard.tsx
+++ b/core/auth-frontend/src/components/AuthStrategyCard.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from "react";
 import {
   StrategyConfigCard,
   type ConfigSection,
-  type LucideIconName,
   type OptionsResolver,
 } from "@checkstack/ui";
 import { usePluginClient } from "@checkstack/frontend-api";
@@ -87,7 +86,7 @@ export function AuthStrategyCard({
         id: strategy.id,
         displayName: strategy.displayName,
         description: strategy.description,
-        icon: strategy.icon as LucideIconName,
+        icon: strategy.icon,
         enabled: strategy.enabled,
       }}
       configSections={configSections}

--- a/core/automation-frontend/package.json
+++ b/core/automation-frontend/package.json
@@ -28,7 +28,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0",
     "yaml": "^2.6.1"

--- a/core/automation-frontend/src/index.tsx
+++ b/core/automation-frontend/src/index.tsx
@@ -8,12 +8,31 @@ import {
   pluginMetadata,
   automationAccess,
 } from "@checkstack/automation-common";
-import { AutomationListPage } from "./pages/AutomationListPage";
-import { AutomationEditPage } from "./pages/AutomationEditPage";
-import { RunsPage } from "./pages/RunsPage";
-import { RunDetailPage } from "./pages/RunDetailPage";
-import { TemplatePlaygroundPage } from "./pages/TemplatePlaygroundPage";
+import { lazy } from "react";
 import { AutomationMenuItems } from "./components/AutomationMenuItems";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const AutomationListPage = lazy(() =>
+  import("./pages/AutomationListPage").then((m) => ({
+    default: m.AutomationListPage,
+  })),
+);
+const AutomationEditPage = lazy(() =>
+  import("./pages/AutomationEditPage").then((m) => ({
+    default: m.AutomationEditPage,
+  })),
+);
+const RunsPage = lazy(() =>
+  import("./pages/RunsPage").then((m) => ({ default: m.RunsPage })),
+);
+const RunDetailPage = lazy(() =>
+  import("./pages/RunDetailPage").then((m) => ({ default: m.RunDetailPage })),
+);
+const TemplatePlaygroundPage = lazy(() =>
+  import("./pages/TemplatePlaygroundPage").then((m) => ({
+    default: m.TemplatePlaygroundPage,
+  })),
+);
 
 export {
   generateAutomationContextTypes,

--- a/core/backend-api/src/auth-strategy.ts
+++ b/core/backend-api/src/auth-strategy.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { Migration } from "./config-versioning";
-import type { LucideIconName } from "@checkstack/common";
+import type { IconName } from "@checkstack/common";
 
 /**
  * Migration chain for auth strategy configurations.
@@ -21,8 +21,11 @@ export interface AuthStrategy<Config = unknown> {
   /** Optional description of the strategy */
   description?: string;
 
-  /** Lucide icon name in PascalCase (e.g., 'Github', 'Chrome', 'Mail') */
-  icon?: LucideIconName;
+  /**
+   * Icon name in PascalCase. A lucide icon (e.g. 'Mail') or a vendored brand
+   * icon (e.g. 'Github') - see `IconName` / `DynamicIcon`.
+   */
+  icon?: IconName;
 
   /** Current version of the configuration schema */
   configVersion: number;

--- a/core/cache-frontend/package.json
+++ b/core/cache-frontend/package.json
@@ -26,7 +26,7 @@
     "@checkstack/frontend-api": "workspace:*",
     "@checkstack/infrastructure-common": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "^0.468.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.3.1"
   },
   "devDependencies": {

--- a/core/catalog-frontend/package.json
+++ b/core/catalog-frontend/package.json
@@ -25,7 +25,7 @@
     "@checkstack/ui": "workspace:*",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0"
   },

--- a/core/catalog-frontend/src/index.tsx
+++ b/core/catalog-frontend/src/index.tsx
@@ -12,10 +12,23 @@ import {
 import { Server, FolderTree } from "lucide-react";
 import { registerSubjectKind } from "@checkstack/notification-frontend";
 
-import { CatalogPage } from "./components/CatalogPage";
-import { CatalogConfigPage } from "./components/CatalogConfigPage";
+import { lazy } from "react";
 import { CatalogUserMenuItems } from "./components/UserMenuItems";
-import { SystemDetailPage } from "./components/SystemDetailPage";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const CatalogPage = lazy(() =>
+  import("./components/CatalogPage").then((m) => ({ default: m.CatalogPage })),
+);
+const CatalogConfigPage = lazy(() =>
+  import("./components/CatalogConfigPage").then((m) => ({
+    default: m.CatalogConfigPage,
+  })),
+);
+const SystemDetailPage = lazy(() =>
+  import("./components/SystemDetailPage").then((m) => ({
+    default: m.SystemDetailPage,
+  })),
+);
 
 // Notification subject kinds emitted by catalog (see catalog-common's
 // `createSystemSubject` / `createGroupSubject`). Registered at module load

--- a/core/command-frontend/package.json
+++ b/core/command-frontend/package.json
@@ -13,7 +13,7 @@
     "@checkstack/common": "workspace:*",
     "@checkstack/frontend-api": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "^0.468.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^7.1.1"
   },

--- a/core/common/package.json
+++ b/core/common/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@orpc/contract": "^1.13.14",
-    "lucide-react": "0.562.0",
+    "lucide-react": "^1.17.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/core/common/src/icons.ts
+++ b/core/common/src/icons.ts
@@ -15,12 +15,27 @@ import { z } from "zod";
 export type LucideIconName = keyof typeof icons;
 
 /**
- * Zod schema for LucideIconName.
- * Uses string at runtime but infers LucideIconName type for compile-time safety.
+ * Brand icon names that lucide-react v1 removed (all brand marks were dropped
+ * for trademark reasons) but that we still support as data-driven icon names.
+ * The frontend's `DynamicIcon` resolves these to vendored brand SVGs in
+ * `@checkstack/ui`. Keep this in sync with the `brandIcons` map there.
+ */
+export type BrandIconName = "Github" | "Gitlab";
+
+/**
+ * Any icon name accepted across the platform: a lucide icon or a vendored
+ * brand icon.
+ * @example "CircleAlert", "Settings", "Github"
+ */
+export type IconName = LucideIconName | BrandIconName;
+
+/**
+ * Zod schema for {@link IconName}.
+ * Uses string at runtime but infers `IconName` for compile-time safety.
  * Use this in RPC contracts to get proper type inference.
  *
  * @example
  * const schema = z.object({ icon: lucideIconSchema.optional() });
- * // Infers: { icon?: LucideIconName }
+ * // Infers: { icon?: IconName }
  */
-export const lucideIconSchema = z.string() as z.ZodType<LucideIconName>;
+export const lucideIconSchema = z.string() as z.ZodType<IconName>;

--- a/core/dashboard-frontend/package.json
+++ b/core/dashboard-frontend/package.json
@@ -32,7 +32,7 @@
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0"
   },

--- a/core/dependency-frontend/package.json
+++ b/core/dependency-frontend/package.json
@@ -24,7 +24,7 @@
     "@checkstack/signal-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "@xyflow/react": "^12.10.2",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.20.0"
   },

--- a/core/dependency-frontend/src/index.tsx
+++ b/core/dependency-frontend/src/index.tsx
@@ -14,11 +14,18 @@ import {
   SystemStateBadgesSlot,
   SystemEditorSlot,
 } from "@checkstack/catalog-common";
+import { lazy } from "react";
 import { DependencyBadge } from "./components/DependencyBadge";
 import { DependencyAlert } from "./components/DependencyAlert";
 import { DependencyEditor } from "./components/DependencyEditor";
-import { DependencyMapPage } from "./components/DependencyMapPage";
 import { DependencyMenuItems } from "./components/DependencyMenuItems";
+
+// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
+const DependencyMapPage = lazy(() =>
+  import("./components/DependencyMapPage").then((m) => ({
+    default: m.DependencyMapPage,
+  })),
+);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -33,7 +33,7 @@
     "better-auth": "^1.1.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",

--- a/core/frontend/src/App.tsx
+++ b/core/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { Suspense, useMemo } from "react";
 import {
   BrowserRouter,
   Routes,
@@ -174,14 +174,27 @@ function AppContent() {
                 </div>
               }
             />
-            {/* Plugin Routes */}
+            {/* Plugin Routes. Most plugins lazy-load their page bodies via
+                `React.lazy` (so the route's component chunk is fetched on
+                navigation, not in the initial load), so each element is wrapped
+                in a Suspense boundary. The fallback mirrors RouteGuard's
+                access-loading state and uses the `usePerformance`-aware
+                LoadingSpinner. */}
             {pluginRegistry.getAllRoutes().map((route) => (
               <Route
                 key={route.path}
                 path={route.path}
                 element={
                   <RouteGuard accessRule={route.accessRule}>
-                    {route.element}
+                    <Suspense
+                      fallback={
+                        <div className="h-full flex items-center justify-center p-8">
+                          <LoadingSpinner />
+                        </div>
+                      }
+                    >
+                      {route.element}
+                    </Suspense>
                   </RouteGuard>
                 }
               />

--- a/core/frontend/vite.config.ts
+++ b/core/frontend/vite.config.ts
@@ -103,6 +103,56 @@ export default defineConfig(() => {
       // Don't wipe dist/ — the vendor build (build:vendor) writes to dist/vendor/
       // before this build runs, and we need to preserve those files
       emptyOutDir: false,
+      rollupOptions: {
+        output: {
+          // Split heavy / stable vendor code into dedicated chunks so the
+          // initial (login) load stays small and chunks cache independently.
+          // This complements the `React.lazy(CodeEditor)` split: it does not by
+          // itself keep Monaco off the login page (that's the lazy boundary in
+          // CodeEditor.tsx), but it guarantees the whole `@codingame/*` /
+          // monaco stack lands in ONE chunk that is only fetched when an editor
+          // mounts, rather than smeared across many shared chunks.
+          manualChunks(id) {
+            if (!id.includes("node_modules")) {
+              return;
+            }
+            // NB: do NOT try to hand-group lucide icon modules here. The same
+            // per-icon modules are reached BOTH statically (`import { Plus }
+            // from "lucide-react"` across the app, which must stay eager) and
+            // dynamically (DynamicIcon's lazy icon registry). A manualChunk
+            // keys off module id only, so it can't tell the two apart and ends
+            // up pulling the whole icon set into the eager graph. The lazy
+            // boundary for the data-driven icon set lives in DynamicIcon /
+            // iconRegistry instead (see core/ui).
+            // NOTE: we deliberately do NOT hand-group the Monaco / VS Code
+            // editor stack here. Rollup's natural code-splitting already
+            // isolates it: every `@codingame/*` / `@typefox/*` /
+            // monaco-languageclient module is reachable only through the lazy
+            // `CodeEditor` / `validateScripts` boundaries (see CodeEditor.tsx),
+            // so it lands in dynamically-imported chunks that the initial
+            // (login) load never fetches. A manual `monaco` chunk is actively
+            // harmful: a tiny `@codingame/*` module is pulled in EAGERLY as a
+            // transitive dep of non-editor code, and folding it into one big
+            // chunk with the lazy editor body makes the entire ~10 MB chunk a
+            // static dependency of the entry, re-shipping Monaco to the login
+            // page. Leaving it to natural splitting keeps the heavy editor body
+            // lazy while that tiny eager stub stays inlined where it belongs.
+
+            // The React runtime: one stable chunk shared across the whole app.
+            // `dedupe` above already guarantees a single copy; this only
+            // controls which output file it lands in.
+            if (
+              id.includes("/react/") ||
+              id.includes("/react-dom/") ||
+              id.includes("/react-router") ||
+              id.includes("/scheduler/")
+            ) {
+              return "react-vendor";
+            }
+            return;
+          },
+        },
+      },
     },
     resolve: {
       // Force all monorepo packages to use the same React copy at build time.

--- a/core/gitops-frontend/package.json
+++ b/core/gitops-frontend/package.json
@@ -18,7 +18,7 @@
     "@checkstack/gitops-common": "workspace:*",
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0"
   },

--- a/core/gitops-frontend/src/components/ProviderList.tsx
+++ b/core/gitops-frontend/src/components/ProviderList.tsx
@@ -22,15 +22,11 @@ import {
   Badge,
   useToast,
   toastError,
-} from "@checkstack/ui";
-import {
-  Plus,
-  RefreshCw,
-  Trash2,
-  Pencil,
-  Github,
+  // Brand marks were removed from lucide v1; use the vendored ones.
+  GithubIcon as Github,
   GitlabIcon,
-} from "lucide-react";
+} from "@checkstack/ui";
+import { Plus, RefreshCw, Trash2, Pencil } from "lucide-react";
 import { ProviderEditor } from "./ProviderEditor";
 
 const formatInterval = (seconds: number) => {

--- a/core/gitops-frontend/src/index.tsx
+++ b/core/gitops-frontend/src/index.tsx
@@ -9,10 +9,19 @@ import {
   gitopsAccess,
 } from "@checkstack/gitops-common";
 
-import { GitOpsPage } from "./pages/GitOpsPage";
-import { KindRegistryPage } from "./pages/KindRegistryPage";
+import { lazy } from "react";
 import { GitOpsMenuItem } from "./components/GitOpsMenuItem";
 import { KindRegistryMenuItem } from "./components/KindRegistryMenuItem";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const GitOpsPage = lazy(() =>
+  import("./pages/GitOpsPage").then((m) => ({ default: m.GitOpsPage })),
+);
+const KindRegistryPage = lazy(() =>
+  import("./pages/KindRegistryPage").then((m) => ({
+    default: m.KindRegistryPage,
+  })),
+);
 
 export const gitopsPlugin = createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/healthcheck-frontend/package.json
+++ b/core/healthcheck-frontend/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.20.0",
     "recharts": "^3.6.0",

--- a/core/healthcheck-frontend/src/auto-charts/extension.tsx
+++ b/core/healthcheck-frontend/src/auto-charts/extension.tsx
@@ -5,12 +5,21 @@
  * for all strategies that have schema metadata.
  */
 
+import { lazy, Suspense } from "react";
 import { createSlotExtension } from "@checkstack/frontend-api";
+import { Skeleton } from "@checkstack/ui";
 import {
   HealthCheckDiagramSlot,
   type HealthCheckDiagramSlotContext,
 } from "../slots";
-import { AutoChartGrid } from "./AutoChartGrid";
+
+// Lazy-loaded: AutoChartGrid pulls in recharts (~300 KB). This extension is
+// registered eagerly at plugin load, so a static import would ship recharts in
+// the initial bundle even though charts only render inside the (on-demand)
+// HealthCheckDiagramSlot. Deferring it keeps recharts out of the initial load.
+const AutoChartGrid = lazy(() =>
+  import("./AutoChartGrid").then((m) => ({ default: m.AutoChartGrid })),
+);
 
 /**
  * Extension that renders auto-generated charts for any strategy.
@@ -22,6 +31,10 @@ import { AutoChartGrid } from "./AutoChartGrid";
 export const autoChartExtension = createSlotExtension(HealthCheckDiagramSlot, {
   id: "healthcheck.auto-charts",
   component: (context: HealthCheckDiagramSlotContext) => {
-    return <AutoChartGrid context={context} />;
+    return (
+      <Suspense fallback={<Skeleton className="h-48 w-full" />}>
+        <AutoChartGrid context={context} />
+      </Suspense>
+    );
   },
 });

--- a/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, lazy, Suspense } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   usePluginClient,
@@ -17,7 +17,13 @@ import {
 } from "@checkstack/ui";
 import { Heart } from "lucide-react";
 import { HealthCheckSparkline } from "./HealthCheckSparkline";
-import { HealthCheckDrawer } from "./HealthCheckDrawer";
+// Lazy-loaded: the drawer pulls in the recharts-based latency/timeline charts
+// (~300 KB). This component is an eagerly-registered slot extension, so a static
+// import would ship recharts in the initial bundle. The drawer only renders when
+// a check is selected, so deferring it keeps charts out of the initial load.
+const HealthCheckDrawer = lazy(() =>
+  import("./HealthCheckDrawer").then((m) => ({ default: m.HealthCheckDrawer })),
+);
 
 import type {
   StateThresholds,
@@ -206,16 +212,18 @@ export function HealthCheckSystemOverview(props: SlotProps) {
         </CardContent>
       </Card>
 
-      {/* Slide-over Drawer */}
+      {/* Slide-over Drawer (lazy: loads the chart bundle on first open) */}
       {selectedCheck && (
-        <HealthCheckDrawer
-          item={selectedCheck}
-          systemId={systemId}
-          open={!!selectedCheck}
-          onOpenChange={(open) => {
-            if (!open) setSelectedCheck(undefined);
-          }}
-        />
+        <Suspense fallback={null}>
+          <HealthCheckDrawer
+            item={selectedCheck}
+            systemId={systemId}
+            open={!!selectedCheck}
+            onOpenChange={(open) => {
+              if (!open) setSelectedCheck(undefined);
+            }}
+          />
+        </Suspense>
       )}
     </>
   );

--- a/core/healthcheck-frontend/src/index.tsx
+++ b/core/healthcheck-frontend/src/index.tsx
@@ -3,18 +3,18 @@ import {
   createSlotExtension,
   UserMenuItemsSlot,
 } from "@checkstack/frontend-api";
-import { HealthCheckConfigPage } from "./pages/HealthCheckConfigPage";
-import { StrategyPickerPage } from "./pages/StrategyPickerPage";
-import { HealthCheckIDEPage } from "./pages/HealthCheckIDEPage";
-import { AssignmentIDEPage } from "./pages/AssignmentIDEPage";
-import { HealthCheckHistoryPage } from "./pages/HealthCheckHistoryPage";
-import { HealthCheckHistoryDetailPage } from "./pages/HealthCheckHistoryDetailPage";
+import { lazy } from "react";
 import { HealthCheckMenuItems } from "./components/HealthCheckMenuItems";
 import { HealthCheckSystemOverview } from "./components/HealthCheckSystemOverview";
 import { SystemHealthCheckAssignment } from "./components/SystemHealthCheckAssignment";
 import { SystemHealthBadge } from "./components/SystemHealthBadge";
 import { healthCheckAccess } from "@checkstack/healthcheck-common";
-import { autoChartExtension } from "./auto-charts";
+// Import directly from the extension module, NOT the `./auto-charts` barrel:
+// the barrel statically re-exports AutoChartGrid + SingleRunChartGrid (both
+// pull in recharts), so importing the extension through it would drag recharts
+// into this eagerly-loaded plugin entry. The extension itself lazy-loads the
+// chart grid.
+import { autoChartExtension } from "./auto-charts/extension";
 
 import {
   SystemDetailsSlot,
@@ -43,6 +43,38 @@ export {
 // Export hooks for reusable data fetching
 export { useHealthCheckData } from "./hooks";
 export { useStrategySchemas } from "./auto-charts/useStrategySchemas";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const HealthCheckConfigPage = lazy(() =>
+  import("./pages/HealthCheckConfigPage").then((m) => ({
+    default: m.HealthCheckConfigPage,
+  })),
+);
+const StrategyPickerPage = lazy(() =>
+  import("./pages/StrategyPickerPage").then((m) => ({
+    default: m.StrategyPickerPage,
+  })),
+);
+const HealthCheckIDEPage = lazy(() =>
+  import("./pages/HealthCheckIDEPage").then((m) => ({
+    default: m.HealthCheckIDEPage,
+  })),
+);
+const AssignmentIDEPage = lazy(() =>
+  import("./pages/AssignmentIDEPage").then((m) => ({
+    default: m.AssignmentIDEPage,
+  })),
+);
+const HealthCheckHistoryPage = lazy(() =>
+  import("./pages/HealthCheckHistoryPage").then((m) => ({
+    default: m.HealthCheckHistoryPage,
+  })),
+);
+const HealthCheckHistoryDetailPage = lazy(() =>
+  import("./pages/HealthCheckHistoryDetailPage").then((m) => ({
+    default: m.HealthCheckHistoryDetailPage,
+  })),
+);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/incident-frontend/package.json
+++ b/core/incident-frontend/package.json
@@ -25,7 +25,7 @@
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.20.0"
   },

--- a/core/incident-frontend/src/index.tsx
+++ b/core/incident-frontend/src/index.tsx
@@ -12,12 +12,27 @@ import {
   SystemDetailsTopSlot,
   SystemStateBadgesSlot,
 } from "@checkstack/catalog-common";
-import { IncidentConfigPage } from "./pages/IncidentConfigPage";
-import { IncidentDetailPage } from "./pages/IncidentDetailPage";
-import { SystemIncidentHistoryPage } from "./pages/SystemIncidentHistoryPage";
+import { lazy } from "react";
 import { SystemIncidentPanel } from "./components/SystemIncidentPanel";
 import { SystemIncidentBadge } from "./components/SystemIncidentBadge";
 import { IncidentMenuItems } from "./components/IncidentMenuItems";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const IncidentConfigPage = lazy(() =>
+  import("./pages/IncidentConfigPage").then((m) => ({
+    default: m.IncidentConfigPage,
+  })),
+);
+const IncidentDetailPage = lazy(() =>
+  import("./pages/IncidentDetailPage").then((m) => ({
+    default: m.IncidentDetailPage,
+  })),
+);
+const SystemIncidentHistoryPage = lazy(() =>
+  import("./pages/SystemIncidentHistoryPage").then((m) => ({
+    default: m.SystemIncidentHistoryPage,
+  })),
+);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/infrastructure-frontend/package.json
+++ b/core/infrastructure-frontend/package.json
@@ -25,7 +25,7 @@
     "@checkstack/frontend-api": "workspace:*",
     "@checkstack/infrastructure-common": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "^0.468.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.3.1",
     "react-router-dom": "^7.1.1"
   },

--- a/core/infrastructure-frontend/src/index.tsx
+++ b/core/infrastructure-frontend/src/index.tsx
@@ -3,12 +3,19 @@ import {
   createSlotExtension,
   createFrontendPlugin,
 } from "@checkstack/frontend-api";
-import { InfrastructureConfigPage } from "./pages/InfrastructureConfigPage";
+import { lazy } from "react";
 import { InfrastructureUserMenuItems } from "./components/UserMenuItems";
 import {
   pluginMetadata,
   infrastructureRoutes,
 } from "@checkstack/infrastructure-common";
+
+// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
+const InfrastructureConfigPage = lazy(() =>
+  import("./pages/InfrastructureConfigPage").then((m) => ({
+    default: m.InfrastructureConfigPage,
+  })),
+);
 
 export const infrastructurePlugin = createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/integration-frontend/package.json
+++ b/core/integration-frontend/package.json
@@ -19,7 +19,7 @@
     "@checkstack/signal-frontend": "workspace:*",
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0"
   },

--- a/core/integration-frontend/src/index.tsx
+++ b/core/integration-frontend/src/index.tsx
@@ -8,9 +8,20 @@ import {
   pluginMetadata,
   integrationAccess,
 } from "@checkstack/integration-common";
-import { IntegrationsLandingPage } from "./pages/IntegrationsLandingPage";
-import { ProviderConnectionsPage } from "./pages/ProviderConnectionsPage";
+import { lazy } from "react";
 import { IntegrationMenuItem } from "./components/IntegrationMenuItem";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const IntegrationsLandingPage = lazy(() =>
+  import("./pages/IntegrationsLandingPage").then((m) => ({
+    default: m.IntegrationsLandingPage,
+  })),
+);
+const ProviderConnectionsPage = lazy(() =>
+  import("./pages/ProviderConnectionsPage").then((m) => ({
+    default: m.ProviderConnectionsPage,
+  })),
+);
 
 /**
  * Integration frontend — now scoped to connection management. The

--- a/core/maintenance-frontend/package.json
+++ b/core/maintenance-frontend/package.json
@@ -25,7 +25,7 @@
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.20.0"
   },

--- a/core/maintenance-frontend/src/index.tsx
+++ b/core/maintenance-frontend/src/index.tsx
@@ -12,12 +12,27 @@ import {
   SystemDetailsTopSlot,
   SystemStateBadgesSlot,
 } from "@checkstack/catalog-common";
-import { MaintenanceConfigPage } from "./pages/MaintenanceConfigPage";
-import { SystemMaintenanceHistoryPage } from "./pages/SystemMaintenanceHistoryPage";
-import { MaintenanceDetailPage } from "./pages/MaintenanceDetailPage";
+import { lazy } from "react";
 import { SystemMaintenancePanel } from "./components/SystemMaintenancePanel";
 import { SystemMaintenanceBadge } from "./components/SystemMaintenanceBadge";
 import { MaintenanceMenuItems } from "./components/MaintenanceMenuItems";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const MaintenanceConfigPage = lazy(() =>
+  import("./pages/MaintenanceConfigPage").then((m) => ({
+    default: m.MaintenanceConfigPage,
+  })),
+);
+const SystemMaintenanceHistoryPage = lazy(() =>
+  import("./pages/SystemMaintenanceHistoryPage").then((m) => ({
+    default: m.SystemMaintenanceHistoryPage,
+  })),
+);
+const MaintenanceDetailPage = lazy(() =>
+  import("./pages/MaintenanceDetailPage").then((m) => ({
+    default: m.MaintenanceDetailPage,
+  })),
+);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/notification-frontend/package.json
+++ b/core/notification-frontend/package.json
@@ -20,7 +20,7 @@
     "@checkstack/signal-frontend": "workspace:*",
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0"
   },

--- a/core/notification-frontend/src/index.tsx
+++ b/core/notification-frontend/src/index.tsx
@@ -8,11 +8,26 @@ import {
   notificationRoutes,
   pluginMetadata,
 } from "@checkstack/notification-common";
+import { lazy } from "react";
 import { NotificationBell } from "./components/NotificationBell";
-import { NotificationsPage } from "./pages/NotificationsPage";
-import { NotificationSettingsPage } from "./pages/NotificationSettingsPage";
-import { DeliveryAttemptsPage } from "./pages/DeliveryAttemptsPage";
 import { NotificationUserMenuItems } from "./components/UserMenuItems";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const NotificationsPage = lazy(() =>
+  import("./pages/NotificationsPage").then((m) => ({
+    default: m.NotificationsPage,
+  })),
+);
+const NotificationSettingsPage = lazy(() =>
+  import("./pages/NotificationSettingsPage").then((m) => ({
+    default: m.NotificationSettingsPage,
+  })),
+);
+const DeliveryAttemptsPage = lazy(() =>
+  import("./pages/DeliveryAttemptsPage").then((m) => ({
+    default: m.DeliveryAttemptsPage,
+  })),
+);
 
 // Plugin-extensible kind registry — domain frontends call `registerSubjectKind`
 // at module load to bind their kinds (e.g., "catalog.system") to icon + label.

--- a/core/pluginmanager-frontend/package.json
+++ b/core/pluginmanager-frontend/package.json
@@ -18,7 +18,7 @@
     "@checkstack/pluginmanager-common": "workspace:*",
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.22.0"
   },

--- a/core/pluginmanager-frontend/src/index.tsx
+++ b/core/pluginmanager-frontend/src/index.tsx
@@ -7,10 +7,25 @@ import {
   pluginManagerRoutes,
   pluginManagerAccess,
 } from "@checkstack/pluginmanager-common";
-import { InstalledPluginsPage } from "./pages/InstalledPluginsPage";
-import { InstallPluginPage } from "./pages/InstallPluginPage";
-import { PluginEventsPage } from "./pages/PluginEventsPage";
+import { lazy } from "react";
 import { PluginManagerMenuItem } from "./PluginManagerMenuItem";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const InstalledPluginsPage = lazy(() =>
+  import("./pages/InstalledPluginsPage").then((m) => ({
+    default: m.InstalledPluginsPage,
+  })),
+);
+const InstallPluginPage = lazy(() =>
+  import("./pages/InstallPluginPage").then((m) => ({
+    default: m.InstallPluginPage,
+  })),
+);
+const PluginEventsPage = lazy(() =>
+  import("./pages/PluginEventsPage").then((m) => ({
+    default: m.PluginEventsPage,
+  })),
+);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/queue-frontend/package.json
+++ b/core/queue-frontend/package.json
@@ -29,7 +29,7 @@
     "@checkstack/ui": "workspace:*",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
-    "lucide-react": "^0.468.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.3.1",
     "react-router-dom": "^7.1.1",
     "zod": "^4.0.0"

--- a/core/satellite-frontend/package.json
+++ b/core/satellite-frontend/package.json
@@ -21,7 +21,7 @@
     "@checkstack/gitops-frontend": "workspace:*",
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.20.0"
   },

--- a/core/satellite-frontend/src/index.tsx
+++ b/core/satellite-frontend/src/index.tsx
@@ -8,8 +8,15 @@ import {
   pluginMetadata,
   satelliteAccess,
 } from "@checkstack/satellite-common";
-import { SatelliteListPage } from "./pages/SatelliteListPage";
+import { lazy } from "react";
 import { SatelliteMenuItems } from "./components/SatelliteMenuItems";
+
+// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
+const SatelliteListPage = lazy(() =>
+  import("./pages/SatelliteListPage").then((m) => ({
+    default: m.SatelliteListPage,
+  })),
+);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/script-packages-frontend/package.json
+++ b/core/script-packages-frontend/package.json
@@ -26,7 +26,7 @@
     "@checkstack/frontend-api": "workspace:*",
     "@checkstack/script-packages-common": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "0.562.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.3.1",
     "react-router-dom": "^6.20.0"
   },

--- a/core/script-packages-frontend/src/index.tsx
+++ b/core/script-packages-frontend/src/index.tsx
@@ -8,8 +8,15 @@ import {
   scriptPackagesAccess,
   pluginMetadata,
 } from "@checkstack/script-packages-common";
-import { ScriptPackagesSettingsPage } from "./pages/ScriptPackagesSettingsPage";
+import { lazy } from "react";
 import { ScriptPackagesMenuItems } from "./components/ScriptPackagesMenuItems";
+
+// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
+const ScriptPackagesSettingsPage = lazy(() =>
+  import("./pages/ScriptPackagesSettingsPage").then((m) => ({
+    default: m.ScriptPackagesSettingsPage,
+  })),
+);
 
 /**
  * Frontend plugin for script-package management.

--- a/core/scripts/src/templates/frontend/src/index.tsx.hbs
+++ b/core/scripts/src/templates/frontend/src/index.tsx.hbs
@@ -1,6 +1,17 @@
+import { lazy } from "react";
 import { createFrontendPlugin } from "@checkstack/frontend-api";
-import { {{pluginNamePascal}}ListPage } from "./components/{{pluginNamePascal}}ListPage";
 import { {{pluginNameCamel}}Routes, pluginMetadata, {{pluginNameCamel}}Access } from "@checkstack/{{pluginBaseName}}-common";
+
+// Route pages are lazy-loaded so each page's component body is split into a
+// per-route chunk fetched on navigation, not bundled into the initial app
+// load. The app shell renders every route element inside a Suspense boundary,
+// so the plugin only needs to hand it a lazy component. Keep this pattern for
+// new pages; nav/slot extension components stay statically imported.
+const {{pluginNamePascal}}ListPage = lazy(() =>
+  import("./components/{{pluginNamePascal}}ListPage").then((m) => ({
+    default: m.{{pluginNamePascal}}ListPage,
+  })),
+);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/secrets-frontend/package.json
+++ b/core/secrets-frontend/package.json
@@ -29,7 +29,7 @@
     "@checkstack/frontend-api": "workspace:*",
     "@checkstack/secrets-common": "workspace:*",
     "@checkstack/ui": "workspace:*",
-    "lucide-react": "0.562.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.3.1",
     "react-router-dom": "^6.20.0"
   },

--- a/core/secrets-frontend/src/index.tsx
+++ b/core/secrets-frontend/src/index.tsx
@@ -8,8 +8,15 @@ import {
   secretsAccess,
   pluginMetadata,
 } from "@checkstack/secrets-common";
-import { SecretsSettingsPage } from "./pages/SecretsSettingsPage";
+import { lazy } from "react";
 import { SecretsMenuItems } from "./components/SecretsMenuItems";
+
+// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
+const SecretsSettingsPage = lazy(() =>
+  import("./pages/SecretsSettingsPage").then((m) => ({
+    default: m.SecretsSettingsPage,
+  })),
+);
 
 /**
  * Frontend plugin for the Secrets platform.

--- a/core/slo-frontend/package.json
+++ b/core/slo-frontend/package.json
@@ -24,7 +24,7 @@
     "@checkstack/tips-frontend": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.17.0",
     "react": "^18.2.0",
     "react-router-dom": "^6.20.0",
     "recharts": "^3.8.1"

--- a/core/slo-frontend/src/index.tsx
+++ b/core/slo-frontend/src/index.tsx
@@ -4,9 +4,7 @@ import {
   UserMenuItemsSlot,
 } from "@checkstack/frontend-api";
 import { sloRoutes, pluginMetadata, sloAccess } from "@checkstack/slo-common";
-import { SloOverviewPage } from "./pages/SloOverviewPage";
-import { SloConfigPage } from "./pages/SloConfigPage";
-import { SloDetailPage } from "./pages/SloDetailPage";
+import { lazy } from "react";
 import { SystemSloPanel } from "./components/SystemSloPanel";
 import { SystemSloBadge } from "./components/SystemSloBadge";
 import { SloMenuItems } from "./components/SloMenuItems";
@@ -14,6 +12,19 @@ import {
   SystemDetailsTopSlot,
   SystemStateBadgesSlot,
 } from "@checkstack/catalog-common";
+
+// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
+const SloOverviewPage = lazy(() =>
+  import("./pages/SloOverviewPage").then((m) => ({
+    default: m.SloOverviewPage,
+  })),
+);
+const SloConfigPage = lazy(() =>
+  import("./pages/SloConfigPage").then((m) => ({ default: m.SloConfigPage })),
+);
+const SloDetailPage = lazy(() =>
+  import("./pages/SloDetailPage").then((m) => ({ default: m.SloDetailPage })),
+);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,

--- a/core/theme-frontend/package.json
+++ b/core/theme-frontend/package.json
@@ -19,7 +19,7 @@
     "@checkstack/common": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "react": "^18.2.0",
-    "lucide-react": "^0.344.0"
+    "lucide-react": "^1.17.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/core/tips-frontend/package.json
+++ b/core/tips-frontend/package.json
@@ -20,7 +20,7 @@
     "@checkstack/common": "workspace:*",
     "@checkstack/ui": "workspace:*",
     "react": "^18.2.0",
-    "lucide-react": "^0.344.0"
+    "lucide-react": "^1.17.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -26,7 +26,7 @@
     "date-fns": "^4.1.0",
     "fast-xml-parser": "^5.8.0",
     "jsonc-parser": "^3.3.1",
-    "lucide-react": "0.562.0",
+    "lucide-react": "^1.17.0",
     "monaco-languageclient": "10.7.0",
     "react": "^18.2.0",
     "react-day-picker": "^9.13.0",

--- a/core/ui/src/components/ActionCard.tsx
+++ b/core/ui/src/components/ActionCard.tsx
@@ -10,7 +10,7 @@ import {
 import { Card, CardContent, CardHeader } from "./Card";
 import { Button } from "./Button";
 import { Toggle } from "./Toggle";
-import { DynamicIcon, type LucideIconName } from "./DynamicIcon";
+import { DynamicIcon, type IconName } from "./DynamicIcon";
 import { Badge, type BadgeProps } from "./Badge";
 import { Popover, PopoverContent, PopoverTrigger } from "./Popover";
 import { DropdownMenuItem, MenuCloseContext } from "./Menu";
@@ -23,7 +23,7 @@ import { cn } from "../utils";
  */
 export interface ActionCardMenuItem {
   label: string;
-  icon?: LucideIconName;
+  icon?: IconName;
   onClick: () => void;
   /** `destructive` tints the item red (e.g. Delete). Defaults to neutral. */
   variant?: "default" | "destructive";
@@ -38,8 +38,8 @@ export interface ActionCardProps {
   description?: string;
   /** Plugin/category label rendered as a subdued badge. */
   category?: string;
-  /** Lucide icon (PascalCase) shown to the left of the title. */
-  icon?: LucideIconName;
+  /** Icon (PascalCase) shown to the left of the title - lucide or brand. */
+  icon?: IconName;
   /** Toggle for the action's `enabled` flag. Omit to hide the toggle. */
   enabled?: boolean;
   onEnabledChange?: (enabled: boolean) => void;

--- a/core/ui/src/components/BrandIcon.tsx
+++ b/core/ui/src/components/BrandIcon.tsx
@@ -1,0 +1,57 @@
+import type { SVGProps } from "react";
+import type { BrandIconName } from "@checkstack/common";
+
+// Brand marks vendored as inline SVGs.
+//
+// lucide-react v1 removed ALL brand icons (GitHub, GitLab, ...) for trademark
+// reasons, so we ship the handful we actually need ourselves. Path data is the
+// official mark from Simple Icons (https://simpleicons.org), ISC/CC0. Props
+// mirror the slice of the lucide icon surface our call sites use (`className` +
+// pass-through SVG props), so these are drop-in replacements for the old
+// `import { Github } from "lucide-react"`. `fill="currentColor"` makes them
+// inherit text color like a lucide icon does via `stroke="currentColor"`.
+
+type BrandIconProps = SVGProps<SVGSVGElement>;
+
+export const GithubIcon = ({ className, ...props }: BrandIconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    width={24}
+    height={24}
+    fill="currentColor"
+    className={className}
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+  </svg>
+);
+
+export const GitlabIcon = ({ className, ...props }: BrandIconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    width={24}
+    height={24}
+    fill="currentColor"
+    className={className}
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="m23.6004 9.5927-.0337-.0862L20.3.9814a.851.851 0 0 0-.3362-.405.8748.8748 0 0 0-.9997.0539.8748.8748 0 0 0-.29.4399l-2.2055 6.748H7.5375l-2.2057-6.748a.8573.8573 0 0 0-.29-.4412.8748.8748 0 0 0-.9997-.0537.8585.8585 0 0 0-.3362.4049L.4332 9.5015l-.0325.0862a6.0657 6.0657 0 0 0 2.0119 7.0105l.0113.0087.03.0213 4.976 3.7264 2.462 1.8633 1.4995 1.1321a1.0085 1.0085 0 0 0 1.2197 0l1.4995-1.1321 2.4619-1.8633 5.006-3.7489.0125-.01a6.0682 6.0682 0 0 0 2.0094-7.003z" />
+  </svg>
+);
+
+/**
+ * Brand-name -> component map. Used by `DynamicIcon` to resolve a data-driven
+ * icon name (e.g. an auth strategy's `icon: "Github"`) to a vendored brand
+ * mark, since these names no longer exist in lucide's `icons` export. Keys are
+ * the `BrandIconName` union from `@checkstack/common`, so adding a brand there
+ * without a component here is a type error.
+ */
+export const brandIcons: Record<
+  BrandIconName,
+  (props: BrandIconProps) => React.JSX.Element
+> = {
+  Github: GithubIcon,
+  Gitlab: GitlabIcon,
+};

--- a/core/ui/src/components/CodeEditor/CodeEditor.tsx
+++ b/core/ui/src/components/CodeEditor/CodeEditor.tsx
@@ -2,9 +2,9 @@
 // `@typefox/monaco-editor-react`-backed `TypefoxEditor` (real VS Code language
 // services in the browser). Consumers (DynamicForm, automation, healthcheck)
 // import this and are unaffected by the underlying editor implementation.
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { Maximize2 } from "lucide-react";
-import { TypefoxEditor, type TypefoxEditorProps } from "./TypefoxEditor";
+import type { TypefoxEditorProps } from "./TypefoxEditor";
 import { popoutTitle } from "./popoutTitle";
 import type { CodeEditorProps } from "./types";
 import {
@@ -13,7 +13,33 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../Dialog";
+import { Skeleton } from "../Skeleton";
 import { cn } from "../../utils";
+
+// Lazy-load the Monaco-backed editor so the entire `@codingame/*` / Monaco
+// stack is split into its own chunk and only fetched when a `<CodeEditor />`
+// actually mounts. This keeps Monaco off pages that merely import primitives
+// from the `@checkstack/ui` barrel (e.g. the login page), which would otherwise
+// statically pull it in via this module. The public `<CodeEditor />` API is
+// unchanged; the laziness lives entirely behind it.
+const TypefoxEditor = lazy(() =>
+  import("./TypefoxEditor").then((module) => ({
+    default: module.TypefoxEditor,
+  })),
+);
+
+/**
+ * Suspense fallback shown while the Monaco chunk loads. A plain `Skeleton`
+ * block (which already honours `usePerformance` / `isLowPower`) sized to the
+ * editor's height, so the layout doesn't jump and low-power devices avoid a
+ * heavy spinner.
+ */
+const EditorLoadingFallback = ({ minHeightPx }: { minHeightPx: number }) => (
+  <Skeleton
+    className="w-full rounded-md"
+    style={{ height: `${minHeightPx}px` }}
+  />
+);
 
 /**
  * Code editor with context-aware IntelliSense, template / shell completion, and
@@ -74,7 +100,9 @@ export const CodeEditor = ({
 
   return (
     <div className="relative">
-      <TypefoxEditor id={editorId} {...sharedEditorProps} />
+      <Suspense fallback={<EditorLoadingFallback minHeightPx={minHeightPx} />}>
+        <TypefoxEditor id={editorId} {...sharedEditorProps} />
+      </Suspense>
       {allowPopout && (
         <button
           type="button"
@@ -109,11 +137,15 @@ export const CodeEditor = ({
               `${id}-popout` id => distinct model URI. */}
           {popoutOpen && (
             <div className="flex-1 min-h-0">
-              <TypefoxEditor
-                id={`${editorId}-popout`}
-                fillHeight
-                {...sharedEditorProps}
-              />
+              <Suspense
+                fallback={<EditorLoadingFallback minHeightPx={minHeightPx} />}
+              >
+                <TypefoxEditor
+                  id={`${editorId}-popout`}
+                  fillHeight
+                  {...sharedEditorProps}
+                />
+              </Suspense>
             </div>
           )}
         </DialogContent>

--- a/core/ui/src/components/CodeEditor/TypefoxEditor.tsx
+++ b/core/ui/src/components/CodeEditor/TypefoxEditor.tsx
@@ -26,8 +26,8 @@ import {
   typescriptDefaults,
   javascriptDefaults,
   ensureStandaloneWorkerFactory,
-  markVscodeServicesReady,
 } from "./monacoTsService";
+import { markVscodeServicesReady } from "./vscodeServicesSignal";
 // Named import also triggers the side-effect registration of the REAL VS Code
 // JSON language service (proper highlighting + completion + folding), replacing
 // the hand-rolled `json-template` Monarch grammar. We turn its built-in

--- a/core/ui/src/components/CodeEditor/index.ts
+++ b/core/ui/src/components/CodeEditor/index.ts
@@ -38,7 +38,9 @@ export {
 // Subscribe to / query the monaco-vscode "services ready" transition so a
 // consumer (the automation editor's script validator + its hidden services
 // booter) can react the moment the first editor initializes the services.
+// Sourced from the Monaco-free signal module so this barrel re-export does NOT
+// drag the `@codingame/*` stack onto pages that never mount an editor.
 export {
   onVscodeServicesReady,
   areVscodeServicesReady,
-} from "./monacoTsService";
+} from "./vscodeServicesSignal";

--- a/core/ui/src/components/CodeEditor/monacoTsService.ts
+++ b/core/ui/src/components/CodeEditor/monacoTsService.ts
@@ -65,43 +65,11 @@ const tsWorkerLoader: WorkerLoader = () =>
 const jsonWorkerLoader: WorkerLoader = () =>
   new Worker(jsonWorkerUrl, { type: "module" });
 
-// The monaco-vscode API initializes globally exactly ONCE, and that init is
-// owned by the editor wrapper (`MonacoEditorReactComp`) - it throws "Services
-// are already initialized" if anything else inits first. So the headless
-// validator must NOT touch the worker / models until an editor has brought the
-// services up. The editor flips this flag from its `onEditorStartDone`; the
-// validator checks it and otherwise no-ops. Net effect: scripts validate once
-// any script editor has been opened this session (covering collapsed cards
-// from then on); a never-opened, all-collapsed automation is left to the
-// deferred backend typecheck.
-let vscodeServicesReady = false;
-const servicesReadyListeners = new Set<() => void>();
-
-/** Called by the editor once the monaco-vscode services have initialized. */
-export const markVscodeServicesReady = (): void => {
-  if (vscodeServicesReady) return;
-  vscodeServicesReady = true;
-  for (const listener of servicesReadyListeners) listener();
-  servicesReadyListeners.clear();
-};
-
-/** True once an editor has initialized the monaco-vscode services. */
-export const areVscodeServicesReady = (): boolean => vscodeServicesReady;
-
-/**
- * Subscribe to the one-time "services ready" transition. Fires immediately if
- * already ready. Returns an unsubscribe. Lets the headless validator re-run the
- * moment the first editor brings the services up (otherwise a never-edited
- * definition would not re-validate just because a card was opened).
- */
-export const onVscodeServicesReady = (listener: () => void): (() => void) => {
-  if (vscodeServicesReady) {
-    listener();
-    return () => {};
-  }
-  servicesReadyListeners.add(listener);
-  return () => servicesReadyListeners.delete(listener);
-};
+// The "monaco-vscode services ready" signal (`markVscodeServicesReady` /
+// `areVscodeServicesReady` / `onVscodeServicesReady`) lives in the Monaco-free
+// `vscodeServicesSignal` module so the barrel and the automation editor can
+// observe readiness without importing this Monaco-heavy module. See that file
+// for the full rationale.
 
 let workerFactoryRegistered = false;
 

--- a/core/ui/src/components/CodeEditor/validateScripts.ts
+++ b/core/ui/src/components/CodeEditor/validateScripts.ts
@@ -15,21 +15,26 @@
 // global to the shared service). Prepending the type defs onto each validated
 // source keeps `context` scoped to that one off-screen file. See
 // `buildValidationSource`.
-import * as monaco from "@codingame/monaco-vscode-editor-api";
-import {
-  getJavaScriptWorker,
-  getTypeScriptWorker,
-} from "@codingame/monaco-vscode-standalone-typescript-language-features";
-import {
-  areVscodeServicesReady,
-  ensureStandaloneStdlib,
-} from "./monacoTsService";
+//
+// The Monaco editor API, the standalone TS worker accessors, and the shared
+// `monacoTsService` setup are imported LAZILY (in-body `await import(...)`)
+// rather than at module scope. This keeps the entire `@codingame/*` stack off
+// the `@checkstack/ui` barrel: `validateTypeScriptSources` is re-exported from
+// the barrel, so a static Monaco import here would ship Monaco to every page
+// that touches the barrel (e.g. the login page). The lazy imports only resolve
+// once an editor has already brought the services up, so they hit an
+// already-loaded chunk and add no extra cost.
+import { areVscodeServicesReady } from "./vscodeServicesSignal";
 import {
   buildValidationSource,
   mapWorkerDiagnostics,
   type RawTsDiagnostic,
   type ScriptDiagnostic,
 } from "./scriptDiagnostics";
+
+type MonacoEditorApi = typeof import("@codingame/monaco-vscode-editor-api");
+type TsLanguageFeatures =
+  typeof import("@codingame/monaco-vscode-standalone-typescript-language-features");
 
 export type { ScriptDiagnostic } from "./scriptDiagnostics";
 
@@ -72,7 +77,26 @@ export async function validateTypeScriptSources({
   if (!areVscodeServicesReady()) {
     return results;
   }
+
+  // Lazy-load the Monaco stack only now that an editor has brought the services
+  // up (keeps these heavy `@codingame/*` modules off the barrel - see the
+  // module header). Because services are ready, these chunks are already
+  // resolved, so the imports are effectively free here.
+  let monaco: MonacoEditorApi;
+  let getJavaScriptWorker: TsLanguageFeatures["getJavaScriptWorker"];
+  let getTypeScriptWorker: TsLanguageFeatures["getTypeScriptWorker"];
   try {
+    const [editorApi, tsLanguageFeatures, { ensureStandaloneStdlib }] =
+      await Promise.all([
+        import("@codingame/monaco-vscode-editor-api"),
+        import(
+          "@codingame/monaco-vscode-standalone-typescript-language-features"
+        ),
+        import("./monacoTsService"),
+      ]);
+    monaco = editorApi;
+    getJavaScriptWorker = tsLanguageFeatures.getJavaScriptWorker;
+    getTypeScriptWorker = tsLanguageFeatures.getTypeScriptWorker;
     await ensureStandaloneStdlib();
   } catch {
     return results;
@@ -80,7 +104,15 @@ export async function validateTypeScriptSources({
 
   for (const input of sources) {
     try {
-      results.set(input.id, await validateOne(input));
+      results.set(
+        input.id,
+        await validateOne({
+          input,
+          monaco,
+          getJavaScriptWorker,
+          getTypeScriptWorker,
+        }),
+      );
     } catch {
       results.set(input.id, []);
     }
@@ -88,9 +120,17 @@ export async function validateTypeScriptSources({
   return results;
 }
 
-async function validateOne(
-  input: ScriptValidationInput,
-): Promise<ScriptDiagnostic[]> {
+async function validateOne({
+  input,
+  monaco,
+  getJavaScriptWorker,
+  getTypeScriptWorker,
+}: {
+  input: ScriptValidationInput;
+  monaco: MonacoEditorApi;
+  getJavaScriptWorker: TsLanguageFeatures["getJavaScriptWorker"];
+  getTypeScriptWorker: TsLanguageFeatures["getTypeScriptWorker"];
+}): Promise<ScriptDiagnostic[]> {
   const { text, prependedLineCount } = buildValidationSource({
     typeDefinitions: input.typeDefinitions,
     source: input.source,

--- a/core/ui/src/components/CodeEditor/vscodeServicesSignal.ts
+++ b/core/ui/src/components/CodeEditor/vscodeServicesSignal.ts
@@ -1,0 +1,49 @@
+// Lightweight, Monaco-free signal for the one-time "monaco-vscode services
+// ready" transition.
+//
+// Extracted from `monacoTsService` so consumers that only need to OBSERVE
+// readiness (the `@checkstack/ui` barrel re-export, the automation editor's
+// `ScriptServicesBooter` + headless validator) do NOT transitively pull the
+// entire `@codingame/*` Monaco stack into their bundle. Importing this module
+// loads zero Monaco code, so pages that never mount an editor (e.g. the login
+// page) stay Monaco-free.
+//
+// Why a global flag at all: the monaco-vscode API initializes globally exactly
+// ONCE, and that init is owned by the editor wrapper (`MonacoEditorReactComp`),
+// which throws "Services are already initialized" if anything else inits first.
+// So the headless validator must NOT touch the worker / models until an editor
+// has brought the services up. The editor flips this flag from its
+// `onEditorStartDone` (via `markVscodeServicesReady`); the validator checks
+// `areVscodeServicesReady()` and otherwise no-ops. Net effect: scripts validate
+// once any script editor has been opened this session (covering collapsed cards
+// from then on); a never-opened, all-collapsed automation is left to the
+// deferred backend typecheck.
+
+let vscodeServicesReady = false;
+const servicesReadyListeners = new Set<() => void>();
+
+/** Called by the editor once the monaco-vscode services have initialized. */
+export const markVscodeServicesReady = (): void => {
+  if (vscodeServicesReady) return;
+  vscodeServicesReady = true;
+  for (const listener of servicesReadyListeners) listener();
+  servicesReadyListeners.clear();
+};
+
+/** True once an editor has initialized the monaco-vscode services. */
+export const areVscodeServicesReady = (): boolean => vscodeServicesReady;
+
+/**
+ * Subscribe to the one-time "services ready" transition. Fires immediately if
+ * already ready. Returns an unsubscribe. Lets the headless validator re-run the
+ * moment the first editor brings the services up (otherwise a never-edited
+ * definition would not re-validate just because a card was opened).
+ */
+export const onVscodeServicesReady = (listener: () => void): (() => void) => {
+  if (vscodeServicesReady) {
+    listener();
+    return () => {};
+  }
+  servicesReadyListeners.add(listener);
+  return () => servicesReadyListeners.delete(listener);
+};

--- a/core/ui/src/components/DynamicIcon.tsx
+++ b/core/ui/src/components/DynamicIcon.tsx
@@ -1,29 +1,46 @@
-import { icons, type LucideIcon } from "lucide-react";
-import { Settings } from "lucide-react";
-import type { LucideIconName } from "@checkstack/common";
+import { lazy, Suspense } from "react";
+import { Settings, type LucideIcon } from "lucide-react";
+import type { IconName, BrandIconName } from "@checkstack/common";
+import { brandIcons } from "./BrandIcon";
 
-// Re-export the type for convenience
-export type { LucideIconName } from "@checkstack/common";
+// Re-export the icon-name types for convenience.
+export type { IconName, LucideIconName } from "@checkstack/common";
 
 /**
  * Props for the DynamicIcon component
  */
 export interface DynamicIconProps {
-  /** Lucide icon name in PascalCase (e.g., 'AlertCircle', 'HeartPulse') */
-  name?: LucideIconName;
+  /**
+   * Icon name. Lucide names are PascalCase (e.g. 'CircleAlert', 'HeartPulse');
+   * the few brand names lucide v1 dropped ('Github', 'Gitlab') resolve to
+   * vendored marks.
+   */
+  name?: IconName;
   /** CSS class name to apply to the icon */
   className?: string;
   /** Fallback icon if name is not provided */
   fallback?: LucideIcon;
 }
 
+// The lucide icon set is loaded lazily through `iconRegistry` (see that file):
+// importing lucide's `icons` map eagerly would ship the entire ~1600-icon set
+// in the initial bundle. `RegistryIcon` is the only importer of that map, and
+// it's behind React.lazy, so the icon set is fetched on demand the first time a
+// data-driven icon renders - never in the initial load.
+const RegistryIcon = lazy(() => import("./iconRegistry"));
+
+function isBrandIcon(name: string): name is BrandIconName {
+  return Object.prototype.hasOwnProperty.call(brandIcons, name);
+}
+
 /**
- * Dynamically renders a Lucide icon by name.
- * Falls back to Settings icon if the icon name is not provided.
+ * Dynamically renders an icon by name. Lucide icons are code-split into a single
+ * on-demand chunk; vendored brand icons render synchronously. Falls back to the
+ * Settings icon if no name is provided.
  *
  * @example
- * <DynamicIcon name="AlertCircle" />
- * <DynamicIcon name="HeartPulse" className="h-6 w-6" />
+ * <DynamicIcon name="CircleAlert" />
+ * <DynamicIcon name="Github" className="h-6 w-6" />
  */
 export function DynamicIcon({
   name,
@@ -34,12 +51,17 @@ export function DynamicIcon({
     return <FallbackIcon className={className} />;
   }
 
-  const Icon = icons[name];
-
-  // Fallback if icon name doesn't exist in lucide-react
-  if (!Icon) {
-    return <FallbackIcon className={className} />;
+  // Brand marks lucide v1 removed - render the vendored component synchronously.
+  if (isBrandIcon(name)) {
+    const Brand = brandIcons[name];
+    return <Brand className={className} />;
   }
 
-  return <Icon className={className} />;
+  return (
+    // Invisible, correctly-sized placeholder while the icon chunk loads, so
+    // there's no layout shift and no flash of a wrong (fallback) icon.
+    <Suspense fallback={<span aria-hidden className={className} />}>
+      <RegistryIcon name={name} className={className} />
+    </Suspense>
+  );
 }

--- a/core/ui/src/components/StrategyConfigCard.tsx
+++ b/core/ui/src/components/StrategyConfigCard.tsx
@@ -6,7 +6,7 @@ import { Badge, type BadgeProps } from "./Badge";
 import { Toggle } from "./Toggle";
 import { DynamicForm } from "./DynamicForm";
 import type { OptionsResolver } from "./DynamicForm/types";
-import { DynamicIcon, type LucideIconName } from "./DynamicIcon";
+import { DynamicIcon, type IconName } from "./DynamicIcon";
 import { MarkdownBlock } from "./Markdown";
 import { cn } from "../utils";
 
@@ -38,8 +38,8 @@ export interface StrategyConfigCardData {
   displayName: string;
   /** Optional description shown below the title */
   description?: string;
-  /** Lucide icon name in PascalCase (e.g., 'AlertCircle', 'HeartPulse') */
-  icon?: LucideIconName;
+  /** Icon name in PascalCase - a lucide icon or a vendored brand icon. */
+  icon?: IconName;
   /** Whether the strategy is currently enabled */
   enabled: boolean;
 }

--- a/core/ui/src/components/iconRegistry.tsx
+++ b/core/ui/src/components/iconRegistry.tsx
@@ -1,0 +1,27 @@
+import { icons } from "lucide-react";
+import type { LucideIconName } from "@checkstack/common";
+
+// Lazy-loaded icon registry.
+//
+// Importing lucide's `icons` map pulls the ENTIRE ~1600-icon set into one
+// module. This file is therefore imported ONLY via `React.lazy` from
+// `DynamicIcon`, so that whole set lands in a single on-demand chunk that the
+// initial load never fetches (DynamicIcon isn't rendered in the global nav -
+// it's used in dialogs, cards, and specific pages). Statically named-imported
+// icons elsewhere (`import { Plus } from "lucide-react"`) are unaffected and
+// tree-shaken normally into their eager chunks.
+
+/**
+ * Render a lucide icon by its PascalCase name. Falls back to the `Settings`
+ * icon for an unknown name (matching the previous DynamicIcon behaviour).
+ */
+export default function RegistryIcon({
+  name,
+  className,
+}: {
+  name: LucideIconName;
+  className?: string;
+}) {
+  const Icon = icons[name] ?? icons.Settings;
+  return <Icon className={className} />;
+}

--- a/core/ui/src/index.ts
+++ b/core/ui/src/index.ts
@@ -49,6 +49,7 @@ export * from "./components/StatusUpdateTimeline";
 export * from "./components/LinksEditor";
 export * from "./components/Slider";
 export * from "./components/DynamicIcon";
+export * from "./components/BrandIcon";
 export * from "./components/StrategyConfigCard";
 export * from "./components/Markdown";
 export * from "./components/ColorPicker";


### PR DESCRIPTION
Halves the initial-load JS by deferring everything heavy that isn't needed to paint the first screen, and modernises the icon stack.

## Initial-load JS (gzip), clean prod build
`~810 KB → ~445 KB` (~45%). No Monaco, full icon set, recharts, or route-page bodies in the initial load.

| stage | gzip |
|---|---|
| baseline (Monaco on login page) | ~810 KB+ |
| sever Monaco from `@checkstack/ui` barrel | ~810 KB |
| lazy plugin route pages | ~679 KB |
| lazy lucide icon set (DynamicIcon) | ~559 KB |
| lazy recharts chart extensions | **~445 KB** |

## What changed

**Monaco off the barrel** — all three static edges cut (the original analysis only found two): lazy `TypefoxEditor`, in-body `await import` in `validateScripts`, and a new Monaco-free `vscodeServicesSignal` module. Public `@checkstack/ui` API unchanged.

**Lazy plugin route pages** — every route `element` is `React.lazy`, with one shared `<Suspense>` in `App.tsx`. Auth pages stay eager. `FrontendPlugin` contract / loader / registry unchanged.

**Icon set lazy** — `DynamicIcon` no longer eagerly imports lucide's full `icons` map (~1 MB); it lives in a `React.lazy` `iconRegistry` chunk fetched on first data-driven icon. Statically named-imported icons tree-shake normally.

**Charts lazy** — recharts-backed health-check charts (~400 KB) deferred via the auto-chart slot extension + an on-demand drawer.

**lucide-react v1** (⚠️ BREAKING for icon imports) — unified from 5 drifting versions to `^1.17.0`. v1 removed brand icons, so GitHub/GitLab are vendored in `@checkstack/ui`; a new `IconName` (`LucideIconName | BrandIconName`) in `@checkstack/common` keeps data-driven brand names working. External consumers importing a brand icon from `lucide-react` must switch to the vendored marks.

**Vite** — added a `react-vendor` `manualChunks` split; documented why Monaco/lucide must **not** be hand-grouped (shared static+dynamic modules get forced eager).

**Tooling** — the frontend plugin scaffold template now lazy-loads route pages by default.

## Verification
`typecheck` (clean) + `lint` pass; `@checkstack/ui` (262) and `automation-frontend` (128) tests pass. Three changesets included (all minor; BETA, no major bumps).

## Follow-up (not in this PR)
Strategy 2 — deferring whole-plugin module evaluation — is intentionally left out. The data shows the remaining eager weight is shell-level shared vendor (react-query, orpc, the markdown stack behind the always-on AnnouncementBanner), not plugin code, so it's tracked as a separate effort (worth doing while there are no external plugins, mainly to future-proof the plugin contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)