### PR TITLE
fix(dependency-frontend): fill height + render through PageLayout

### DIFF
--- a/.changeset/dependency-map-scroll.md
+++ b/.changeset/dependency-map-scroll.md
@@ -2,9 +2,10 @@
 "@checkstack/dependency-frontend": patch
 ---
 
-Fix the dependency map page filling height with a fixed `calc(100vh - 12rem)`,
+Fix the dependency map page's scrolling and make its header consistent with the
+rest of the app. The page sized its canvas with a fixed `calc(100vh - 12rem)`,
 which could overshoot the available space (double-scroll) depending on viewport
-chrome. The page now fills the app shell's bounded flex content area via
-`flex-1 min-h-0`, so the React Flow canvas sizes to the remaining space and only
-it scrolls/pans - the page itself never scrolls. Same approach as the AI chat
-page fix.
+chrome, and it used a bespoke `<h1>` header with no icon. It now renders through
+`PageLayout` (with the `GitBranch` nav icon and `fillHeight`), so the React Flow
+canvas fills the app shell's bounded flex content area and only it scrolls/pans -
+the page itself never scrolls.

--- a/.changeset/dependency-map-scroll.md
+++ b/.changeset/dependency-map-scroll.md
@@ -1,0 +1,10 @@
+---
+"@checkstack/dependency-frontend": patch
+---
+
+Fix the dependency map page filling height with a fixed `calc(100vh - 12rem)`,
+which could overshoot the available space (double-scroll) depending on viewport
+chrome. The page now fills the app shell's bounded flex content area via
+`flex-1 min-h-0`, so the React Flow canvas sizes to the remaining space and only
+it scrolls/pans - the page itself never scrolls. Same approach as the AI chat
+page fix.

--- a/core/dependency-frontend/src/components/DependencyMapPage.tsx
+++ b/core/dependency-frontend/src/components/DependencyMapPage.tsx
@@ -411,14 +411,14 @@ function DependencyMapContent() {
 
   if (loading) {
     return (
-      <div className="h-[calc(100vh-12rem)] flex items-center justify-center">
+      <div className="flex-1 min-h-0 flex items-center justify-center">
         <LoadingSpinner />
       </div>
     );
   }
 
   return (
-    <div className="h-[calc(100vh-12rem)] rounded-xl border border-border overflow-hidden bg-background/50">
+    <div className="flex-1 min-h-0 rounded-xl border border-border overflow-hidden bg-background/50">
       <ReactFlow<SystemNode, DependencyEdge>
         nodes={nodes}
         edges={edges}
@@ -705,8 +705,8 @@ function DependencyMapContent() {
  */
 const DependencyMapPageContent = () => {
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
+    <div className="flex flex-1 min-h-0 flex-col gap-4">
+      <div className="flex shrink-0 items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-foreground">Dependency Map</h1>
           <p className="text-sm text-muted-foreground mt-1">

--- a/core/dependency-frontend/src/components/DependencyMapPage.tsx
+++ b/core/dependency-frontend/src/components/DependencyMapPage.tsx
@@ -26,11 +26,12 @@ import {
   Button,
   Badge,
   LoadingSpinner,
+  PageLayout,
   useToast,
   usePerformance,
   cn,
 } from "@checkstack/ui";
-import { Maximize2, Save, RefreshCw, Trash2 } from "lucide-react";
+import { Maximize2, Save, RefreshCw, Trash2, GitBranch } from "lucide-react";
 import type { ImpactType } from "@checkstack/dependency-common";
 import { DependencyEdgeForm } from "./DependencyEdgeForm";
 import { useProvenanceLocks } from "@checkstack/gitops-frontend";
@@ -701,24 +702,22 @@ function DependencyMapContent() {
 }
 
 /**
- * Dependency Map page — wrapped in ReactFlowProvider and Suspense.
+ * Dependency Map page — standard PageLayout header (matching the GitBranch nav
+ * icon), full-height so the canvas fills the viewport. Wrapped in
+ * ReactFlowProvider and Suspense.
  */
 const DependencyMapPageContent = () => {
   return (
-    <div className="flex flex-1 min-h-0 flex-col gap-4">
-      <div className="flex shrink-0 items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">Dependency Map</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Interactive topology view of system dependencies. Drag nodes to
-            rearrange — positions auto-save.
-          </p>
-        </div>
-      </div>
+    <PageLayout
+      title="Dependency Map"
+      subtitle="Interactive topology view of system dependencies. Drag nodes to rearrange; positions auto-save."
+      icon={GitBranch}
+      fillHeight
+    >
       <ReactFlowProvider>
         <DependencyMapContent />
       </ReactFlowProvider>
-    </div>
+    </PageLayout>
   );
 };
 


### PR DESCRIPTION
Follow-up to #306. The dependency map page (a) used the same fragile `h-[calc(100vh-12rem)]` viewport-math pattern that could double-scroll, and (b) had a bespoke `<h1>` header with **no icon**, so it looked different from every other page.

## Fix
The page now renders through **`PageLayout`** (which #306 gave a `fillHeight` opt-in):
- Standard header with the **`GitBranch`** icon - the same icon the route declares for the sidebar nav, so the header and nav now match.
- `fillHeight` establishes the bounded flex height chain, so the React Flow canvas fills the content area via `flex-1 min-h-0` (no `calc(100vh-…)`); only the canvas scrolls/pans, never the page.

This replaces the interim manual flex-fill header from the first commit on this branch.

## Verification
- Reproduced the structure headless (PageLayout `fillHeight` → `ReactFlowProvider` → a `height:100%` canvas child): `main` does not scroll, the canvas gets a bounded height and the `height:100%` React Flow element fills it exactly.
- `bun run typecheck` and `bun run lint` pass. Single-file change (+ changeset).

> Verified the layout math in a repro; the live page needs the authed app. Happy to confirm on `/dependency` in a running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)