### PR TITLE
fix: break backend-api <-> cache-api/queue-api publish-time dependency cycle

### DIFF
--- a/.changeset/break-backend-api-cache-queue-cycle.md
+++ b/.changeset/break-backend-api-cache-queue-cycle.md
@@ -1,0 +1,12 @@
+---
+"@checkstack/common": minor
+"@checkstack/backend-api": patch
+"@checkstack/cache-api": patch
+"@checkstack/queue-api": patch
+---
+
+Break the publish-time dependency cycle between `@checkstack/backend-api` and `@checkstack/cache-api` / `@checkstack/queue-api`.
+
+`cache-api` and `queue-api` only ever used `Logger` and `Migration` from `backend-api` as `import type`, yet declared `@checkstack/backend-api` as a runtime dependency. In the monorepo this is harmless (everything resolves via `workspace:*`), but once published, `bun publish` freezes each `workspace:*` into a concrete pin of the *other* package's then-current version. Because the dependency is mutual, a consumer installing these packages from the registry must resolve `backend-api -> cache-api -> backend-api -> ...` backward through release history until it reaches ancient versions that shipped raw `workspace:*` ranges and a long-removed `@checkstack/cache-api@0.1.0` pin - which fail to resolve. This surfaced as `bun install` errors (and a missing `checkstack-dev` binary) in freshly scaffolded standalone plugins.
+
+`Logger` and `Migration` now live in `@checkstack/common` (a dependency-free leaf package). `@checkstack/backend-api` re-exports both for backward compatibility, so existing `import type { Logger, Migration } from "@checkstack/backend-api"` call sites are unchanged. `cache-api` and `queue-api` now depend on `@checkstack/common` instead of `@checkstack/backend-api`, removing the cycle.

