### PR TITLE
fix(frontend): vite build broken after monacoViteConfig move (bare .ts import)

### DIFF
--- a/core/frontend/vite.config.ts
+++ b/core/frontend/vite.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
-import { monacoViteConfig } from "@checkstack/ui/src/vite-monaco";
+// Relative (not the bare `@checkstack/ui/...` specifier): Vite's config loader
+// externalizes bare node_modules imports, which would leave this `.ts` file
+// un-transpiled at config-load time (ERR_UNKNOWN_FILE_EXTENSION). A relative
+// path is bundled into the config instead.
+import { monacoViteConfig } from "../ui/src/vite-monaco";
 
 // Monorepo root is 2 levels up from core/frontend
 const monorepoRoot = path.resolve(__dirname, "../..");


### PR DESCRIPTION
## Regression

#299 moved `monacoViteConfig` into `@checkstack/ui`, and `core/frontend/vite.config.ts` imported it via the **bare** specifier `@checkstack/ui/src/vite-monaco`. Vite's config loader **externalizes** bare node_modules imports, so the `.ts` helper is left un-transpiled at config-load time and **`vite build` fails**:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for .../core/ui/src/vite-monaco.ts
```

This breaks `bun run --filter @checkstack/frontend build` on `main`.

## Why it slipped through

- The dev-server and Storybook paths (which I did verify) don't load `core/frontend/vite.config.ts`.
- **No CI job builds the frontend** — Typecheck/Test/Lint/Integration don't run `vite build`. (The e2e suite does, but it isn't in PR checks.)

## Fix

Import the helper relatively (`../ui/src/vite-monaco`) — Vite's config loader bundles relative imports, transpiling the `.ts`. Verified: `vite build` succeeds (7860 modules, exit 0).

A follow-up will add a frontend-build (and external-plugin install) check to CI so this class of break is caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)