### PR TITLE
fix(auth): guard anonymous role against inert (authenticated-only) access rules

### DIFF
--- a/.changeset/anonymous-rule-guardrail.md
+++ b/.changeset/anonymous-rule-guardrail.md
@@ -1,0 +1,33 @@
+---
+"@checkstack/backend": minor
+"@checkstack/backend-api": patch
+"@checkstack/auth-backend": patch
+"@checkstack/auth-common": patch
+"@checkstack/auth-frontend": patch
+---
+
+Guard the role editor against granting inert (and misleading) permissions to the
+anonymous role.
+
+RPC procedures carry two independent axes: `userType` (the hard authentication
+gate) and `access` rules (authorization). An admin can grant the anonymous role
+any access rule, but if the procedures needing that rule are `userType:
+"authenticated"`/`"user"`, the grant does nothing - the auth middleware rejects
+unauthenticated callers BEFORE access rules are checked (so there is no security
+hole; the grant is simply inert). After anonymous users started seeing
+permission-gated UI, such a grant would surface as visible-but-broken controls.
+
+- The backend now computes, from contract metadata, the access rules an anonymous
+  caller can actually use (a rule is "usable" iff at least one `public` procedure
+  requires it) via `pluginManager.getAnonymousUsableAccessRuleIds()`, exposed to
+  plugins through the plugin environment.
+- `auth.getAccessRules` annotates each rule with `anonymousUsable`.
+- `auth.updateRole` REFUSES to ADD a non-usable rule to the anonymous role
+  (existing grants are untouched, so no configuration can be wedged). This is a
+  guardrail, not an enforcement change - RPC authorization is unchanged.
+- The role editor disables non-usable rules (with an explanation) when editing
+  the anonymous role.
+
+Verified live: `getAccessRules` reports 11 anonymous-usable vs 58 not; granting
+`incident.incident.manage` to the anonymous role returns HTTP 400 with a clear
+message.

--- a/core/auth-backend/src/index.ts
+++ b/core/auth-backend/src/index.ts
@@ -323,11 +323,18 @@ export default createBackendPlugin({
       getStrategies: () => strategies,
     };
 
-    // Access rule registry - gets all access rules from PluginManager
+    // Access rule registry - gets all access rules from PluginManager, annotated
+    // with `anonymousUsable` (whether a `public` procedure actually requires the
+    // rule) so the role editor can guard anonymous-role grants.
     const accessRuleRegistry = {
       getAccessRules: () => {
-        // Get all access rules from the central PluginManager registry
-        return env.pluginManager.getAllAccessRules();
+        const usable = new Set(
+          env.pluginManager.getAnonymousUsableAccessRuleIds(),
+        );
+        return env.pluginManager.getAllAccessRules().map((rule) => ({
+          ...rule,
+          anonymousUsable: usable.has(rule.id),
+        }));
       },
     };
 

--- a/core/auth-backend/src/router.ts
+++ b/core/auth-backend/src/router.ts
@@ -190,6 +190,8 @@ export const createAuthRouter = (
       description?: string;
       isDefault?: boolean;
       isPublic?: boolean;
+      /** Whether an anonymous caller can actually use this rule (a public RPC requires it). */
+      anonymousUsable?: boolean;
     }[];
   },
   getBetterAuth: () =>
