### PR TITLE
feat(anomaly): auto-resolve at new normal + global suppression

### DIFF
--- a/.changeset/anomaly-autoresolve-suppress.md
+++ b/.changeset/anomaly-autoresolve-suppress.md
@@ -1,0 +1,18 @@
+---
+"@checkstack/anomaly-backend": minor
+"@checkstack/anomaly-common": minor
+"@checkstack/anomaly-frontend": minor
+---
+
+Auto-resolve anomalies that settle at a new normal, and add global suppression.
+
+Part A (bug fix): a confirmed anomaly used to stay stuck in `anomaly` indefinitely when the metric settled at a *new* stable level (the classic "broken, then fixed at a clearly different value" case) — every fresh sample was still anomalous against the stale baseline, so recovery only fired once the slow hourly analyzer dragged the mean across. Both detectors now carry a baseline-independent self-resolution path:
+
+- Spike: each healthy sample for a confirmed anomaly is appended to a rolling window on the row's metadata; after `STABLE_RESOLUTION_RUN_COUNT` (5) consecutive samples sit within `STABLE_RESOLUTION_RELATIVE_BAND` (10%) of each other, the row self-resolves to `recovered`.
+- Drift: when the projected change goes flat relative to the new mean for `STABLE_DRIFT_RESOLUTION_RUN_COUNT` (2) consecutive analyzer runs, the row self-resolves.
+
+The original baseline-relative recovery path is unchanged.
+
+Part B (feature): global (per-row, not per-user) suppression. New `suppressedAt` / `suppressedValue` / `suppressedBaseline` columns on the `anomalies` table (Drizzle migration `0005`), `suppressAnomaly` / `unsuppressAnomaly` RPCs gated by `anomaly_feed.manage`, and a `suppression` filter on `getAnomalies` (default `active` hides suppressed rows). Suppressed rows drop out of the dashboard badge/widget active count, and the widget exposes an eye-off suppress affordance on confirmed anomalies. Suppression auto-clears ("changes again") once the observed value moves more than `SUPPRESSION_REACTIVATION_DELTA` (25%) from the value it was suppressed at. All suppression state lives on the shared `anomalies` row (Postgres), so every pod reads the same active/suppressed set.
+
+Distinct from the existing per-user notification mute, which only silences notifications while the row stays active.

--- a/core/anomaly-backend/drizzle/0005_cute_blonde_phantom.sql
+++ b/core/anomaly-backend/drizzle/0005_cute_blonde_phantom.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "anomalies" ADD COLUMN "suppressed_at" timestamp;--> statement-breakpoint
+ALTER TABLE "anomalies" ADD COLUMN "suppressed_value" double precision;--> statement-breakpoint
+ALTER TABLE "anomalies" ADD COLUMN "suppressed_baseline" double precision;

