### PR TITLE
fix(create-checkstack-plugin): pin @checkstack/scripts version exposing ./scaffold

### DIFF
--- a/.changeset/fix-scaffold-scripts-pin.md
+++ b/.changeset/fix-scaffold-scripts-pin.md
@@ -1,0 +1,5 @@
+---
+"create-checkstack-plugin": patch
+---
+
+Fix `Cannot find module '@checkstack/scripts/scaffold'` when running `bun create checkstack-plugin`. The `0.1.0` release pinned `@checkstack/scripts@0.3.4`, which predates the `./scaffold` subpath export (first shipped in `0.4.0`). This release pins a version of `@checkstack/scripts` that exposes `./scaffold`. `0.1.0` has been deprecated on npm.

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "core/about-common": {
       "name": "@checkstack/about-common",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -38,7 +38,7 @@
     },
     "core/about-frontend": {
       "name": "@checkstack/about-frontend",
-      "version": "0.2.23",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/about-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "core/ai-backend": {
       "name": "@checkstack/ai-backend",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.48",
         "@checkstack/ai-common": "workspace:*",
@@ -86,7 +86,7 @@
     },
     "core/ai-common": {
       "name": "@checkstack/ai-common",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.14.4",
@@ -100,7 +100,7 @@
     },
     "core/ai-frontend": {
       "name": "@checkstack/ai-frontend",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@checkstack/ai-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -120,7 +120,7 @@
     },
     "core/announcement-backend": {
       "name": "@checkstack/announcement-backend",
-      "version": "0.3.13",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-backend": "workspace:*",
@@ -146,7 +146,7 @@
     },
     "core/announcement-common": {
       "name": "@checkstack/announcement-common",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -161,7 +161,7 @@
     },
     "core/announcement-frontend": {
       "name": "@checkstack/announcement-frontend",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "core/anomaly-backend": {
       "name": "@checkstack/anomaly-backend",
-      "version": "1.1.9",
+      "version": "1.2.0",
       "dependencies": {
         "@checkstack/ai-backend": "workspace:*",
         "@checkstack/anomaly-common": "workspace:*",
@@ -220,7 +220,7 @@
     },
     "core/anomaly-common": {
       "name": "@checkstack/anomaly-common",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "core/anomaly-frontend": {
       "name": "@checkstack/anomaly-frontend",
-      "version": "0.4.8",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -263,7 +263,7 @@
     },
     "core/api-docs-common": {
       "name": "@checkstack/api-docs-common",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -275,7 +275,7 @@
     },
     "core/api-docs-frontend": {
       "name": "@checkstack/api-docs-frontend",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -294,7 +294,7 @@
     },
     "core/auth-backend": {
       "name": "@checkstack/auth-backend",
-      "version": "0.4.33",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "core/auth-common": {
       "name": "@checkstack/auth-common",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.14.4",
@@ -336,7 +336,7 @@
     },
     "core/auth-frontend": {
       "name": "@checkstack/auth-frontend",
-      "version": "0.6.7",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -358,7 +358,7 @@
     },
     "core/automation-backend": {
       "name": "@checkstack/automation-backend",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/ai-backend": "workspace:*",
         "@checkstack/ai-common": "workspace:*",
@@ -401,7 +401,7 @@
     },
     "core/automation-common": {
       "name": "@checkstack/automation-common",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -417,7 +417,7 @@
     },
     "core/automation-frontend": {
       "name": "@checkstack/automation-frontend",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/automation-common": "workspace:*",
@@ -449,7 +449,7 @@
     },
     "core/backend": {
       "name": "@checkstack/backend",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
         "@checkstack/api-docs-common": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -489,7 +489,7 @@
     },
     "core/backend-api": {
       "name": "@checkstack/backend-api",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@checkstack/cache-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -521,7 +521,7 @@
     },
     "core/cache-api": {
       "name": "@checkstack/cache-api",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -533,7 +533,7 @@
     },
     "core/cache-backend": {
       "name": "@checkstack/cache-backend",
-      "version": "0.3.8",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -550,7 +550,7 @@
     },
     "core/cache-common": {
       "name": "@checkstack/cache-common",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.14.4",
@@ -564,7 +564,7 @@
     },
     "core/cache-frontend": {
       "name": "@checkstack/cache-frontend",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/cache-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -583,7 +583,7 @@
     },
     "core/cache-utils": {
       "name": "@checkstack/cache-utils",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@checkstack/cache-api": "workspace:*",
       },
@@ -596,7 +596,7 @@
     },
     "core/catalog-backend": {
       "name": "@checkstack/catalog-backend",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "@checkstack/ai-backend": "workspace:*",
         "@checkstack/ai-common": "workspace:*",
@@ -632,7 +632,7 @@
     },
     "core/catalog-common": {
       "name": "@checkstack/catalog-common",
-      "version": "2.2.3",
+      "version": "2.3.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -649,7 +649,7 @@
     },
     "core/catalog-frontend": {
       "name": "@checkstack/catalog-frontend",
-      "version": "0.10.7",
+      "version": "0.11.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -677,7 +677,7 @@
     },
     "core/command-backend": {
       "name": "@checkstack/command-backend",
-      "version": "0.1.33",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-common": "workspace:*",
@@ -695,7 +695,7 @@
     },
     "core/command-common": {
       "name": "@checkstack/command-common",
-      "version": "0.2.14",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.14.4",
@@ -709,7 +709,7 @@
     },
     "core/command-frontend": {
       "name": "@checkstack/command-frontend",
-      "version": "0.2.42",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/command-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -728,7 +728,7 @@
     },
     "core/common": {
       "name": "@checkstack/common",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@orpc/contract": "^1.14.4",
         "lucide-react": "^1.17.0",
@@ -742,7 +742,7 @@
     },
     "core/create-checkstack-plugin": {
       "name": "create-checkstack-plugin",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "bin": {
         "create-checkstack-plugin": "./src/cli.ts",
       },
@@ -759,7 +759,7 @@
     },
     "core/dashboard-frontend": {
       "name": "@checkstack/dashboard-frontend",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/catalog-frontend": "workspace:*",
@@ -788,7 +788,7 @@
     },
     "core/dependency-backend": {
       "name": "@checkstack/dependency-backend",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "@checkstack/ai-backend": "workspace:*",
         "@checkstack/automation-backend": "workspace:*",
@@ -822,7 +822,7 @@
     },
     "core/dependency-common": {
       "name": "@checkstack/dependency-common",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -840,7 +840,7 @@
     },
     "core/dependency-frontend": {
       "name": "@checkstack/dependency-frontend",
-      "version": "0.4.8",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -866,7 +866,7 @@
     },
     "core/dev-server": {
       "name": "@checkstack/dev-server",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "bin": {
         "checkstack-dev": "./src/dev-server.ts",
       },
@@ -912,7 +912,7 @@
     },
     "core/frontend": {
       "name": "@checkstack/frontend",
-      "version": "0.6.7",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/about-frontend": "workspace:*",
         "@checkstack/announcement-frontend": "workspace:*",
@@ -952,7 +952,7 @@
     },
     "core/frontend-api": {
       "name": "@checkstack/frontend-api",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -974,7 +974,7 @@
     },
     "core/gitops-backend": {
       "name": "@checkstack/gitops-backend",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -1001,7 +1001,7 @@
     },
     "core/gitops-common": {
       "name": "@checkstack/gitops-common",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/secrets-common": "workspace:*",
@@ -1016,7 +1016,7 @@
     },
     "core/gitops-frontend": {
       "name": "@checkstack/gitops-frontend",
-      "version": "0.4.7",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1036,7 +1036,7 @@
     },
     "core/healthcheck-backend": {
       "name": "@checkstack/healthcheck-backend",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@checkstack/ai-backend": "workspace:*",
         "@checkstack/ai-common": "workspace:*",
@@ -1085,7 +1085,7 @@
     },
     "core/healthcheck-common": {
       "name": "@checkstack/healthcheck-common",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1101,7 +1101,7 @@
     },
     "core/healthcheck-frontend": {
       "name": "@checkstack/healthcheck-frontend",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "dependencies": {
         "@checkstack/anomaly-common": "workspace:*",
         "@checkstack/auth-frontend": "workspace:*",
@@ -1137,7 +1137,7 @@
     },
     "core/incident-backend": {
       "name": "@checkstack/incident-backend",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@checkstack/ai-backend": "workspace:*",
         "@checkstack/ai-common": "workspace:*",
@@ -1173,7 +1173,7 @@
     },
     "core/incident-common": {
       "name": "@checkstack/incident-common",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1191,7 +1191,7 @@
     },
     "core/incident-frontend": {
       "name": "@checkstack/incident-frontend",
-      "version": "0.8.8",
+      "version": "0.9.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -1218,7 +1218,7 @@
     },
     "core/infrastructure-common": {
       "name": "@checkstack/infrastructure-common",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1233,7 +1233,7 @@
     },
     "core/infrastructure-frontend": {
       "name": "@checkstack/infrastructure-frontend",
-      "version": "0.2.11",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1252,7 +1252,7 @@
     },
     "core/integration-backend": {
       "name": "@checkstack/integration-backend",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/command-backend": "workspace:*",
@@ -1278,7 +1278,7 @@
     },
     "core/integration-common": {
       "name": "@checkstack/integration-common",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1293,7 +1293,7 @@
     },
     "core/integration-frontend": {
       "name": "@checkstack/integration-frontend",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1314,7 +1314,7 @@
     },
     "core/maintenance-backend": {
       "name": "@checkstack/maintenance-backend",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "@checkstack/ai-backend": "workspace:*",
         "@checkstack/ai-common": "workspace:*",
@@ -1348,7 +1348,7 @@
     },
     "core/maintenance-common": {
       "name": "@checkstack/maintenance-common",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1366,7 +1366,7 @@
     },
     "core/maintenance-frontend": {
       "name": "@checkstack/maintenance-frontend",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/catalog-common": "workspace:*",
@@ -1393,7 +1393,7 @@
     },
     "core/notification-backend": {
       "name": "@checkstack/notification-backend",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -1421,7 +1421,7 @@
     },
     "core/notification-common": {
       "name": "@checkstack/notification-common",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1436,7 +1436,7 @@
     },
     "core/notification-frontend": {
       "name": "@checkstack/notification-frontend",
-      "version": "0.4.7",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1458,7 +1458,7 @@
     },
     "core/pluginmanager-common": {
       "name": "@checkstack/pluginmanager-common",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
@@ -1471,7 +1471,7 @@
     },
     "core/pluginmanager-frontend": {
       "name": "@checkstack/pluginmanager-frontend",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1491,7 +1491,7 @@
     },
     "core/queue-api": {
       "name": "@checkstack/queue-api",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "zod": "^4.0.0",
@@ -1503,7 +1503,7 @@
     },
     "core/queue-backend": {
       "name": "@checkstack/queue-backend",
-      "version": "0.3.8",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1522,7 +1522,7 @@
     },
     "core/queue-common": {
       "name": "@checkstack/queue-common",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1537,7 +1537,7 @@
     },
     "core/queue-frontend": {
       "name": "@checkstack/queue-frontend",
-      "version": "0.4.7",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1561,11 +1561,11 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.93.0",
+      "version": "0.94.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1581,7 +1581,7 @@
     },
     "core/satellite-backend": {
       "name": "@checkstack/satellite-backend",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/automation-common": "workspace:*",
@@ -1616,7 +1616,7 @@
     },
     "core/satellite-common": {
       "name": "@checkstack/satellite-common",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
@@ -1632,7 +1632,7 @@
     },
     "core/satellite-frontend": {
       "name": "@checkstack/satellite-frontend",
-      "version": "0.3.8",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1655,7 +1655,7 @@
     },
     "core/script-packages-backend": {
       "name": "@checkstack/script-packages-backend",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/auth-common": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -1678,7 +1678,7 @@
     },
     "core/script-packages-common": {
       "name": "@checkstack/script-packages-common",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/signal-common": "workspace:*",
@@ -1693,7 +1693,7 @@
     },
     "core/script-packages-frontend": {
       "name": "@checkstack/script-packages-frontend",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1714,7 +1714,7 @@
     },
     "core/script-packages-store-postgres": {
       "name": "@checkstack/script-packages-store-postgres",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1732,7 +1732,7 @@
     },
     "core/script-packages-store-s3": {
       "name": "@checkstack/script-packages-store-s3",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1748,7 +1748,7 @@
     },
     "core/scripts": {
       "name": "@checkstack/scripts",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "bin": {
         "checkstack-scripts": "./src/cli.ts",
       },
@@ -1772,7 +1772,7 @@
     },
     "core/sdk": {
       "name": "@checkstack/sdk",
-      "version": "0.93.0",
+      "version": "0.94.0",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/anomaly-common": "workspace:*",
@@ -1808,7 +1808,7 @@
     },
     "core/secrets-backend": {
       "name": "@checkstack/secrets-backend",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1833,7 +1833,7 @@
     },
     "core/secrets-backend-local": {
       "name": "@checkstack/secrets-backend-local",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1857,7 +1857,7 @@
     },
     "core/secrets-backend-vault": {
       "name": "@checkstack/secrets-backend-vault",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1882,7 +1882,7 @@
     },
     "core/secrets-common": {
       "name": "@checkstack/secrets-common",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.14.4",
@@ -1897,7 +1897,7 @@
     },
     "core/secrets-frontend": {
       "name": "@checkstack/secrets-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -1916,7 +1916,7 @@
     },
     "core/signal-backend": {
       "name": "@checkstack/signal-backend",
-      "version": "0.2.12",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -1932,7 +1932,7 @@
     },
     "core/signal-common": {
       "name": "@checkstack/signal-common",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
@@ -1945,7 +1945,7 @@
     },
     "core/signal-frontend": {
       "name": "@checkstack/signal-frontend",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/signal-common": "workspace:*",
       },
@@ -1961,7 +1961,7 @@
     },
     "core/slo-backend": {
       "name": "@checkstack/slo-backend",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/ai-backend": "workspace:*",
         "@checkstack/automation-backend": "workspace:*",
@@ -1997,7 +1997,7 @@
     },
     "core/slo-common": {
       "name": "@checkstack/slo-common",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -2013,7 +2013,7 @@
     },
     "core/slo-frontend": {
       "name": "@checkstack/slo-frontend",
-      "version": "0.4.8",
+      "version": "0.5.0",
       "dependencies": {
         "@checkstack/catalog-common": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2040,7 +2040,7 @@
     },
     "core/template-engine": {
       "name": "@checkstack/template-engine",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
@@ -2053,7 +2053,7 @@
     },
     "core/test-utils-backend": {
       "name": "@checkstack/test-utils-backend",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2069,7 +2069,7 @@
     },
     "core/test-utils-frontend": {
       "name": "@checkstack/test-utils-frontend",
-      "version": "0.0.5",
+      "version": "0.1.0",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.0.0",
         "@testing-library/dom": "^10.0.0",
@@ -2089,7 +2089,7 @@
     },
     "core/theme-backend": {
       "name": "@checkstack/theme-backend",
-      "version": "0.1.37",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2111,7 +2111,7 @@
     },
     "core/theme-common": {
       "name": "@checkstack/theme-common",
-      "version": "0.1.14",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.14.4",
@@ -2125,7 +2125,7 @@
     },
     "core/theme-frontend": {
       "name": "@checkstack/theme-frontend",
-      "version": "0.1.45",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2144,7 +2144,7 @@
     },
     "core/tips-backend": {
       "name": "@checkstack/tips-backend",
-      "version": "0.2.8",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2166,7 +2166,7 @@
     },
     "core/tips-common": {
       "name": "@checkstack/tips-common",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@orpc/contract": "^1.14.4",
@@ -2180,7 +2180,7 @@
     },
     "core/tips-frontend": {
       "name": "@checkstack/tips-frontend",
-      "version": "0.2.7",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/auth-frontend": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2207,7 +2207,7 @@
     },
     "core/ui": {
       "name": "@checkstack/ui",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "@checkstack/frontend-api": "workspace:*",
@@ -2285,7 +2285,7 @@
     },
     "plugins/auth-credential-backend": {
       "name": "@checkstack/auth-credential-backend",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2299,7 +2299,7 @@
     },
     "plugins/auth-github-backend": {
       "name": "@checkstack/auth-github-backend",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2313,7 +2313,7 @@
     },
     "plugins/auth-ldap-backend": {
       "name": "@checkstack/auth-ldap-backend",
-      "version": "0.1.34",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -2332,7 +2332,7 @@
     },
     "plugins/auth-saml-backend": {
       "name": "@checkstack/auth-saml-backend",
-      "version": "0.1.33",
+      "version": "0.2.0",
       "dependencies": {
         "@checkstack/auth-backend": "workspace:*",
         "@checkstack/auth-common": "workspace:*",
@@ -2350,7 +2350,7 @@
     },
     "plugins/cache-memory-backend": {
       "name": "@checkstack/cache-memory-backend",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/cache-api": "workspace:*",
@@ -2366,7 +2366,7 @@
     },
     "plugins/cache-memory-common": {
       "name": "@checkstack/cache-memory-common",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -2377,7 +2377,7 @@
     },
     "plugins/collector-hardware-backend": {
       "name": "@checkstack/collector-hardware-backend",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2393,7 +2393,7 @@
     },
     "plugins/healthcheck-dns-backend": {
       "name": "@checkstack/healthcheck-dns-backend",
-      "version": "0.2.23",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2408,7 +2408,7 @@
     },
     "plugins/healthcheck-grpc-backend": {
       "name": "@checkstack/healthcheck-grpc-backend",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2424,7 +2424,7 @@
     },
     "plugins/healthcheck-http-backend": {
       "name": "@checkstack/healthcheck-http-backend",
-      "version": "0.3.23",
+      "version": "0.4.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2440,7 +2440,7 @@
     },
     "plugins/healthcheck-jenkins-backend": {
       "name": "@checkstack/healthcheck-jenkins-backend",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2455,7 +2455,7 @@
     },
     "plugins/healthcheck-mysql-backend": {
       "name": "@checkstack/healthcheck-mysql-backend",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2471,7 +2471,7 @@
     },
     "plugins/healthcheck-ping-backend": {
       "name": "@checkstack/healthcheck-ping-backend",
-      "version": "0.2.23",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2486,7 +2486,7 @@
     },
     "plugins/healthcheck-postgres-backend": {
       "name": "@checkstack/healthcheck-postgres-backend",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2503,7 +2503,7 @@
     },
     "plugins/healthcheck-rcon-backend": {
       "name": "@checkstack/healthcheck-rcon-backend",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2520,7 +2520,7 @@
     },
     "plugins/healthcheck-rcon-common": {
       "name": "@checkstack/healthcheck-rcon-common",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -2533,7 +2533,7 @@
     },
     "plugins/healthcheck-redis-backend": {
       "name": "@checkstack/healthcheck-redis-backend",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2549,7 +2549,7 @@
     },
     "plugins/healthcheck-script-backend": {
       "name": "@checkstack/healthcheck-script-backend",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2566,7 +2566,7 @@
     },
     "plugins/healthcheck-ssh-backend": {
       "name": "@checkstack/healthcheck-ssh-backend",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2584,7 +2584,7 @@
     },
     "plugins/healthcheck-ssh-common": {
       "name": "@checkstack/healthcheck-ssh-common",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -2597,7 +2597,7 @@
     },
     "plugins/healthcheck-tcp-backend": {
       "name": "@checkstack/healthcheck-tcp-backend",
-      "version": "0.2.23",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2612,7 +2612,7 @@
     },
     "plugins/healthcheck-tls-backend": {
       "name": "@checkstack/healthcheck-tls-backend",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2627,7 +2627,7 @@
     },
     "plugins/integration-jira-backend": {
       "name": "@checkstack/integration-jira-backend",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2648,7 +2648,7 @@
     },
     "plugins/integration-jira-common": {
       "name": "@checkstack/integration-jira-common",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@checkstack/common": "workspace:*",
         "zod": "^4.2.1",
@@ -2662,7 +2662,7 @@
     },
     "plugins/integration-script-backend": {
       "name": "@checkstack/integration-script-backend",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/automation-common": "workspace:*",
@@ -2684,7 +2684,7 @@
     },
     "plugins/integration-teams-backend": {
       "name": "@checkstack/integration-teams-backend",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2701,7 +2701,7 @@
     },
     "plugins/integration-webex-backend": {
       "name": "@checkstack/integration-webex-backend",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2718,7 +2718,7 @@
     },
     "plugins/integration-webhook-backend": {
       "name": "@checkstack/integration-webhook-backend",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@checkstack/automation-backend": "workspace:*",
         "@checkstack/backend-api": "workspace:*",
@@ -2735,7 +2735,7 @@
     },
     "plugins/notification-backstage-backend": {
       "name": "@checkstack/notification-backstage-backend",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2749,7 +2749,7 @@
     },
     "plugins/notification-discord-backend": {
       "name": "@checkstack/notification-discord-backend",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2763,7 +2763,7 @@
     },
     "plugins/notification-gotify-backend": {
       "name": "@checkstack/notification-gotify-backend",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2777,7 +2777,7 @@
     },
     "plugins/notification-pushover-backend": {
       "name": "@checkstack/notification-pushover-backend",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2791,7 +2791,7 @@
     },
     "plugins/notification-slack-backend": {
       "name": "@checkstack/notification-slack-backend",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2805,7 +2805,7 @@
     },
     "plugins/notification-smtp-backend": {
       "name": "@checkstack/notification-smtp-backend",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2821,7 +2821,7 @@
     },
     "plugins/notification-teams-backend": {
       "name": "@checkstack/notification-teams-backend",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2835,7 +2835,7 @@
     },
     "plugins/notification-telegram-backend": {
       "name": "@checkstack/notification-telegram-backend",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2851,7 +2851,7 @@
     },
     "plugins/notification-webex-backend": {
       "name": "@checkstack/notification-webex-backend",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2865,7 +2865,7 @@
     },
     "plugins/queue-bullmq-backend": {
       "name": "@checkstack/queue-bullmq-backend",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2883,7 +2883,7 @@
     },
     "plugins/queue-bullmq-common": {
       "name": "@checkstack/queue-bullmq-common",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },
@@ -2895,7 +2895,7 @@
     },
     "plugins/queue-memory-backend": {
       "name": "@checkstack/queue-memory-backend",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
@@ -2912,7 +2912,7 @@
     },
     "plugins/queue-memory-common": {
       "name": "@checkstack/queue-memory-common",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@checkstack/common": "workspace:*",
       },


### PR DESCRIPTION
## What

Fixes `bun create checkstack-plugin` failing immediately with:

```
error: Cannot find module '@checkstack/scripts/scaffold'
```

Two commits:

1. **chore: sync `bun.lock` with workspace package versions** - the committed lockfile recorded stale workspace versions (e.g. `core/scripts` at `0.3.4` while its `package.json` is `0.4.0`), across ~141 packages. `bun publish` rewrites `workspace:*` from the **lockfile**, so a manual publish off `main` pins outdated published versions of sibling packages.
2. **fix(create-checkstack-plugin): changeset** - adds a `patch` changeset so the next release ships `0.1.1` pinning a `@checkstack/scripts` version that exposes the `./scaffold` subpath export (first shipped in `0.4.0`).

## Why it broke

`create-checkstack-plugin@0.1.0` was published with `@checkstack/scripts@0.3.4` pinned. That version predates the `./scaffold` export, so `src/scaffold-standalone.ts`'s `import "@checkstack/scripts/scaffold"` resolves to nothing at install time. The bad pin originated from a manual `bun publish` against the stale lockfile above; CI never hits this because it runs `bun install` (refreshing the lock) before publishing and does not use `--frozen-lockfile`.

## Out-of-band actions already taken

- `create-checkstack-plugin@0.1.1` published manually pinning `@checkstack/scripts@0.4.0` (verified the packed `package.json`).
- `create-checkstack-plugin@0.1.0` deprecated on npm.

So this PR reconciles the repo with npm: the changeset's next release computes `0.1.1`, which the publish pipeline treats as already-published and skips.

## Docs

No external API/contract surface changed - internal dependency pin + lockfile hygiene only, so no docs update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)