### PR TITLE
fix(announcement-backend): invalidate cache after updateAnnouncement

### DIFF
--- a/.changeset/announcement-update-cache-invalidation.md
+++ b/.changeset/announcement-update-cache-invalidation.md
@@ -1,0 +1,7 @@
+---
+"@checkstack/announcement-backend": patch
+---
+
+fix(announcement-backend): invalidate cache after updateAnnouncement
+
+`updateAnnouncement` was missing the `await Promise.all([cache.invalidateAllActive(), cache.invalidateListAll()])` call that `createAnnouncement` and `deleteAnnouncement` already perform. This caused edited announcements (e.g. toggling active to false) to remain stale in both the admin list and the public active-announcements cache for up to the 45 s TTL, making the change appear to have no effect until the cache expired.

--- a/core/announcement-backend/src/router.test.ts
+++ b/core/announcement-backend/src/router.test.ts
@@ -345,6 +345,43 @@ describe("Announcement Router", () => {
       );
     });
 
+    it("invalidates both active and list-all caches after a successful update", async () => {
+      const context = createMockRpcContext({ user: adminUser });
+
+      const invalidateAllActiveSpy = mock(() => Promise.resolve(0));
+      const invalidateListAllSpy = mock(() => Promise.resolve());
+
+      const spyCache: AnnouncementCache = {
+        ...passthroughCache,
+        invalidateAllActive: invalidateAllActiveSpy,
+        invalidateListAll: invalidateListAllSpy,
+      };
+
+      const routerWithSpyCache = createAnnouncementRouter(
+        mockDb as never,
+        mockSignalService,
+        spyCache,
+      );
+
+      const updatedRow = { ...sampleAnnouncement, active: false };
+      mockDb.update.mockReturnValueOnce({
+        set: mock(() => ({
+          where: mock(() => ({
+            returning: mock(() => Promise.resolve([updatedRow])),
+          })),
+        })),
+      } as never);
+
+      await call(
+        routerWithSpyCache.updateAnnouncement,
+        { id: "ann-1", active: false },
+        { context },
+      );
+
+      expect(invalidateAllActiveSpy).toHaveBeenCalledTimes(1);
+      expect(invalidateListAllSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("throws NOT_FOUND for non-existent announcement", async () => {
       const context = createMockRpcContext({ user: adminUser });
 

--- a/core/announcement-backend/src/router.ts
+++ b/core/announcement-backend/src/router.ts
@@ -245,6 +245,11 @@ export function createAnnouncementRouter(
 
       const announcement = toAnnouncement(row);
 
+      await Promise.all([
+        cache.invalidateAllActive(),
+        cache.invalidateListAll(),
+      ]);
+
       await signalService.broadcast(ANNOUNCEMENT_UPDATED, {
         announcementId: announcement.id,
         action: "updated",


### PR DESCRIPTION
`updateAnnouncement` persisted changes but never invalidated the active/list caches (unlike create/delete), so edits (e.g. flipping to inactive) stayed stale for up to the 45s TTL.

- Add `await Promise.all([cache.invalidateAllActive(), cache.invalidateListAll()])` after the update, mirroring create/delete.
- Regression test asserting both invalidations fire (fails if the fix is reverted).
- Patch changeset.

Checks: typecheck, lint, `bun test announcement-backend` (14 pass) all green.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
