### PR TITLE
fix(slo): keep SLO overview cards content-sized next to the sidebar

### DIFF
--- a/.changeset/slo-overview-card-height.md
+++ b/.changeset/slo-overview-card-height.md
@@ -1,0 +1,11 @@
+---
+"@checkstack/slo-frontend": patch
+---
+
+fix(slo): make SLO overview cards fill their grid cell height
+
+On the SLO Dashboard the cards are wrapped in stretched grid items
+(`items-stretch`), so each card's anchor grew to the tallest card in its row
+while the card inside kept its natural height - leaving empty space below the
+shorter cards. The card and its anchor now use `h-full` so the card fills the
+cell and all cards in a row line up.

--- a/.changeset/slo-overview-card-height.md
+++ b/.changeset/slo-overview-card-height.md
@@ -2,10 +2,11 @@
 "@checkstack/slo-frontend": patch
 ---
 
-fix(slo): make SLO overview cards fill their grid cell height
+fix(slo): stop SLO overview cards stretching to the sidebar height
 
-On the SLO Dashboard the cards are wrapped in stretched grid items
-(`items-stretch`), so each card's anchor grew to the tallest card in its row
-while the card inside kept its natural height - leaving empty space below the
-shorter cards. The card and its anchor now use `h-full` so the card fills the
-cell and all cards in a row line up.
+On the SLO Dashboard the card grid sits next to a taller sidebar in an
+`items-stretch` layout, so the card grid was stretched to the sidebar's
+height and the default `align-content` then stretched the card rows to fill
+it, leaving large empty space inside each card. The card grid now uses
+`content-start` so rows stay content-sized, while `h-full` on the card/anchor
+still makes cards within the same row match each other.

--- a/core/slo-frontend/src/pages/SloOverviewPage.tsx
+++ b/core/slo-frontend/src/pages/SloOverviewPage.tsx
@@ -89,9 +89,9 @@ const SloOverviewPageContent: React.FC = () => {
                 to={resolveRoute(sloRoutes.routes.detail, {
                   sloId: item.objective.id,
                 })}
-                className="block no-underline"
+                className="block no-underline h-full"
               >
-                <Card className="transition-colors hover:border-primary/50">
+                <Card className="h-full transition-colors hover:border-primary/50">
                   <CardHeader className="pb-3">
                     <div className="flex items-center justify-between">
                       <CardTitle className="text-sm font-medium">

--- a/core/slo-frontend/src/pages/SloOverviewPage.tsx
+++ b/core/slo-frontend/src/pages/SloOverviewPage.tsx
@@ -82,7 +82,11 @@ const SloOverviewPageContent: React.FC = () => {
         />
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* content-start: this grid is stretched to the sidebar's height by
+              the outer items-stretch grid; without it, the default align-content
+              stretches the card rows to fill that height. Keep cards content-sized
+              while h-full still makes cards within a row match each other. */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 content-start">
             {objectives.map((item) => (
               <Link
                 key={item.objective.id}


### PR DESCRIPTION
## Problem

On the **SLO Dashboard** the objective cards had large empty whitespace inside them. The card grid sits in the left column of an outer `lg:grid-cols-[1fr_300px]` grid next to a sidebar. The outer grid is `items-stretch`, so the card grid is stretched to the (taller) sidebar's height, and a CSS grid's default `align-content` then stretches the card *rows* to fill that height — inflating every card.

## Fix

Add `content-start` to the card grid so its rows stay content-sized regardless of the stretched container height. `h-full` on the card and its anchor is kept so that cards **within the same row** still match each other's height (avoids the original ragged-bottom look when two cards in a row have different content).

Net effect: cards use only the height they need, and cards in a row line up.

## Tests

Pure CSS/layout change (Tailwind classes); no logic to unit-test. `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)