--- a/core/anomaly-backend/drizzle/meta/0005_snapshot.json
+++ b/core/anomaly-backend/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,419 @@
+{
+  "id": "845d6dfb-760a-47da-820b-6357758651ca",
+  "prevId": "d2a17ab6-efcd-4936-a870-ee045c74e10e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.anomalies": {
+      "name": "anomalies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "anomaly_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'spike'"
+        },
+        "state": {
+          "name": "state",
+          "type": "anomaly_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "anomaly_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baseline_value": {
+          "name": "baseline_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline_std_dev": {
+          "name": "baseline_std_dev",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviation": {
+          "name": "deviation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspicious_run_count": {
+          "name": "suspicious_run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmation_threshold": {
+          "name": "confirmation_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovered_at": {
+          "name": "recovered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_value": {
+          "name": "suppressed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_baseline": {
+          "name": "suppressed_baseline",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_assignments": {
+      "name": "anomaly_assignments",
+      "schema": "",
+      "columns": {
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "anomaly_assignments_pk": {
+          "name": "anomaly_assignments_pk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "system_id",
+            "configuration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_baselines": {
+      "name": "anomaly_baselines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean": {
+          "name": "mean",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "std_dev": {
+          "name": "std_dev",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trend_slope": {
+          "name": "trend_slope",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dominant_value": {
+          "name": "dominant_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dominant_ratio": {
+          "name": "dominant_ratio",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "anomaly_baselines_unique_path": {
+          "name": "anomaly_baselines_unique_path",
+          "nullsNotDistinct": false,
+          "columns": [
+            "system_id",
+            "configuration_id",
+            "field_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_configurations": {
+      "name": "anomaly_configurations",
+      "schema": "",
+      "columns": {
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_notification_mutes": {
+      "name": "anomaly_notification_mutes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_at": {
+          "name": "muted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anomaly_notification_mutes_user_idx": {
+          "name": "anomaly_notification_mutes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anomaly_notification_mutes_system_idx": {
+          "name": "anomaly_notification_mutes_system_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anomaly_notification_mutes_user_id_system_id_field_path_pk": {
+          "name": "anomaly_notification_mutes_user_id_system_id_field_path_pk",
+          "columns": [
+            "user_id",
+            "system_id",
+            "field_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.anomaly_direction": {
+      "name": "anomaly_direction",
+      "schema": "public",
+      "values": [
+        "above",
+        "below",
+        "changed"
+      ]
+    },
+    "public.anomaly_kind": {
+      "name": "anomaly_kind",
+      "schema": "public",
+      "values": [
+        "spike",
+        "drift"
+      ]
+    },
+    "public.anomaly_state": {
+      "name": "anomaly_state",
+      "schema": "public",
+      "values": [
+        "suspicious",
+        "anomaly",
+        "recovered"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/core/anomaly-backend/drizzle/meta/_journal.json
+++ b/core/anomaly-backend/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777549186811,
       "tag": "0004_gray_trauma",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1780347895517,
+      "tag": "0005_cute_blonde_phantom",
+      "breakpoints": true
     }
   ]
 }

--- a/core/anomaly-backend/src/detector.test.ts
+++ b/core/anomaly-backend/src/detector.test.ts
@@ -886,6 +886,167 @@ describe("Anomaly Detector — processCheckCompleted", () => {
     expect(broadcastPayload).toMatchObject({ newState: "recovered" });
   });
 
+  // ─── PART A: self-resolution (settled at a new level) ─────────────────
+
+  test("self-resolves a confirmed anomaly once recent samples settle at a new level", async () => {
+    const baseline = createBaseline({ mean: 100, stdDev: 10 });
+    const cache = createMockCache(new Map([[cacheKeyPrefix, baseline]]));
+    const catalogClient = createMockCatalogClient();
+    const notificationClient = createMockNotificationClient(["user-1"]);
+    // Four prior healthy samples already sitting at the new stable level (~200);
+    // the fifth (anomalousResult = 200) completes the window → self-resolve.
+    const db = createMockDb({
+      existingAnomaly: {
+        id: "anomaly-stuck",
+        systemId,
+        configurationId,
+        fieldPath: "collectors.http.request.responseTimeMs",
+        state: "anomaly",
+        suspiciousRunCount: 5,
+        confirmationThreshold: 3,
+        baselineValue: 100,
+        observedValue: "200",
+        suppressedAt: null,
+        suppressedValue: null,
+        metadata: { recentSamples: [200, 200, 200, 200] },
+      },
+    });
+
+    await processCheckCompleted({
+      ...baseProps,
+      latencyMs: 50,
+      result: anomalousResult, // still 10σ above the stale baseline
+      db: db as never,
+      cache,
+      logger: createMockLogger() as never,
+      catalogClient: catalogClient as never,
+      notificationClient: notificationClient as never,
+    });
+
+    expect(db._updateCalls.length).toBe(1);
+    expect(db._updateCalls[0]).toMatchObject({ state: "recovered" });
+    // Recovery notification is dispatched.
+    expect(notificationClient.notifyForSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not self-resolve while the window is still filling", async () => {
+    const baseline = createBaseline({ mean: 100, stdDev: 10 });
+    const cache = createMockCache(new Map([[cacheKeyPrefix, baseline]]));
+    const db = createMockDb({
+      existingAnomaly: {
+        id: "anomaly-filling",
+        systemId,
+        configurationId,
+        fieldPath: "collectors.http.request.responseTimeMs",
+        state: "anomaly",
+        suspiciousRunCount: 5,
+        confirmationThreshold: 3,
+        baselineValue: 100,
+        observedValue: "200",
+        suppressedAt: null,
+        suppressedValue: null,
+        metadata: { recentSamples: [200, 200] },
+      },
+    });
+
+    await processCheckCompleted({
+      ...baseProps,
+      latencyMs: 50,
+      result: anomalousResult,
+      db: db as never,
+      cache,
+      logger: createMockLogger() as never,
+      catalogClient: createMockCatalogClient() as never,
+      notificationClient: createMockNotificationClient() as never,
+    });
+
+    expect(db._updateCalls.length).toBe(1);
+    // Still anomalous: only the rolling window/observed value is updated.
+    expect(db._updateCalls[0]).not.toHaveProperty("state");
+    expect(db._updateCalls[0].metadata).toMatchObject({
+      recentSamples: [200, 200, 200],
+    });
+  });
+
+  // ─── PART B: auto-unsuppress ("changes again") ────────────────────────
+
+  test("auto-unsuppresses a suppressed anomaly when the value changes again", async () => {
+    const baseline = createBaseline({ mean: 100, stdDev: 10 });
+    const cache = createMockCache(new Map([[cacheKeyPrefix, baseline]]));
+    const db = createMockDb({
+      existingAnomaly: {
+        id: "anomaly-suppressed",
+        systemId,
+        configurationId,
+        fieldPath: "collectors.http.request.responseTimeMs",
+        state: "anomaly",
+        suspiciousRunCount: 5,
+        confirmationThreshold: 3,
+        baselineValue: 100,
+        observedValue: "200",
+        suppressedAt: new Date(),
+        suppressedValue: 200, // suppressed at ~200; new value 200 is unchanged...
+        metadata: {},
+      },
+    });
+
+    // anomalousResult is 200 — within band → must NOT auto-unsuppress.
+    await processCheckCompleted({
+      ...baseProps,
+      latencyMs: 50,
+      result: anomalousResult,
+      db: db as never,
+      cache,
+      logger: createMockLogger() as never,
+      catalogClient: createMockCatalogClient() as never,
+      notificationClient: createMockNotificationClient() as never,
+    });
+    const unsuppressed = db._updateCalls.find(
+      (c) => c.suppressedAt === null,
+    );
+    expect(unsuppressed).toBeUndefined();
+  });
+
+  test("auto-unsuppresses when the value moves outside the reactivation band", async () => {
+    // Baseline far below so the new high value is still anomalous and reaches
+    // the anomaly branch; suppressed at 50, observed jumps to 200 (>25% move).
+    const baseline = createBaseline({ mean: 100, stdDev: 10 });
+    const cache = createMockCache(new Map([[cacheKeyPrefix, baseline]]));
+    const db = createMockDb({
+      existingAnomaly: {
+        id: "anomaly-suppressed-2",
+        systemId,
+        configurationId,
+        fieldPath: "collectors.http.request.responseTimeMs",
+        state: "anomaly",
+        suspiciousRunCount: 5,
+        confirmationThreshold: 3,
+        baselineValue: 100,
+        observedValue: "50",
+        suppressedAt: new Date(),
+        suppressedValue: 50,
+        metadata: {},
+      },
+    });
+
+    await processCheckCompleted({
+      ...baseProps,
+      latencyMs: 50,
+      result: anomalousResult, // 200, far from suppressedValue 50
+      db: db as never,
+      cache,
+      logger: createMockLogger() as never,
+      catalogClient: createMockCatalogClient() as never,
+      notificationClient: createMockNotificationClient() as never,
+    });
+
+    expect(db._updateCalls.length).toBe(1);
+    expect(db._updateCalls[0]).toMatchObject({
+      suppressedAt: null,
+      suppressedValue: null,
+    });
+  });
+
   // ─── Notification resilience ──────────────────────────────────────────
 
   test("does not crash when notification dispatch fails", async () => {

--- a/core/anomaly-backend/src/detector.ts
+++ b/core/anomaly-backend/src/detector.ts
@@ -7,6 +7,10 @@ import {
   isAnomalous,
   isCategoricalAnomalous,
   resolveEffectiveConfig,
+  appendRecentSample,
+  hasSettledAtNewLevel,
+  hasChangedSinceSuppression,
+  type AnomalyMetadata,
   type FieldBaseline,
 } from "@checkstack/anomaly-common";
 import type { Logger } from "@checkstack/backend-api";
@@ -340,13 +344,112 @@ export async function processCheckCompleted({
             .where(eq(schema.anomalies.id, existingAnomaly.id));
         }
       } else if (existingAnomaly.state === "anomaly") {
-        await db
-          .update(schema.anomalies)
-          .set({
-            observedValue: String(value),
-            deviation,
+        // PART B: a suppressed anomaly auto-unsuppresses once the metric
+        // "changes again" — the observed value moves outside the relative band
+        // around the value it was suppressed at. We detect that here (the only
+        // place fresh samples flow through) before the self-resolution check so
+        // a re-activated anomaly resumes normal lifecycle handling.
+        const suppressedValue = existingAnomaly.suppressedValue;
+        if (
+          existingAnomaly.suppressedAt &&
+          typeof value === "number" &&
+          typeof suppressedValue === "number" &&
+          hasChangedSinceSuppression({
+            observedValue: value,
+            suppressedValue,
           })
-          .where(eq(schema.anomalies.id, existingAnomaly.id));
+        ) {
+          await db
+            .update(schema.anomalies)
+            .set({
+              suppressedAt: null,
+              suppressedValue: null,
+              suppressedBaseline: null,
+              observedValue: String(value),
+              deviation,
+            })
+            .where(eq(schema.anomalies.id, existingAnomaly.id));
+          await routerCache?.invalidateAnomalies();
+          if (signalService) {
+            await signalService.broadcast(ANOMALY_STATE_CHANGED, {
+              systemId,
+              anomalyId: existingAnomaly.id,
+              newState: "anomaly",
+            });
+          }
+          continue;
+        }
+
+        // PART A: self-resolution. The value is still anomalous against the
+        // (stale) baseline, but if the recent healthy samples have settled into
+        // a tight relative band the metric has found a new normal — resolve
+        // independently of the slow baseline analyzer. We keep a rolling window
+        // of recent samples on the row's metadata (shared Postgres, so every
+        // pod sees the same window).
+        if (typeof value === "number") {
+          const metadata = (existingAnomaly.metadata ??
+            {}) as AnomalyMetadata;
+          const recentSamples = appendRecentSample(
+            metadata.recentSamples,
+            value,
+          );
+
+          if (hasSettledAtNewLevel(recentSamples)) {
+            await db
+              .update(schema.anomalies)
+              .set({
+                state: "recovered",
+                recoveredAt: new Date(),
+                observedValue: String(value),
+                deviation,
+                metadata: { ...metadata, recentSamples: [] },
+              })
+              .where(eq(schema.anomalies.id, existingAnomaly.id));
+            logger.info(
+              `Anomaly self-resolved (settled at new level) for ${systemId} on ${path}`,
+            );
+
+            await routerCache?.invalidateAnomalies();
+
+            if (signalService) {
+              await signalService.broadcast(ANOMALY_STATE_CHANGED, {
+                systemId,
+                anomalyId: existingAnomaly.id,
+                newState: "recovered",
+              });
+            }
+
+            await dispatchAnomalyNotification({
+              action: "recovered",
+              systemId,
+              fieldPath: path,
+              observedValue: value,
+              baselineMean: baseline.mean,
+              catalogClient,
+              notificationClient,
+              db,
+              logger,
+            });
+            continue;
+          }
+
+          await db
+            .update(schema.anomalies)
+            .set({
+              observedValue: String(value),
+              deviation,
+              metadata: { ...metadata, recentSamples },
+            })
+            .where(eq(schema.anomalies.id, existingAnomaly.id));
+        } else {
+          await db
+            .update(schema.anomalies)
+            .set({
+              observedValue: String(value),
+              deviation,
+            })
+            .where(eq(schema.anomalies.id, existingAnomaly.id));
+        }
       }
     } else {
       if (existingAnomaly) {
@@ -361,6 +464,11 @@ export async function processCheckCompleted({
               state: "recovered",
               recoveredAt: new Date(),
               observedValue: String(value),
+              // Baseline-relative recovery clears any active suppression and the
+              // rolling self-resolution window — the row is no longer active.
+              suppressedAt: null,
+              suppressedValue: null,
+              suppressedBaseline: null,
             })
             .where(eq(schema.anomalies.id, existingAnomaly.id));
           logger.info(`Anomaly recovered for ${systemId} on ${path}`);

--- a/core/anomaly-backend/src/drift-evaluator.test.ts
+++ b/core/anomaly-backend/src/drift-evaluator.test.ts
@@ -1,7 +1,11 @@
 import { describe, test, expect, mock } from "bun:test";
 import { evaluateDrift } from "./drift-evaluator";
 import * as schema from "./schema";
-import type { AnomalySettings, FieldBaseline } from "@checkstack/anomaly-common";
+import {
+  STABLE_DRIFT_RESOLUTION_RUN_COUNT,
+  type AnomalySettings,
+  type FieldBaseline,
+} from "@checkstack/anomaly-common";
 
 function createBaseline(overrides: Partial<FieldBaseline> = {}): FieldBaseline {
   return {
@@ -355,6 +359,97 @@ describe("evaluateDrift", () => {
       expect(db._updateCalls.length).toBe(1);
       expect(db._updateCalls[0].state).toBe("recovered");
       expect(notification.notifyForSubscription).toHaveBeenCalledTimes(1);
+    });
+
+    // ─── PART A: drift self-resolution (settled at a new level) ──────────
+
+    // Statistically drifting (slope×n = 150 ≫ 2×σ = 20) yet the projected
+    // change is tiny relative to the new mean (150 / 10000 = 1.5% < band) — the
+    // metric has settled at a high new level the 7-day window hasn't caught up to.
+    const flatHighMeanBaseline = createBaseline({
+      mean: 10000,
+      stdDev: 10,
+      trendSlope: 1.5,
+      sampleCount: 100,
+    });
+
+    test("self-resolves a confirmed drift once slope is flat relative to the new mean for N runs", async () => {
+      const existing = {
+        id: "drift-stuck",
+        state: "anomaly",
+        suspiciousRunCount: 2,
+        confirmationThreshold: 2,
+        // One prior flat run already recorded; this run reaches the threshold.
+        metadata: { stableDriftRunCount: STABLE_DRIFT_RESOLUTION_RUN_COUNT - 1 },
+      };
+      const db = createMockDb({ existingAnomaly: existing });
+      const notification = createMockNotificationClient();
+      await evaluateDrift({
+        ...baseProps,
+        baseline: flatHighMeanBaseline,
+        schemaDirection: "lower-is-better",
+        templateConfig: defaultTemplate,
+        db: db as never,
+        catalogClient: createMockCatalogClient() as never,
+        notificationClient: notification as never,
+        logger: createMockLogger() as never,
+      });
+      expect(db._updateCalls.length).toBe(1);
+      expect(db._updateCalls[0].state).toBe("recovered");
+      expect(notification.notifyForSubscription).toHaveBeenCalledTimes(1);
+    });
+
+    test("accumulates the flat-run counter without resolving prematurely", async () => {
+      const existing = {
+        id: "drift-counting",
+        state: "anomaly",
+        suspiciousRunCount: 2,
+        confirmationThreshold: 2,
+        metadata: {},
+      };
+      const db = createMockDb({ existingAnomaly: existing });
+      await evaluateDrift({
+        ...baseProps,
+        baseline: flatHighMeanBaseline,
+        schemaDirection: "lower-is-better",
+        templateConfig: defaultTemplate,
+        db: db as never,
+        catalogClient: createMockCatalogClient() as never,
+        notificationClient: createMockNotificationClient() as never,
+        logger: createMockLogger() as never,
+      });
+      expect(db._updateCalls.length).toBe(1);
+      expect(db._updateCalls[0].state).toBeUndefined();
+      expect(db._updateCalls[0].metadata).toMatchObject({
+        stableDriftRunCount: 1,
+      });
+    });
+
+    test("resets the flat-run counter when drift is steep again", async () => {
+      const existing = {
+        id: "drift-resteepening",
+        state: "anomaly",
+        suspiciousRunCount: 2,
+        confirmationThreshold: 2,
+        metadata: { stableDriftRunCount: 1 },
+      };
+      const db = createMockDb({ existingAnomaly: existing });
+      // driftingBaseline: mean 200, projectedChange 150 → 75% of mean → not flat.
+      await evaluateDrift({
+        ...baseProps,
+        baseline: driftingBaseline,
+        schemaDirection: "lower-is-better",
+        templateConfig: defaultTemplate,
+        db: db as never,
+        catalogClient: createMockCatalogClient() as never,
+        notificationClient: createMockNotificationClient() as never,
+        logger: createMockLogger() as never,
+      });
+      expect(db._updateCalls.length).toBe(1);
+      expect(db._updateCalls[0].state).toBeUndefined();
+      expect(db._updateCalls[0].metadata).toMatchObject({
+        stableDriftRunCount: 0,
+      });
     });
 
     test("does nothing when no row and no drift (steady state)", async () => {

--- a/core/anomaly-backend/src/drift-evaluator.ts
+++ b/core/anomaly-backend/src/drift-evaluator.ts
@@ -8,7 +8,10 @@ import {
   ANOMALY_TREND_DETECTED,
   detectDrift,
   resolveEffectiveConfig,
+  isDriftFlatRelative,
+  STABLE_DRIFT_RESOLUTION_RUN_COUNT,
   type AnomalyDirection,
+  type AnomalyMetadata,
   type AnomalySettings,
   type FieldBaseline,
 } from "@checkstack/anomaly-common";
@@ -211,11 +214,65 @@ export async function evaluateDrift({
     }
 
     if (existing.state === "anomaly") {
+      // PART A (drift self-resolution): the slope-based detector still reports
+      // drift because the 7-day window straddles the old and new regimes, but
+      // if the *projected change relative to the (new) mean* has gone flat for
+      // several consecutive analyzer runs, the metric has settled at its new
+      // level — resolve independently of the slow window catching up. The
+      // run-count lives on the row's metadata (shared Postgres) so it survives
+      // across whichever pod claims the analyzer job.
+      const metadata = (existing.metadata ?? {}) as AnomalyMetadata;
+      const flat = isDriftFlatRelative({
+        projectedChange: driftResult.projectedChange,
+        mean: baseline.mean,
+      });
+      const stableDriftRunCount = flat
+        ? (metadata.stableDriftRunCount ?? 0) + 1
+        : 0;
+
+      if (stableDriftRunCount >= STABLE_DRIFT_RESOLUTION_RUN_COUNT) {
+        await db
+          .update(schema.anomalies)
+          .set({
+            state: "recovered",
+            recoveredAt: new Date(),
+            observedValue: baseline.mean.toString(),
+            deviation: driftResult.deviationSigmas,
+            metadata: { ...metadata, stableDriftRunCount: 0 },
+          })
+          .where(eq(schema.anomalies.id, existing.id));
+        logger.info(
+          `Drift self-resolved (settled at new level) for ${systemId} on ${fieldPath}`,
+        );
+
+        if (signalService) {
+          await signalService.broadcast(ANOMALY_STATE_CHANGED, {
+            systemId,
+            anomalyId: existing.id,
+            newState: "recovered",
+          });
+        }
+
+        await dispatchAnomalyNotification({
+          action: "drift_recovered",
+          systemId,
+          fieldPath,
+          observedValue: baseline.mean,
+          baselineMean: baseline.mean,
+          catalogClient,
+          notificationClient,
+          db,
+          logger,
+        });
+        return;
+      }
+
       await db
         .update(schema.anomalies)
         .set({
           observedValue: baseline.mean.toString(),
           deviation: driftResult.deviationSigmas,
+          metadata: { ...metadata, stableDriftRunCount },
         })
         .where(eq(schema.anomalies.id, existing.id));
       return;
@@ -241,6 +298,9 @@ export async function evaluateDrift({
         state: "recovered",
         recoveredAt: new Date(),
         observedValue: baseline.mean.toString(),
+        suppressedAt: null,
+        suppressedValue: null,
+        suppressedBaseline: null,
       })
       .where(eq(schema.anomalies.id, existing.id));
     logger.info(`Drift recovered for ${systemId} on ${fieldPath}`);

--- a/core/anomaly-backend/src/router.ts
+++ b/core/anomaly-backend/src/router.ts
@@ -80,6 +80,28 @@ export function createRouter(
       }
     ),
 
+    suppressAnomaly: os.suppressAnomaly.handler(
+      async ({ input }) => {
+        const success = await service.suppressAnomaly({
+          anomalyId: input.anomalyId,
+          systemId: input.systemId,
+        });
+        await cache.invalidateAnomalies();
+        return { success };
+      },
+    ),
+
+    unsuppressAnomaly: os.unsuppressAnomaly.handler(
+      async ({ input }) => {
+        const success = await service.unsuppressAnomaly({
+          anomalyId: input.anomalyId,
+          systemId: input.systemId,
+        });
+        await cache.invalidateAnomalies();
+        return { success };
+      },
+    ),
+
     listAnomalyNotificationMutes: os.listAnomalyNotificationMutes.handler(
       async ({ input, context }) => {
         const userId = (context.user as RealUser).id;

--- a/core/anomaly-backend/src/schema.ts
+++ b/core/anomaly-backend/src/schema.ts
@@ -52,6 +52,21 @@ export const anomalies = pgTable("anomalies", {
   startedAt: timestamp("started_at").defaultNow().notNull(),
   confirmedAt: timestamp("confirmed_at"),
   recoveredAt: timestamp("recovered_at"),
+  /**
+   * Global (per-row) suppression. We model suppression as a flag layered on top
+   * of `state` rather than a new `suppressed` enum value: the existing
+   * suspicious/anomaly/recovered state machine (in both the spike detector and
+   * the drift evaluator) stays intact, and un-suppressing simply reveals the
+   * underlying state again. A NULL `suppressedAt` means "not suppressed".
+   *
+   * Lives on the shared `anomalies` row (Postgres) so every horizontally-scaled
+   * pod reads the same suppressed/active set — see state-and-scale.md. The
+   * snapshot columns capture the value/baseline at suppression time so the
+   * inline detector can auto-unsuppress once the metric "changes again".
+   */
+  suppressedAt: timestamp("suppressed_at"),
+  suppressedValue: doublePrecision("suppressed_value"),
+  suppressedBaseline: doublePrecision("suppressed_baseline"),
   metadata: jsonb("metadata").$type<Record<string, unknown>>(),
 });
 

--- a/core/anomaly-backend/src/service.ts
+++ b/core/anomaly-backend/src/service.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, inArray } from "drizzle-orm";
+import { eq, and, desc, inArray, isNull, isNotNull } from "drizzle-orm";
 import type { SafeDatabase } from "@checkstack/backend-api";
 import * as schema from "./schema";
 import { anomalySettingsConfig } from "./config";
@@ -13,6 +13,12 @@ export class AnomalyService {
     configurationId?: string;
     state?: schema.AnomalyState;
     kind?: schema.AnomalyKind;
+    /**
+     * Suppression filter. Defaults to "active": suppressed rows are excluded
+     * from the active view. Pass "suppressed" to list only suppressed rows, or
+     * "all" to ignore the suppression flag entirely.
+     */
+    suppression?: "active" | "suppressed" | "all";
     limit?: number;
   }) {
     const conditions = [];
@@ -32,6 +38,13 @@ export class AnomalyService {
       conditions.push(eq(schema.anomalies.kind, params.kind));
     }
 
+    const suppression = params.suppression ?? "active";
+    if (suppression === "active") {
+      conditions.push(isNull(schema.anomalies.suppressedAt));
+    } else if (suppression === "suppressed") {
+      conditions.push(isNotNull(schema.anomalies.suppressedAt));
+    }
+
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
     const results = await this.db
@@ -44,11 +57,110 @@ export class AnomalyService {
     return results.map((r) => ({
       ...r,
       startedAt: r.startedAt.toISOString(),
-       
+
       confirmedAt: r.confirmedAt?.toISOString() ?? null,
-       
+
       recoveredAt: r.recoveredAt?.toISOString() ?? null,
+
+      suppressedAt: r.suppressedAt?.toISOString() ?? null,
     }));
+  }
+
+  /**
+   * Globally suppress a single anomaly row. Snapshots the current observed
+   * value and baseline so the inline detector can auto-unsuppress once the
+   * metric "changes again" (moves outside the relative reactivation band).
+   *
+   * The mutation is scoped by BOTH `anomalyId` and `systemId` — the access
+   * gate authorizes the caller on `systemId`, so we must verify the target row
+   * actually belongs to that system, otherwise a user with `feed.manage` on
+   * system A could suppress system B's anomaly by passing B's id (IDOR).
+   *
+   * Only confirmed (`state === "anomaly"`) rows can be suppressed: the
+   * auto-unsuppress re-evaluation lives in the confirmed-anomaly branch of the
+   * detector, and a suppressed suspicious row would otherwise still confirm and
+   * notify. Returns false if no matching confirmed row exists.
+   */
+  async suppressAnomaly({
+    anomalyId,
+    systemId,
+  }: {
+    anomalyId: string;
+    systemId: string;
+  }): Promise<boolean> {
+    const [existing] = await this.db
+      .select()
+      .from(schema.anomalies)
+      .where(
+        and(
+          eq(schema.anomalies.id, anomalyId),
+          eq(schema.anomalies.systemId, systemId),
+        ),
+      )
+      .limit(1);
+
+    if (!existing || existing.state !== "anomaly") return false;
+
+    const observedNumeric = Number(existing.observedValue);
+
+    await this.db
+      .update(schema.anomalies)
+      .set({
+        suppressedAt: new Date(),
+        suppressedValue: Number.isFinite(observedNumeric)
+          ? observedNumeric
+          : null,
+        suppressedBaseline: existing.baselineValue,
+      })
+      .where(
+        and(
+          eq(schema.anomalies.id, anomalyId),
+          eq(schema.anomalies.systemId, systemId),
+        ),
+      );
+
+    return true;
+  }
+
+  /**
+   * Clear suppression on a single anomaly row. Scoped by both `anomalyId` and
+   * `systemId` for the same IDOR reason as {@link suppressAnomaly}.
+   */
+  async unsuppressAnomaly({
+    anomalyId,
+    systemId,
+  }: {
+    anomalyId: string;
+    systemId: string;
+  }): Promise<boolean> {
+    const [existing] = await this.db
+      .select()
+      .from(schema.anomalies)
+      .where(
+        and(
+          eq(schema.anomalies.id, anomalyId),
+          eq(schema.anomalies.systemId, systemId),
+        ),
+      )
+      .limit(1);
+
+    if (!existing) return false;
+
+    await this.db
+      .update(schema.anomalies)
+      .set({
+        suppressedAt: null,
+        suppressedValue: null,
+        suppressedBaseline: null,
+      })
+      .where(
+        and(
+          eq(schema.anomalies.id, anomalyId),
+          eq(schema.anomalies.systemId, systemId),
+        ),
+      );
+
+    return true;
   }
 
   async getAnomalyBaselines(params: {

--- a/core/anomaly-backend/src/suppression.test.ts
+++ b/core/anomaly-backend/src/suppression.test.ts
@@ -1,0 +1,290 @@
+import { describe, test, expect, mock } from "bun:test";
+import { AnomalyService } from "./service";
+import * as schema from "./schema";
+
+/**
+ * Exercises the global (per-row) suppression surface on AnomalyService:
+ * suppress snapshots the observed value + baseline, unsuppress clears them,
+ * getAnomalies honours the suppression filter, and — critically — both
+ * mutations are scoped by `(anomalyId, systemId)` so a caller authorized on
+ * one system cannot mutate another system's row (IDOR). The detector-side
+ * auto-unsuppress lives in detector.test.ts.
+ */
+
+/**
+ * Walk a drizzle WHERE condition object and collect every embedded scalar
+ * value. Lets the mock faithfully simulate Postgres row scoping: a query for
+ * `and(eq(id, X), eq(systemId, Y))` returns the stored row only when both X
+ * and Y match it (just like the real `WHERE id = X AND system_id = Y`).
+ */
+function collectConditionValues(node: unknown): Set<string> {
+  const acc = new Set<string>();
+  const seen = new Set<unknown>();
+  const walk = (x: unknown): void => {
+    if (x == null || typeof x !== "object" || seen.has(x)) return;
+    seen.add(x);
+    const rec = x as Record<string, unknown>;
+    if (
+      "value" in rec &&
+      (typeof rec.value === "string" || typeof rec.value === "number")
+    ) {
+      acc.add(String(rec.value));
+    }
+    for (const key of Object.keys(rec)) walk(rec[key]);
+  };
+  walk(node);
+  return acc;
+}
+
+function createMockDb({
+  storedRow,
+}: {
+  storedRow?: Record<string, unknown>;
+} = {}) {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const whereSnapshots: unknown[] = [];
+
+  /**
+   * Returns the stored row only when the condition mentions every scalar
+   * identity field the row carries that the service scopes on (id + systemId).
+   * If the condition is absent (e.g. unfiltered getAnomalies) the row passes.
+   */
+  const rowsFor = (cond: unknown): Record<string, unknown>[] => {
+    if (!storedRow) return [];
+    if (cond === undefined) return [storedRow];
+    const values = collectConditionValues(cond);
+    const id = storedRow.id;
+    const systemId = storedRow.systemId;
+    const idMatches = id === undefined || values.has(String(id));
+    const systemMatches =
+      systemId === undefined || values.has(String(systemId));
+    return idMatches && systemMatches ? [storedRow] : [];
+  };
+
+  const makeThenable = (rows: unknown[]) => {
+    const promise = Promise.resolve(rows);
+    return {
+      then: promise.then.bind(promise),
+      catch: promise.catch.bind(promise),
+      limit: mock(() => Promise.resolve(rows)),
+      orderBy: mock(() => ({
+        limit: mock(() => Promise.resolve(rows)),
+      })),
+    };
+  };
+
+  const db = {
+    select: mock(() => ({
+      from: mock(() => ({
+        where: mock((cond: unknown) => {
+          whereSnapshots.push(cond);
+          return makeThenable(rowsFor(cond));
+        }),
+        // Unfiltered consumption (no .where()) — returns the row unscoped.
+        ...makeThenable(storedRow ? [storedRow] : []),
+      })),
+    })),
+    update: mock(() => ({
+      set: mock((values: Record<string, unknown>) => ({
+        where: mock(() => {
+          updateCalls.push(values);
+          return Promise.resolve();
+        }),
+      })),
+    })),
+    _updateCalls: updateCalls,
+    _whereSnapshots: whereSnapshots,
+  };
+  return db;
+}
+
+const confirmedRow = {
+  id: "a1",
+  systemId: "sys-A",
+  state: "anomaly" as const,
+  observedValue: "250",
+  baselineValue: 100,
+};
+
+describe("AnomalyService.suppressAnomaly", () => {
+  test("snapshots observed value + baseline and sets suppressedAt", async () => {
+    const db = createMockDb({ storedRow: confirmedRow });
+    const service = new AnomalyService(db as never);
+
+    const ok = await service.suppressAnomaly({
+      anomalyId: "a1",
+      systemId: "sys-A",
+    });
+
+    expect(ok).toBe(true);
+    expect(db._updateCalls.length).toBe(1);
+    expect(db._updateCalls[0]).toMatchObject({
+      suppressedValue: 250,
+      suppressedBaseline: 100,
+    });
+    expect(db._updateCalls[0].suppressedAt).toBeInstanceOf(Date);
+  });
+
+  test("stores null suppressedValue for a non-numeric observed value", async () => {
+    const db = createMockDb({
+      storedRow: {
+        id: "a2",
+        systemId: "sys-A",
+        state: "anomaly",
+        observedValue: "ERROR",
+        baselineValue: null,
+      },
+    });
+    const service = new AnomalyService(db as never);
+
+    await service.suppressAnomaly({ anomalyId: "a2", systemId: "sys-A" });
+
+    expect(db._updateCalls[0].suppressedValue).toBeNull();
+  });
+
+  test("returns false (no write) when the row does not exist", async () => {
+    const db = createMockDb();
+    const service = new AnomalyService(db as never);
+
+    const ok = await service.suppressAnomaly({
+      anomalyId: "missing",
+      systemId: "sys-A",
+    });
+
+    expect(ok).toBe(false);
+    expect(db._updateCalls.length).toBe(0);
+  });
+
+  // ─── IDOR regression ──────────────────────────────────────────────────
+  test("cannot suppress a row belonging to a different system", async () => {
+    // Row b1 belongs to system B; attacker authorized on system A passes B's id.
+    const db = createMockDb({
+      storedRow: {
+        id: "b1",
+        systemId: "sys-B",
+        state: "anomaly",
+        observedValue: "250",
+        baselineValue: 100,
+      },
+    });
+    const service = new AnomalyService(db as never);
+
+    const ok = await service.suppressAnomaly({
+      anomalyId: "b1",
+      systemId: "sys-A",
+    });
+
+    expect(ok).toBe(false);
+    expect(db._updateCalls.length).toBe(0);
+  });
+
+  // ─── State guard ──────────────────────────────────────────────────────
+  test("refuses to suppress a non-confirmed (suspicious) row", async () => {
+    const db = createMockDb({
+      storedRow: {
+        id: "a3",
+        systemId: "sys-A",
+        state: "suspicious",
+        observedValue: "250",
+        baselineValue: 100,
+      },
+    });
+    const service = new AnomalyService(db as never);
+
+    const ok = await service.suppressAnomaly({
+      anomalyId: "a3",
+      systemId: "sys-A",
+    });
+
+    expect(ok).toBe(false);
+    expect(db._updateCalls.length).toBe(0);
+  });
+});
+
+describe("AnomalyService.unsuppressAnomaly", () => {
+  test("clears all suppression columns", async () => {
+    const db = createMockDb({ storedRow: confirmedRow });
+    const service = new AnomalyService(db as never);
+
+    const ok = await service.unsuppressAnomaly({
+      anomalyId: "a1",
+      systemId: "sys-A",
+    });
+
+    expect(ok).toBe(true);
+    expect(db._updateCalls[0]).toMatchObject({
+      suppressedAt: null,
+      suppressedValue: null,
+      suppressedBaseline: null,
+    });
+  });
+
+  test("returns false when the row does not exist", async () => {
+    const db = createMockDb();
+    const service = new AnomalyService(db as never);
+
+    expect(
+      await service.unsuppressAnomaly({ anomalyId: "x", systemId: "sys-A" }),
+    ).toBe(false);
+    expect(db._updateCalls.length).toBe(0);
+  });
+
+  // ─── IDOR regression ──────────────────────────────────────────────────
+  test("cannot unsuppress a row belonging to a different system", async () => {
+    const db = createMockDb({
+      storedRow: {
+        id: "b1",
+        systemId: "sys-B",
+        state: "anomaly",
+        observedValue: "250",
+        suppressedAt: new Date(),
+      },
+    });
+    const service = new AnomalyService(db as never);
+
+    const ok = await service.unsuppressAnomaly({
+      anomalyId: "b1",
+      systemId: "sys-A",
+    });
+
+    expect(ok).toBe(false);
+    expect(db._updateCalls.length).toBe(0);
+  });
+});
+
+describe("AnomalyService.getAnomalies suppression filter", () => {
+  test("default ('active') adds a suppressedAt IS NULL predicate", async () => {
+    const db = createMockDb();
+    const service = new AnomalyService(db as never);
+
+    await service.getAnomalies({ systemId: "sys-1" });
+
+    // A where() with a non-undefined condition was issued (the active filter
+    // contributes a predicate even when no other filters are set).
+    expect(db._whereSnapshots.length).toBe(1);
+    expect(db._whereSnapshots[0]).toBeDefined();
+  });
+
+  test("ISO-formats suppressedAt in the returned DTO", async () => {
+    const suppressedAt = new Date("2026-05-01T00:00:00.000Z");
+    const db = createMockDb({
+      storedRow: {
+        // No `id` field: getAnomalies scopes by systemId (+ the suppression
+        // predicate), not by row id, so the mock only enforces systemId here.
+        systemId: "sys-1",
+        startedAt: new Date("2026-04-01T00:00:00.000Z"),
+        confirmedAt: null,
+        recoveredAt: null,
+        suppressedAt,
+      },
+    });
+    const service = new AnomalyService(db as never);
+
+    const [row] = await service.getAnomalies({
+      systemId: "sys-1",
+      suppression: "suppressed",
+    });
+
+    expect(row.suppressedAt).toBe(suppressedAt.toISOString());
+  });
+});

--- a/core/anomaly-common/src/engine/self-resolution.test.ts
+++ b/core/anomaly-common/src/engine/self-resolution.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect } from "bun:test";
+import {
+  STABLE_RESOLUTION_RUN_COUNT,
+  STABLE_RESOLUTION_RELATIVE_BAND,
+  SUPPRESSION_REACTIVATION_DELTA,
+  hasSettledAtNewLevel,
+  appendRecentSample,
+  isDriftFlatRelative,
+  hasChangedSinceSuppression,
+} from "./self-resolution";
+
+describe("hasSettledAtNewLevel", () => {
+  test("false when fewer than the required number of samples", () => {
+    const window = Array.from(
+      { length: STABLE_RESOLUTION_RUN_COUNT - 1 },
+      () => 500,
+    );
+    expect(hasSettledAtNewLevel(window)).toBe(false);
+  });
+
+  test("true when enough samples sit inside the tight relative band", () => {
+    // All within 10% of mean 500 → settled at a new level.
+    const window = [500, 505, 498, 502, 500];
+    expect(window.length).toBe(STABLE_RESOLUTION_RUN_COUNT);
+    expect(hasSettledAtNewLevel(window)).toBe(true);
+  });
+
+  test("false when samples are still spread wider than the band", () => {
+    // (max-min)/mean = (700-300)/500 = 0.8 ≫ band
+    const window = [300, 700, 400, 600, 500];
+    expect(hasSettledAtNewLevel(window)).toBe(false);
+  });
+
+  test("only considers the most recent STABLE_RESOLUTION_RUN_COUNT samples", () => {
+    // Old volatile prefix, recent settled suffix.
+    const window = [10, 9000, 500, 502, 498, 500, 501];
+    expect(hasSettledAtNewLevel(window)).toBe(true);
+  });
+
+  test("band boundary is inclusive", () => {
+    // spread exactly at the band edge relative to mean
+    const mean = 100;
+    const spread = STABLE_RESOLUTION_RELATIVE_BAND * mean; // 10
+    const window = [mean - spread / 2, mean, mean, mean, mean + spread / 2];
+    expect(hasSettledAtNewLevel(window)).toBe(true);
+  });
+});
+
+describe("appendRecentSample", () => {
+  test("appends to an empty window", () => {
+    expect(appendRecentSample(undefined, 5)).toEqual([5]);
+  });
+
+  test("caps the window at STABLE_RESOLUTION_RUN_COUNT, dropping oldest", () => {
+    let window: number[] | undefined;
+    for (let i = 0; i < STABLE_RESOLUTION_RUN_COUNT + 3; i++) {
+      window = appendRecentSample(window, i);
+    }
+    expect(window).toHaveLength(STABLE_RESOLUTION_RUN_COUNT);
+    // Last value pushed was N+2; window keeps the most recent N.
+    expect(window?.at(-1)).toBe(STABLE_RESOLUTION_RUN_COUNT + 2);
+    expect(window?.[0]).toBe(3);
+  });
+});
+
+describe("isDriftFlatRelative", () => {
+  test("true when projected change is small relative to mean", () => {
+    expect(isDriftFlatRelative({ projectedChange: 5, mean: 1000 })).toBe(true);
+  });
+
+  test("false when projected change is large relative to mean", () => {
+    expect(isDriftFlatRelative({ projectedChange: 500, mean: 1000 })).toBe(
+      false,
+    );
+  });
+
+  test("handles near-zero mean without dividing by zero", () => {
+    expect(isDriftFlatRelative({ projectedChange: 0, mean: 0 })).toBe(true);
+    expect(isDriftFlatRelative({ projectedChange: 1, mean: 0 })).toBe(false);
+  });
+});
+
+describe("hasChangedSinceSuppression", () => {
+  test("false when the value stays within the reactivation band", () => {
+    // 10% move, band is 25%
+    expect(
+      hasChangedSinceSuppression({ observedValue: 110, suppressedValue: 100 }),
+    ).toBe(false);
+  });
+
+  test("true when the value moves beyond the reactivation band", () => {
+    const beyond = 100 * (1 + SUPPRESSION_REACTIVATION_DELTA) + 1;
+    expect(
+      hasChangedSinceSuppression({
+        observedValue: beyond,
+        suppressedValue: 100,
+      }),
+    ).toBe(true);
+  });
+
+  test("reacts to moves in either direction", () => {
+    expect(
+      hasChangedSinceSuppression({ observedValue: 50, suppressedValue: 100 }),
+    ).toBe(true);
+  });
+});

--- a/core/anomaly-common/src/engine/self-resolution.ts
+++ b/core/anomaly-common/src/engine/self-resolution.ts
@@ -1,0 +1,115 @@
+/**
+ * Self-resolution and suppression heuristics.
+ *
+ * PART A (auto-resolve): a confirmed anomaly must clear once the metric settles
+ * at a *new* stable level, even while that level is still anomalous against the
+ * stale baseline. The classic case is "broken then fixed at a clearly different
+ * value": the new value IS the new normal, but the relative resolver keeps
+ * comparing against the old mean and never fires until the slow hourly baseline
+ * analyzer drags the mean across. These pure helpers give both the spike
+ * detector and the drift evaluator a baseline-independent escape hatch.
+ *
+ * PART B (suppression): an operator can silence a known anomaly. It auto-clears
+ * ("changes again") once the observed value moves outside a relative band around
+ * the value it was suppressed at.
+ */
+
+/**
+ * Number of consecutive healthy samples that must sit inside the tight band
+ * before a confirmed spike anomaly self-resolves.
+ *
+ * Chosen as 5: deliberately stricter than the typical confirmation window
+ * (~3 runs) so a brief cluster of similar values can't masquerade as a new
+ * stable regime, while still resolving within a handful of check cycles rather
+ * than the hours-to-days the baseline analyzer would take.
+ */
+export const STABLE_RESOLUTION_RUN_COUNT = 5;
+
+/**
+ * Maximum relative spread, (max − min) / max(|mean|, ε), the recent-sample
+ * window may have to count as "settled". 0.10 == within 10% of each other.
+ *
+ * Tight enough that genuinely volatile metrics never qualify, loose enough to
+ * absorb normal jitter around a new operating point.
+ */
+export const STABLE_RESOLUTION_RELATIVE_BAND = 0.1;
+
+/**
+ * Number of consecutive baseline-analyzer runs a confirmed *drift* anomaly must
+ * show a flat (relative) slope before it self-resolves. The analyzer runs
+ * hourly, so 2 runs ≈ the metric has held its new level for ~2h, which is the
+ * same confidence shape as the drift confirmation threshold.
+ */
+export const STABLE_DRIFT_RESOLUTION_RUN_COUNT = 2;
+
+/**
+ * Relative band for "the suppressed metric changed again". When the observed
+ * value moves more than 25% away from the value it was suppressed at (relative
+ * to that value), the suppression auto-clears. Chosen wider than the
+ * self-resolution band: suppression is a deliberate operator action, so we only
+ * undo it on a clearly material move, not on routine jitter.
+ */
+export const SUPPRESSION_REACTIVATION_DELTA = 0.25;
+
+/**
+ * Returns true when the supplied rolling window of recent healthy samples has
+ * both (a) reached the required length and (b) settled inside the tight
+ * relative band — i.e. the metric has found a new stable level.
+ */
+export function hasSettledAtNewLevel(samples: number[]): boolean {
+  if (samples.length < STABLE_RESOLUTION_RUN_COUNT) return false;
+
+  const window = samples.slice(-STABLE_RESOLUTION_RUN_COUNT);
+  const min = Math.min(...window);
+  const max = Math.max(...window);
+  const mean = window.reduce((sum, v) => sum + v, 0) / window.length;
+  const denominator = Math.max(Math.abs(mean), Number.EPSILON);
+
+  return (max - min) / denominator <= STABLE_RESOLUTION_RELATIVE_BAND;
+}
+
+/**
+ * Append a sample to a rolling window, keeping at most
+ * {@link STABLE_RESOLUTION_RUN_COUNT} most-recent entries (oldest-first).
+ */
+export function appendRecentSample(
+  existing: number[] | undefined,
+  value: number,
+): number[] {
+  const next = [...(existing ?? []), value];
+  return next.slice(-STABLE_RESOLUTION_RUN_COUNT);
+}
+
+/**
+ * Returns true when the projected drift change is flat relative to the current
+ * mean — the trend has stopped walking and the metric is holding its new level.
+ */
+export function isDriftFlatRelative({
+  projectedChange,
+  mean,
+}: {
+  projectedChange: number;
+  mean: number;
+}): boolean {
+  const denominator = Math.max(Math.abs(mean), Number.EPSILON);
+  return Math.abs(projectedChange) / denominator <= STABLE_RESOLUTION_RELATIVE_BAND;
+}
+
+/**
+ * Returns true when an observed value has moved outside the relative band
+ * around the value an anomaly was suppressed at — i.e. it "changed again" and
+ * suppression should auto-clear.
+ */
+export function hasChangedSinceSuppression({
+  observedValue,
+  suppressedValue,
+}: {
+  observedValue: number;
+  suppressedValue: number;
+}): boolean {
+  const denominator = Math.max(Math.abs(suppressedValue), Number.EPSILON);
+  return (
+    Math.abs(observedValue - suppressedValue) / denominator >
+    SUPPRESSION_REACTIVATION_DELTA
+  );
+}

--- a/core/anomaly-common/src/index.ts
+++ b/core/anomaly-common/src/index.ts
@@ -3,6 +3,7 @@ export * from "./engine/baseline";
 export * from "./engine/thresholds";
 export * from "./engine/config";
 export * from "./engine/drift";
+export * from "./engine/self-resolution";
 export * from "./access";
 export * from "./rpc-contract";
 export * from "./plugin-metadata";

--- a/core/anomaly-common/src/rpc-contract.ts
+++ b/core/anomaly-common/src/rpc-contract.ts
@@ -21,6 +21,9 @@ export const AnomalyDtoSchema = z.object({
   startedAt: z.string(),
   confirmedAt: z.string().nullable(),
   recoveredAt: z.string().nullable(),
+  suppressedAt: z.string().nullable(),
+  suppressedValue: z.number().nullable(),
+  suppressedBaseline: z.number().nullable(),
   metadata: z.record(z.string(), z.unknown()).nullable(),
 });
 
@@ -101,6 +104,11 @@ export const anomalyContract = {
       configurationId: z.string().optional(),
       state: AnomalyStateSchema.optional(),
       kind: AnomalyKindSchema.optional(),
+      /**
+       * Suppression filter. "active" (default) hides globally-suppressed rows,
+       * "suppressed" lists only them, "all" ignores the flag.
+       */
+      suppression: z.enum(["active", "suppressed", "all"]).optional(),
       limit: z.number().optional().default(50),
     }))
     .output(z.array(AnomalyDtoSchema)),
@@ -197,6 +205,46 @@ export const anomalyContract = {
       z.object({
         systemId: z.string(),
         fieldPath: z.string().default(""),
+      }),
+    )
+    .output(z.object({ success: z.boolean() })),
+
+  /**
+   * Globally suppress an anomaly row so it disappears from the active feed
+   * until the metric "changes again". Suppression is per-row (not per-user)
+   * and lives in shared Postgres so every pod sees the same active set.
+   * Gated by `feed.manage`. Idempotent.
+   */
+  suppressAnomaly: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [anomalyAccess.feed.manage],
+    instanceAccess: { idParam: "systemId" },
+  })
+    .route({ method: "POST" })
+    .input(
+      z.object({
+        systemId: z.string(),
+        anomalyId: z.string(),
+      }),
+    )
+    .output(z.object({ success: z.boolean() })),
+
+  /**
+   * Manually clear suppression on an anomaly row, returning it to the active
+   * feed. Gated by `feed.manage`. Idempotent.
+   */
+  unsuppressAnomaly: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [anomalyAccess.feed.manage],
+    instanceAccess: { idParam: "systemId" },
+  })
+    .route({ method: "POST" })
+    .input(
+      z.object({
+        systemId: z.string(),
+        anomalyId: z.string(),
       }),
     )
     .output(z.object({ success: z.boolean() })),

--- a/core/anomaly-common/src/schema.ts
+++ b/core/anomaly-common/src/schema.ts
@@ -33,6 +33,19 @@ export const AnomalyMetadataSchema = z
   .object({
     trendData: z.record(z.string(), z.unknown()).optional(),
     relatedAnomalies: z.array(z.string()).optional(), // UUIDs
+    /**
+     * Rolling window of the most recent healthy numeric samples, used by the
+     * self-resolution path (PART A) to decide that the metric has settled at a
+     * new stable level even while it is still anomalous against the stale
+     * baseline. Oldest-first; capped at {@link STABLE_RESOLUTION_RUN_COUNT}.
+     */
+    recentSamples: z.array(z.number()).optional(),
+    /**
+     * Count of consecutive baseline-analyzer runs in which a confirmed drift
+     * anomaly's slope has been flat relative to the (new) mean. Used by the
+     * drift self-resolution path.
+     */
+    stableDriftRunCount: z.number().optional(),
   })
   .catchall(z.unknown());
 export type AnomalyMetadata = z.infer<typeof AnomalyMetadataSchema>;

--- a/core/anomaly-frontend/src/components/AnomalyFieldMuteList.tsx
+++ b/core/anomaly-frontend/src/components/AnomalyFieldMuteList.tsx
@@ -23,8 +23,11 @@ export const AnomalyFieldMuteList: React.FC<{
   const anomalyClient = usePluginClient(AnomalyApi);
   const toast = useToast();
 
+  // Notification mute is a per-user concern orthogonal to global suppression,
+  // so the mute-management list must include suppressed rows — otherwise a
+  // field that is both suppressed and muted would lose its unmute affordance.
   const { data: anomalies = [] } = anomalyClient.getAnomalies.useQuery(
-    { systemId, limit: 50 },
+    { systemId, limit: 50, suppression: "all" },
     { staleTime: 30_000 },
   );
 

--- a/core/anomaly-frontend/src/components/SystemAnomalyWidget.tsx
+++ b/core/anomaly-frontend/src/components/SystemAnomalyWidget.tsx
@@ -26,6 +26,7 @@ import {
   LineChart,
   Bell,
   BellOff,
+  EyeOff,
 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { Link } from "react-router-dom";
@@ -114,12 +115,16 @@ function AnomalyRow({
   isMuted,
   onToggleMute,
   isToggling,
+  onSuppress,
+  isSuppressing,
 }: {
   anomaly: AnomalyDto;
   systemId: string;
   isMuted: boolean;
   onToggleMute: (fieldPath: string, isMuted: boolean) => void;
   isToggling: boolean;
+  onSuppress: (anomalyId: string) => void;
+  isSuppressing: boolean;
 }) {
   const isSuspicious = anomaly.state === "suspicious";
   const isDrift = anomaly.kind === "drift";
@@ -237,6 +242,23 @@ function AnomalyRow({
             <Bell className="h-3.5 w-3.5" />
           )}
         </Button>
+        {!isSuspicious && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-foreground"
+            disabled={isSuppressing}
+            title="Suppress this anomaly until it changes again"
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onSuppress(anomaly.id);
+            }}
+          >
+            <EyeOff className="h-3.5 w-3.5" />
+          </Button>
+        )}
         <ArrowRight className="h-3.5 w-3.5 text-muted-foreground/40 group-hover:text-muted-foreground transition-colors" />
       </div>
     </Link>
@@ -301,6 +323,19 @@ export const SystemAnomalyWidget: React.FC<Props> = ({ system }) => {
     } else {
       muteMutation.mutate({ systemId: system.id, fieldPath });
     }
+  };
+
+  // Suppressing removes the row from the active feed. The mutation invalidates
+  // the anomaly plugin's own queries on success, so the active list (which
+  // defaults to the "active" suppression filter) refetches without the row.
+  const suppressMutation = anomalyClient.suppressAnomaly.useMutation({
+    onError: () => {
+      toast.error("Failed to suppress anomaly");
+    },
+  });
+
+  const handleSuppress = (anomalyId: string) => {
+    suppressMutation.mutate({ systemId: system.id, anomalyId });
   };
 
   const isLoading = loadingConfirmed || loadingSuspicious;
@@ -397,6 +432,8 @@ export const SystemAnomalyWidget: React.FC<Props> = ({ system }) => {
               isMuted={isSystemMuted || mutedFields.has(anomaly.fieldPath)}
               onToggleMute={handleToggleMute}
               isToggling={isToggling}
+              onSuppress={handleSuppress}
+              isSuppressing={suppressMutation.isPending}
             />
           ))}
         </div>

--- a/docs/src/content/docs/developer-guide/backend/healthchecks/anomaly-detection.md
+++ b/docs/src/content/docs/developer-guide/backend/healthchecks/anomaly-detection.md
@@ -273,6 +273,7 @@ Plugin authors should pick conservative defaults for `x-anomaly-sensitivity`, `x
 | `deviation` | Sigma distance — for drifts, sigmas of projected change. |
 | `suspiciousRunCount` / `confirmationThreshold` | Confirmation-window state. |
 | `startedAt` / `confirmedAt` / `recoveredAt` | Lifecycle timestamps. |
+| `suppressedAt` / `suppressedValue` / `suppressedBaseline` | Global suppression flag + snapshot (see [5.6](#56-global-suppression)). `suppressedAt IS NULL` means not suppressed. |
 
 ### 5.2 State Machine (shared by spike + drift)
 
@@ -298,7 +299,7 @@ Plugin authors should pick conservative defaults for `x-anomaly-sensitivity`, `x
 | `normal → suspicious` | Silent | Transient noise is absorbed without alerting operators. |
 | `suspicious → anomaly` | **Confirmed** notification | Fires after the confirmation window is met (default 3 for spikes, 2 for drifts). |
 | `suspicious → normal` | Silent | The row is deleted — transient spike absorbed. |
-| `anomaly → recovered` | **Recovered** notification | Importance: `info` ("Good news"). |
+| `anomaly → recovered` | **Recovered** notification | Importance: `info` ("Good news"). Fires on either the baseline-relative path or the self-resolution path (see [5.5](#55-self-resolution-new-normal)). |
 | `recovered → archived` | None | Retained for historical analysis (default 30 days). |
 
 ### 5.3 Confirmation Windows
@@ -311,6 +312,29 @@ Plugin authors should pick conservative defaults for `x-anomaly-sensitivity`, `x
 ### 5.4 Cold Start
 
 The engine refuses to evaluate a field until the baseline has at least **24 samples** (`MIN_BASELINE_SAMPLES`). Before that, the field shows as "Learning" in the UI and no anomalies can fire. This prevents storms of false positives on freshly-deployed health checks.
+
+### 5.5 Self-resolution (new normal)
+
+A confirmed anomaly used to be able to stay stuck indefinitely when the metric settled at a *new* level that became the real normal (the classic "broken, then fixed at a clearly different value" case): every fresh sample was still anomalous against the stale baseline, so the baseline-relative recovery branch never ran, and the row only cleared once the slow hourly analyzer dragged the mean across — hours to days later.
+
+Both detectors now carry a baseline-independent escape hatch:
+
+- **Spike** ([detector.ts](../../core/anomaly-backend/src/detector.ts)): each healthy sample for a confirmed anomaly is appended to a rolling window stored on the row's `metadata.recentSamples`. Once `STABLE_RESOLUTION_RUN_COUNT` (5) consecutive samples sit inside a relative band of each other (`STABLE_RESOLUTION_RELATIVE_BAND`, 10%), the row self-resolves to `recovered` — even while still anomalous against the old baseline.
+- **Drift** ([drift-evaluator.ts](../../core/anomaly-backend/src/drift-evaluator.ts)): the slope-based detector keeps reporting drift while the 7-day window straddles both regimes. When the *projected change relative to the new mean* goes flat for `STABLE_DRIFT_RESOLUTION_RUN_COUNT` (2) consecutive analyzer runs (tracked via `metadata.stableDriftRunCount`), the row self-resolves.
+
+The constants live in [engine/self-resolution.ts](../../core/anomaly-common/src/engine/self-resolution.ts). The original baseline-relative recovery path is unchanged and still fires first when applicable. The rolling counters live on the shared `anomalies` row (Postgres), so they survive across whichever pod claims the work.
+
+### 5.6 Global suppression
+
+Operators can **suppress** a confirmed anomaly so it disappears from the active feed until it "changes again". Suppression is **global (per row), not per-user** — distinct from the per-user notification mute in [8.2](#82-per-field-and-per-system-mute), which only silences notifications while the row stays active.
+
+Suppression is modelled as a **flag layered on top of `state`** (a nullable `suppressedAt`), not a new enum value: the suspicious/anomaly/recovered state machine stays intact and un-suppressing simply reveals the underlying state again. Suppressing snapshots `suppressedValue` (the observed value) and `suppressedBaseline`.
+
+- `suppressAnomaly` / `unsuppressAnomaly` RPCs (gated by `anomaly_feed.manage`) set and clear the flag. Both are scoped by `(anomalyId, systemId)` so a caller authorized on one system cannot mutate another system's row, and `suppressAnomaly` only acts on rows already in the `anomaly` state.
+- `getAnomalies` takes a `suppression` filter: `"active"` (default, hides suppressed rows), `"suppressed"`, or `"all"`. The dashboard badge and widget use the default, so suppressed rows drop out of the active count.
+- **Auto-unsuppress** ("changes again"): the inline detector clears suppression once a fresh observed value moves more than `SUPPRESSION_REACTIVATION_DELTA` (25%) away from `suppressedValue`. A baseline-relative recovery also clears suppression.
+
+Suppression state lives on the shared `anomalies` row, so every horizontally-scaled pod reads the same suppressed/active set.
 
 ---
 
@@ -387,6 +411,9 @@ Anomaly notifications target a dedicated per-system notification group, namespac
 The `anomaly_notification_mutes` table holds user-scoped mutes. A row's existence means that user has muted notifications for that `(systemId, fieldPath)` pair. An empty `fieldPath` represents a system-wide mute. The dispatcher consults this table after fetching subscribers and filters out muted users before calling `notifyUsers`.
 
 The system anomaly widget on each system detail page exposes a bell icon on every anomaly row (per-field mute) plus a `Mute all` toggle in the card header (per-system mute). Mutes are user-scoped and persist across sessions.
+
+> [!NOTE]
+> A mute only silences notifications — the anomaly row stays active and visible. To hide a row from the active feed entirely, use [global suppression](#56-global-suppression) (the eye-off icon on a confirmed anomaly row), which is per-row rather than per-user.
 
 ---
 
@@ -477,6 +504,9 @@ The statistical core lives in `core/anomaly-common` and has zero database/cache 
 | `isCategoricalAnomalous` | [engine/thresholds.ts](../../core/anomaly-common/src/engine/thresholds.ts) | Dominance trigger math. |
 | `detectDrift` | [engine/drift.ts](../../core/anomaly-common/src/engine/drift.ts) | Drift trigger math. |
 | `resolveEffectiveConfig` | [engine/config.ts](../../core/anomaly-common/src/engine/config.ts) | Three-layer override resolution. |
+| `hasSettledAtNewLevel` / `appendRecentSample` | [engine/self-resolution.ts](../../core/anomaly-common/src/engine/self-resolution.ts) | Spike self-resolution: rolling window + tight-band test. |
+| `isDriftFlatRelative` | [engine/self-resolution.ts](../../core/anomaly-common/src/engine/self-resolution.ts) | Drift self-resolution: flat-relative-slope test. |
+| `hasChangedSinceSuppression` | [engine/self-resolution.ts](../../core/anomaly-common/src/engine/self-resolution.ts) | Auto-unsuppress: relative-move test. |
 
 These are deterministic, side-effect-free functions — ideal for unit tests.
 


### PR DESCRIPTION
Part A (bug): a confirmed anomaly now auto-resolves once the metric settles at a new stable level - after N consecutive healthy samples within a tight relative band - for both the spike detector and the drift state machine.

Part B (feature): global, per-row suppression (Postgres-backed, scale-correct):
- New suppression columns + migration; suppress/unsuppress RPCs; default `getAnomalies` excludes suppressed; auto-unsuppress when the value moves outside the suppressed band by a delta; frontend suppress affordance + hidden from active count.
- Security: suppress/unsuppress scoped by `(anomalyId, systemId)` to close an IDOR where a user could mutate another system's anomaly; cross-system regression test added. State guard so only confirmed anomalies are suppressible.
- Tests for both auto-resolve paths and suppression/auto-unsuppress (136 pass); docs updated; minor changeset.

Checks: typecheck, lint, anomaly tests (136) green.

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
