### PR TITLE
fix(ai): make the chat off-topic classifier a deny-list (fewer false refusals)

### DIFF
--- a/.changeset/ai-chat-classifier-denylist.md
+++ b/.changeset/ai-chat-classifier-denylist.md
@@ -1,0 +1,17 @@
+---
+"@checkstack/ai-backend": patch
+---
+
+fix(ai): make the chat off-topic classifier a deny-list (fewer false refusals)
+
+The topical pre-classifier refused legitimate operations questions such as
+"analyze the problems <system> has in <environment>" with "That looks outside
+my scope". The system prompt was an allow-list that enumerated resources and
+CRUD verbs, so anything phrased with an unlisted verb (analyze, investigate,
+diagnose, ...) or about an unlisted concept could fall through to OFF_TOPIC.
+
+The classifier is now a deny-list: everything is ON_TOPIC by default and only a
+few clearly-unrelated categories (general-purpose coding help, creative
+writing, math/homework, general trivia/world knowledge) are rejected. It no
+longer enumerates resources, tools, or verbs, so adding new tools/resources
+never requires a prompt edit. The fail-open parser is unchanged.

--- a/core/ai-backend/src/chat/classifier.logic.test.ts
+++ b/core/ai-backend/src/chat/classifier.logic.test.ts
@@ -12,56 +12,47 @@ describe("buildClassifierPrompt", () => {
     });
     expect(prompt).toBe("Summarize the open incidents");
     expect(system.length).toBeGreaterThan(0);
-    // The system prompt names the platform domains so the model knows what is
-    // on-topic.
     expect(system).toContain("Checkstack");
     expect(system).toContain("ON_TOPIC");
     expect(system).toContain("OFF_TOPIC");
   });
 
