### PR TITLE
fix(automation-common): remove ReDoS from toShellEnvKey underscore trim

### DIFF
--- a/.changeset/shell-env-redos.md
+++ b/.changeset/shell-env-redos.md
@@ -1,0 +1,11 @@
+---
+"@checkstack/automation-common": patch
+---
+
+fix(automation-common): remove polynomial-time backtracking from `toShellEnvKey`
+
+The underscore-trim step used the naive `/^_+|_+$/g` pattern, whose trailing
+alternative can start matching anywhere within a run of underscores, giving
+quadratic match time on adversarial input (CodeQL `js/polynomial-redos`). A
+negative look-behind now anchors where the trailing run may begin, keeping the
+trim linear regardless of input shape.

--- a/core/automation-common/src/shell-env.test.ts
+++ b/core/automation-common/src/shell-env.test.ts
@@ -25,4 +25,13 @@ describe("toShellEnvKey", () => {
   it("uses the exported prefix constant", () => {
     expect(toShellEnvKey("x").startsWith(SHELL_ENV_PREFIX)).toBe(true);
   });
+
+  it("handles long runs of separators without polynomial backtracking", () => {
+    // Guards against ReDoS reintroduction in the trim step: a long run of
+    // separator-only input must trim to an empty body quickly.
+    const start = performance.now();
+    expect(toShellEnvKey(`${".".repeat(100_000)}a`)).toBe("CHECKSTACK_A");
+    expect(toShellEnvKey(".".repeat(100_000))).toBe("CHECKSTACK_");
+    expect(performance.now() - start).toBeLessThan(1_000);
+  });
 });

--- a/core/automation-common/src/shell-env.ts
+++ b/core/automation-common/src/shell-env.ts
@@ -28,6 +28,9 @@ export function toShellEnvKey(path: string): string {
   const normalized = path
     .toUpperCase()
     .replaceAll(/[^A-Z0-9]+/g, "_")
-    .replaceAll(/^_+|_+$/g, "");
+    // Trim leading/trailing `_`. The negative look-behind on the trailing
+    // alternative anchors where the underscore run may start matching,
+    // avoiding the polynomial-time backtracking of a naive `/^_+|_+$/g`.
+    .replaceAll(/^_+|(?<!_)_+$/g, "");
   return `${SHELL_ENV_PREFIX}${normalized}`;
 }


### PR DESCRIPTION
Fixes code scanning alert [#8](https://github.com/enyineer/checkstack/security/code-scanning/8) (`js/polynomial-redos`, high severity).

## Problem

`toShellEnvKey` in `core/automation-common/src/shell-env.ts` trimmed leading/trailing underscores with the classic ReDoS pattern `/^_+|_+$/g`. The trailing alternative `_+$` can begin matching at any position inside a run of underscores, so on input that does not end in an underscore the engine retries each underscore once per character — quadratic match time. Since the path argument derives from library input (scope paths), this is exploitable as a denial-of-service vector.

## Fix

Anchored the trailing alternative with a negative look-behind (`/^_+|(?<!_)_+$/g`), the rewrite CodeQL recommends. This removes the ambiguity about where the trailing underscore run starts matching, keeping the trim linear. No behavior change to the produced env-var names.

## Tests

Added a regression test feeding a 100k-separator pathological input and asserting correct output completes in under 1s. All 6 `toShellEnvKey` tests pass.

## Verification

- `bun test core/automation-common/src/shell-env.test.ts` — 6 pass
- `bun run lint` — clean
- Typecheck: the changed file compiles; pre-existing lucide-react `Github`/`Gitlab` icon errors are unrelated to this change (present on `main` without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)