### PR TITLE
refactor(frontend-api): lazy-by-default, framework-owned plugin contribution contract

### DIFF
--- a/.changeset/lazy-plugin-contribution-contract.md
+++ b/.changeset/lazy-plugin-contribution-contract.md
@@ -1,0 +1,40 @@
+---
+"@checkstack/frontend-api": minor
+"@checkstack/frontend": minor
+"@checkstack/scripts": minor
+"@checkstack/about-frontend": minor
+"@checkstack/announcement-frontend": minor
+"@checkstack/anomaly-frontend": minor
+"@checkstack/api-docs-frontend": minor
+"@checkstack/automation-frontend": minor
+"@checkstack/catalog-frontend": minor
+"@checkstack/dashboard-frontend": minor
+"@checkstack/dependency-frontend": minor
+"@checkstack/gitops-frontend": minor
+"@checkstack/healthcheck-frontend": minor
+"@checkstack/incident-frontend": minor
+"@checkstack/infrastructure-frontend": minor
+"@checkstack/integration-frontend": minor
+"@checkstack/maintenance-frontend": minor
+"@checkstack/notification-frontend": minor
+"@checkstack/pluginmanager-frontend": minor
+"@checkstack/satellite-frontend": minor
+"@checkstack/script-packages-frontend": minor
+"@checkstack/secrets-frontend": minor
+"@checkstack/slo-frontend": minor
+---
+
+Harden the frontend plugin contribution contract: lazy-by-default, framework-owned loading, and runtime-addable.
+
+BREAKING (frontend plugin contract): plugins now declare contributions lazily and let the framework own code-splitting, Suspense, and error isolation, instead of handing over eager React elements.
+
+- **Routes** now use `load: () => import("./Page").then((m) => ({ default: m.Page }))` instead of `element: <Page />`. The framework wraps each route in `React.lazy` + Suspense + a per-plugin error boundary. `element` is still accepted for the rare page that must paint without a chunk fetch (e.g. the login page); provide exactly one of `load` / `element`.
+- **Slot extensions** accept either an eager `component` (light, always-on contributions - navbar/user-menu/badges) or a lazy `load` (heavy/page-scoped contributions - dashboards, editors, chart panels). New `getLazyContribution` + `ExtensionComponent` exports from `@checkstack/frontend-api` render either kind uniformly.
+
+This also fixes two gaps that runtime-installed (remote/external) plugins depend on:
+- `ExtensionSlot` now subscribes to the plugin registry, so a plugin added at runtime appears in navbar/dashboard/detail slots without a reload.
+- The app's API registry rebuilds when the plugin set changes (`getPlugins()` now returns an immutable snapshot consumed via `useSyncExternalStore`), so a runtime-added plugin's `apis` register.
+
+A per-plugin error boundary now contains a contribution that fails to load or render, so one bad (third-party) plugin degrades gracefully instead of crashing the shell.
+
+Bundle effect: heavy extension components (dashboard, anomaly IDE panels, dependency editor, healthcheck system overview) leave the initial load. The initial-load JS reduction is small on its own (the eager floor is shell-level shared vendor, not plugin code); the primary value is the hardened, future-proof contract for external plugins.

--- a/core/about-frontend/src/index.tsx
+++ b/core/about-frontend/src/index.tsx
@@ -4,13 +4,7 @@ import {
 } from "@checkstack/frontend-api";
 import { createRoutes } from "@checkstack/common";
 import { pluginMetadata } from "@checkstack/about-common";
-import { lazy } from "react";
 import { AboutMenuItem } from "./AboutMenuItem";
