### PR TITLE
docs(gitops-kinds): document Automation conditions variants

### DIFF
--- a/docs/src/content/docs/user-guide/reference/gitops-kinds.md
+++ b/docs/src/content/docs/user-guide/reference/gitops-kinds.md
@@ -157,6 +157,44 @@ spec:
 
 The `spec` accepts every automation field: `triggers` (with optional `for:` dwells), structured `conditions`, the full action catalog, `mode`, `concurrency_scope`, `max_runs`, `uses_state`, and `state_window_minutes`. Validation is the same `AutomationDefinitionSchema` the editor uses, so a definition that round-trips in the UI is a valid descriptor.
 
+#### Conditions
+
+`conditions` is an array; every entry must pass (logical AND across the array) before the actions run. Each entry is one of: a template string, an `and` / `or` / `not` combinator, or a structured variant (`numeric_state`, `time`, `state`).
+
+```yaml
+conditions:
+  # Combinator: and / or / not (recursive, nest any condition)
+  - and:
+      - "health.system.status == 'unhealthy'"
+      - or:
+          - "trigger.payload.severity == 'critical'"
+          - not: "health.system.in_maintenance"
+
+  # numeric_state: compare a numeric value (literal or scope path) to above / below bounds
+  - numeric_state:
+      value: "health.system.p95_latency_ms"
+      above: 500
+
+  # time: on-call / quiet-hours gating via HH:mm bounds and weekday list
+  # after > before = overnight window wrapping midnight
+  - time:
+      after: "22:00"
+      before: "06:00"
+      weekday: [1, 2, 3, 4, 5]
+      timezone: "Europe/Berlin"
+
+  # state: true when the named system entity has been in status for at least `for`
+  - state:
+      entity: "payments-api"
+      status: unhealthy
+      for: { minutes: 30 }
+```
+
+> [!NOTE]
+> The system referenced by a `state` condition's `entity` (and any system a `numeric_state` path reads via `health.systems[id]`) must be resolved into scope. It is the trigger's context system by default; list additional system ids in `spec.uses_state` for cross-system rules.
+
+For full per-variant semantics - including overnight window wrapping, scope path resolution, and dwell behaviour - see the [Automation primitives reference](/checkstack/developer-guide/backend/automations/primitives/) (Conditions section).
+
 The polymorphic config blocks document themselves in the editor: each `triggers[].config` shows the schema for the chosen `triggers[].event`, and each `actions[].config` shows the schema for the chosen `actions[].action`. The same per-variant docs appear in the Kind Registry Browser, so you can discover the exact fields a trigger or provider action expects without leaving the UI.
 
 The optional `metadata.labels.group` label sets the automation's grouping label (the same field as the UI group picker), which organises the automations list into collapsible sections. It is a row-level field, not part of the `spec` definition. Omit it (or leave it blank) to keep the automation in the implicit "Ungrouped" bucket.


### PR DESCRIPTION
The GitOps kind reference only showed a single template-string condition. Adds a `Conditions` subsection under `kind: Automation` covering the `and`/`or`/`not` combinators and the `numeric_state` / `time` / `state` structured variants, with a combined YAML example mirroring `primitives.md`, a scope-resolution note, and a cross-link to the primitives reference. Verified against `ConditionSchema`. Docs-only, no changeset.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)