--- a/bun.lock
+++ b/bun.lock
@@ -523,7 +523,7 @@
       "name": "@checkstack/cache-api",
       "version": "0.3.9",
       "dependencies": {
-        "@checkstack/backend-api": "workspace:*",
+        "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -1493,7 +1493,7 @@
       "name": "@checkstack/queue-api",
       "version": "0.3.9",
       "dependencies": {
-        "@checkstack/backend-api": "workspace:*",
+        "@checkstack/common": "workspace:*",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -1561,7 +1561,7 @@
     },
     "core/release": {
       "name": "@checkstack/release",
-      "version": "0.94.0",
+      "version": "0.95.0",
     },
     "core/satellite": {
       "name": "@checkstack/satellite",
@@ -1772,7 +1772,7 @@
     },
     "core/sdk": {
       "name": "@checkstack/sdk",
-      "version": "0.94.0",
+      "version": "0.95.0",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/anomaly-common": "workspace:*",

--- a/core/backend-api/src/config-versioning.ts
+++ b/core/backend-api/src/config-versioning.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { extractErrorMessage } from "@checkstack/common";
+import type { Migration } from "@checkstack/common";
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // Storage Interfaces (simple data shapes for DB/API)
@@ -34,19 +35,12 @@ export interface VersionedPluginRecord<T = unknown> extends VersionedRecord<T> {
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 /**
- * Type-safe migration from one data version to another.
- * Used for backward-compatible schema evolution.
+ * The canonical `Migration` definition now lives in `@checkstack/common` so
+ * that low-level packages (`@checkstack/cache-api`, `@checkstack/queue-api`)
+ * can reference it without depending on `backend-api` and creating a
+ * publish-time dependency cycle. Re-exported here for backward compatibility.
  */
-export interface Migration<TFrom = unknown, TTo = unknown> {
-  /** Version number migrating from */
-  fromVersion: number;
-  /** Version number migrating to (must be fromVersion + 1) */
-  toVersion: number;
-  /** Human-readable description of what this migration does */
-  description: string;
-  /** Migration function that transforms old data to new format */
-  migrate(data: TFrom): TTo | Promise<TTo>;
-}
+export type { Migration } from "@checkstack/common";
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // Migration Chain Validation

--- a/core/backend-api/src/types.ts
+++ b/core/backend-api/src/types.ts
@@ -2,45 +2,12 @@ import { ZodSchema } from "zod";
 import { ClientDefinition, InferClient } from "@checkstack/common";
 
 /**
- * Backend logger interface used everywhere in the platform via `RpcContext.logger`
- * and the various `coreServices.logger` accessors.
- *
- * Each method accepts a free-form trailing argument list (`...args: unknown[]`)
- * so the long-standing varargs callsites — `logger.error("…", err)` where `err`
- * is an `Error`, or `logger.info("…", value1, value2)` — keep working unchanged.
- *
- * For NEW code, prefer the structured-metadata shape:
- *
- *   logger.info("did something", { userId, durationMs });
- *
- * Winston's `splat` handling treats a single trailing plain object as
- * structured metadata (merged into the log entry), and an `Error` instance as
- * a special-cased error (with stack). Either shape lands in the same vararg
- * slot here, so this signature covers both without overload churn.
- *
- * Auto-injected metadata (when the request flows through
- * `correlationMiddleware`): `{ correlationId, pluginId, userId? }`. Do NOT
- * include secrets in the structured-metadata object — it is forwarded
- * verbatim to the log destination.
+ * The canonical `Logger` definition now lives in `@checkstack/common` so that
+ * low-level packages (`@checkstack/cache-api`, `@checkstack/queue-api`) can
+ * reference it without depending on `backend-api` and creating a publish-time
+ * dependency cycle. Re-exported here for backward compatibility.
  */
-export interface Logger {
-  info(message: string, ...args: unknown[]): void;
-  error(message: string, ...args: unknown[]): void;
-  warn(message: string, ...args: unknown[]): void;
-  debug(message: string, ...args: unknown[]): void;
-  /**
-   * Returns a derived logger with the supplied metadata bound to every
-   * subsequent log entry. Used by `correlationMiddleware` to attach
-   * `{ correlationId, pluginId, userId? }`, and available to handlers that
-   * want a tighter scope (e.g. `ctx.logger.child({ jobId })`).
-   *
-   * Optional only to keep minimal test-mock logger objects compatible with
-   * this interface — production loggers (Winston via `core/backend`) always
-   * implement it. Call sites that rely on metadata binding should branch
-   * on presence and fall back to the base logger when it is not available.
-   */
-  child?(meta: Record<string, unknown>): Logger;
-}
+export type { Logger } from "@checkstack/common";
 
 export interface Fetch {
   fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;

--- a/core/cache-api/package.json
+++ b/core/cache-api/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "main": "src/index.ts",
   "dependencies": {
-    "@checkstack/backend-api": "workspace:*",
+    "@checkstack/common": "workspace:*",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/core/cache-api/src/cache-plugin.ts
+++ b/core/cache-api/src/cache-plugin.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { CacheProvider } from "./cache-provider";
-import type { Logger, Migration } from "@checkstack/backend-api";
+import type { Logger, Migration } from "@checkstack/common";
 
 /**
  * Plugin interface for cache backend implementations.

--- a/core/cache-api/tsconfig.json
+++ b/core/cache-api/tsconfig.json
@@ -2,5 +2,10 @@
   "extends": "@checkstack/tsconfig/backend.json",
   "include": [
     "src"
+  ],
+  "references": [
+    {
+      "path": "../common"
+    }
   ]
 }

--- a/core/common/src/index.ts
+++ b/core/common/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./types";
+export * from "./logger";
+export * from "./migration";
 export * from "./actor";
 export * from "./pagination";
 export * from "./routes";

--- a/core/common/src/logger.ts
+++ b/core/common/src/logger.ts
@@ -1,0 +1,46 @@
+/**
+ * Backend logger interface used everywhere in the platform via `RpcContext.logger`
+ * and the various `coreServices.logger` accessors.
+ *
+ * Each method accepts a free-form trailing argument list (`...args: unknown[]`)
+ * so the long-standing varargs callsites - `logger.error("…", err)` where `err`
+ * is an `Error`, or `logger.info("…", value1, value2)` - keep working unchanged.
+ *
+ * For NEW code, prefer the structured-metadata shape:
+ *
+ *   logger.info("did something", { userId, durationMs });
+ *
+ * Winston's `splat` handling treats a single trailing plain object as
+ * structured metadata (merged into the log entry), and an `Error` instance as
+ * a special-cased error (with stack). Either shape lands in the same vararg
+ * slot here, so this signature covers both without overload churn.
+ *
+ * Auto-injected metadata (when the request flows through
+ * `correlationMiddleware`): `{ correlationId, pluginId, userId? }`. Do NOT
+ * include secrets in the structured-metadata object - it is forwarded
+ * verbatim to the log destination.
+ *
+ * Lives in `@checkstack/common` (rather than `@checkstack/backend-api`) so that
+ * low-level packages such as `@checkstack/cache-api` and `@checkstack/queue-api`
+ * can reference it without taking a dependency on `backend-api` - which would
+ * create a publish-time dependency cycle. `@checkstack/backend-api` re-exports
+ * it for backward compatibility.
+ */
+export interface Logger {
+  info(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  debug(message: string, ...args: unknown[]): void;
+  /**
+   * Returns a derived logger with the supplied metadata bound to every
+   * subsequent log entry. Used by `correlationMiddleware` to attach
+   * `{ correlationId, pluginId, userId? }`, and available to handlers that
+   * want a tighter scope (e.g. `ctx.logger.child({ jobId })`).
+   *
+   * Optional only to keep minimal test-mock logger objects compatible with
+   * this interface - production loggers (Winston via `core/backend`) always
+   * implement it. Call sites that rely on metadata binding should branch
+   * on presence and fall back to the base logger when it is not available.
+   */
+  child?(meta: Record<string, unknown>): Logger;
+}

--- a/core/common/src/migration.ts
+++ b/core/common/src/migration.ts
@@ -1,0 +1,21 @@
+/**
+ * Type-safe migration from one data version to another.
+ * Used for backward-compatible schema evolution (see `Versioned` /
+ * `MigrationBuilder` in `@checkstack/backend-api`).
+ *
+ * Lives in `@checkstack/common` (rather than `@checkstack/backend-api`) so that
+ * low-level packages such as `@checkstack/cache-api` and `@checkstack/queue-api`
+ * can reference it without taking a dependency on `backend-api` - which would
+ * create a publish-time dependency cycle. `@checkstack/backend-api` re-exports
+ * it for backward compatibility.
+ */
+export interface Migration<TFrom = unknown, TTo = unknown> {
+  /** Version number migrating from */
+  fromVersion: number;
+  /** Version number migrating to (must be fromVersion + 1) */
+  toVersion: number;
+  /** Human-readable description of what this migration does */
+  description: string;
+  /** Migration function that transforms old data to new format */
+  migrate(data: TFrom): TTo | Promise<TTo>;
+}

--- a/core/create-checkstack-plugin/src/local-registry.test.ts
+++ b/core/create-checkstack-plugin/src/local-registry.test.ts
@@ -36,6 +36,9 @@ describe("buildVerdaccioConfig", () => {
     expect(yaml).toContain("publish: $anonymous");
     expect(yaml).toContain("listen: 0.0.0.0:4999");
     expect(yaml).toContain('storage: "/tmp/store"');
+    // Large bundled platform tarballs must not hit Verdaccio's 10mb default
+    // body cap (413 Payload Too Large).
+    expect(yaml).toContain("max_body_size: 500mb");
     // Falls back to the public registry for third-party transitive deps.
     expect(yaml).toContain("proxy: npmjs");
   });

--- a/core/create-checkstack-plugin/src/local-registry.ts
+++ b/core/create-checkstack-plugin/src/local-registry.ts
@@ -81,6 +81,10 @@ export function buildVerdaccioConfig({
     "    access: $all",
     "    publish: $anonymous",
     "    proxy: npmjs",
+    // Bundled platform packages (e.g. @checkstack/frontend, @checkstack/ui)
+    // ship large tarballs that blow past Verdaccio's 10mb default body cap and
+    // get rejected with a 413. Raise the ceiling well above the largest pack.
+    "max_body_size: 500mb",
     "log: { type: stdout, format: pretty, level: warn }",
     `listen: 0.0.0.0:${port}`,
     "",

--- a/core/queue-api/package.json
+++ b/core/queue-api/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "main": "src/index.ts",
   "dependencies": {
-    "@checkstack/backend-api": "workspace:*",
+    "@checkstack/common": "workspace:*",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/core/queue-api/src/queue-plugin.ts
+++ b/core/queue-api/src/queue-plugin.ts
@@ -6,7 +6,7 @@ import type {
   ListJobsOptions,
   ListJobsResult,
 } from "./queue";
-import type { Migration, Logger } from "@checkstack/backend-api";
+import type { Migration, Logger } from "@checkstack/common";
 
 export interface QueuePlugin<Config = unknown> {
   id: string;

--- a/core/queue-api/tsconfig.json
+++ b/core/queue-api/tsconfig.json
@@ -2,5 +2,10 @@
   "extends": "@checkstack/tsconfig/backend.json",
   "include": [
     "src"
+  ],
+  "references": [
+    {
+      "path": "../common"
+    }
   ]
 }


### PR DESCRIPTION
## Symptom

A freshly scaffolded standalone plugin (`bun create checkstack-plugin`) fails on `bun install` / `bun dev`:

```
error: No version matching "0.1.0" found for specifier "@checkstack/cache-api" (but package exists)
error: @checkstack/backend-api@workspace:* failed to resolve
error: @checkstack/queue-api@workspace:* failed to resolve
…
$ checkstack-dev: command not found   # because install never completed, bin never linked
```

## Root cause

`@checkstack/cache-api` and `@checkstack/queue-api` import **only types** from `@checkstack/backend-api`:

```ts
import type { Logger, Migration } from "@checkstack/backend-api";
```

…but declared `@checkstack/backend-api` as a runtime **`dependency`** (`workspace:*`). Meanwhile `backend-api` depends on both (real value imports). In the monorepo this is invisible - `workspace:*` resolves locally. Once published, `bun publish` freezes each `workspace:*` into a **concrete pin of the other package's then-current version**. Because the edge is mutual, a registry consumer must walk:

```
backend-api@0.21.0 -> cache-api@0.3.8 -> backend-api@0.18.0 -> cache-api@0.3.5 -> …
  … -> backend-api@0.13.0 (cache-api@0.1.0) … -> backend-api@0.5.1 (workspace:*)
```

…backward through the **entire release history** until it reaches ancient versions that shipped raw `workspace:*` ranges and the long-removed `@checkstack/cache-api@0.1.0` pin. Those specifiers don't resolve, so `bun install` aborts and `checkstack-dev` is never linked.

It only surfaced now because a scaffolded plugin is the first consumer to resolve these packages **from the registry**, without `workspace:*` shielding them.

## Fix

`Logger` and `Migration` are pure, self-contained interfaces. Moved them to `@checkstack/common` (a dependency-free leaf package):

- `core/common/src/logger.ts`, `core/common/src/migration.ts` (+ index exports)
- `@checkstack/backend-api` re-exports both for backward compatibility - the ~92 existing `import { Logger, Migration } from "@checkstack/backend-api"` call sites are **unchanged** (public API preserved)
- `cache-api` / `queue-api` now depend on `@checkstack/common` instead of `@checkstack/backend-api`

No more back-edge to `backend-api` → no cycle → published trees stop chaining through history.

## Commits

1. **`fix:` break the dependency cycle** - the change described above.
2. **`chore(create-checkstack-plugin):` raise Verdaccio body limit** - a test-harness fix. The `external-plugin-lifecycle` integration test publishes the full workspace to a throwaway local Verdaccio; large bundled tarballs (`@checkstack/frontend`, `@checkstack/ui`, …) exceeded Verdaccio's 10mb default `max_body_size` and were rejected with `413 Payload Too Large`, aborting the test in `beforeAll`. Raised the cap to `500mb` in `buildVerdaccioConfig` (+ regression assertion). Local-only: CI presets its own registry via `CHECKSTACK_SCAFFOLD_REGISTRY` and never uses this config.

## Release / propagation

Changeset bumps `common` (minor; new public types) and `backend-api` / `cache-api` / `queue-api` (patch). `updateInternalDependencies: patch` republishes `backend-api` with corrected `cache-api` / `queue-api` pins. After release, the scaffolder pins the fixed versions and the chain terminates at `common`.

## Verification

- `bun run typecheck` - 0 errors (all 141 packages; `tsgo -b` rebuilds the graph)
- `bun run lint` - clean
- Unit tests: `common` 26 pass, `backend-api` 408 pass, `cache-api` 6 pass; `queue-api` is interface-only (no tests)
- Project references regenerated (`cache-api` / `queue-api` now reference `../common`)
- **End-to-end workflow** (`external-plugin-lifecycle.it.test.ts`, `CHECKSTACK_IT=1`, local Verdaccio + Postgres): **4/4 pass, 56 assertions** - scaffold → `bun install` → `plugin-pack --bundle` → boot dev server; `POST /api/widget/getItems` == 200 (JSON array), Vite frontend up, plugin's own Tailwind class compiled in dev CSS.

> [!NOTE]
> The Verdaccio lane holds a single version per package, so it validates the **workflow**, not the cycle-history regression specifically (that only reproduces against real npm's full version history). The cycle fix's real-world proof is releasing this PR and re-scaffolding against npm.

## Docs

No public contract change - `Logger` / `Migration` remain importable from `@checkstack/backend-api` via re-export - so no docs update needed.

## Note for maintainer

This does **not** retroactively fix the already-published broken versions; it fixes everything published from here forward. To unblock an existing scaffolded plugin before the next release, re-scaffold after release, or add `overrides` in the generated root `package.json` pinning `@checkstack/backend-api` / `cache-api` / `queue-api` to single versions to collapse the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)