@@ -450,6 +452,36 @@ export const createAuthRouter = (
     const isAnonymousRole = id === ANONYMOUS_ROLE_ID;
     if (isAnonymousRole) {
       const allPerms = accessRuleRegistry.getAccessRules();
+
+      // GUARDRAIL: refuse to ADD an access rule to the anonymous role that no
+      // `public` endpoint uses. The auth middleware rejects unauthenticated
+      // callers BEFORE checking access rules, so such a grant is inert and
+      // misleading (the admin would think anonymous users gained a capability
+      // they cannot actually use). Only NEWLY-added inert rules are blocked;
+      // anything already on the role is left untouched so this can never wedge
+      // an existing configuration.
+      const usableIds = new Set(
+        allPerms.filter((p) => p.anonymousUsable).map((p) => p.id),
+      );
+      const currentAnonRows = await internalDb
+        .select()
+        .from(schema.roleAccessRule)
+        .where(eq(schema.roleAccessRule.roleId, ANONYMOUS_ROLE_ID));
+      const currentAnonRules = new Set(
+        currentAnonRows.map((r) => r.accessRuleId),
+      );
+      const inertAdditions = validAccessRules.filter(
+        (p) => !usableIds.has(p) && !currentAnonRules.has(p),
+      );
+      if (inertAdditions.length > 0) {
+        throw new ORPCError("BAD_REQUEST", {
+          message:
+            "These access rules cannot be granted to the anonymous role - no " +
+            "public endpoint uses them, so only authenticated callers could " +
+            `ever exercise them: ${inertAdditions.join(", ")}`,
+        });
+      }
+
       const publicDefaultPermIds = allPerms
         .filter((p) => p.isPublic)
         .map((p) => p.id);

--- a/core/auth-common/src/rpc-contract.ts
+++ b/core/auth-common/src/rpc-contract.ts
@@ -27,6 +27,13 @@ const RoleDtoSchema = z.object({
 const AccessRuleDtoSchema = z.object({
   id: z.string(),
   description: z.string().optional(),
+  /**
+   * Whether an anonymous caller can actually USE this rule (a `public` procedure
+   * requires it). The role editor uses this to warn/disable granting inert
+   * permissions to the anonymous role. Absent/false => only authenticated
+   * procedures need it, so granting it to the anonymous role has no effect.
+   */
+  anonymousUsable: z.boolean().optional(),
 });
 
 const StrategyDtoSchema = z.object({

--- a/core/auth-frontend/src/api.ts
+++ b/core/auth-frontend/src/api.ts
@@ -31,6 +31,12 @@ export interface Role {
 export interface AccessRuleEntry {
   id: string;
   description?: string;
+  /**
+   * Whether an anonymous caller can actually use this rule (a public endpoint
+   * requires it). When false, granting it to the anonymous role is inert, so the
+   * role editor disables it for that role.
+   */
+  anonymousUsable?: boolean;
 }
 
 export interface AuthStrategy {

--- a/core/auth-frontend/src/components/RoleDialog.tsx
+++ b/core/auth-frontend/src/components/RoleDialog.tsx
@@ -62,6 +62,14 @@ export const RoleDialog: React.FC<RoleDialogProps> = ({
   const isAdminRole = role?.id === "admin";
   // Disable access rules for admin (wildcard) or user's own roles (prevent elevation)
   const accessRulesDisabled = isAdminRole || isUserRole;
+  // The anonymous role may only hold rules that a PUBLIC endpoint actually uses;
+  // granting an authenticated-only rule to it is inert (the server rejects
+  // unauthenticated callers before checking rules). Mirrors the backend guardrail.
+  const isAnonymousRole = role?.id === "anonymous";
+  const isBlockedForAnonymous = (perm: AccessRuleEntry): boolean =>
+    isAnonymousRole &&
+    perm.anonymousUsable === false &&
+    !selectedAccessRules.has(perm.id);
 
   // Group access rules by plugin
   const accessRulesByPlugin: Record<string, AccessRuleEntry[]> = {};
@@ -78,6 +86,10 @@ export const RoleDialog: React.FC<RoleDialogProps> = ({
     if (newSelected.has(accessRuleId)) {
       newSelected.delete(accessRuleId);
     } else {
+      // Defense in depth: never add a rule the anonymous role can't use (the
+      // checkbox is also disabled, and the backend rejects it).
+      const perm = accessRulesList.find((p) => p.id === accessRuleId);
+      if (perm && isBlockedForAnonymous(perm)) return;
       newSelected.add(accessRuleId);
     }
     setSelectedAccessRules(newSelected);
@@ -155,6 +167,16 @@ export const RoleDialog: React.FC<RoleDialogProps> = ({
                 <AlertDescription>
                   You cannot modify access rules for a role you currently have.
                   This prevents accidental self-lockout from the system.
+                </AlertDescription>
+              </Alert>
+            )}
+            {isAnonymousRole && (
+              <Alert variant="info" className="mb-3">
+                <AlertDescription>
+                  The anonymous role applies to signed-out visitors. Rules that
+                  no public page or endpoint uses are disabled here - granting
+                  them would have no effect, since anonymous visitors are
+                  rejected before those rules are checked.
                 </AlertDescription>
               </Alert>
             )}
@@ -236,14 +258,21 @@ export const RoleDialog: React.FC<RoleDialogProps> = ({
                           }
 
                           // Use editable checkbox design when access rules are editable
+                          const blockedForAnonymous =
+                            isBlockedForAnonymous(perm);
                           return (
                             <div
                               key={perm.id}
-                              className="flex items-start space-x-3 p-2 rounded-md hover:bg-muted/50 transition-colors"
+                              className={`flex items-start space-x-3 p-2 rounded-md transition-colors ${
+                                blockedForAnonymous
+                                  ? "opacity-50"
+                                  : "hover:bg-muted/50"
+                              }`}
                             >
                               <Checkbox
                                 id={`perm-${perm.id}`}
                                 checked={selectedAccessRules.has(perm.id)}
+                                disabled={blockedForAnonymous}
                                 onCheckedChange={() =>
                                   handleToggleAccessRule(perm.id)
                                 }
@@ -251,12 +280,22 @@ export const RoleDialog: React.FC<RoleDialogProps> = ({
                               />
                               <label
                                 htmlFor={`perm-${perm.id}`}
-                                className="text-sm cursor-pointer flex-1 space-y-1"
+                                className={`text-sm flex-1 space-y-1 ${
+                                  blockedForAnonymous
+                                    ? "cursor-not-allowed"
+                                    : "cursor-pointer"
+                                }`}
                               >
                                 <div className="font-medium">{perm.id}</div>
                                 {perm.description && (
                                   <div className="text-xs text-muted-foreground">
                                     {perm.description}
+                                  </div>
+                                )}
+                                {blockedForAnonymous && (
+                                  <div className="text-xs text-muted-foreground italic">
+                                    Not available to anonymous visitors (no public
+                                    endpoint uses this rule).
                                   </div>
                                 )}
                               </label>

--- a/core/backend-api/src/plugin-system.ts
+++ b/core/backend-api/src/plugin-system.ts
@@ -139,6 +139,12 @@ export type BackendPluginRegistry = {
   ) => void;
   pluginManager: {
     getAllAccessRules: () => { id: string; description?: string }[];
+    /**
+     * Qualified ids of access rules an anonymous caller can actually use (rules
+     * required by at least one `public` procedure). Used to guard the role
+     * editor against granting inert permissions to the anonymous role.
+     */
+    getAnonymousUsableAccessRuleIds: () => string[];
   };
 };
 

--- a/core/backend/src/plugin-manager.anon-rules.test.ts
+++ b/core/backend/src/plugin-manager.anon-rules.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { access } from "@checkstack/common";
+import { collectAnonymousUsableRuleIds } from "./plugin-manager";
+
+// A fake contract is just a record of procedures; each procedure carries its
+// metadata under `~orpc.meta`, exactly like a real oRPC contract procedure.
+const proc = (userType: string, access_: ReturnType<typeof access>[]) => ({
+  ["~orpc"]: { meta: { userType, access: access_ } },
+});
+
+const incidentRead = access("incident", "read", "", { pluginId: "incident" });
+const incidentManage = access("incident", "manage", "", {
+  pluginId: "incident",
+});
+const catalogRead = access("system", "read", "", { pluginId: "catalog" });
+
+describe("collectAnonymousUsableRuleIds", () => {
+  test("includes rules required by a public procedure (qualified id)", () => {
+    const contracts = [
+      { getIncidents: proc("public", [incidentRead]) },
+      { getSystems: proc("public", [catalogRead]) },
+    ];
+    expect(collectAnonymousUsableRuleIds(contracts).sort()).toEqual([
+      "catalog.system.read",
+      "incident.incident.read",
+    ]);
+  });
+
+  test("excludes rules required only by authenticated/user procedures", () => {
+    const contracts = [
+      {
+        createIncident: proc("authenticated", [incidentManage]),
+        deleteIncident: proc("user", [incidentManage]),
+      },
+    ];
+    expect(collectAnonymousUsableRuleIds(contracts)).toEqual([]);
+  });
+
+  test("a rule on BOTH a public and an authenticated procedure is usable", () => {
+    const contracts = [
+      {
+        getIncidents: proc("public", [incidentRead]),
+        createIncident: proc("authenticated", [incidentManage]),
+      },
+    ];
+    // read is usable (public); manage is not (only authenticated).
+    expect(collectAnonymousUsableRuleIds(contracts)).toEqual([
+      "incident.incident.read",
+    ]);
+  });
+
+  test("ignores procedures without metadata and anonymous-userType ones", () => {
+    const contracts = [
+      { notAProc: {} as unknown },
+      // anonymous userType skips access checks entirely, so its rules are not
+      // 'usable via grant' - they would never be consulted.
+      { ping: proc("anonymous", [incidentRead]) },
+    ];
+    expect(collectAnonymousUsableRuleIds(contracts)).toEqual([]);
+  });
+});

--- a/core/backend/src/plugin-manager.ts
+++ b/core/backend/src/plugin-manager.ts
@@ -15,7 +15,11 @@ import {
   HookUnsubscribe,
 } from "@checkstack/backend-api";
 import type { AnyContractRouter } from "@orpc/contract";
-import type { AccessRule, PluginMetadata } from "@checkstack/common";
+import type {
+  AccessRule,
+  PluginMetadata,
+  ProcedureMetadata,
+} from "@checkstack/common";
 import { extractErrorMessage } from "@checkstack/common";
 
 // Extracted modules
@@ -29,6 +33,32 @@ import { getPluginSchemaName } from "@checkstack/drizzle-helper";
 import { stripPublicSchemaFromMigrations } from "./utils/strip-public-schema";
 import { runPluginMigrations } from "./utils/run-plugin-migrations";
 import { createScopedDb } from "./utils/scoped-db";
+
+/**
+ * Collect the qualified ids (`{pluginId}.{ruleId}`) of access rules an ANONYMOUS
+ * caller can actually use: a rule is included iff at least one procedure that
+ * requires it has `userType: "public"` (the only userType where the anonymous
+ * role's rules are consulted). Pure + exported for unit testing.
+ */
+export function collectAnonymousUsableRuleIds(
+  contracts: Iterable<unknown>,
+): string[] {
+  const usable = new Set<string>();
+  for (const contract of contracts) {
+    for (const procedure of Object.values(
+      contract as Record<string, unknown>,
+    )) {
+      const meta = (
+        procedure as { ["~orpc"]?: { meta?: ProcedureMetadata } } | undefined
+      )?.["~orpc"]?.meta;
+      if (meta?.userType !== "public") continue;
+      for (const rule of meta.access ?? []) {
+        usable.add(`${rule.pluginId}.${rule.id}`);
+      }
+    }
+  }
+  return [...usable];
+}
 
 export interface DeregisterOptions {
   deleteSchema: boolean;
@@ -208,6 +238,22 @@ export class PluginManager {
     return new Map(this.pluginContractRegistry);
   }
 
+  /**
+   * Qualified ids (`{pluginId}.{ruleId}`) of access rules an ANONYMOUS caller can
+   * actually USE: a rule is included iff at least one registered procedure that
+   * requires it has `userType: "public"` - the only userType where the anonymous
+   * role's granted rules are consulted. Rules used solely by
+   * authenticated/user/service procedures are excluded: granting them to the
+   * anonymous role is inert (the auth middleware rejects unauthenticated callers
+   * before access rules are checked), so the role editor uses this to avoid
+   * misleading "granted but unusable" anonymous permissions.
+   */
+  getAnonymousUsableAccessRuleIds(): string[] {
+    return collectAnonymousUsableRuleIds(
+      this.pluginContractRegistry.values(),
+    );
+  }
+
   async loadPlugins(
     rootRouter: Hono,
     manualPlugins: BackendPlugin[] = [],
@@ -228,6 +274,8 @@ export class PluginManager {
         extensionPointManager: this.extensionPointManager,
         registeredAccessRules: this.registeredAccessRules,
         getAllAccessRules: () => this.getAllAccessRules(),
+        getAnonymousUsableAccessRuleIds: () =>
+          this.getAnonymousUsableAccessRuleIds(),
         db,
         pluginMetadataRegistry: this.pluginMetadataRegistry,
         cleanupHandlers: this.cleanupHandlers,
@@ -772,6 +820,8 @@ export class PluginManager {
         },
         pluginManager: {
           getAllAccessRules: () => this.getAllAccessRules(),
+          getAnonymousUsableAccessRuleIds: () =>
+            this.getAnonymousUsableAccessRuleIds(),
         },
       });
 

--- a/core/backend/src/plugin-manager/plugin-loader.getservice.test.ts
+++ b/core/backend/src/plugin-manager/plugin-loader.getservice.test.ts
@@ -32,6 +32,7 @@ function makeDeps(registry: ServiceRegistry): PluginLoaderDeps {
     extensionPointManager: createExtensionPointManager(),
     registeredAccessRules: [] as (AccessRule & { pluginId: string })[],
     getAllAccessRules: () => [],
+    getAnonymousUsableAccessRuleIds: () => [],
     db: {} as PluginLoaderDeps["db"],
     pluginMetadataRegistry: new Map<string, PluginMetadata>(),
     cleanupHandlers: new Map<string, Array<() => Promise<void>>>(),

--- a/core/backend/src/plugin-manager/plugin-loader.skip-naming.test.ts
+++ b/core/backend/src/plugin-manager/plugin-loader.skip-naming.test.ts
@@ -32,6 +32,7 @@ function makeDeps(registry: ServiceRegistry): PluginLoaderDeps {
     extensionPointManager: createExtensionPointManager(),
     registeredAccessRules: [] as (AccessRule & { pluginId: string })[],
     getAllAccessRules: () => [],
+    getAnonymousUsableAccessRuleIds: () => [],
     db: {} as PluginLoaderDeps["db"],
     pluginMetadataRegistry: new Map<string, PluginMetadata>(),
     cleanupHandlers: new Map<string, Array<() => Promise<void>>>(),

--- a/core/backend/src/plugin-manager/plugin-loader.ts
+++ b/core/backend/src/plugin-manager/plugin-loader.ts
@@ -48,6 +48,7 @@ export interface PluginLoaderDeps {
   extensionPointManager: ExtensionPointManager;
   registeredAccessRules: (AccessRule & { pluginId: string })[];
   getAllAccessRules: () => AccessRule[];
+  getAnonymousUsableAccessRuleIds: () => string[];
   db: SafeDatabase<Record<string, unknown>>;
   /**
    * Map of pluginId -> PluginMetadata for request-time context injection.
@@ -236,6 +237,8 @@ export function registerPlugin({
     },
     pluginManager: {
       getAllAccessRules: () => deps.getAllAccessRules(),
+      getAnonymousUsableAccessRuleIds: () =>
+        deps.getAnonymousUsableAccessRuleIds(),
     },
   });
 }


### PR DESCRIPTION
Follow-up to the access-rule qualification work (PR #311). Addresses the userType/access-rule consistency gap on RPC routers.

## Background: no security hole, but a real consistency gap
RPC procedures define two **independent** axes — `userType` (the hard authentication gate) and `access` rules (authorization). The auth middleware enforces `userType` **before** access rules (`rpc.ts`: anonymous → 401 on any non-`public` endpoint), so granting the anonymous role any rule can **never** let it call an `authenticated` RPC — the grant is simply **inert**. After anonymous users began seeing permission-gated UI, such an inert grant would surface as **visible-but-broken** controls.

## Fix (guardrail only — RPC enforcement is unchanged)
- **Backend**: `pluginManager.getAnonymousUsableAccessRuleIds()` computes, from contract metadata, the rules an anonymous caller can actually use — a rule is "usable" iff at least one **`public`** procedure requires it. Exposed to plugins via the plugin environment.
- **`auth.getAccessRules`** annotates each rule with `anonymousUsable`.
- **`auth.updateRole`** refuses to **ADD** a non-usable rule to the **anonymous** role (existing grants are left untouched, so no configuration can be wedged).
- **Role editor** disables non-usable rules (with an explanation) when editing the anonymous role.

The contract-walking logic is extracted to a pure, unit-tested `collectAnonymousUsableRuleIds`.

## Verification
- `bun run typecheck` ✓, `bun run lint` ✓, 728 backend/auth tests pass (incl. new unit tests).
- Live (dev-auth): `getAccessRules` reports **11 anonymous-usable / 58 not**; granting `incident.incident.manage` to the anonymous role → **HTTP 400** with a clear message; `incident.incident.read` is usable, `incident.incident.manage` is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)