-  test("system prompt explicitly lists meta/capability questions as ON_TOPIC", () => {
-    const { system } = buildClassifierPrompt({ userText: "what can you do?" });
-    // Must contain language that classifies assistant capability/meta questions
-    // as ON_TOPIC. If this regresses (e.g. someone tightens the prompt and
-    // removes the meta allowance), this assertion catches it.
-    expect(system).toMatch(/what can you do|meta.*capability|capability.*question/i);
+  // The classifier is a DENY-LIST: it must NOT enumerate resources/tools/verbs
+  // (so new tools never require a prompt edit). Everything is ON_TOPIC by
+  // default; only a few obviously-unrelated categories are rejected.
+  test("treats everything as ON_TOPIC by default", () => {
+    const { system } = buildClassifierPrompt({ userText: "x" });
+    expect(system.toLowerCase()).toMatch(
+      /everything[^.]*on_topic|on_topic by default/i,
+    );
   });
 
-  test("system prompt explicitly lists greetings as ON_TOPIC", () => {
-    const { system } = buildClassifierPrompt({ userText: "hi" });
-    // Greetings / conversational openers must be named in the ON_TOPIC section.
-    expect(system).toMatch(/greeting|conversational opener|\"hi\"/i);
-  });
-
-  test("system prompt explicitly lists how-to/conceptual questions as ON_TOPIC", () => {
-    const { system } = buildClassifierPrompt({
-      userText: "how do health checks work?",
-    });
-    // How-to and conceptual questions about using Checkstack must be on-topic.
-    expect(system).toMatch(/how.to|conceptual/i);
-  });
-
-  test("system prompt restricts OFF_TOPIC to CLEARLY unrelated requests only", () => {
+  test("restricts OFF_TOPIC to CLEARLY unrelated requests only", () => {
     const { system } = buildClassifierPrompt({ userText: "write me a poem" });
-    // The word "clearly" (or equivalent) must gate the OFF_TOPIC definition so
-    // borderline messages default to ON_TOPIC.
-    expect(system).toMatch(/clearly unrelated|CLEARLY unrelated/i);
+    expect(system).toMatch(/clearly unrelated/i);
   });
 
-  test("system prompt names maintenances and a CRUD-action allowance as ON_TOPIC", () => {
-    // Regression for the real bug: "Create a maintenance" was refused because
-    // maintenances were not listed and there was no generic action allowance.
-    const { system } = buildClassifierPrompt({
-      userText: "Create a maintenance",
-    });
-    expect(system.toLowerCase()).toContain("maintenance");
-    // Any create/list/update/delete request must be ON_TOPIC by default.
-    expect(system).toMatch(/create[^.]*list[^.]*update[^.]*delete/i);
+  test("names the obviously off-topic categories (coding, writing, math, trivia)", () => {
+    const { system } = buildClassifierPrompt({ userText: "x" });
+    const lower = system.toLowerCase();
+    expect(lower).toMatch(/coding|programming/);
+    expect(lower).toContain("writing");
+    expect(lower).toMatch(/math|homework/);
+    expect(lower).toMatch(/trivia|world knowledge/);
   });
 
-  test("system prompt retains the 'when in doubt' ON_TOPIC default", () => {
+  test("retains the 'when in doubt' ON_TOPIC default", () => {
     const { system } = buildClassifierPrompt({ userText: "???" });
     expect(system).toMatch(/when in doubt.*on_topic/i);
+  });
+
+  test("does NOT enumerate platform resource types (deny-list, not allow-list)", () => {
+    // Guards the design: if someone reverts to an allow-list that lists
+    // resources, this catches it. The prompt should not need editing when tools
+    // are added, so it must not pin specific resource names.
+    const { system } = buildClassifierPrompt({ userText: "x" });
+    expect(system.toLowerCase()).not.toContain("anomal");
+    expect(system.toLowerCase()).not.toContain("slo");
   });
 });
 

--- a/core/ai-backend/src/chat/classifier.logic.ts
+++ b/core/ai-backend/src/chat/classifier.logic.ts
@@ -17,28 +17,25 @@ export type ClassifierVerdict = "ON_TOPIC" | "OFF_TOPIC";
  * System prompt for the classifier. Kept tiny + deterministic: the model must
  * reply with a bare token so the (cheap) call stays short. The parser defends
  * against any decoration regardless.
+ *
+ * Deliberately a DENY-LIST, not an allow-list: it does NOT enumerate Checkstack
+ * resources, tools, or verbs (those change constantly and must never require a
+ * prompt edit). Everything is ON_TOPIC by default; only a few obviously
+ * unrelated categories are rejected. This biases hard toward letting real ops
+ * questions through.
  */
 const CLASSIFIER_SYSTEM_PROMPT =
-  "You are a topical classifier for Checkstack, an operations platform covering " +
-  "incidents, health checks, anomalies, automations, maintenances/maintenance " +
-  "windows, dependencies, systems and services, notifications, SLOs, " +
-  "integrations, on-call, and general monitoring/operations. Decide whether the " +
-  "user's message is ON_TOPIC or OFF_TOPIC. " +
-  "ON_TOPIC includes: operating or reasoning about Checkstack or any of its " +
-  "resources and configuration; meta/capability questions about the assistant " +
-  "itself (\"what can you do\", \"who are you\", \"help\", \"what features do you " +
-  "have\"); greetings and conversational openers (\"hi\", \"hello\", \"hey\"); " +
-  "how-to or conceptual questions about using Checkstack features or workflows " +
-  "(\"how do health checks work\", \"how do I create an automation\"). " +
-  "IMPORTANT: any request to create, add, list, show, view, find, update, edit, " +
-  "schedule, start, stop, resolve, acknowledge, or delete something is ON_TOPIC " +
-  "by default - it is almost certainly an action on a platform resource (e.g. " +
-  "\"create a maintenance\", \"list incidents\", \"schedule downtime\"), EVEN IF " +
-  "the resource type is not named in the list above. " +
-  "OFF_TOPIC means ONLY requests that are CLEARLY unrelated to operating this " +
-  "platform: general-purpose coding help, creative writing, math homework, and " +
-  "general trivia or knowledge questions. " +
-  "When in doubt, reply ON_TOPIC. Reply with the token only.";
+  "You are a topical gate for Checkstack, an operations and monitoring " +
+  "assistant. Treat essentially EVERYTHING as ON_TOPIC by default - any " +
+  "question or request about operating, analyzing, troubleshooting, " +
+  "configuring, or reasoning about Checkstack, its data, systems, services, " +
+  "environments, or their problems and status, any action on a resource, " +
+  "questions about your own capabilities, and greetings. " +
+  "Reply OFF_TOPIC ONLY when the message is CLEARLY unrelated to operating this " +
+  "platform - that is ONLY: general-purpose programming/coding help, creative " +
+  "writing, math or homework, or general trivia and world knowledge. " +
+  "Everything else is ON_TOPIC. When in doubt, reply ON_TOPIC. Reply with the " +
+  "token only.";
 
 /**
  * The canned refusal returned (over the normal SSE stream) when the classifier


### PR DESCRIPTION
## Problem

The AI chat's topical pre-classifier refused a legitimate operations question — *"Please analyze the problems &lt;System&gt; has in &lt;Environment&gt;"* — with "That looks outside my scope". It happens too often.

## Cause

The classifier system prompt was an **allow-list**: it enumerated resource types (incidents, health checks, SLOs, …) and a fixed CRUD verb list (create/list/update/delete/…). A message phrased with an unlisted verb (analyze, investigate, diagnose) or about an unnamed concept could fall through to OFF_TOPIC. It also had to be maintained every time a tool/resource was added.

## Fix

Flip it to a **deny-list**:
- Everything is **ON_TOPIC by default**.
- Reply OFF_TOPIC **only** for clearly-unrelated categories: general-purpose coding help, creative writing, math/homework, general trivia/world knowledge.
- No enumeration of resources, tools, or verbs — so adding new tools/resources **never requires a prompt edit** (the maintenance concern raised in the request).

The fail-open parser (`parseClassifierVerdict`) and the streamTurn short-circuit are unchanged; this only broadens what counts as on-topic.

## Tests

Rewrote the prompt tests to the deny-list invariants: everything-ON_TOPIC-by-default, OFF_TOPIC restricted to "clearly unrelated", the four off-topic categories named, the "when in doubt → ON_TOPIC" default retained, and a guard that the prompt does **not** pin resource names (so it can't silently regress to an allow-list). `parseClassifierVerdict` tests unchanged. The streamTurn integration tests (off-topic "write me a hello world react component" still refuses; on-topic proceeds) still pass.

`bun run typecheck`, `bun run lint`, `bun run test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)