### PR TITLE
feat(eslint): add checkstack/no-unguarded-animation rule (warn)

### DIFF
--- a/.changeset/guard-ui-animations-low-power.md
+++ b/.changeset/guard-ui-animations-low-power.md
@@ -1,0 +1,7 @@
+---
+"@checkstack/ui": minor
+---
+
+Guard shared component animations behind `usePerformance().isLowPower`.
+
+`Tabs` (panel enter), `ConfirmationModal` (open enter), `Accordion` (expand/collapse height) and `CodeEditor` (popout-button backdrop blur) previously applied their `animate-*` / `backdrop-blur` classes unconditionally. They now drop those classes when the device reports the low-power tier, matching the existing `LoadingSpinner` / `Skeleton` behaviour and the `.agent/rules/performance.md` degradation rule. No public API change; on normal-power devices the rendered output is unchanged.

--- a/core/ui/src/components/Accordion.tsx
+++ b/core/ui/src/components/Accordion.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronDown } from "lucide-react";
 import { cn } from "../utils";
+import { usePerformance } from "./PerformanceProvider";
 
 const Accordion = AccordionPrimitive.Root;
 
@@ -40,15 +41,22 @@ AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 const AccordionContent = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Content
-    ref={ref}
-    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
-    {...props}
-  >
-    <div className={cn("pb-4 pt-0", className)}>{children}</div>
-  </AccordionPrimitive.Content>
-));
+>(({ className, children, ...props }, ref) => {
+  const { isLowPower } = usePerformance();
+  return (
+    <AccordionPrimitive.Content
+      ref={ref}
+      className={cn(
+        "overflow-hidden text-sm transition-all",
+        !isLowPower &&
+          "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+      )}
+      {...props}
+    >
+      <div className={cn("pb-4 pt-0", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+});
 
 AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 

--- a/core/ui/src/components/CodeEditor/CodeEditor.tsx
+++ b/core/ui/src/components/CodeEditor/CodeEditor.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from "../Dialog";
 import { Skeleton } from "../Skeleton";
+import { usePerformance } from "../PerformanceProvider";
 import { cn } from "../../utils";
 
 // Lazy-load the Monaco-backed editor so the entire `@codingame/*` / Monaco
@@ -70,6 +71,7 @@ export const CodeEditor = ({
   title,
 }: CodeEditorProps) => {
   const [popoutOpen, setPopoutOpen] = useState(false);
+  const { isLowPower } = usePerformance();
 
   // CodeEditorProps.minHeight is a CSS length string ("240px"); TypefoxEditor
   // takes a pixel number.
@@ -113,7 +115,8 @@ export const CodeEditor = ({
             // Sits above the editor in the top-right corner. A faint background
             // keeps the muted icon legible over code; hover emphasises it.
             "absolute right-2 top-2 z-10 inline-flex h-7 w-7 items-center justify-center",
-            "rounded-md bg-background/70 text-muted-foreground backdrop-blur-sm",
+            "rounded-md bg-background/70 text-muted-foreground",
+            !isLowPower && "backdrop-blur-sm",
             "transition-colors hover:bg-accent hover:text-accent-foreground",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
           )}

--- a/core/ui/src/components/ConfirmationModal.tsx
+++ b/core/ui/src/components/ConfirmationModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { cn } from "../utils";
 import { Button } from "./Button";
+import { usePerformance } from "./PerformanceProvider";
 import { AlertTriangle, X } from "lucide-react";
 
 export interface ConfirmationModalProps {
@@ -26,6 +27,8 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   variant = "danger",
   isLoading = false,
 }) => {
+  const { isLowPower } = usePerformance();
+
   if (!isOpen) return;
 
   const handleConfirm = () => {
@@ -65,7 +68,10 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
       onClick={handleBackdropClick}
     >
       <div
-        className="bg-background rounded-lg shadow-xl max-w-md w-full mx-4 my-4 max-h-[calc(100dvh-2rem)] overflow-y-auto animate-in fade-in zoom-in duration-200 pointer-events-auto"
+        className={cn(
+          "bg-background rounded-lg shadow-xl max-w-md w-full mx-4 my-4 max-h-[calc(100dvh-2rem)] overflow-y-auto pointer-events-auto",
+          !isLowPower && "animate-in fade-in zoom-in duration-200",
+        )}
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"

--- a/core/ui/src/components/Tabs.tsx
+++ b/core/ui/src/components/Tabs.tsx
@@ -1,4 +1,6 @@
 import React, { useRef } from "react";
+import { cn } from "../utils";
+import { usePerformance } from "./PerformanceProvider";
 
 export interface TabItem {
   id: string;
@@ -126,13 +128,17 @@ export const TabPanel: React.FC<TabPanelProps> = ({
   className = "",
 }) => {
   const isActive = activeTab === id;
+  const { isLowPower } = usePerformance();
 
   return isActive ? (
     <div
       id={`tabpanel-${id}`}
       role="tabpanel"
       aria-labelledby={`tab-${id}`}
-      className={`animate-in fade-in-0 duration-200 ${className}`}
+      className={cn(
+        !isLowPower && "animate-in fade-in-0 duration-200",
+        className,
+      )}
     >
       {children}
     </div>

--- a/docs/src/content/docs/developer-guide/frontend/performance.md
+++ b/docs/src/content/docs/developer-guide/frontend/performance.md
@@ -1,0 +1,99 @@
+---
+title: "Performance degradation"
+description: "Gate animation and backdrop-blur classes behind usePerformance().isLowPower, enforced by the checkstack/no-unguarded-animation ESLint rule."
+---
+
+Checkstack targets a wide range of devices, so expensive visual effects must
+degrade gracefully on low-power hardware. The `.agent/rules/performance.md`
+rule mandates that animations, backdrop blurs, and heavy transitions be
+disabled when the device reports a low-power tier. The
+`checkstack/no-unguarded-animation` ESLint rule is the forcing function that
+catches new effects that forget this.
+
+## The canonical guard idiom
+
+Read the device tier from the `usePerformance` hook and gate the effect class
+behind `isLowPower`. Use the `cn(...)` helper so the class is dropped entirely
+when the device is low-power:
+
+```tsx
+import { usePerformance } from "@checkstack/ui";
+
+function LoadingSpinner({ size }: { size: Size }) {
+  const { isLowPower } = usePerformance();
+  return (
+    <svg
+      className={cn(
+        "text-muted-foreground",
+        !isLowPower && "animate-spin",
+        sizeClasses[size],
+      )}
+    />
+  );
+}
+```
+
+A conditional expression works too, and a JS-level guard is fine for
+value-based animations (e.g. an animated counter that jumps straight to its
+target when `isLowPower` is true):
+
+```tsx
+className={isLowPower ? "" : "animate-pulse"}
+```
+
+```tsx
+if (value === 0 || duration === 0 || isLowPower) {
+  setDisplayValue(value);
+  return;
+}
+```
+
+## What the lint rule checks
+
+`checkstack/no-unguarded-animation` runs at `warn` severity over frontend
+source only (`core/*-frontend/src`, `plugins/*-frontend/src`, `core/ui/src`).
+Storybook stories and test files are excluded. It scans `className` / `class`
+attributes and the string arguments of `cn()` / `clsx()` / `cva()`, matching
+the `animate-*`, `backdrop-blur*`, `fade-in*`, `fade-out*`, `zoom-in*`,
+`zoom-out*`, `slide-in-*`, and `slide-out-*` Tailwind families.
+
+A static lint cannot prove a runtime guard, so the rule biases toward few
+false positives:
+
+- A matched class that is the right operand of a logical or conditional
+  expression referencing `isLowPower` (the idiom above) is treated as guarded
+  and never warned.
+- For class strings composed across multiple statements, the rule only warns
+  when the enclosing module never references `isLowPower` at all. If the guard
+  appears anywhere in the file, the rule assumes the author handled it and
+  stays silent.
+
+> [!NOTE]
+> The rule is `warn`-only and MUST NOT be escalated to `error` (nor forced
+> green via `--max-warnings 0`). It informs authors; it does not block CI.
+> See `.agent/rules/code-style-guide.md`.
+
+### Options
+
+Two options mirror the allow-list shape of the other custom rules:
+
+```js
+"checkstack/no-unguarded-animation": [
+  "warn",
+  {
+    // Cheap/always-on tokens that never need a guard (exact class match).
+    allowedClasses: ["fade-in-0"],
+    // Extra guard identifier names beyond the built-in `isLowPower`.
+    additionalGuardIdentifiers: ["reduceMotion"],
+  },
+],
+```
+
+## Known gap: CSS @keyframes
+
+The rule cannot see raw CSS `@keyframes` / `animation:` declarations in `.css`
+files (e.g. `core/ui/src/themes.css`), because ESLint does not parse CSS and
+the guard there is runtime class-swapping rather than a static expression.
+Covering that would need a separate stylelint pass or a class-name allow-list
+convention. Until then, guard CSS-driven animations by toggling the class that
+applies them behind `isLowPower`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -122,6 +122,35 @@ export default tseslint.config(
       ],
     },
   },
+  // Performance degradation tripwire (.agent/rules/performance.md): animation /
+  // backdrop-blur classes must be gated behind usePerformance().isLowPower.
+  // Scoped to frontend source ONLY (the rule is a no-op elsewhere anyway, but
+  // scoping keeps the intent explicit). Storybook stories and test files are
+  // excluded — stories intentionally showcase effects unguarded, and *.test.ts*
+  // is already in the top-level `ignores`. Severity is intentionally `warn` and
+  // MUST NOT be escalated to `error` (nor forced green via --max-warnings 0):
+  // a sound static proof of a runtime guard is impossible, so this informs
+  // authors rather than blocking CI (see .agent/rules/code-style-guide.md).
+  {
+    files: [
+      "core/*-frontend/src/**/*.{ts,tsx}",
+      "plugins/*-frontend/src/**/*.{ts,tsx}",
+      "core/ui/src/**/*.{ts,tsx}",
+    ],
+    ignores: ["core/ui/stories/**"],
+    rules: {
+      "checkstack/no-unguarded-animation": [
+        "warn",
+        {
+          // Cheap/always-on tokens that never need a guard. Empty by default;
+          // add single-frame entry tokens here only with a measured reason.
+          allowedClasses: [],
+          // Extra guard identifier names beyond the built-in `isLowPower`.
+          additionalGuardIdentifiers: [],
+        },
+      ],
+    },
+  },
   // Frontend packages: ban console.* to enforce proper error handling
   {
     files: [

--- a/scripts/eslint-rules/checkstack-plugin.mjs
+++ b/scripts/eslint-rules/checkstack-plugin.mjs
@@ -12,6 +12,7 @@ import enforcePackageMetadata from "./enforce-package-metadata.mjs";
 import { noEslintDisableAny } from "./no-eslint-disable-any.mjs";
 import { noUnmanagedEntityState } from "./no-unmanaged-entity-state.mjs";
 import { noPodLocalEntityState } from "./no-pod-local-entity-state.mjs";
+import { noUnguardedAnimation } from "./no-unguarded-animation.mjs";
 
 export default {
   rules: {
@@ -23,5 +24,6 @@ export default {
     "no-eslint-disable-any": noEslintDisableAny,
     "no-unmanaged-entity-state": noUnmanagedEntityState,
     "no-pod-local-entity-state": noPodLocalEntityState,
+    "no-unguarded-animation": noUnguardedAnimation,
   },
 };

--- a/scripts/eslint-rules/no-unguarded-animation.mjs
+++ b/scripts/eslint-rules/no-unguarded-animation.mjs
@@ -1,0 +1,314 @@
+/**
+ * Custom ESLint rule: no-unguarded-animation
+ *
+ * Forcing function for `.agent/rules/performance.md`: expensive visual effects
+ * (CSS animations, backdrop blurs, entry/exit transitions) MUST degrade on
+ * low-power devices by being gated behind `usePerformance().isLowPower`. Nothing
+ * else enforces this today, so new unguarded effects slip in silently.
+ *
+ * Severity is intentionally `warn` in `eslint.config.mjs` and MUST NEVER be
+ * escalated to `error` (and never via `--max-warnings 0`): a sound static proof
+ * of a runtime guard is impossible, so this is an informational tripwire that
+ * biases toward FEW false positives, not a CI gate. See
+ * `.agent/rules/code-style-guide.md` ("do NOT escalate warnings to errors").
+ *
+ * It fires only inside frontend source (`core/*-frontend/src`,
+ * `plugins/*-frontend/src`, `core/ui/src`). Storybook stories and test files are
+ * excluded via `eslint.config.mjs` `ignores` (stories intentionally showcase
+ * effects unguarded).
+ *
+ * ## What it inspects
+ *
+ *   - JSX `className` / `class` attribute values: string literals and the
+ *     static quasis of template literals.
+ *   - The string-literal arguments (and their template quasis) passed to the
+ *     class-composition helpers `cn(...)`, `clsx(...)`, and `cva(...)`.
+ *
+ * Each collected literal is tested against an animation/blur token regex
+ * (`animate-`, `backdrop-blur`, `fade-in`, `fade-out`, `zoom-in`, `zoom-out`,
+ * `slide-in-`, `slide-out-`).
+ *
+ * ## Suppression heuristic (precision over recall)
+ *
+ *   1. Precise signal — a matched literal that is the right operand of a logical
+ *      expression (`!isLowPower && "animate-spin"`) or a branch of a conditional
+ *      (`isLowPower ? "" : "animate-spin"`) whose test references `isLowPower`
+ *      (or any `additionalGuardIdentifiers`) is treated as guarded and NOT
+ *      reported.
+ *   2. Coarse fallback — for className shapes not expressible as #1 (composed
+ *      across multiple statements, JS-level guards, etc.) the rule only reports
+ *      when the ENCLOSING MODULE never references `isLowPower` (or a configured
+ *      guard identifier) at all. If the guard appears anywhere in the file the
+ *      author is assumed to have handled it and the rule stays silent. This
+ *      deliberately trades recall for precision.
+ *
+ * ## Options
+ *
+ *   {
+ *     // Animation/blur tokens that are cheap/always-on and never need a guard
+ *     // (e.g. a single-frame `fade-in-0`). Matched per whitespace-separated
+ *     // class token; an exact match suppresses that token.
+ *     allowedClasses: string[],
+ *     // Extra guard identifier names beyond `isLowPower` (non-standard guard
+ *     // names) that satisfy both the precise and coarse checks.
+ *     additionalGuardIdentifiers: string[],
+ *   }
+ *
+ * ## Known gap (out of scope, intentional)
+ *
+ * This rule cannot see raw CSS `@keyframes` / `animation:` declarations in
+ * `.css` files (e.g. `core/ui/src/themes.css`) — ESLint does not parse CSS, and
+ * the runtime guard there is class-swapping, not a static expression. Covering
+ * that needs a separate stylelint pass or a class-name allowlist convention.
+ */
+
+const DEFAULT_GUARD = "isLowPower";
+
+// Animation / blur token matcher. Matches the documented Tailwind utility
+// families (and the `tailwindcss-animate` entry/exit utilities).
+const ANIMATION_TOKEN_REGEX =
+  /\b(?:animate-[\w-]+|backdrop-blur(?:-[\w-]+)?|fade-in(?:-[\w-]+)?|fade-out(?:-[\w-]+)?|zoom-in(?:-[\w-]+)?|zoom-out(?:-[\w-]+)?|slide-in-[\w-]+|slide-out-[\w-]+)/;
+
+/** Only fire inside frontend source trees. */
+const FRONTEND_REGEX =
+  /(?:^|[\\/])(?:(?:core|plugins)[\\/][^\\/]*-frontend|core[\\/]ui)[\\/]src[\\/]/;
+
+// Class-composition helpers whose string arguments carry className tokens.
+const CLASS_HELPERS = new Set(["cn", "clsx", "cva"]);
+
+/**
+ * Find the first animation/blur class token in a class string, skipping tokens
+ * that are explicitly allow-listed. Returns the matched token or undefined.
+ * @param {string} value
+ * @param {Set<string>} allowedClasses
+ * @returns {string | undefined}
+ */
+function findAnimationToken(value, allowedClasses) {
+  for (const token of value.split(/\s+/)) {
+    if (token.length === 0) continue;
+    if (allowedClasses.has(token)) continue;
+    if (ANIMATION_TOKEN_REGEX.test(token)) return token;
+  }
+  return;
+}
+
+/**
+ * Does an AST node reference any of the guard identifiers? Walks plain
+ * identifier / unary / member shapes used in guard expressions.
+ * @param {object | null | undefined} node
+ * @param {Set<string>} guards
+ * @returns {boolean}
+ */
+function referencesGuard(node, guards) {
+  if (!node || typeof node !== "object") return false;
+  if (node.type === "Identifier") return guards.has(node.name);
+  if (node.type === "UnaryExpression") {
+    return referencesGuard(node.argument, guards);
+  }
+  if (node.type === "LogicalExpression" || node.type === "BinaryExpression") {
+    return (
+      referencesGuard(node.left, guards) || referencesGuard(node.right, guards)
+    );
+  }
+  if (node.type === "MemberExpression") {
+    return (
+      referencesGuard(node.object, guards) ||
+      (node.computed ? referencesGuard(node.property, guards) : false)
+    );
+  }
+  if (node.type === "CallExpression") {
+    return (
+      referencesGuard(node.callee, guards) ||
+      node.arguments.some((argument) => referencesGuard(argument, guards))
+    );
+  }
+  return false;
+}
+
+/**
+ * Is this literal node guarded by a precise, low-false-positive expression?
+ * True when the literal is (transitively through grouping) the operand of a
+ * logical expression or a branch of a conditional whose controlling expression
+ * references a guard identifier — e.g. `!isLowPower && "animate-spin"` or
+ * `isLowPower ? "" : "animate-spin"`.
+ * @param {object} literalNode
+ * @param {Set<string>} guards
+ * @returns {boolean}
+ */
+function isPreciselyGuarded(literalNode, guards) {
+  let current = literalNode;
+  let parent = current.parent;
+  while (parent) {
+    if (parent.type === "LogicalExpression") {
+      // `<guard-expr> && "animate-..."` / `... || "animate-..."`: the test is
+      // the left operand and references a guard.
+      if (referencesGuard(parent.left, guards)) return true;
+    } else if (parent.type === "ConditionalExpression") {
+      // `<guard-expr> ? a : b`: either branch is guarded by the test.
+      if (
+        (parent.consequent === current || parent.alternate === current) &&
+        referencesGuard(parent.test, guards)
+      ) {
+        return true;
+      }
+    } else if (
+      // Keep climbing through transparent grouping/positions; stop at
+      // boundaries where a guard could no longer apply to this literal.
+      parent.type !== "TemplateLiteral" &&
+      parent.type !== "JSXExpressionContainer" &&
+      parent.type !== "JSXAttribute"
+    ) {
+      // For any other parent (call args, array elements, object props, JSX
+      // attribute value, etc.) the precise signal does not apply — fall back.
+      return false;
+    }
+    current = parent;
+    parent = current.parent;
+  }
+  return false;
+}
+
+export const noUnguardedAnimation = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Warn on Tailwind animation/blur classes that are not gated behind usePerformance().isLowPower (performance degradation, .agent/rules/performance.md).",
+      recommended: false,
+    },
+    messages: {
+      unguardedAnimation:
+        "'{{token}}' is not guarded by 'isLowPower'. Gate animation/blur classes behind usePerformance().isLowPower (see .agent/rules/performance.md), e.g. `!isLowPower && \"{{token}}\"`. If this effect is cheap/always-on, add it to this rule's 'allowedClasses' option.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedClasses: {
+            type: "array",
+            items: { type: "string" },
+          },
+          additionalGuardIdentifiers: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const filePath = context.filename || context.getFilename();
+    if (!FRONTEND_REGEX.test(filePath)) {
+      return {};
+    }
+
+    const options = context.options[0] ?? {};
+    const allowedClasses = new Set(options.allowedClasses);
+    const guards = new Set([DEFAULT_GUARD, ...(options.additionalGuardIdentifiers ?? [])]);
+
+    // Whether the enclosing module references a guard identifier ANYWHERE. Used
+    // by the coarse fallback: if it does, assume the author handled degradation.
+    let moduleReferencesGuard = false;
+
+    // Pending reports, resolved at Program:exit once we know whether the module
+    // references a guard. A precise-guard match is dropped immediately; an
+    // unguarded literal is queued and only emitted if the module never mentions
+    // a guard.
+    const pending = [];
+
+    /**
+     * Inspect one literal class string for an animation token and decide.
+     * @param {object} literalNode  the AST node carrying `value` (Literal or
+     *   TemplateElement); reported as the violation site.
+     * @param {string} value  the raw class string.
+     * @param {object} guardScopeNode  the node used for the precise-guard climb
+     *   (for template quasis this is the enclosing TemplateLiteral so the climb
+     *   sees the logical/conditional parent).
+     */
+    function inspect(literalNode, value, guardScopeNode) {
+      const token = findAnimationToken(value, allowedClasses);
+      if (token === undefined) return;
+      if (isPreciselyGuarded(guardScopeNode, guards)) return;
+      pending.push({ node: literalNode, token });
+    }
+
+    /**
+     * Collect class strings from a className/class value node or a class-helper
+     * argument node.
+     * @param {object} node
+     */
+    function collectFromValueNode(node) {
+      if (!node) return;
+      if (node.type === "Literal" && typeof node.value === "string") {
+        inspect(node, node.value, node);
+        return;
+      }
+      if (node.type === "TemplateLiteral") {
+        for (const quasi of node.quasis) {
+          const raw = quasi.value.cooked ?? quasi.value.raw;
+          if (typeof raw === "string") inspect(quasi, raw, quasi);
+        }
+        return;
+      }
+      if (node.type === "JSXExpressionContainer") {
+        collectFromValueNode(node.expression);
+        return;
+      }
+      // Logical / conditional class expressions: recurse so a precise guard on
+      // an inner literal is still detected.
+      if (node.type === "LogicalExpression") {
+        collectFromValueNode(node.left);
+        collectFromValueNode(node.right);
+        return;
+      }
+      if (node.type === "ConditionalExpression") {
+        collectFromValueNode(node.consequent);
+        collectFromValueNode(node.alternate);
+        return;
+      }
+      // CallExpression (e.g. a `cn(...)` inside className) is intentionally NOT
+      // recursed here — the dedicated `CallExpression` visitor handles every
+      // cn()/clsx()/cva() call site directly, so recursing would double-report.
+    }
+
+    return {
+      Identifier(node) {
+        if (guards.has(node.name)) moduleReferencesGuard = true;
+      },
+
+      JSXAttribute(node) {
+        const name =
+          node.name?.type === "JSXIdentifier" ? node.name.name : undefined;
+        if (name !== "className" && name !== "class") return;
+        collectFromValueNode(node.value);
+      },
+
+      CallExpression(node) {
+        const callee = node.callee;
+        const calleeName =
+          callee.type === "Identifier"
+            ? callee.name
+            : callee.type === "MemberExpression" &&
+                !callee.computed &&
+                callee.property.type === "Identifier"
+              ? callee.property.name
+              : undefined;
+        if (calleeName === undefined || !CLASS_HELPERS.has(calleeName)) return;
+        for (const argument of node.arguments) collectFromValueNode(argument);
+      },
+
+      "Program:exit"() {
+        if (moduleReferencesGuard) return;
+        for (const { node, token } of pending) {
+          context.report({
+            node,
+            messageId: "unguardedAnimation",
+            data: { token },
+          });
+        }
+      },
+    };
+  },
+};

--- a/scripts/eslint-rules/no-unguarded-animation.test.ts
+++ b/scripts/eslint-rules/no-unguarded-animation.test.ts
@@ -1,0 +1,115 @@
+import { describe, it } from "bun:test";
+import { RuleTester } from "eslint";
+
+import { noUnguardedAnimation } from "./no-unguarded-animation.mjs";
+
+// Drive ESLint's RuleTester through bun:test's describe/it so failures surface
+// as normal test cases (RuleTester calls these statics internally).
+RuleTester.describe = (text, fn) => describe(text, fn);
+RuleTester.it = (text, fn) => it(text, fn);
+RuleTester.itOnly = (text, fn) => it(text, fn);
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+// A path inside frontend source (the rule's structural scope).
+const FRONTEND = "/repo/core/ui/src/components/Widget.tsx";
+// A path OUTSIDE any frontend src tree (rule must be a no-op here).
+const BACKEND = "/repo/core/incident-backend/src/service.ts";
+
+ruleTester.run("no-unguarded-animation", noUnguardedAnimation, {
+  valid: [
+    // No animation class at all.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className="flex gap-2" />;`,
+    },
+    // Animation class OUTSIDE frontend src is not flagged (structural scope).
+    {
+      filename: BACKEND,
+      code: `const x = "animate-spin fade-in";`,
+    },
+    // Precise guard: right operand of a `!isLowPower && "..."` logical expr.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className={cn("base", !isLowPower && "animate-spin")} />;`,
+    },
+    // Precise guard: conditional branch gated by isLowPower.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className={isLowPower ? "" : "animate-pulse"} />;`,
+    },
+    // Coarse fallback: module references isLowPower somewhere, so a bare
+    // template-literal className is assumed handled and stays silent.
+    {
+      filename: FRONTEND,
+      code: `
+        const { isLowPower } = usePerformance();
+        const cls = isLowPower ? "" : "x";
+        const x = <div className={\`animate-in fade-in-0 \${cls}\`} />;
+      `,
+    },
+    // allowedClasses escape hatch suppresses an otherwise-flagged token.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className="fade-in-0" />;`,
+      options: [{ allowedClasses: ["fade-in-0"] }],
+    },
+    // Custom guard identifier via additionalGuardIdentifiers (precise form).
+    {
+      filename: FRONTEND,
+      code: `const x = <div className={cn(!reduceMotion && "animate-spin")} />;`,
+      options: [{ additionalGuardIdentifiers: ["reduceMotion"] }],
+    },
+    // Non-animation backdrop is fine; only blur is flagged.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className="bg-card border" />;`,
+    },
+    // Coarse fallback: once the module references isLowPower anywhere (here in a
+    // precise guard), an adjacent bare animation literal is assumed handled and
+    // stays silent. This deliberately trades recall for precision.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className={cn(!isLowPower && "animate-spin", "animate-pulse")} />;`,
+    },
+  ],
+
+  invalid: [
+    // Bare string-literal className with an animation token, no guard anywhere.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className="animate-spin" />;`,
+      errors: [{ messageId: "unguardedAnimation", data: { token: "animate-spin" } }],
+    },
+    // Template-literal quasi (the documented Tabs.tsx shape) with no guard.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className={\`animate-in fade-in-0 duration-200\`} />;`,
+      errors: [{ messageId: "unguardedAnimation" }],
+    },
+    // backdrop-blur is flagged like animations.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className="backdrop-blur-sm bg-card/80" />;`,
+      errors: [{ messageId: "unguardedAnimation", data: { token: "backdrop-blur-sm" } }],
+    },
+    // Unguarded literal inside cn(): the module never references isLowPower.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className={cn("base", "animate-pulse")} />;`,
+      errors: [{ messageId: "unguardedAnimation", data: { token: "animate-pulse" } }],
+    },
+    // slide-in-/zoom-in token families.
+    {
+      filename: FRONTEND,
+      code: `const x = <div className="slide-in-from-top zoom-in-95" />;`,
+      errors: [{ messageId: "unguardedAnimation" }],
+    },
+  ],
+});


### PR DESCRIPTION
Adds a warn-only custom lint rule flagging Tailwind animation/blur classes not gated behind `usePerformance().isLowPower` (per `.agent/rules/performance.md`).

- `scripts/eslint-rules/no-unguarded-animation.mjs` with the file-level heuristic from the issue; `allowedClasses` + `additionalGuardIdentifiers` options.
- 14 RuleTester cases; wired at **warn** (never escalated), scoped to frontend src, stories + tests excluded.
- Doc page on the rule + the canonical guard idiom.
- Fixed the 4 unguarded `core/ui/src` sites; 29 plugin-level warnings left intentionally (out of scope). `@checkstack/ui` minor changeset for the guard behavior change.

Checks: rule tests (14), typecheck, lint (0 errors) green.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)
