### PR TITLE
fix(dashboard): align text and link system-signal rows

### DIFF
--- a/.changeset/dashboard-signal-row-align.md
+++ b/.changeset/dashboard-signal-row-align.md
@@ -1,0 +1,9 @@
+---
+"@checkstack/dashboard-frontend": patch
+---
+
+Align dashboard system-signal rows. Text (non-link) signals - shown when the
+viewer can't open the target - were indented ~0.5rem further right than link
+signals, because the link row used a negative horizontal margin (`-mx-2`) to let
+its hover background bleed past the text while the text row did not. The text row
+now uses the same horizontal box, so link and text signals line up.

--- a/core/dashboard-frontend/src/components/ProblemSystemCard.tsx
+++ b/core/dashboard-frontend/src/components/ProblemSystemCard.tsx
@@ -77,7 +77,9 @@ const SignalTextRow: React.FC<{ signal: SystemSignal; isLowPower: boolean }> = (
   signal,
   isLowPower,
 }) => (
-  <li className="flex items-center gap-2.5 px-2 py-1.5">
+  // Same horizontal box as SignalLinkRow (`-mx-2 px-2`) so text and link rows
+  // line up - the link's negative margin would otherwise sit it 0.5rem left.
+  <li className="-mx-2 flex items-center gap-2.5 px-2 py-1.5">
     <SignalInner signal={signal} isLowPower={isLowPower} interactive={false} />
   </li>
 );


### PR DESCRIPTION
Small UI consistency fix in the dashboard's per-system signal list (`ProblemSystemCard`).

**Problem:** signals the viewer can't open render as plain text instead of a link. Those text rows were indented ~0.5rem further **right** than the link rows.

**Cause:** `SignalLinkRow` uses a negative horizontal margin (`-mx-2`) so its rounded hover background bleeds past the text; `SignalTextRow` only had `px-2`, so its content started 0.5rem further in.

**Fix:** give the text row the same horizontal box (`-mx-2 px-2`) so link and text signals line up exactly.

`typecheck` ✓, `lint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)