-
-// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
-const AboutPage = lazy(() =>
-  import("./AboutPage").then((m) => ({ default: m.AboutPage })),
-);
 
 export const aboutRoutes = createRoutes(pluginMetadata.pluginId, {
   page: "/",
@@ -21,7 +15,7 @@ export const aboutPlugin = createFrontendPlugin({
   routes: [
     {
       route: aboutRoutes.routes.page,
-      element: <AboutPage />,
+      load: () => import("./AboutPage").then((m) => ({ default: m.AboutPage })),
     },
   ],
   extensions: [

--- a/core/announcement-frontend/src/index.tsx
+++ b/core/announcement-frontend/src/index.tsx
@@ -9,23 +9,18 @@ import {
   pluginMetadata,
   announcementAccess,
 } from "@checkstack/announcement-common";
-import { lazy } from "react";
 import { AnnouncementMenuItems } from "./components/AnnouncementMenuItems";
 import { DashboardAnnouncements } from "./components/DashboardAnnouncements";
-
-// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
-const AnnouncementManagePage = lazy(() =>
-  import("./pages/AnnouncementManagePage").then((m) => ({
-    default: m.AnnouncementManagePage,
-  })),
-);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
   routes: [
     {
       route: announcementRoutes.routes.manage,
-      element: <AnnouncementManagePage />,
+      load: () =>
+        import("./pages/AnnouncementManagePage").then((m) => ({
+          default: m.AnnouncementManagePage,
+        })),
       title: "Manage Announcements",
       accessRule: announcementAccess.manage,
     },

--- a/core/anomaly-frontend/src/plugin.tsx
+++ b/core/anomaly-frontend/src/plugin.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react";
 import { definePluginMetadata } from "@checkstack/common";
 import { FrontendPlugin, createSlotExtension } from "@checkstack/frontend-api";
 import {
@@ -14,13 +15,25 @@ import {
 } from "@checkstack/catalog-common";
 import { registerSubscriptionSubControls } from "@checkstack/notification-frontend";
 import { anomalySystemSubscription } from "@checkstack/anomaly-common";
-import { AnomalyConfigPanel } from "./components/AnomalyConfigPanel";
-import { AnomalyTemplatePanel } from "./components/AnomalyTemplatePanel";
 import { SystemAnomalyBadge } from "./components/SystemAnomalyBadge";
 import { SystemAnomalyWidget } from "./components/SystemAnomalyWidget";
 import { AnomalyFieldMuteList } from "./components/AnomalyFieldMuteList";
 import { IDETreeNode } from "@checkstack/ui";
 import { Activity } from "lucide-react";
+
+// Heavy IDE panels — lazy-loaded so they stay out of the initial bundle and
+// load only when their IDE node is actually selected (the eager guards below
+// decide that), not whenever the IDE panel slot renders.
+const AnomalyTemplatePanel = lazy(() =>
+  import("./components/AnomalyTemplatePanel").then((m) => ({
+    default: m.AnomalyTemplatePanel,
+  })),
+);
+const AnomalyConfigPanel = lazy(() =>
+  import("./components/AnomalyConfigPanel").then((m) => ({
+    default: m.AnomalyConfigPanel,
+  })),
+);
 
 const pluginMetadata = definePluginMetadata({
   pluginId: "anomaly",
@@ -55,7 +68,11 @@ export const plugin: FrontendPlugin = {
         if (!context.selectedNode?.startsWith("anomaly-template:")) {
           return <></>;
         }
-        return <AnomalyTemplatePanel context={context} />;
+        return (
+          <Suspense fallback={null}>
+            <AnomalyTemplatePanel context={context} />
+          </Suspense>
+        );
       },
     }),
     createSlotExtension(AssignmentIDENodeSlot, {
@@ -77,7 +94,11 @@ export const plugin: FrontendPlugin = {
         if (!context.selectedNode?.startsWith("anomaly:")) {
           return <></>;
         }
-        return <AnomalyConfigPanel context={context} />;
+        return (
+          <Suspense fallback={null}>
+            <AnomalyConfigPanel context={context} />
+          </Suspense>
+        );
       },
     }),
   ],

--- a/core/api-docs-frontend/src/index.tsx
+++ b/core/api-docs-frontend/src/index.tsx
@@ -5,13 +5,7 @@ import {
 } from "@checkstack/frontend-api";
 import { createRoutes } from "@checkstack/common";
 import { pluginMetadata, apiDocsAccess } from "@checkstack/api-docs-common";
-import { lazy } from "react";
 import { ApiDocsMenuItem } from "./ApiDocsMenuItem";
-
-// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
-const ApiDocsPage = lazy(() =>
-  import("./ApiDocsPage").then((m) => ({ default: m.ApiDocsPage })),
-);
 
 export const apiDocsRoutes = createRoutes(pluginMetadata.pluginId, {
   docs: "/",
@@ -22,7 +16,7 @@ export const apiDocsPlugin = createFrontendPlugin({
   routes: [
     {
       route: apiDocsRoutes.routes.docs,
-      element: <ApiDocsPage />,
+      load: () => import("./ApiDocsPage").then((m) => ({ default: m.ApiDocsPage })),
       accessRule: apiDocsAccess.view,
     },
   ],

--- a/core/automation-frontend/src/index.tsx
+++ b/core/automation-frontend/src/index.tsx
@@ -8,31 +8,7 @@ import {
   pluginMetadata,
   automationAccess,
 } from "@checkstack/automation-common";
-import { lazy } from "react";
 import { AutomationMenuItems } from "./components/AutomationMenuItems";
-
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const AutomationListPage = lazy(() =>
-  import("./pages/AutomationListPage").then((m) => ({
-    default: m.AutomationListPage,
-  })),
-);
-const AutomationEditPage = lazy(() =>
-  import("./pages/AutomationEditPage").then((m) => ({
-    default: m.AutomationEditPage,
-  })),
-);
-const RunsPage = lazy(() =>
-  import("./pages/RunsPage").then((m) => ({ default: m.RunsPage })),
-);
-const RunDetailPage = lazy(() =>
-  import("./pages/RunDetailPage").then((m) => ({ default: m.RunDetailPage })),
-);
-const TemplatePlaygroundPage = lazy(() =>
-  import("./pages/TemplatePlaygroundPage").then((m) => ({
-    default: m.TemplatePlaygroundPage,
-  })),
-);
 
 export {
   generateAutomationContextTypes,
@@ -71,37 +47,52 @@ export default createFrontendPlugin({
   routes: [
     {
       route: automationRoutes.routes.list,
-      element: <AutomationListPage />,
+      load: () =>
+        import("./pages/AutomationListPage").then((m) => ({
+          default: m.AutomationListPage,
+        })),
       title: "Automations",
       accessRule: automationAccess.read,
     },
     {
       route: automationRoutes.routes.create,
-      element: <AutomationEditPage />,
+      load: () =>
+        import("./pages/AutomationEditPage").then((m) => ({
+          default: m.AutomationEditPage,
+        })),
       title: "New automation",
       accessRule: automationAccess.manage,
     },
     {
       route: automationRoutes.routes.edit,
-      element: <AutomationEditPage />,
+      load: () =>
+        import("./pages/AutomationEditPage").then((m) => ({
+          default: m.AutomationEditPage,
+        })),
       title: "Edit automation",
       accessRule: automationAccess.read,
     },
     {
       route: automationRoutes.routes.runs,
-      element: <RunsPage />,
+      load: () => import("./pages/RunsPage").then((m) => ({ default: m.RunsPage })),
       title: "Run history",
       accessRule: automationAccess.read,
     },
     {
       route: automationRoutes.routes.runDetail,
-      element: <RunDetailPage />,
+      load: () =>
+        import("./pages/RunDetailPage").then((m) => ({
+          default: m.RunDetailPage,
+        })),
       title: "Run details",
       accessRule: automationAccess.read,
     },
     {
       route: automationRoutes.routes.playground,
-      element: <TemplatePlaygroundPage />,
+      load: () =>
+        import("./pages/TemplatePlaygroundPage").then((m) => ({
+          default: m.TemplatePlaygroundPage,
+        })),
       title: "Template playground",
       accessRule: automationAccess.read,
     },

--- a/core/catalog-frontend/src/index.tsx
+++ b/core/catalog-frontend/src/index.tsx
@@ -12,23 +12,7 @@ import {
 import { Server, FolderTree } from "lucide-react";
 import { registerSubjectKind } from "@checkstack/notification-frontend";
 
-import { lazy } from "react";
 import { CatalogUserMenuItems } from "./components/UserMenuItems";
-
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const CatalogPage = lazy(() =>
-  import("./components/CatalogPage").then((m) => ({ default: m.CatalogPage })),
-);
-const CatalogConfigPage = lazy(() =>
-  import("./components/CatalogConfigPage").then((m) => ({
-    default: m.CatalogConfigPage,
-  })),
-);
-const SystemDetailPage = lazy(() =>
-  import("./components/SystemDetailPage").then((m) => ({
-    default: m.SystemDetailPage,
-  })),
-);
 
 // Notification subject kinds emitted by catalog (see catalog-common's
 // `createSystemSubject` / `createGroupSubject`). Registered at module load
@@ -49,16 +33,25 @@ export const catalogPlugin = createFrontendPlugin({
   routes: [
     {
       route: catalogRoutes.routes.home,
-      element: <CatalogPage />,
+      load: () =>
+        import("./components/CatalogPage").then((m) => ({
+          default: m.CatalogPage,
+        })),
     },
     {
       route: catalogRoutes.routes.config,
-      element: <CatalogConfigPage />,
+      load: () =>
+        import("./components/CatalogConfigPage").then((m) => ({
+          default: m.CatalogConfigPage,
+        })),
       accessRule: catalogAccess.system.manage,
     },
     {
       route: catalogRoutes.routes.systemDetail,
-      element: <SystemDetailPage />,
+      load: () =>
+        import("./components/SystemDetailPage").then((m) => ({
+          default: m.SystemDetailPage,
+        })),
     },
   ],
   extensions: [

--- a/core/dashboard-frontend/src/index.tsx
+++ b/core/dashboard-frontend/src/index.tsx
@@ -1,5 +1,4 @@
 import { FrontendPlugin, DashboardSlot } from "@checkstack/frontend-api";
-import { Dashboard } from "./Dashboard";
 import { pluginMetadata } from "./pluginMetadata";
 
 export const dashboardPlugin: FrontendPlugin = {
@@ -8,7 +7,12 @@ export const dashboardPlugin: FrontendPlugin = {
     {
       id: "dashboard-main",
       slot: DashboardSlot,
-      component: Dashboard as React.ComponentType<unknown>,
+      // Heavy dashboard (widgets/charts) — lazy so it stays out of the initial
+      // bundle; it renders only on the "/" dashboard route.
+      load: () =>
+        import("./Dashboard").then((m) => ({
+          default: m.Dashboard as React.ComponentType<unknown>,
+        })),
     },
   ],
 };

--- a/core/dependency-frontend/src/index.tsx
+++ b/core/dependency-frontend/src/index.tsx
@@ -14,18 +14,9 @@ import {
   SystemStateBadgesSlot,
   SystemEditorSlot,
 } from "@checkstack/catalog-common";
-import { lazy } from "react";
 import { DependencyBadge } from "./components/DependencyBadge";
 import { DependencyAlert } from "./components/DependencyAlert";
-import { DependencyEditor } from "./components/DependencyEditor";
 import { DependencyMenuItems } from "./components/DependencyMenuItems";
-
-// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
-const DependencyMapPage = lazy(() =>
-  import("./components/DependencyMapPage").then((m) => ({
-    default: m.DependencyMapPage,
-  })),
-);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
@@ -36,7 +27,10 @@ export default createFrontendPlugin({
   routes: [
     {
       route: dependencyRoutes.routes.map,
-      element: <DependencyMapPage />,
+      load: () =>
+        import("./components/DependencyMapPage").then((m) => ({
+          default: m.DependencyMapPage,
+        })),
       title: "Dependency Map",
       accessRule: dependencyAccess.dependency.read,
     },
@@ -53,7 +47,12 @@ export default createFrontendPlugin({
     }),
     createSlotExtension(SystemEditorSlot, {
       id: "dependency.system-editor",
-      component: DependencyEditor,
+      // Heavy editor form — lazy-loaded so it stays out of the initial bundle
+      // and loads only when a system's editor slot renders.
+      load: () =>
+        import("./components/DependencyEditor").then((m) => ({
+          default: m.DependencyEditor,
+        })),
     }),
     createSlotExtension(UserMenuItemsSlot, {
       id: "dependency.user-menu.map",

--- a/core/frontend-api/src/components/ExtensionSlot.tsx
+++ b/core/frontend-api/src/components/ExtensionSlot.tsx
@@ -1,6 +1,47 @@
-import { pluginRegistry } from "../plugin-registry";
-import type { SlotContext } from "../plugin";
+import type { ComponentType } from "react";
+import type { Extension, SlotContext } from "../plugin";
 import type { SlotDefinition } from "../slots";
+import { useSlotExtensions } from "../use-slot-extensions";
+import { getLazyContribution } from "./LazyContribution";
+
+/**
+ * Render a single extension's UI, handling both contribution kinds: an eager
+ * `component` renders directly; a lazy `load` renders through
+ * {@link getLazyContribution} (code-split + Suspense + per-plugin error
+ * boundary). Use this when you drive rendering yourself from
+ * {@link useSlotExtensions} (e.g. a tab bar that renders only the active tab);
+ * for rendering ALL of a slot's extensions, use {@link ExtensionSlot}.
+ */
+export function ExtensionComponent<
+  TSlot extends SlotDefinition<unknown, unknown>
+>({
+  extension,
+  context,
+}: {
+  extension: Extension<TSlot>;
+  context?: SlotContext<TSlot>;
+}) {
+  // The slot's context was type-checked against this extension at registration
+  // time (createSlotExtension); it's erased to a props bag for rendering.
+  const props = (context ?? {}) as Record<string, unknown>;
+
+  if (extension.component) {
+    const Component = extension.component as ComponentType<
+      Record<string, unknown>
+    >;
+    return <Component {...props} />;
+  }
+  if (extension.load) {
+    const Lazy = getLazyContribution({
+      id: extension.id,
+      load: extension.load as () => Promise<{
+        default: ComponentType<Record<string, unknown>>;
+      }>,
+    });
+    return <Lazy {...props} />;
+  }
+  return null;
+}
 
 /**
  * Type-safe props for ExtensionSlot.
@@ -15,6 +56,12 @@ type ExtensionSlotProps<TSlot extends SlotDefinition<unknown, unknown>> =
 /**
  * Renders all extensions registered for the given slot.
  *
+ * Subscribes to the plugin registry (via {@link useSlotExtensions}), so
+ * extensions contributed by plugins loaded AT RUNTIME (installed remotely)
+ * appear without a manual refresh. Eager (`component`) extensions render
+ * directly; lazy (`load`) extensions render through {@link getLazyContribution}
+ * (code-split + Suspense + per-plugin error boundary).
+ *
  * @example
  * ```tsx
  * // Slot with context - context is required and type-checked
@@ -28,7 +75,7 @@ export function ExtensionSlot<TSlot extends SlotDefinition<unknown, unknown>>({
   slot,
   context,
 }: ExtensionSlotProps<TSlot>) {
-  const extensions = pluginRegistry.getExtensions(slot.id);
+  const extensions = useSlotExtensions(slot);
 
   if (extensions.length === 0) {
     return <></>;
@@ -36,10 +83,9 @@ export function ExtensionSlot<TSlot extends SlotDefinition<unknown, unknown>>({
 
   return (
     <>
-      {extensions.map((ext) => {
-        const Component = ext.component as React.ComponentType<Record<string, unknown>>;
-        return <Component key={ext.id} {...(context ?? {})} />;
-      })}
+      {extensions.map((ext) => (
+        <ExtensionComponent key={ext.id} extension={ext} context={context} />
+      ))}
     </>
   );
 }

--- a/core/frontend-api/src/components/LazyContribution.tsx
+++ b/core/frontend-api/src/components/LazyContribution.tsx
@@ -1,0 +1,104 @@
+import React, { Suspense, type ComponentType } from "react";
+
+/**
+ * Framework-owned wrapper for a lazily-loaded plugin contribution (a route page
+ * or a heavy slot extension declared via a `load` thunk).
+ *
+ * It does three things a plugin should NOT have to reimplement:
+ *  1. `React.lazy(load)` — code-splits the contribution so its chunk is fetched
+ *     on demand, not in the initial app load.
+ *  2. `<Suspense>` — shows a fallback while the chunk loads.
+ *  3. `<PluginErrorBoundary>` — contains a load/render failure to this one
+ *     contribution. A third-party plugin that throws (bad bundle, runtime
+ *     error) degrades to a small inline fallback instead of white-screening the
+ *     whole shell. This is essential once external plugins exist.
+ *
+ * Components are cached by a stable `id` so the same `React.lazy` instance is
+ * reused across renders (recreating it would discard its loaded state and
+ * remount on every parent render).
+ */
+
+interface PluginErrorBoundaryProps {
+  /** Human-readable contribution id, used in the console error + fallback. */
+  label: string;
+  fallback: React.ReactNode;
+  children: React.ReactNode;
+}
+
+interface PluginErrorBoundaryState {
+  hasError: boolean;
+}
+
+class PluginErrorBoundary extends React.Component<
+  PluginErrorBoundaryProps,
+  PluginErrorBoundaryState
+> {
+  state: PluginErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): PluginErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error(
+      `❌ Plugin contribution "${this.props.label}" failed to load/render:`,
+      error,
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
+
+/** Props a plugin contribution component may receive (slot context, or none). */
+type ContributionProps = Record<string, unknown>;
+
+type LazyLoader = () => Promise<{ default: ComponentType<ContributionProps> }>;
+
+interface GetLazyContributionArgs {
+  /** Stable identity for caching (route path or extension id). */
+  id: string;
+  load: LazyLoader;
+  /** Shown while the chunk loads. Defaults to nothing (invisible). */
+  suspenseFallback?: React.ReactNode;
+  /** Shown if the chunk fails to load/render. Defaults to nothing. */
+  errorFallback?: React.ReactNode;
+}
+
+// Cache keyed by `id` so the lazy component (and its loaded state) is stable
+// across renders. Contributions have heterogeneous prop shapes, so the cache is
+// typed by the shared `ContributionProps` upper bound.
+const lazyComponentCache = new Map<string, ComponentType<ContributionProps>>();
+
+/**
+ * Return a stable component that lazily loads `load` and renders it inside a
+ * Suspense + error boundary. Safe to call on every render — memoised by `id`.
+ */
+export function getLazyContribution({
+  id,
+  load,
+  suspenseFallback = null,
+  errorFallback = null,
+}: GetLazyContributionArgs): ComponentType<ContributionProps> {
+  const cached = lazyComponentCache.get(id);
+  if (cached) {
+    return cached;
+  }
+
+  const Lazy = React.lazy(load);
+  const Wrapped: ComponentType<ContributionProps> = (props) => (
+    <PluginErrorBoundary label={id} fallback={errorFallback}>
+      <Suspense fallback={suspenseFallback}>
+        <Lazy {...props} />
+      </Suspense>
+    </PluginErrorBoundary>
+  );
+  Wrapped.displayName = `LazyContribution(${id})`;
+
+  lazyComponentCache.set(id, Wrapped);
+  return Wrapped;
+}

--- a/core/frontend-api/src/index.ts
+++ b/core/frontend-api/src/index.ts
@@ -4,6 +4,7 @@ export * from "./core-apis";
 export * from "./plugin";
 export * from "./plugin-registry";
 export * from "./components/ExtensionSlot";
+export * from "./components/LazyContribution";
 export * from "./use-slot-extensions";
 export * from "./utils";
 export * from "./slots";

--- a/core/frontend-api/src/plugin-registry.ts
+++ b/core/frontend-api/src/plugin-registry.ts
@@ -1,4 +1,8 @@
+import type { ComponentType, ReactNode } from "react";
 import { FrontendPlugin, Extension } from "./plugin";
+
+/** Lazy page loader, as declared on a {@link PluginRoute}. */
+type RouteLoader = () => Promise<{ default: ComponentType }>;
 
 /**
  * Listener function for registry changes
@@ -12,13 +16,20 @@ interface ResolvedRoute {
   id: string;
   path: string;
   pluginId: string;
-  element?: React.ReactNode;
+  /** Exactly one of `load` (lazy) / `element` (eager) is set. */
+  load?: RouteLoader;
+  element?: ReactNode;
   title?: string;
   accessRule?: string;
 }
 
 class PluginRegistry {
   private plugins: FrontendPlugin[] = [];
+  // Immutable snapshot of `plugins`, rebuilt on every change. `getPlugins()`
+  // returns this so callers (and `useSyncExternalStore`) get a referentially
+  // stable value between changes and a NEW reference when the set changes —
+  // `plugins` itself is mutated in place, so its reference never changes.
+  private pluginsSnapshot: readonly FrontendPlugin[] = [];
   private extensions = new Map<string, Extension[]>();
   private routeMap = new Map<string, ResolvedRoute>();
 
@@ -59,6 +70,7 @@ class PluginRegistry {
         id: route.route.id,
         path: fullPath,
         pluginId: route.route.pluginId,
+        load: route.load,
         element: route.element,
         title: route.title,
         accessRule: route.accessRule?.id,
@@ -151,8 +163,8 @@ class PluginRegistry {
     return this.plugins.some((p) => p.metadata.pluginId === pluginId);
   }
 
-  getPlugins() {
-    return this.plugins;
+  getPlugins(): readonly FrontendPlugin[] {
+    return this.pluginsSnapshot;
   }
 
   getExtensions(slotId: string): Extension[] {
@@ -173,6 +185,8 @@ class PluginRegistry {
 
         return {
           path: fullPath,
+          pluginId: route.route.pluginId,
+          load: route.load,
           element: route.element,
           title: route.title,
           accessRule: route.accessRule?.id,
@@ -229,6 +243,9 @@ class PluginRegistry {
 
   private incrementVersion() {
     this.version++;
+    // Rebuild the immutable snapshot so external subscribers see a new
+    // reference (required for useSyncExternalStore / useMemo to recompute).
+    this.pluginsSnapshot = [...this.plugins];
     for (const listener of this.listeners) {
       listener();
     }

--- a/core/frontend-api/src/plugin.ts
+++ b/core/frontend-api/src/plugin.ts
@@ -41,26 +41,47 @@ export interface Extension<
 > {
   id: string;
   slot: TSlot;
-  component: React.ComponentType<SlotContext<TSlot>>;
+  /**
+   * Eager component. Use for LIGHT, always-rendered contributions (navbar,
+   * user-menu items) where code-splitting would just add a load flash. Exactly
+   * one of `component` / `load` is set.
+   */
+  component?: React.ComponentType<SlotContext<TSlot>>;
+  /**
+   * Lazy loader for HEAVY or page-scoped contributions. The framework wraps it
+   * in React.lazy + Suspense + a per-plugin error boundary (see
+   * `getLazyContribution`), so the chunk loads on demand and a failure is
+   * contained to this contribution. Named exports: `() => import("./X").then(
+   * (m) => ({ default: m.X }))`.
+   */
+  load?: () => Promise<{
+    default: React.ComponentType<SlotContext<TSlot>>;
+  }>;
   metadata?: SlotMetadata<TSlot>;
 }
 
+/** A contribution is provided either eagerly (`component`) or lazily (`load`). */
+type SlotExtensionImpl<TSlot extends SlotDefinition<unknown, unknown>> =
+  | {
+      component: React.ComponentType<SlotContext<TSlot>>;
+      load?: never;
+    }
+  | {
+      load: () => Promise<{
+        default: React.ComponentType<SlotContext<TSlot>>;
+      }>;
+      component?: never;
+    };
+
 /**
  * Input shape for `createSlotExtension`. Requires `metadata` when the slot
- * declares a non-`undefined` metadata type, forbids it otherwise.
+ * declares a non-`undefined` metadata type, forbids it otherwise, and requires
+ * exactly one of `component` (eager) / `load` (lazy).
  */
 type SlotExtensionInput<TSlot extends SlotDefinition<unknown, unknown>> =
   SlotMetadata<TSlot> extends undefined
-    ? {
-        id: string;
-        component: React.ComponentType<SlotContext<TSlot>>;
-        metadata?: undefined;
-      }
-    : {
-        id: string;
-        component: React.ComponentType<SlotContext<TSlot>>;
-        metadata: SlotMetadata<TSlot>;
-      };
+    ? { id: string; metadata?: undefined } & SlotExtensionImpl<TSlot>
+    : { id: string; metadata: SlotMetadata<TSlot> } & SlotExtensionImpl<TSlot>;
 
 /**
  * Helper to create a type-safe extension from a slot definition.
@@ -81,19 +102,32 @@ export function createSlotExtension<
  * Route configuration for a frontend plugin.
  * Uses RouteDefinition from the plugin's common package.
  */
-export interface PluginRoute {
+/** Fields common to every route, regardless of eager/lazy. */
+interface PluginRouteBase {
   /** Route definition from common package */
   route: RouteDefinition;
-
-  /** React element to render */
-  element?: React.ReactNode;
-
   /** Page title */
   title?: string;
-
   /** Access rule required to access this route (use access object from common package) */
   accessRule?: AccessRule;
 }
+
+/**
+ * Route configuration for a frontend plugin. Provide EXACTLY one of:
+ *  - `load` (default): a lazy page loader. The framework code-splits the page
+ *    and wraps it in Suspense + a per-plugin error boundary (see
+ *    `getLazyContribution`), so the chunk is fetched on navigation, never in
+ *    the initial load. Named-export pages: `() => import("./pages/Foo").then(
+ *    (m) => ({ default: m.Foo }))`.
+ *  - `element`: an eagerly-rendered element. Reserve for the rare page that
+ *    must paint without a chunk fetch (e.g. the login page on the
+ *    unauthenticated critical path).
+ */
+export type PluginRoute = PluginRouteBase &
+  (
+    | { load: () => Promise<{ default: React.ComponentType }>; element?: never }
+    | { element: React.ReactNode; load?: never }
+  );
 
 /**
  * Frontend plugin configuration.

--- a/core/frontend/src/App.tsx
+++ b/core/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import {
   BrowserRouter,
   Routes,
@@ -15,6 +15,7 @@ import {
   rpcApiRef,
   useApi,
   ExtensionSlot,
+  getLazyContribution,
   pluginRegistry,
   DashboardSlot,
   NavbarRightSlot,
@@ -80,6 +81,26 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+// Stable references for `useSyncExternalStore` subscription to the plugin
+// registry (module scope so they don't change identity across renders).
+const subscribePluginRegistry = (onChange: () => void) =>
+  pluginRegistry.subscribe(onChange);
+const getRegisteredPlugins = () => pluginRegistry.getPlugins();
+
+// Shared fallbacks for lazily-loaded plugin route pages. The loading state
+// mirrors RouteGuard's access-loading look (usePerformance-aware spinner); the
+// error state contains a failed page load instead of white-screening the shell.
+const ROUTE_SUSPENSE_FALLBACK = (
+  <div className="h-full flex items-center justify-center p-8">
+    <LoadingSpinner />
+  </div>
+);
+const ROUTE_ERROR_FALLBACK = (
+  <div className="h-full flex items-center justify-center p-8 text-sm text-muted-foreground">
+    This page failed to load. Try reloading.
+  </div>
+);
 
 /**
  * Component that registers global keyboard shortcuts for all commands.
@@ -174,31 +195,39 @@ function AppContent() {
                 </div>
               }
             />
-            {/* Plugin Routes. Most plugins lazy-load their page bodies via
-                `React.lazy` (so the route's component chunk is fetched on
-                navigation, not in the initial load), so each element is wrapped
-                in a Suspense boundary. The fallback mirrors RouteGuard's
-                access-loading state and uses the `usePerformance`-aware
-                LoadingSpinner. */}
-            {pluginRegistry.getAllRoutes().map((route) => (
-              <Route
-                key={route.path}
-                path={route.path}
-                element={
-                  <RouteGuard accessRule={route.accessRule}>
-                    <Suspense
-                      fallback={
-                        <div className="h-full flex items-center justify-center p-8">
-                          <LoadingSpinner />
-                        </div>
-                      }
-                    >
-                      {route.element}
-                    </Suspense>
-                  </RouteGuard>
-                }
-              />
-            ))}
+            {/* Plugin Routes. Each plugin declares its page via a `load` thunk;
+                the framework (`getLazyContribution`) code-splits it and wraps it
+                in Suspense + a per-plugin error boundary, so the page chunk is
+                fetched on navigation (not in the initial load) and a failing
+                page degrades gracefully instead of crashing the shell. */}
+            {pluginRegistry.getAllRoutes().map((route) => {
+              // A route is either lazy (`load`, the default — framework wraps it
+              // in Suspense + error boundary) or eager (`element`, rare — e.g.
+              // the login page on the critical path).
+              let element: React.ReactNode;
+              if (route.load) {
+                const PageElement = getLazyContribution({
+                  id: route.path,
+                  load: route.load,
+                  suspenseFallback: ROUTE_SUSPENSE_FALLBACK,
+                  errorFallback: ROUTE_ERROR_FALLBACK,
+                });
+                element = <PageElement />;
+              } else {
+                element = route.element;
+              }
+              return (
+                <Route
+                  key={route.path}
+                  path={route.path}
+                  element={
+                    <RouteGuard accessRule={route.accessRule}>
+                      {element}
+                    </RouteGuard>
+                  }
+                />
+              );
+            })}
             {/* Catch-all: show Not Found for unmatched routes */}
             <Route path="*" element={<NotFound />} />
           </Routes>
@@ -217,6 +246,15 @@ function AppWithApis() {
     useRuntimeConfigContext();
   const { baseUrl } = useRuntimeConfig();
 
+  // Subscribe to the plugin registry so the API registry below rebuilds when
+  // plugins register/unregister at runtime (e.g. a remotely-installed plugin),
+  // picking up their `apis` factories. `getPlugins()` returns an immutable
+  // snapshot whose reference changes on every registry change.
+  const plugins = useSyncExternalStore(
+    subscribePluginRegistry,
+    getRegisteredPlugins,
+  );
+
   const apiRegistry = useMemo(() => {
     // Initialize API Registry with core apiRefs
     const registryBuilder = new ApiRegistryBuilder()
@@ -232,7 +270,6 @@ function AppWithApis() {
       });
 
     // Register API factories from plugins
-    const plugins = pluginRegistry.getPlugins();
     for (const plugin of plugins) {
       if (plugin.apis) {
         for (const api of plugin.apis) {
@@ -248,7 +285,7 @@ function AppWithApis() {
     }
 
     return registryBuilder.build();
-  }, [baseUrl]);
+  }, [baseUrl, plugins]);
 
   // Show spinner while fetching runtime config and probing baseUrl.
   if (isConfigLoading) {

--- a/core/frontend/src/plugin-registry.test.ts
+++ b/core/frontend/src/plugin-registry.test.ts
@@ -62,7 +62,12 @@ describe("PluginRegistry", () => {
   it("should aggregate all routes from registered plugins", () => {
     const pluginB: FrontendPlugin = {
       metadata: { pluginId: "plugin-b" },
-      routes: [{ route: pluginBRoutes.routes.home }],
+      routes: [
+        {
+          route: pluginBRoutes.routes.home,
+          element: React.createElement("div", null, "Plugin B Route"),
+        },
+      ],
     };
 
     pluginRegistry.register(mockPlugin);
@@ -104,5 +109,57 @@ describe("PluginRegistry", () => {
     expect(extensions).toHaveLength(2);
     expect(extensions.map((e) => e.id)).toContain("ext-a");
     expect(extensions.map((e) => e.id)).toContain("ext-b");
+  });
+
+  it("getAllRoutes preserves both eager (element) and lazy (load) routes", () => {
+    const loader = () =>
+      Promise.resolve({
+        default: () => React.createElement("div", null, "Lazy"),
+      });
+    const plugin: FrontendPlugin = {
+      metadata: { pluginId: "test" },
+      routes: [
+        { route: testRoutes.routes.home, element: React.createElement("div") },
+        { route: testRoutes.routes.config, load: loader },
+      ],
+    };
+    pluginRegistry.register(plugin);
+
+    const routes = pluginRegistry.getAllRoutes();
+    const home = routes.find((r) => r.path === "/test/");
+    const config = routes.find((r) => r.path === "/test/config");
+    expect(home?.element).toBeDefined();
+    expect(home?.load).toBeUndefined();
+    expect(config?.load).toBe(loader);
+    expect(config?.element).toBeUndefined();
+  });
+
+  it("getPlugins returns a NEW snapshot reference on every change", () => {
+    // Required for useSyncExternalStore / useMemo consumers to recompute when
+    // a plugin is added or removed at runtime.
+    const before = pluginRegistry.getPlugins();
+    pluginRegistry.register(mockPlugin);
+    const afterRegister = pluginRegistry.getPlugins();
+    expect(afterRegister).not.toBe(before);
+    expect(afterRegister).toContain(mockPlugin);
+
+    pluginRegistry.unregister("test");
+    const afterUnregister = pluginRegistry.getPlugins();
+    expect(afterUnregister).not.toBe(afterRegister);
+    expect(afterUnregister).not.toContain(mockPlugin);
+  });
+
+  it("notifies subscribers on register and unregister", () => {
+    let calls = 0;
+    const unsubscribe = pluginRegistry.subscribe(() => {
+      calls += 1;
+    });
+    pluginRegistry.register(mockPlugin);
+    pluginRegistry.unregister("test");
+    expect(calls).toBe(2);
+
+    unsubscribe();
+    pluginRegistry.register(mockPlugin);
+    expect(calls).toBe(2); // no longer notified after unsubscribe
   });
 });

--- a/core/gitops-frontend/src/index.tsx
+++ b/core/gitops-frontend/src/index.tsx
@@ -9,19 +9,8 @@ import {
   gitopsAccess,
 } from "@checkstack/gitops-common";
 
-import { lazy } from "react";
 import { GitOpsMenuItem } from "./components/GitOpsMenuItem";
 import { KindRegistryMenuItem } from "./components/KindRegistryMenuItem";
-
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const GitOpsPage = lazy(() =>
-  import("./pages/GitOpsPage").then((m) => ({ default: m.GitOpsPage })),
-);
-const KindRegistryPage = lazy(() =>
-  import("./pages/KindRegistryPage").then((m) => ({
-    default: m.KindRegistryPage,
-  })),
-);
 
 export const gitopsPlugin = createFrontendPlugin({
   metadata: pluginMetadata,
@@ -29,12 +18,15 @@ export const gitopsPlugin = createFrontendPlugin({
   routes: [
     {
       route: gitopsRoutes.routes.home,
-      element: <GitOpsPage />,
+      load: () => import("./pages/GitOpsPage").then((m) => ({ default: m.GitOpsPage })),
       accessRule: gitopsAccess.provider.read,
     },
     {
       route: gitopsRoutes.routes.kinds,
-      element: <KindRegistryPage />,
+      load: () =>
+        import("./pages/KindRegistryPage").then((m) => ({
+          default: m.KindRegistryPage,
+        })),
       accessRule: gitopsAccess.kinds.read,
     },
   ],

--- a/core/healthcheck-frontend/src/index.tsx
+++ b/core/healthcheck-frontend/src/index.tsx
@@ -3,9 +3,7 @@ import {
   createSlotExtension,
   UserMenuItemsSlot,
 } from "@checkstack/frontend-api";
-import { lazy } from "react";
 import { HealthCheckMenuItems } from "./components/HealthCheckMenuItems";
-import { HealthCheckSystemOverview } from "./components/HealthCheckSystemOverview";
 import { SystemHealthCheckAssignment } from "./components/SystemHealthCheckAssignment";
 import { SystemHealthBadge } from "./components/SystemHealthBadge";
 import { healthCheckAccess } from "@checkstack/healthcheck-common";
@@ -44,80 +42,69 @@ export {
 export { useHealthCheckData } from "./hooks";
 export { useStrategySchemas } from "./auto-charts/useStrategySchemas";
 
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const HealthCheckConfigPage = lazy(() =>
-  import("./pages/HealthCheckConfigPage").then((m) => ({
-    default: m.HealthCheckConfigPage,
-  })),
-);
-const StrategyPickerPage = lazy(() =>
-  import("./pages/StrategyPickerPage").then((m) => ({
-    default: m.StrategyPickerPage,
-  })),
-);
-const HealthCheckIDEPage = lazy(() =>
-  import("./pages/HealthCheckIDEPage").then((m) => ({
-    default: m.HealthCheckIDEPage,
-  })),
-);
-const AssignmentIDEPage = lazy(() =>
-  import("./pages/AssignmentIDEPage").then((m) => ({
-    default: m.AssignmentIDEPage,
-  })),
-);
-const HealthCheckHistoryPage = lazy(() =>
-  import("./pages/HealthCheckHistoryPage").then((m) => ({
-    default: m.HealthCheckHistoryPage,
-  })),
-);
-const HealthCheckHistoryDetailPage = lazy(() =>
-  import("./pages/HealthCheckHistoryDetailPage").then((m) => ({
-    default: m.HealthCheckHistoryDetailPage,
-  })),
-);
-
 export default createFrontendPlugin({
   metadata: pluginMetadata,
   routes: [
     {
       route: healthcheckRoutes.routes.config,
-      element: <HealthCheckConfigPage />,
+      load: () =>
+        import("./pages/HealthCheckConfigPage").then((m) => ({
+          default: m.HealthCheckConfigPage,
+        })),
       title: "Health Checks",
       accessRule: healthCheckAccess.configuration.manage,
     },
     {
       route: healthcheckRoutes.routes.create,
-      element: <StrategyPickerPage />,
+      load: () =>
+        import("./pages/StrategyPickerPage").then((m) => ({
+          default: m.StrategyPickerPage,
+        })),
       title: "Create Health Check",
       accessRule: healthCheckAccess.configuration.manage,
     },
     {
       route: healthcheckRoutes.routes.edit,
-      element: <HealthCheckIDEPage />,
+      load: () =>
+        import("./pages/HealthCheckIDEPage").then((m) => ({
+          default: m.HealthCheckIDEPage,
+        })),
       title: "Edit Health Check",
       accessRule: healthCheckAccess.configuration.manage,
     },
     {
       route: healthcheckRoutes.routes.assignments,
-      element: <AssignmentIDEPage />,
+      load: () =>
+        import("./pages/AssignmentIDEPage").then((m) => ({
+          default: m.AssignmentIDEPage,
+        })),
       title: "Health Check Assignments",
       accessRule: healthCheckAccess.configuration.manage,
     },
     {
       route: healthcheckRoutes.routes.history,
-      element: <HealthCheckHistoryPage />,
+      load: () =>
+        import("./pages/HealthCheckHistoryPage").then((m) => ({
+          default: m.HealthCheckHistoryPage,
+        })),
       title: "Health Check History",
       accessRule: healthCheckAccess.configuration.read,
     },
     {
       route: healthcheckRoutes.routes.historyDetail,
-      element: <HealthCheckHistoryDetailPage />,
+      load: () =>
+        import("./pages/HealthCheckHistoryDetailPage").then((m) => ({
+          default: m.HealthCheckHistoryDetailPage,
+        })),
       title: "Health Check Detail",
       accessRule: healthCheckAccess.details,
     },
     {
       route: healthcheckRoutes.routes.historyRun,
-      element: <HealthCheckHistoryDetailPage />,
+      load: () =>
+        import("./pages/HealthCheckHistoryDetailPage").then((m) => ({
+          default: m.HealthCheckHistoryDetailPage,
+        })),
       title: "Health Check Run",
       accessRule: healthCheckAccess.details,
     },
@@ -136,7 +123,12 @@ export default createFrontendPlugin({
     }),
     createSlotExtension(SystemDetailsSlot, {
       id: "healthcheck.system-details.overview",
-      component: HealthCheckSystemOverview,
+      // Heavier overview (drawer pulls recharts) — lazy so it stays out of the
+      // initial bundle and loads when a system-detail page renders.
+      load: () =>
+        import("./components/HealthCheckSystemOverview").then((m) => ({
+          default: m.HealthCheckSystemOverview,
+        })),
     }),
     createSlotExtension(CatalogSystemActionsSlot, {
       id: "healthcheck.catalog.system-actions",

--- a/core/incident-frontend/src/index.tsx
+++ b/core/incident-frontend/src/index.tsx
@@ -12,45 +12,36 @@ import {
   SystemDetailsTopSlot,
   SystemStateBadgesSlot,
 } from "@checkstack/catalog-common";
-import { lazy } from "react";
 import { SystemIncidentPanel } from "./components/SystemIncidentPanel";
 import { SystemIncidentBadge } from "./components/SystemIncidentBadge";
 import { IncidentMenuItems } from "./components/IncidentMenuItems";
-
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const IncidentConfigPage = lazy(() =>
-  import("./pages/IncidentConfigPage").then((m) => ({
-    default: m.IncidentConfigPage,
-  })),
-);
-const IncidentDetailPage = lazy(() =>
-  import("./pages/IncidentDetailPage").then((m) => ({
-    default: m.IncidentDetailPage,
-  })),
-);
-const SystemIncidentHistoryPage = lazy(() =>
-  import("./pages/SystemIncidentHistoryPage").then((m) => ({
-    default: m.SystemIncidentHistoryPage,
-  })),
-);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
   routes: [
     {
       route: incidentRoutes.routes.config,
-      element: <IncidentConfigPage />,
+      load: () =>
+        import("./pages/IncidentConfigPage").then((m) => ({
+          default: m.IncidentConfigPage,
+        })),
       title: "Incidents",
       accessRule: incidentAccess.incident.manage,
     },
     {
       route: incidentRoutes.routes.detail,
-      element: <IncidentDetailPage />,
+      load: () =>
+        import("./pages/IncidentDetailPage").then((m) => ({
+          default: m.IncidentDetailPage,
+        })),
       title: "Incident Details",
     },
     {
       route: incidentRoutes.routes.systemHistory,
-      element: <SystemIncidentHistoryPage />,
+      load: () =>
+        import("./pages/SystemIncidentHistoryPage").then((m) => ({
+          default: m.SystemIncidentHistoryPage,
+        })),
       title: "System Incident History",
     },
   ],

--- a/core/infrastructure-frontend/src/index.tsx
+++ b/core/infrastructure-frontend/src/index.tsx
@@ -3,26 +3,21 @@ import {
   createSlotExtension,
   createFrontendPlugin,
 } from "@checkstack/frontend-api";
-import { lazy } from "react";
 import { InfrastructureUserMenuItems } from "./components/UserMenuItems";
 import {
   pluginMetadata,
   infrastructureRoutes,
 } from "@checkstack/infrastructure-common";
 
-// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
-const InfrastructureConfigPage = lazy(() =>
-  import("./pages/InfrastructureConfigPage").then((m) => ({
-    default: m.InfrastructureConfigPage,
-  })),
-);
-
 export const infrastructurePlugin = createFrontendPlugin({
   metadata: pluginMetadata,
   routes: [
     {
       route: infrastructureRoutes.routes.config,
-      element: <InfrastructureConfigPage />,
+      load: () =>
+        import("./pages/InfrastructureConfigPage").then((m) => ({
+          default: m.InfrastructureConfigPage,
+        })),
       // No accessRule here — the page handles per-tab access internally
     },
   ],

--- a/core/infrastructure-frontend/src/pages/InfrastructureConfigPage.tsx
+++ b/core/infrastructure-frontend/src/pages/InfrastructureConfigPage.tsx
@@ -4,6 +4,7 @@ import {
   accessApiRef,
   useApi,
   useSlotExtensions,
+  ExtensionComponent,
 } from "@checkstack/frontend-api";
 import { InfrastructureTabsSlot } from "@checkstack/infrastructure-common";
 import { PageLayout, cn } from "@checkstack/ui";
@@ -108,8 +109,9 @@ const InfrastructureConfigPageContent = () => {
 
         <div className="flex-1 min-w-0">
           {activeTabEntry && (
-            <activeTabEntry.extension.component
-              canUpdate={activeTabEntry.manageResult.allowed}
+            <ExtensionComponent
+              extension={activeTabEntry.extension}
+              context={{ canUpdate: activeTabEntry.manageResult.allowed }}
             />
           )}
         </div>

--- a/core/integration-frontend/src/index.tsx
+++ b/core/integration-frontend/src/index.tsx
@@ -8,20 +8,7 @@ import {
   pluginMetadata,
   integrationAccess,
 } from "@checkstack/integration-common";
-import { lazy } from "react";
 import { IntegrationMenuItem } from "./components/IntegrationMenuItem";
-
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const IntegrationsLandingPage = lazy(() =>
-  import("./pages/IntegrationsLandingPage").then((m) => ({
-    default: m.IntegrationsLandingPage,
-  })),
-);
-const ProviderConnectionsPage = lazy(() =>
-  import("./pages/ProviderConnectionsPage").then((m) => ({
-    default: m.ProviderConnectionsPage,
-  })),
-);
 
 /**
  * Integration frontend — now scoped to connection management. The
@@ -35,12 +22,18 @@ export const integrationPlugin = createFrontendPlugin({
   routes: [
     {
       route: integrationRoutes.routes.list,
-      element: <IntegrationsLandingPage />,
+      load: () =>
+        import("./pages/IntegrationsLandingPage").then((m) => ({
+          default: m.IntegrationsLandingPage,
+        })),
       accessRule: integrationAccess.manage,
     },
     {
       route: integrationRoutes.routes.connections,
-      element: <ProviderConnectionsPage />,
+      load: () =>
+        import("./pages/ProviderConnectionsPage").then((m) => ({
+          default: m.ProviderConnectionsPage,
+        })),
       accessRule: integrationAccess.manage,
     },
   ],

--- a/core/maintenance-frontend/src/index.tsx
+++ b/core/maintenance-frontend/src/index.tsx
@@ -12,45 +12,36 @@ import {
   SystemDetailsTopSlot,
   SystemStateBadgesSlot,
 } from "@checkstack/catalog-common";
-import { lazy } from "react";
 import { SystemMaintenancePanel } from "./components/SystemMaintenancePanel";
 import { SystemMaintenanceBadge } from "./components/SystemMaintenanceBadge";
 import { MaintenanceMenuItems } from "./components/MaintenanceMenuItems";
-
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const MaintenanceConfigPage = lazy(() =>
-  import("./pages/MaintenanceConfigPage").then((m) => ({
-    default: m.MaintenanceConfigPage,
-  })),
-);
-const SystemMaintenanceHistoryPage = lazy(() =>
-  import("./pages/SystemMaintenanceHistoryPage").then((m) => ({
-    default: m.SystemMaintenanceHistoryPage,
-  })),
-);
-const MaintenanceDetailPage = lazy(() =>
-  import("./pages/MaintenanceDetailPage").then((m) => ({
-    default: m.MaintenanceDetailPage,
-  })),
-);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
   routes: [
     {
       route: maintenanceRoutes.routes.config,
-      element: <MaintenanceConfigPage />,
+      load: () =>
+        import("./pages/MaintenanceConfigPage").then((m) => ({
+          default: m.MaintenanceConfigPage,
+        })),
       title: "Maintenances",
       accessRule: maintenanceAccess.maintenance.manage,
     },
     {
       route: maintenanceRoutes.routes.systemHistory,
-      element: <SystemMaintenanceHistoryPage />,
+      load: () =>
+        import("./pages/SystemMaintenanceHistoryPage").then((m) => ({
+          default: m.SystemMaintenanceHistoryPage,
+        })),
       title: "System Maintenance History",
     },
     {
       route: maintenanceRoutes.routes.detail,
-      element: <MaintenanceDetailPage />,
+      load: () =>
+        import("./pages/MaintenanceDetailPage").then((m) => ({
+          default: m.MaintenanceDetailPage,
+        })),
       title: "Maintenance Details",
     },
   ],

--- a/core/notification-frontend/src/index.tsx
+++ b/core/notification-frontend/src/index.tsx
@@ -8,26 +8,8 @@ import {
   notificationRoutes,
   pluginMetadata,
 } from "@checkstack/notification-common";
-import { lazy } from "react";
 import { NotificationBell } from "./components/NotificationBell";
 import { NotificationUserMenuItems } from "./components/UserMenuItems";
-
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const NotificationsPage = lazy(() =>
-  import("./pages/NotificationsPage").then((m) => ({
-    default: m.NotificationsPage,
-  })),
-);
-const NotificationSettingsPage = lazy(() =>
-  import("./pages/NotificationSettingsPage").then((m) => ({
-    default: m.NotificationSettingsPage,
-  })),
-);
-const DeliveryAttemptsPage = lazy(() =>
-  import("./pages/DeliveryAttemptsPage").then((m) => ({
-    default: m.DeliveryAttemptsPage,
-  })),
-);
 
 // Plugin-extensible kind registry — domain frontends call `registerSubjectKind`
 // at module load to bind their kinds (e.g., "catalog.system") to icon + label.
@@ -57,15 +39,24 @@ export const notificationPlugin = createFrontendPlugin({
   routes: [
     {
       route: notificationRoutes.routes.home,
-      element: <NotificationsPage />,
+      load: () =>
+        import("./pages/NotificationsPage").then((m) => ({
+          default: m.NotificationsPage,
+        })),
     },
     {
       route: notificationRoutes.routes.settings,
-      element: <NotificationSettingsPage />,
+      load: () =>
+        import("./pages/NotificationSettingsPage").then((m) => ({
+          default: m.NotificationSettingsPage,
+        })),
     },
     {
       route: notificationRoutes.routes.deliveryAttempts,
-      element: <DeliveryAttemptsPage />,
+      load: () =>
+        import("./pages/DeliveryAttemptsPage").then((m) => ({
+          default: m.DeliveryAttemptsPage,
+        })),
     },
   ],
   extensions: [

--- a/core/pluginmanager-frontend/src/index.tsx
+++ b/core/pluginmanager-frontend/src/index.tsx
@@ -7,44 +7,35 @@ import {
   pluginManagerRoutes,
   pluginManagerAccess,
 } from "@checkstack/pluginmanager-common";
-import { lazy } from "react";
 import { PluginManagerMenuItem } from "./PluginManagerMenuItem";
-
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const InstalledPluginsPage = lazy(() =>
-  import("./pages/InstalledPluginsPage").then((m) => ({
-    default: m.InstalledPluginsPage,
-  })),
-);
-const InstallPluginPage = lazy(() =>
-  import("./pages/InstallPluginPage").then((m) => ({
-    default: m.InstallPluginPage,
-  })),
-);
-const PluginEventsPage = lazy(() =>
-  import("./pages/PluginEventsPage").then((m) => ({
-    default: m.PluginEventsPage,
-  })),
-);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
   routes: [
     {
       route: pluginManagerRoutes.routes.installed,
-      element: <InstalledPluginsPage />,
+      load: () =>
+        import("./pages/InstalledPluginsPage").then((m) => ({
+          default: m.InstalledPluginsPage,
+        })),
       title: "Plugin Manager",
       accessRule: pluginManagerAccess.view,
     },
     {
       route: pluginManagerRoutes.routes.install,
-      element: <InstallPluginPage />,
+      load: () =>
+        import("./pages/InstallPluginPage").then((m) => ({
+          default: m.InstallPluginPage,
+        })),
       title: "Install plugin",
       accessRule: pluginManagerAccess.install,
     },
     {
       route: pluginManagerRoutes.routes.events,
-      element: <PluginEventsPage />,
+      load: () =>
+        import("./pages/PluginEventsPage").then((m) => ({
+          default: m.PluginEventsPage,
+        })),
       title: "Plugin events",
       accessRule: pluginManagerAccess.view,
     },

--- a/core/satellite-frontend/src/index.tsx
+++ b/core/satellite-frontend/src/index.tsx
@@ -8,22 +8,17 @@ import {
   pluginMetadata,
   satelliteAccess,
 } from "@checkstack/satellite-common";
-import { lazy } from "react";
 import { SatelliteMenuItems } from "./components/SatelliteMenuItems";
-
-// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
-const SatelliteListPage = lazy(() =>
-  import("./pages/SatelliteListPage").then((m) => ({
-    default: m.SatelliteListPage,
-  })),
-);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
   routes: [
     {
       route: satelliteRoutes.routes.list,
-      element: <SatelliteListPage />,
+      load: () =>
+        import("./pages/SatelliteListPage").then((m) => ({
+          default: m.SatelliteListPage,
+        })),
       title: "Satellites",
       accessRule: satelliteAccess.satellite.read,
     },

--- a/core/script-packages-frontend/src/index.tsx
+++ b/core/script-packages-frontend/src/index.tsx
@@ -8,15 +8,7 @@ import {
   scriptPackagesAccess,
   pluginMetadata,
 } from "@checkstack/script-packages-common";
-import { lazy } from "react";
 import { ScriptPackagesMenuItems } from "./components/ScriptPackagesMenuItems";
-
-// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
-const ScriptPackagesSettingsPage = lazy(() =>
-  import("./pages/ScriptPackagesSettingsPage").then((m) => ({
-    default: m.ScriptPackagesSettingsPage,
-  })),
-);
 
 /**
  * Frontend plugin for script-package management.
@@ -35,7 +27,10 @@ export default createFrontendPlugin({
   routes: [
     {
       route: scriptPackagesRoutes.routes.settings,
-      element: <ScriptPackagesSettingsPage />,
+      load: () =>
+        import("./pages/ScriptPackagesSettingsPage").then((m) => ({
+          default: m.ScriptPackagesSettingsPage,
+        })),
       title: "Script packages",
       accessRule: scriptPackagesAccess.manage,
     },

--- a/core/scripts/src/templates/frontend/src/index.tsx.hbs
+++ b/core/scripts/src/templates/frontend/src/index.tsx.hbs
@@ -1,26 +1,21 @@
-import { lazy } from "react";
 import { createFrontendPlugin } from "@checkstack/frontend-api";
 import { {{pluginNameCamel}}Routes, pluginMetadata, {{pluginNameCamel}}Access } from "@checkstack/{{pluginBaseName}}-common";
-
-// Route pages are lazy-loaded so each page's component body is split into a
-// per-route chunk fetched on navigation, not bundled into the initial app
-// load. The app shell renders every route element inside a Suspense boundary,
-// so the plugin only needs to hand it a lazy component. Keep this pattern for
-// new pages; nav/slot extension components stay statically imported.
-const {{pluginNamePascal}}ListPage = lazy(() =>
-  import("./components/{{pluginNamePascal}}ListPage").then((m) => ({
-    default: m.{{pluginNamePascal}}ListPage,
-  })),
-);
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
 
-  // Register routes using typed route definitions
+  // Register routes using typed route definitions. Each route declares a `load`
+  // thunk: the framework code-splits the page and wraps it in Suspense + a
+  // per-plugin error boundary, so the page chunk is fetched on navigation
+  // (never in the initial app load). Use `load` for pages; light, always-on
+  // slot extensions (navbar/user-menu) use eager `component` instead.
   routes: [
     {
       route: {{pluginNameCamel}}Routes.routes.home,
-      element: <{{pluginNamePascal}}ListPage />,
+      load: () =>
+        import("./components/{{pluginNamePascal}}ListPage").then((m) => ({
+          default: m.{{pluginNamePascal}}ListPage,
+        })),
       title: "{{pluginNamePascal}}",
       accessRule: {{pluginNameCamel}}Access.read,
     },

--- a/core/secrets-frontend/src/index.tsx
+++ b/core/secrets-frontend/src/index.tsx
@@ -8,15 +8,7 @@ import {
   secretsAccess,
   pluginMetadata,
 } from "@checkstack/secrets-common";
-import { lazy } from "react";
 import { SecretsMenuItems } from "./components/SecretsMenuItems";
-
-// Lazy-loaded so the page body is a per-route chunk, not in the initial load.
-const SecretsSettingsPage = lazy(() =>
-  import("./pages/SecretsSettingsPage").then((m) => ({
-    default: m.SecretsSettingsPage,
-  })),
-);
 
 /**
  * Frontend plugin for the Secrets platform.
@@ -33,7 +25,10 @@ export default createFrontendPlugin({
   routes: [
     {
       route: secretsRoutes.routes.home,
-      element: <SecretsSettingsPage />,
+      load: () =>
+        import("./pages/SecretsSettingsPage").then((m) => ({
+          default: m.SecretsSettingsPage,
+        })),
       title: "Secrets",
       accessRule: secretsAccess.secret.manage,
     },

--- a/core/slo-frontend/src/index.tsx
+++ b/core/slo-frontend/src/index.tsx
@@ -4,7 +4,6 @@ import {
   UserMenuItemsSlot,
 } from "@checkstack/frontend-api";
 import { sloRoutes, pluginMetadata, sloAccess } from "@checkstack/slo-common";
-import { lazy } from "react";
 import { SystemSloPanel } from "./components/SystemSloPanel";
 import { SystemSloBadge } from "./components/SystemSloBadge";
 import { SloMenuItems } from "./components/SloMenuItems";
@@ -13,36 +12,32 @@ import {
   SystemStateBadgesSlot,
 } from "@checkstack/catalog-common";
 
-// Lazy-loaded so each page body is a per-route chunk, not in the initial load.
-const SloOverviewPage = lazy(() =>
-  import("./pages/SloOverviewPage").then((m) => ({
-    default: m.SloOverviewPage,
-  })),
-);
-const SloConfigPage = lazy(() =>
-  import("./pages/SloConfigPage").then((m) => ({ default: m.SloConfigPage })),
-);
-const SloDetailPage = lazy(() =>
-  import("./pages/SloDetailPage").then((m) => ({ default: m.SloDetailPage })),
-);
-
 export default createFrontendPlugin({
   metadata: pluginMetadata,
   routes: [
     {
       route: sloRoutes.routes.overview,
-      element: <SloOverviewPage />,
+      load: () =>
+        import("./pages/SloOverviewPage").then((m) => ({
+          default: m.SloOverviewPage,
+        })),
       title: "SLO Dashboard",
     },
     {
       route: sloRoutes.routes.config,
-      element: <SloConfigPage />,
+      load: () =>
+        import("./pages/SloConfigPage").then((m) => ({
+          default: m.SloConfigPage,
+        })),
       title: "SLO Management",
       accessRule: sloAccess.slo.manage,
     },
     {
       route: sloRoutes.routes.detail,
-      element: <SloDetailPage />,
+      load: () =>
+        import("./pages/SloDetailPage").then((m) => ({
+          default: m.SloDetailPage,
+        })),
       title: "SLO Detail",
     },
   ],

--- a/docs/src/content/docs/developer-guide/examples/plugin-templates.md
+++ b/docs/src/content/docs/developer-guide/examples/plugin-templates.md
@@ -97,7 +97,6 @@ export const myFeatureRoutes = createRoutes("my-feature", {
 // plugins/my-feature-frontend/src/index.tsx
 import { createFrontendPlugin, rpcApiRef, type ApiRef } from "@checkstack/frontend-api";
 import { myFeatureApiRef, type MyFeatureApiClient } from "./api";
-import { ItemsPage } from "./components/ItemsPage";
 import { myFeatureRoutes, MyFeatureApi, pluginMetadata, myFeatureAccess } from "@checkstack/my-feature-common";
 
 export default createFrontendPlugin({
@@ -106,7 +105,7 @@ export default createFrontendPlugin({
   routes: [
     {
       route: myFeatureRoutes.routes.home,
-      element: <ItemsPage />,
+      load: () => import("./components/ItemsPage").then((m) => ({ default: m.ItemsPage })),
       title: "Items",
       accessRule: myFeatureAccess.myfeatureRead,
     },

--- a/docs/src/content/docs/developer-guide/frontend/extension-points.md
+++ b/docs/src/content/docs/developer-guide/frontend/extension-points.md
@@ -580,6 +580,33 @@ export const MySystemAction: React.FC<Props> = ({ systemId, systemName }) => {
 > [!TIP]
 > Using `SlotContext` and `createSlotExtension` ensures compile-time type checking. If the slot definition changes, TypeScript will immediately flag any component prop mismatches.
 
+#### Eager `component` vs lazy `load`
+
+Every extension provides exactly one of `component` or `load`:
+
+- `component` (eager) — bundled with the plugin and registered at load. Use for
+  LIGHT, always-rendered contributions (navbar items, user-menu links, status
+  badges) where code-splitting would only add a load flash.
+- `load` (lazy) — a `() => import(...).then((m) => ({ default: m.X }))` thunk.
+  The framework renders it through `React.lazy` inside a Suspense boundary and a
+  per-plugin error boundary, so its chunk is fetched on demand and a failed load
+  is contained to that one contribution. Use for HEAVY or page-scoped
+  contributions (dashboards, editors, chart panels).
+
+```typescript
+createSlotExtension(SystemEditorSlot, {
+  id: "myplugin.system-editor",
+  // Heavy editor → lazy; only loads when the editor slot renders.
+  load: () =>
+    import("./components/MyEditor").then((m) => ({ default: m.MyEditor })),
+});
+```
+
+If you read extensions yourself via `useSlotExtensions` (e.g. to build a tab
+bar) instead of `<ExtensionSlot>`, render each one with the `<ExtensionComponent
+extension={ext} context={...} />` helper so both eager and lazy contributions
+are handled uniformly.
+
 #### Typed Metadata on Extensions
 
 Some slots need each extension to declare a static descriptor at registration

--- a/docs/src/content/docs/developer-guide/frontend/plugins.md
+++ b/docs/src/content/docs/developer-guide/frontend/plugins.md
@@ -121,17 +121,20 @@ export const MyFeaturePage = () => {
 
 ```typescript
 import { createFrontendPlugin } from "@checkstack/frontend-api";
-import { MyFeaturePage } from "./components/MyFeaturePage";
 import { myFeatureRoutes, pluginMetadata } from "@checkstack/myfeature-common";
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
 
-  // Register routes using typed route definitions
+  // Register routes using typed route definitions. `load` lazily imports the
+  // page; the framework code-splits it behind Suspense + an error boundary.
   routes: [
     {
       route: myFeatureRoutes.routes.home,
-      element: <MyFeaturePage />,
+      load: () =>
+        import("./components/MyFeaturePage").then((m) => ({
+          default: m.MyFeaturePage,
+        })),
     },
   ],
 });
@@ -172,6 +175,8 @@ metadata: pluginMetadata
 #### `routes` (optional)
 
 Register pages and their routes using RouteDefinitions from the common package.
+Provide exactly one of `load` (lazy, the default) or `element` (eager). `load`
+is code-split by the framework and fetched on navigation:
 
 ```typescript
 import { myRoutes } from "@checkstack/myplugin-common";
@@ -179,25 +184,43 @@ import { myRoutes } from "@checkstack/myplugin-common";
 routes: [
   {
     route: myRoutes.routes.home,
-    element: <ItemListPage />,
+    load: () =>
+      import("./pages/ItemListPage").then((m) => ({ default: m.ItemListPage })),
     title: "Items", // Optional: page title
     accessRule: access.itemRead.id, // Optional: required access rule
   },
 ]
 ```
 
+Use `element: <Page />` instead of `load` only for a page that must paint
+without a chunk fetch (e.g. a login page on the unauthenticated critical path).
+
 #### `extensions` (optional)
 
-Register components to inject into extension slots.
+Register UI to inject into extension slots. Provide exactly one of:
+
+- `component` — an eagerly-bundled component. Use for LIGHT, always-on
+  contributions (navbar items, user-menu links, badges) where code-splitting
+  would just add a load flash.
+- `load` — a lazy loader (same shape as a route's `load`). Use for HEAVY or
+  page-scoped contributions (dashboards, editors, chart panels); the framework
+  code-splits it behind Suspense + a per-plugin error boundary.
 
 ```typescript
-import { UserMenuItemsSlot } from "@checkstack/frontend-api";
+import { UserMenuItemsSlot, SystemEditorSlot } from "@checkstack/frontend-api";
 
 extensions: [
   {
     id: "myplugin.user-menu.items",
     slot: UserMenuItemsSlot,
-    component: MyUserMenuItems,
+    component: MyUserMenuItems, // light, always rendered → eager
+  },
+  {
+    id: "myplugin.system-editor",
+    slot: SystemEditorSlot,
+    // heavy, page-scoped → lazy
+    load: () =>
+      import("./components/MyEditor").then((m) => ({ default: m.MyEditor })),
   },
 ]
 ```
@@ -394,8 +417,11 @@ import { access } from "@checkstack/myplugin-common";
 
 routes: [
   {
-    path: "/config",
-    element: <ItemConfigPage />,
+    route: myRoutes.routes.config,
+    load: () =>
+      import("./pages/ItemConfigPage").then((m) => ({
+        default: m.ItemConfigPage,
+      })),
     accessRule: access.itemManage.id,
   },
 ]

--- a/docs/src/content/docs/developer-guide/frontend/routing.md
+++ b/docs/src/content/docs/developer-guide/frontend/routing.md
@@ -30,35 +30,43 @@ export { yourPluginRoutes } from "./routes";
 
 ### Using Routes (Frontend Plugin)
 
-Import the routes and use them with the `route` field:
+Each route declares a `load` thunk that imports its page module. The framework
+code-splits the page and wraps it in a Suspense boundary plus a per-plugin error
+boundary, so the page's JavaScript is fetched on navigation (never in the
+initial app load) and a page that fails to load degrades gracefully instead of
+crashing the shell. Plugins do NOT call `React.lazy` themselves.
 
 ```tsx
 // In your-plugin-frontend/src/index.tsx
 import { createFrontendPlugin } from "@checkstack/frontend-api";
-import { yourPluginRoutes, pluginMetadata } from "@checkstack/your-plugin-common";
-import { HomePage } from "./pages/HomePage";
-import { ConfigPage } from "./pages/ConfigPage";
-import { DetailPage } from "./pages/DetailPage";
+import { yourPluginRoutes, pluginMetadata, yourPluginAccess } from "@checkstack/your-plugin-common";
 
 export default createFrontendPlugin({
   metadata: pluginMetadata,
   routes: [
     {
       route: yourPluginRoutes.routes.home,
-      element: <HomePage />,
+      // `load` returns the page module. For a named export, map it to `default`:
+      load: () => import("./pages/HomePage").then((m) => ({ default: m.HomePage })),
     },
     {
       route: yourPluginRoutes.routes.config,
-      element: <ConfigPage />,
+      load: () => import("./pages/ConfigPage").then((m) => ({ default: m.ConfigPage })),
       accessRule: yourPluginAccess.manage,
     },
     {
       route: yourPluginRoutes.routes.detail,
-      element: <DetailPage />,
+      load: () => import("./pages/DetailPage").then((m) => ({ default: m.DetailPage })),
     },
   ],
 });
 ```
+
+> [!NOTE]
+> A route may instead provide an eager `element: <Page />` (mutually exclusive
+> with `load`). Reserve this for the rare page that must paint without a chunk
+> fetch - e.g. the login page on the unauthenticated critical path. Everything
+> else should use `load`.
 
 ## Route Resolution
 


### PR DESCRIPTION
Follow-up to #236. Hardens the frontend plugin contract for external/installable plugins and converges bundled + remote plugins on one lazy-loading model.

> **Why now:** once external plugins exist, the plugin contract is a frozen public API — changing it later is a breaking migration forced on every third-party author. With no external plugins yet, this is a free in-repo refactor. The byte savings are minor (the eager floor is shell-level shared vendor, not plugin code); the value is the **contract** + closing the runtime-add gaps.

## Contract (⚠️ BREAKING for plugin authors)
- **Routes** declare `load: () => import("./Page").then((m) => ({ default: m.Page }))` instead of `element: <Page />`. The framework owns `React.lazy` + Suspense + a per-plugin error boundary. `element` is still accepted for the rare page that must paint without a chunk fetch (e.g. login); provide exactly one.
- **Slot extensions** accept eager `component` (light, always-on — navbar/user-menu/badges) **or** lazy `load` (heavy/page-scoped — dashboards, editors, chart panels). New `getLazyContribution` + `ExtensionComponent` exports render either kind uniformly.

## Fixes the runtime-add path (what external plugins depend on)
- `ExtensionSlot` now subscribes to the registry → a plugin installed at runtime appears in navbar/dashboard/detail slots without a reload (previously it never re-rendered).
- The API registry rebuilds when the plugin set changes — `getPlugins()` returns an immutable snapshot consumed via `useSyncExternalStore` — so a runtime-added plugin's `apis` register (previously the `useMemo` only depended on `baseUrl`).

## Robustness
A per-plugin error boundary contains a contribution that fails to load/render, so one bad (third-party) plugin degrades to a contained fallback instead of white-screening the shell.

## Scope
- Migrated all bundled plugins to the new contract; lazy-loaded the heavy extensions (dashboard, anomaly IDE panels, dependency editor, healthcheck system overview) — confirmed out of the initial preload set.
- Updated the scaffold template (`bun run create`) and frontend developer docs (routing / plugins / extension-points / plugin-templates).
- Extended `plugin-registry` tests (immutable snapshot reference change, `load`/`element` routes, subscribe/unsubscribe).
- `auth-frontend` intentionally keeps eager `element` routes (unauthenticated critical path).

## Verification
`typecheck` (clean) + `lint` pass; `core/frontend` (incl. new registry tests), `@checkstack/ui` (262), `automation-frontend` (128) tests pass. Prod build: heavy extension chunks no longer in the initial load; initial-load JS ~445 KB → ~435 KB gzip (small, as expected). Changeset included (minor; BETA, no major; notes the breaking contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)