### PR TITLE
docs: lead marketing copy with the reactive automation engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ Example of rich notification delivery via Telegram with formatted messages and d
 </details>
 
 <details>
-<summary><strong>🔌 Integrations & Queues</strong></summary>
+<summary><strong>🔌 Automation Actions - Integrations & Queues</strong></summary>
 
 ### Integration Connections
-Configure connections to external systems like Jira, Microsoft Teams, Webex, and custom webhooks, then call them as actions inside your automations.
+Connect to external systems like Jira, Microsoft Teams, Webex, and custom webhooks - each becomes a first-class action you can call from any automation workflow.
 ![Integration Management](assets/screenshots/integration-management.png)
 
 ### Queue Management

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Checkstack
-description: Plugin-based application platform with extensible architecture.
+description: A reactive automation engine and dependency-aware SLOs in one self-hosted platform - monitoring that doesn't just alert, it reacts.
 template: splash
 hero:
-  tagline: A pluggable platform for health checks, incidents, and operational signals. Run it yourself, or extend it with typed plugins.
+  tagline: Monitoring that doesn't just alert. It reacts. Wire any event to an ordered workflow with a reactive automation engine and dependency-aware SLOs.
   image:
     file: ../../assets/logo.svg
   actions:


### PR DESCRIPTION
Reframes the README "Integrations & Queues" screenshot section as automation actions and updates the docs splash hero (`index.mdx` tagline + description) to lead with the reactive automation engine, mirroring the README hero. Copy-only.

Note: the planned automation **screenshot** section was intentionally NOT added - it needs a human-captured `automation-*.png` asset that doesn't exist yet (adding a broken image ref would be worse). Follow-up once the screenshot exists.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
