### PR TITLE
fix(ai/jira/automations): make ai_analyze structured output work + 6 bugs surfaced by E2E

### DIFF
--- a/.changeset/ai-analyze-structured-output.md
+++ b/.changeset/ai-analyze-structured-output.md
@@ -1,0 +1,15 @@
+---
+"@checkstack/ai-backend": patch
+---
+
+Fix the AI analyze action's structured output (`outputFields`) failing on
+OpenAI-compatible providers without native structured-output support (OpenRouter,
+DeepSeek, Ollama, ...). The JSON schema sent via `responseFormat` is silently
+dropped by those providers, and the prompt never described the schema, so the
+model was never told which fields were required and omitted them ("No object
+generated: response did not match schema"). The structured-output pass now
+embeds the JSON Schema in the prompt, so it works on any OpenAI-compatible model.
+The repair loop is also more effective: on a failed attempt it now feeds back the
+specific field-level validation errors and the model's rejected output (instead
+of the generic "did not match schema" message) and reinforces the schema more
+firmly on repeated misses.

--- a/.changeset/jira-additional-fields-coercion.md
+++ b/.changeset/jira-additional-fields-coercion.md
@@ -1,0 +1,13 @@
+---
+"@checkstack/integration-jira-backend": patch
+---
+
+Coerce and validate `create_issue` field mappings against the live Jira field
+schema. The mapping value is always a config string, but Jira fields are typed,
+so the action now fetches the project+issue-type field metadata and converts each
+value to the shape Jira expects: `labels` (array of string) becomes a real array,
+a number field becomes a number, a select maps to `{ id }` from its allowed
+values, etc. It also VALIDATES up front — an unknown field key or an option value
+outside the field's allowed set fails the step with a clear message instead of an
+opaque Jira 400. Scalar fields were already fine; array/object/option fields now
+work.

--- a/.changeset/jira-field-type-hints.md
+++ b/.changeset/jira-field-type-hints.md
@@ -1,0 +1,12 @@
+---
+"@checkstack/integration-jira-backend": patch
+"@checkstack/integration-jira-common": patch
+---
+
+Surface each Jira field's value TYPE in the `create_issue` additional-fields
+option list (`fieldOptions`), via the option's `description` — e.g. `labels` is
+shown as "array of string", a story-points field as "number", and a select as
+"option; one of: …". Previously the resolver returned only the field key + name,
+so the model (and the editor) knew the field but had to guess the value shape and
+would, for example, send a bare string for an array-typed field like `labels`.
+The field's `schema.items` (array element type) is now also captured.

--- a/.changeset/jira-search-jql-migration.md
+++ b/.changeset/jira-search-jql-migration.md
@@ -1,0 +1,13 @@
+---
+"@checkstack/integration-jira-backend": patch
+---
+
+Fix the Jira `search_issues` action failing with HTTP 410 on Jira Cloud. Atlassian
+deprecated the legacy `/rest/api/3/search` endpoint on 2024-05-01 and removed it on
+2025-05-01 (CHANGE-2046), so every Cloud search (and the "create a ticket only if
+none is open" pattern that depends on it) broke. The client now calls
+`/rest/api/3/search/jql` for Cloud connections (deriving result existence from the
+returned issues, since the new endpoint returns no `total`), while Jira Data
+Center / Server (on-prem) connections keep using the legacy `/search`, which they
+still serve and where `/search/jql` does not exist. The endpoint is selected by the
+connection's auth mode (cloud vs datacenter).

--- a/.changeset/nested-resolver-fields.md
+++ b/.changeset/nested-resolver-fields.md
@@ -1,0 +1,13 @@
+---
+"@checkstack/automation-backend": minor
+---
+
+The AI assistant can now discover dynamic-option values for config fields nested
+inside an array of rows (e.g. a Jira `create_issue`'s `fieldMappings[].fieldKey`,
+which lists a project + issue type's additional/custom fields). `getResolverField`
+and `listResolverFields` (and thus the `automation.resolveActionOptions` tool) now
+accept a DOTTED field path that steps through object `properties` and array
+`items.properties`, so the model can resolve `fieldMappings.fieldKey` the same way
+it resolves top-level fields like `projectKey`. Previously only top-level resolver
+fields were reachable, so the assistant could not discover (and therefore could
+not populate) additional Jira fields.

--- a/.changeset/produces-double-prefix.md
+++ b/.changeset/produces-double-prefix.md
@@ -1,0 +1,30 @@
+---
+"@checkstack/automation-backend": patch
+"@checkstack/catalog-backend": patch
+"@checkstack/dependency-backend": patch
+"@checkstack/healthcheck-backend": patch
+"@checkstack/maintenance-backend": patch
+"@checkstack/notification-backend": patch
+---
+
+Fix producing automation actions that double-prefixed their artifact type. The
+action registry qualifies `produces` with the owning plugin id, but several
+actions set `produces` to an already-qualified id, so it became
+`plugin.plugin.type` (e.g. `automation.automation.analysis`,
+`maintenance.maintenance.window`). This stored artifacts under a type that
+matched no registered artifact type, and — because the run scope exposes a
+produced artifact under its type's local name — broke the documented downstream
+reference `artifacts.<actionId>.<name>.<field>` (a `choose`/condition/template
+referencing the analysis output, a created incident/maintenance/etc. silently
+saw `undefined` and took the wrong branch).
+
+Fixed in `ai_analyze` (`analysis`), the built-in `notify_user`
+(`notify_user_result`), and the catalog (`system_record`), maintenance
+(`window`), notification (`send_result`), dependency (`edge`), and healthcheck
+(`assignment`) actions — each now uses the unqualified local id matching its
+artifact-type definition.
+
+BREAKING (beta): any automation that referenced one of these artifacts via the
+old double-prefixed scope key (e.g. `artifacts.x['automation.analysis']`) must
+switch to the documented form (`artifacts.x.analysis.<field>`). The
+double-prefixed key was never the intended/documented path.

--- a/.changeset/template-not-keyword.md
+++ b/.changeset/template-not-keyword.md
@@ -1,0 +1,10 @@
+---
+"@checkstack/template-engine": patch
+---
+
+Support `not` as a prefix negation keyword in condition/template expressions
+(e.g. `not artifacts.search.issue_search.found`), matching the documented
+pattern and what `!` already does. Previously only `!` was accepted and the
+`not` keyword threw `Expected EXPR_CLOSE but found IDENT`, so a `choose`/
+condition that used the (advertised) `not ...` form failed to evaluate at run
+time. The `not` FILTER (`value | not`) is parsed after a pipe and is unaffected.

--- a/core/ai-backend/src/agent-runner.test.ts
+++ b/core/ai-backend/src/agent-runner.test.ts
@@ -352,7 +352,15 @@ describe("createAgentRunner", () => {
       systemsSeen.push(args.system ?? "");
       attempt += 1;
       if (attempt === 1) {
-        throw new Error("severity must be one of low|medium|high");
+        // Shape of a real AI-SDK NoObjectGeneratedError: a generic top-level
+        // message, with the actionable field-level detail in `cause` and the
+        // model's rejected output in `text`.
+        const err = new Error(
+          "No object generated: response did not match schema.",
+        ) as Error & { text?: string; cause?: { message: string } };
+        err.text = '{"sev":"high"}';
+        err.cause = { message: "severity: expected string, received undefined" };
+        throw err;
       }
       return { object: { severity: "high" }, usage: {} };
     });
@@ -376,9 +384,20 @@ describe("createAgentRunner", () => {
 
     expect(generateObject).toHaveBeenCalledTimes(2);
     expect(result.object).toEqual({ severity: "high" });
-    // The retry's system prompt carries the prior failure as repair guidance.
-    expect(systemsSeen[1]).toContain("rejected");
-    expect(systemsSeen[1]).toContain("severity must be one of");
+    // The system prompt DESCRIBES the required schema (field names) on EVERY
+    // attempt. The OpenAI-compatible provider drops the JSON schema sent via
+    // responseFormat (supportsStructuredOutputs: false), so without this the
+    // model is never told the shape and omits required fields. Regression guard.
+    expect(systemsSeen[0]).toMatch(/JSON Schema/i);
+    expect(systemsSeen[0]).toContain("severity");
+    // The retry's repair guidance surfaces the ACTIONABLE detail, not the
+    // generic "no object generated" line: the field-level validation cause and
+    // the model's own rejected output, so a dumber model can self-correct.
+    expect(systemsSeen[1]).toContain("REJECTED");
+    expect(systemsSeen[1]).toContain("severity: expected string, received undefined");
+    expect(systemsSeen[1]).toContain('You returned: {"sev":"high"}');
+    // The full schema is restated on the retry too.
+    expect(systemsSeen[1]).toMatch(/JSON Schema|"severity"/);
   });
 
   it("gives up after the bounded retries and propagates the last schema error", async () => {

--- a/core/ai-backend/src/agent-runner.ts
+++ b/core/ai-backend/src/agent-runner.ts
@@ -30,6 +30,7 @@ import {
   type LanguageModel,
 } from "ai";
 import { z } from "zod";
+import { toJsonSchema } from "@checkstack/backend-api";
 import { toModelSchema } from "./chat/model-schema";
 import {
   buildDateTimeContext,
@@ -337,8 +338,17 @@ async function generateStructuredWithRepair({
   // Same single model-boundary date handling as the tool path: the schema's
   // dates must serialize AND the model's ISO strings coerce back to Date.
   const schema = toModelSchema(outputSchema);
+  // Describe the required shape IN THE PROMPT. The OpenAI-compatible provider has
+  // `supportsStructuredOutputs: false`, so the JSON schema sent via
+  // `responseFormat` is dropped by the SDK (warns + ignored) — without this the
+  // model is never told which fields are required and omits them. Embedding the
+  // JSON Schema makes structured output work on any OpenAI-compatible model.
+  const schemaJson = JSON.stringify(toJsonSchema(outputSchema));
   const baseSystem =
-    "Produce the structured result from the analysis below. Use only information present in it; do not invent values.";
+    "Produce the structured result from the analysis below. Use only information " +
+    "present in it; do not invent values. Respond with ONLY a single JSON object " +
+    "that conforms EXACTLY to this JSON Schema — include every required field and " +
+    `add no extra fields:\n${schemaJson}`;
   let repairNote = "";
   let lastError: unknown;
 
@@ -353,10 +363,50 @@ async function generateStructuredWithRepair({
       return res.object;
     } catch (error) {
       lastError = error;
-      repairNote = ` Your previous output was rejected: ${extractErrorMessage(
-        error,
-      )}. Return ONLY a value that exactly matches the required schema.`;
+      repairNote = buildRepairNote({ error, schemaJson, attempt });
     }
   }
   throw lastError;
+}
+
+/**
+ * Build escalating repair guidance after a structured-output attempt failed.
+ *
+ * The generic `NoObjectGeneratedError` message ("response did not match schema")
+ * is useless to the model — the actionable detail lives in its `cause` (the
+ * field-level validation errors, e.g. "reason: expected string, received
+ * undefined") and its `text` (what the model actually returned). We feed BOTH
+ * back, restate the full schema with "every required field" emphasis, and get
+ * firmer after a repeated miss. This is what "dumber" models that ignore the
+ * schema on the first pass need to self-correct instead of failing the step.
+ */
+function buildRepairNote({
+  error,
+  schemaJson,
+  attempt,
+}: {
+  error: unknown;
+  schemaJson: string;
+  attempt: number;
+}): string {
+  const e = error as { text?: unknown; cause?: unknown };
+  const cause = e.cause as { message?: unknown } | undefined;
+  const detail =
+    typeof cause?.message === "string" && cause.message.trim()
+      ? cause.message
+      : extractErrorMessage(error);
+  const returned =
+    typeof e.text === "string" && e.text.trim()
+      ? ` You returned: ${e.text.slice(0, 600)}.`
+      : "";
+  const firmer =
+    attempt >= 1
+      ? " This has now failed more than once — read the schema again and return EVERY required field, correctly typed, with NOTHING else."
+      : "";
+  return (
+    ` Your previous output was REJECTED because it did not match the required schema.${returned}` +
+    ` Validation errors: ${detail}.` +
+    " Respond with ONLY a single JSON object matching this schema, every required" +
+    ` field present and no extra fields or prose:\n${schemaJson}.${firmer}`
+  );
 }

--- a/core/automation-backend/src/ai-action.test.ts
+++ b/core/automation-backend/src/ai-action.test.ts
@@ -111,7 +111,10 @@ function makeGetService(opts: {
 describe("aiAnalyzeAction", () => {
   it("is an AI-category action that produces the analysis artifact", () => {
     expect(aiAnalyzeAction.id).toBe("ai_analyze");
-    expect(aiAnalyzeAction.produces).toBe("automation.analysis");
+    // UNqualified local id — the action registry qualifies it to
+    // `automation.analysis` (matching the artifact type). Pre-qualifying here
+    // would double-prefix to `automation.automation.analysis`.
+    expect(aiAnalyzeAction.produces).toBe("analysis");
   });
 
   it("fails clearly when the automation has no service account", async () => {

--- a/core/automation-backend/src/ai-action.ts
+++ b/core/automation-backend/src/ai-action.ts
@@ -190,7 +190,13 @@ export const aiAnalyzeAction: ActionDefinition<
   icon: "Sparkles",
   connectionProviderId: AI_CONNECTION_PROVIDER_ID,
   config: new Versioned({ version: 1, schema: aiActionConfigSchema }),
-  produces: "automation.analysis",
+  // The action registry qualifies `produces` with the owning plugin id, so this
+  // is the UNqualified local id (matching the artifact type's `id: "analysis"`).
+  // It must NOT be pre-qualified — "automation.analysis" here would be
+  // re-qualified to "automation.automation.analysis", which then exposes the
+  // artifact in scope under that double-prefixed key and breaks the documented
+  // reference `artifacts.<actionId>.analysis.data.<field>`.
+  produces: "analysis",
   execute: async ({ config, scope, logger, rpcClient, getService, runAs }) => {
     if (!runAs) {
       return {

--- a/core/automation-backend/src/ai/action-options.test.ts
+++ b/core/automation-backend/src/ai/action-options.test.ts
@@ -134,3 +134,59 @@ describe("collectProviderActionNodes", () => {
     ]);
   });
 });
+
+/**
+ * A create_issue-shaped schema with a `fieldMappings` array whose per-row
+ * `fieldKey` carries a resolver (the Jira "additional fields" case): the
+ * resolver lives NESTED inside the array's `items.properties`.
+ */
+const SCHEMA_WITH_NESTED_RESOLVER = {
+  type: "object",
+  properties: {
+    connectionId: { type: "string", "x-options-resolver": "connectionOptions" },
+    projectKey: { type: "string", "x-options-resolver": "projectOptions" },
+    issueTypeId: {
+      type: "string",
+      "x-options-resolver": "issueTypeOptions",
+      "x-depends-on": ["connectionId", "projectKey"],
+    },
+    fieldMappings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          fieldKey: {
+            type: "string",
+            "x-options-resolver": "fieldOptions",
+            "x-depends-on": ["connectionId", "projectKey", "issueTypeId"],
+          },
+          value: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+describe("nested (array-item) resolver fields", () => {
+  test("getResolverField resolves a dotted path into an array's row schema", () => {
+    expect(
+      getResolverField(SCHEMA_WITH_NESTED_RESOLVER, "fieldMappings.fieldKey"),
+    ).toEqual({
+      field: "fieldMappings.fieldKey",
+      resolverName: "fieldOptions",
+      dependsOn: ["connectionId", "projectKey", "issueTypeId"],
+    });
+  });
+
+  test("getResolverField returns undefined for a non-resolver nested leaf", () => {
+    expect(
+      getResolverField(SCHEMA_WITH_NESTED_RESOLVER, "fieldMappings.value"),
+    ).toBeUndefined();
+  });
+
+  test("listResolverFields includes the nested field as a dotted path", () => {
+    const fields = listResolverFields(SCHEMA_WITH_NESTED_RESOLVER).map((f) => f.field);
+    expect(fields).toContain("projectKey");
+    expect(fields).toContain("fieldMappings.fieldKey");
+  });
+});

--- a/core/automation-backend/src/ai/action-options.ts
+++ b/core/automation-backend/src/ai/action-options.ts
@@ -35,40 +35,91 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 }
 
 /**
+ * Descend a JSON-schema by a DOTTED field path, stepping through object
+ * `properties` and array `items.properties` at each segment. So `projectKey`
+ * resolves a top-level field, and `fieldMappings.fieldKey` resolves the
+ * per-row `fieldKey` inside the `fieldMappings` array. Returns the leaf
+ * property schema, or `undefined` if any segment is missing.
+ */
+function resolvePropertySchema(
+  configSchema: unknown,
+  fieldPath: string,
+): Record<string, unknown> | undefined {
+  let container = asRecord(asRecord(configSchema)?.properties);
+  let property: Record<string, unknown> | undefined;
+  for (const segment of fieldPath.split(".")) {
+    if (!container) return undefined;
+    property = asRecord(container[segment]);
+    if (!property) return undefined;
+    // Prepare the container for the NEXT segment: an array exposes its row
+    // shape under `items.properties`; an object under `properties`.
+    container =
+      property.type === "array"
+        ? asRecord(asRecord(property.items)?.properties)
+        : asRecord(property.properties);
+  }
+  return property;
+}
+
+/** Read a resolver declaration off a leaf property schema, if it has one. */
+function asResolverField(
+  field: string,
+  property: Record<string, unknown> | undefined,
+): ResolverField | undefined {
+  if (!property) return undefined;
+  const resolverName = property["x-options-resolver"];
+  if (typeof resolverName !== "string" || resolverName.length === 0) {
+    return undefined;
+  }
+  const rawDependsOn = property["x-depends-on"];
+  const dependsOn = Array.isArray(rawDependsOn)
+    ? rawDependsOn.filter((d): d is string => typeof d === "string")
+    : [];
+  return { field, resolverName, dependsOn };
+}
+
+/**
  * Read one config field's resolver declaration from a JSON config schema (the
- * `configSchema` returned by `automation.listActions`). Returns `undefined` when
- * the field does not exist or carries no `x-options-resolver`.
+ * `configSchema` returned by `automation.listActions`). Accepts a DOTTED path
+ * for a field nested inside an array of rows (e.g. `fieldMappings.fieldKey`).
+ * Returns `undefined` when the field does not exist or carries no
+ * `x-options-resolver`.
  */
 export function getResolverField(
   configSchema: unknown,
   field: string,
 ): ResolverField | undefined {
-  const properties = asRecord(asRecord(configSchema)?.properties);
-  const property = asRecord(properties?.[field]);
-  if (!property) return undefined;
-
-  const resolverName = property["x-options-resolver"];
-  if (typeof resolverName !== "string" || resolverName.length === 0) {
-    return undefined;
-  }
-
-  const rawDependsOn = property["x-depends-on"];
-  const dependsOn = Array.isArray(rawDependsOn)
-    ? rawDependsOn.filter((d): d is string => typeof d === "string")
-    : [];
-
-  return { field, resolverName, dependsOn };
+  return asResolverField(field, resolvePropertySchema(configSchema, field));
 }
 
-/** Every resolver-backed field declared on a config schema. */
+/**
+ * Every resolver-backed field declared on a config schema, INCLUDING fields
+ * nested one or more levels inside arrays/objects (emitted as dotted paths, e.g.
+ * `fieldMappings.fieldKey`). A bounded recursion guards against pathological
+ * schemas (config schemas are shallow trees in practice).
+ */
 export function listResolverFields(configSchema: unknown): ResolverField[] {
-  const properties = asRecord(asRecord(configSchema)?.properties);
-  if (!properties) return [];
   const out: ResolverField[] = [];
-  for (const field of Object.keys(properties)) {
-    const resolved = getResolverField(configSchema, field);
-    if (resolved) out.push(resolved);
-  }
+  const walk = (
+    properties: Record<string, unknown> | undefined,
+    prefix: string,
+    depth: number,
+  ): void => {
+    if (!properties || depth > 5) return;
+    for (const key of Object.keys(properties)) {
+      const property = asRecord(properties[key]);
+      if (!property) continue;
+      const path = prefix ? `${prefix}.${key}` : key;
+      const resolver = asResolverField(path, property);
+      if (resolver) out.push(resolver);
+      const nested =
+        property.type === "array"
+          ? asRecord(asRecord(property.items)?.properties)
+          : asRecord(property.properties);
+      if (nested) walk(nested, path, depth + 1);
+    }
+  };
+  walk(asRecord(asRecord(configSchema)?.properties), "", 0);
   return out;
 }
 

--- a/core/automation-backend/src/ai/automation-action-options.ts
+++ b/core/automation-backend/src/ai/automation-action-options.ts
@@ -69,7 +69,7 @@ export function createAutomationResolveOptionsTool(): RegisteredAiTool<
   return {
     name: "automation.resolveActionOptions",
     description:
-      "Resolve the VALID values for a dynamic-option config field of an integration action (e.g. a Jira create_issue's projectKey, issueTypeId, or priorityId), fetched live from the connection - the same list the editor dropdown shows. Use this whenever a field's schema has `x-options-resolver` instead of guessing the value. For a cascading field, pass the fields it depends on via `dependencies` (e.g. { projectKey } when resolving issueTypeId), resolving each dependency's options first. Returns { options: [{ value, label }], note }.",
+      "Resolve the VALID values for a dynamic-option config field of an integration action (e.g. a Jira create_issue's projectKey, issueTypeId, or priorityId), fetched live from the connection - the same list the editor dropdown shows. Use this whenever a field's schema has `x-options-resolver` instead of guessing the value. For a cascading field, pass the fields it depends on via `dependencies` (e.g. { projectKey } when resolving issueTypeId), resolving each dependency's options first. A dynamic-option field nested inside an array of rows is referenced by a DOTTED path of its schema location (arrayField.leafField). Returns { options: [{ value, label }], note }.",
     effect: "read",
     input: ResolveActionOptionsInputSchema,
     output: ResolveActionOptionsOutputSchema,

--- a/core/automation-backend/src/builtin-actions.ts
+++ b/core/automation-backend/src/builtin-actions.ts
@@ -102,7 +102,7 @@ export const notifyUserAction: ActionDefinition<
   category: "Built-in",
   icon: "BellRing",
   config: new Versioned({ version: 1, schema: notifyUserConfigSchema }),
-  produces: "automation.notify_user_result",
+  produces: "notify_user_result",
   execute: async ({ config, logger, rpcClient }) => {
     const notificationClient = rpcClient.forPlugin(NotificationApi);
     try {

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun --env-file=../../.env --watch src/index.ts",
+    "dev:auth": "CHECKSTACK_DEV_AUTH=true bun --env-file=../../.env src/index.ts",
     "typecheck": "tsgo -b",
     "generate": "bun --env-file=../../.env run drizzle-kit generate",
     "lint": "bun run lint:code",

--- a/core/catalog-backend/src/automations.ts
+++ b/core/catalog-backend/src/automations.ts
@@ -176,7 +176,7 @@ export function createCatalogActions(
       version: 1,
       schema: systemUpdateMetadataConfigSchema,
     }),
-    produces: "catalog.system_record",
+    produces: "system_record",
     execute: async ({ config, logger, runId }) => {
       const existing = await deps.entityService.getSystem(config.systemId);
       if (!existing) {

--- a/core/dependency-backend/src/automations.ts
+++ b/core/dependency-backend/src/automations.ts
@@ -217,7 +217,7 @@ export function createDependencyActions(
       version: 1,
       schema: dependencyCreateConfigSchema,
     }),
-    produces: "dependency.edge",
+    produces: "edge",
     execute: async ({ config, logger }) => {
       try {
         // Drive the create through the reactive `dependency-edge` entity
@@ -280,7 +280,7 @@ export function createDependencyActions(
       version: 1,
       schema: dependencyRemoveConfigSchema,
     }),
-    produces: "dependency.edge",
+    produces: "edge",
     execute: async ({ config, logger }) => {
       const existing = await deps.service.getDependencyById(config.dependencyId);
       if (!existing) {

--- a/core/healthcheck-backend/src/automations.ts
+++ b/core/healthcheck-backend/src/automations.ts
@@ -232,7 +232,7 @@ export function createHealthCheckActions(
     category: "Health",
     icon: "Play",
     config: new Versioned({ version: 1, schema: runNowConfigSchema }),
-    produces: "healthcheck.assignment",
+    produces: "assignment",
     execute: async ({ config, logger }) => {
       const queue = deps.queueManager.getQueue<HealthCheckJobPayload>(
         HEALTH_CHECK_QUEUE,
@@ -267,7 +267,7 @@ export function createHealthCheckActions(
     category: "Health",
     icon: "Power",
     config: new Versioned({ version: 1, schema: assignmentToggleConfigSchema }),
-    produces: "healthcheck.assignment",
+    produces: "assignment",
     execute: async ({ config, logger }) => {
       const updated = await deps.service.setAssignmentEnabled(
         config.systemId,
@@ -310,7 +310,7 @@ export function createHealthCheckActions(
     category: "Health",
     icon: "PowerOff",
     config: new Versioned({ version: 1, schema: assignmentToggleConfigSchema }),
-    produces: "healthcheck.assignment",
+    produces: "assignment",
     execute: async ({ config, logger }) => {
       const updated = await deps.service.setAssignmentEnabled(
         config.systemId,

--- a/core/maintenance-backend/src/automations.ts
+++ b/core/maintenance-backend/src/automations.ts
@@ -260,7 +260,7 @@ export function createMaintenanceActions(
     category: "Maintenance",
     icon: "Wrench",
     config: new Versioned({ version: 1, schema: createConfigSchema }),
-    produces: "maintenance.window",
+    produces: "window",
     execute: async ({ config, logger, runId, scope }) => {
       // Drive the create through the reactive `maintenance` entity (§10.2):
       // the REAL write runs inside `apply` and the deriver fires
@@ -307,7 +307,7 @@ export function createMaintenanceActions(
     category: "Maintenance",
     icon: "Wrench",
     config: new Versioned({ version: 1, schema: updateConfigSchema }),
-    produces: "maintenance.window",
+    produces: "window",
     execute: async ({ config, logger, runId, scope }) => {
       // Probe existence first so a missing window returns a clean failure
       // without driving an entity write (no `prev` to snapshot).
@@ -361,7 +361,7 @@ export function createMaintenanceActions(
     category: "Maintenance",
     icon: "MessageSquarePlus",
     config: new Versioned({ version: 1, schema: addUpdateConfigSchema }),
-    produces: "maintenance.window",
+    produces: "window",
     execute: async ({ config, logger, runId, scope }) => {
       // Drive the update through the reactive `maintenance` entity (§10.2):
       // `apply` posts the update row + (optionally) flips status, then
@@ -418,7 +418,7 @@ export function createMaintenanceActions(
     category: "Maintenance",
     icon: "Wrench",
     config: new Versioned({ version: 1, schema: setSystemConfigSchema }),
-    produces: "maintenance.window",
+    produces: "window",
     execute: async ({ config, logger, runId, scope }) => {
       const startAt = now();
       const endAt = new Date(
@@ -474,7 +474,7 @@ export function createMaintenanceActions(
     category: "Maintenance",
     icon: "Wrench",
     config: new Versioned({ version: 1, schema: clearSystemConfigSchema }),
-    produces: "maintenance.window",
+    produces: "window",
     execute: async ({ config, logger, runId, scope }) => {
       const active = await deps.service.getMaintenancesForSystem(config.systemId);
       const closedIds: string[] = [];

--- a/core/notification-backend/src/automations.ts
+++ b/core/notification-backend/src/automations.ts
@@ -149,7 +149,7 @@ export const notificationSendAction: ActionDefinition<
     version: 1,
     schema: notificationSendConfigSchema,
   }),
-  produces: "notification.send_result",
+  produces: "send_result",
   execute: async ({ config, logger, rpcClient }) => {
     const notificationClient = rpcClient.forPlugin(NotificationApi);
     const action =

--- a/core/template-engine/src/__tests__/parser.test.ts
+++ b/core/template-engine/src/__tests__/parser.test.ts
@@ -71,4 +71,19 @@ describe("parseCondition", () => {
   it("rejects malformed input", () => {
     expect(() => parseCondition("foo ==")).toThrow(TemplateParseError);
   });
+
+  it("parses the `not` keyword as prefix negation (like `!`)", () => {
+    // Regression: `when: "not artifacts.x.issue_search.found"` (the documented
+    // negation, which the assistant naturally uses) used to throw
+    // "Expected EXPR_CLOSE but found IDENT".
+    const c = parseCondition("not artifacts.x.issue_search.found");
+    expect(c.root.kind).toBe("unary");
+    expect(parseCondition("!artifacts.x.issue_search.found").root.kind).toBe("unary");
+    expect(parseCondition("not (1 == 2)").root.kind).toBe("unary");
+  });
+
+  it("keeps `not` working as a FILTER name after a pipe (no conflict)", () => {
+    const c = parseCondition("artifacts.x.found | not");
+    expect(c.root.kind).toBe("pipe");
+  });
 });

--- a/core/template-engine/src/parser.ts
+++ b/core/template-engine/src/parser.ts
@@ -215,7 +215,13 @@ class Parser {
   }
 
   private parseUnary(): Expr {
-    if (this.check("NOT")) {
+    // Negation: the `!` operator OR the `not` keyword as a prefix. `not` is
+    // tokenized as an identifier, so we accept it positionally here (a bare
+    // leading `not`). The `not` FILTER (`value | not`) is a filter name parsed
+    // after a PIPE and is unaffected; member access (`x.not`) is parsed after a
+    // DOT and is likewise unaffected.
+    const tok = this.peek();
+    if (tok.kind === "NOT" || (tok.kind === "IDENT" && tok.value === "not")) {
       const opTok = this.advance();
       const operand = this.parseUnary();
       return {

--- a/plugins/integration-jira-backend/src/additional-fields.test.ts
+++ b/plugins/integration-jira-backend/src/additional-fields.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import type { JiraField } from "@checkstack/integration-jira-common";
+import { coerceFieldValue, buildAdditionalFields } from "./additional-fields";
+
+function field(over: Partial<JiraField>): JiraField {
+  return { key: "f", name: "Field", required: false, ...over };
+}
+
+describe("coerceFieldValue", () => {
+  it("wraps a bare string into an array for an array-of-string field (labels)", () => {
+    const r = coerceFieldValue("payments-db", field({ key: "labels", name: "Labels", schema: { type: "array", items: "string" } }));
+    expect(r).toEqual({ ok: true, value: ["payments-db"] });
+  });
+
+  it("accepts a JSON array literal for an array field", () => {
+    const r = coerceFieldValue('["a","b"]', field({ schema: { type: "array", items: "string" } }));
+    expect(r).toEqual({ ok: true, value: ["a", "b"] });
+  });
+
+  it("coerces a number field", () => {
+    expect(coerceFieldValue("5", field({ schema: { type: "number" } }))).toEqual({ ok: true, value: 5 });
+    const bad = coerceFieldValue("five", field({ name: "Story points", schema: { type: "number" } }));
+    expect(bad.ok).toBe(false);
+  });
+
+  it("maps an option value to { id } via allowedValues", () => {
+    const f = field({
+      name: "Severity",
+      schema: { type: "option" },
+      allowedValues: [{ id: "1", name: "High" }, { id: "2", name: "Low" }],
+    });
+    expect(coerceFieldValue("High", f)).toEqual({ ok: true, value: { id: "1" } });
+  });
+
+  it("rejects an option value outside the allowed set", () => {
+    const f = field({
+      name: "Severity",
+      schema: { type: "option" },
+      allowedValues: [{ id: "1", name: "High" }],
+    });
+    const r = coerceFieldValue("Nope", f);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("Allowed: High");
+  });
+
+  it("maps array-of-option elements to { id } via allowedValues", () => {
+    const f = field({
+      name: "Flagged",
+      schema: { type: "array", items: "option" },
+      allowedValues: [{ id: "10", value: "Impediment" }],
+    });
+    expect(coerceFieldValue("Impediment", f)).toEqual({ ok: true, value: [{ id: "10" }] });
+  });
+
+  it("passes string/date types through unchanged", () => {
+    expect(coerceFieldValue("2026-06-15", field({ schema: { type: "date" } }))).toEqual({ ok: true, value: "2026-06-15" });
+    expect(coerceFieldValue("hello", field({ schema: { type: "string" } }))).toEqual({ ok: true, value: "hello" });
+  });
+});
+
+describe("buildAdditionalFields", () => {
+  const fields: JiraField[] = [
+    field({ key: "labels", name: "Labels", schema: { type: "array", items: "string" } }),
+    field({ key: "customfield_10016", name: "Story points", schema: { type: "number" } }),
+  ];
+
+  it("coerces every known mapping into Jira-shaped values", () => {
+    const { additionalFields, errors } = buildAdditionalFields({
+      mappings: [
+        { fieldKey: "labels", value: "payments-db" },
+        { fieldKey: "customfield_10016", value: "8" },
+      ],
+      fields,
+    });
+    expect(errors).toEqual([]);
+    expect(additionalFields).toEqual({ labels: ["payments-db"], customfield_10016: 8 });
+  });
+
+  it("reports an unknown field key as a validation error", () => {
+    const { additionalFields, errors } = buildAdditionalFields({
+      mappings: [{ fieldKey: "made_up", value: "x" }],
+      fields,
+    });
+    expect(additionalFields).toEqual({});
+    expect(errors[0]).toContain('Unknown Jira field "made_up"');
+  });
+});

--- a/plugins/integration-jira-backend/src/additional-fields.ts
+++ b/plugins/integration-jira-backend/src/additional-fields.ts
@@ -1,0 +1,148 @@
+/**
+ * Coerce + VALIDATE operator-supplied `fieldMappings` (each a `{ fieldKey, value }`
+ * where `value` is the rendered template STRING) into the JIRA-shaped values the
+ * REST API expects, using the field metadata Jira itself returned from
+ * create-meta (`JiraField` — `schema.type` / `schema.items` / `allowedValues`).
+ *
+ * Why this exists: the config value is always a string, but Jira fields are
+ * typed — `labels` is an array of string, a story-points field is a number, a
+ * select is `{ id }` from a fixed `allowedValues` set. Without coercion a string
+ * is sent where Jira wants an array/number/object and the create fails with an
+ * opaque 400. Validating against the live schema also lets us reject an unknown
+ * field key or an out-of-set option value with a clear, actionable message
+ * BEFORE the API call (the same metadata the field-discovery resolver surfaces).
+ *
+ * Pure (no I/O) so it is unit-testable; the caller fetches `JiraField[]` and
+ * passes them in.
+ */
+import type { JiraField } from "@checkstack/integration-jira-common";
+
+export interface FieldMapping {
+  fieldKey: string;
+  value: string;
+}
+
+type CoerceResult =
+  | { ok: true; value: unknown }
+  | { ok: false; error: string };
+
+/** Resolve an option string to Jira's `{ id }` shape via the field's allowedValues. */
+function toOption(
+  raw: string,
+  field: JiraField,
+): { ok: true; value: { id: string } } | { ok: false; error: string } {
+  const allowed = field.allowedValues ?? [];
+  if (allowed.length === 0) {
+    // No constrained set advertised; pass the raw value as a name reference.
+    return { ok: true, value: { id: raw } };
+  }
+  const match = allowed.find(
+    (a) => a.id === raw || a.name === raw || a.value === raw,
+  );
+  if (!match) {
+    const names = allowed
+      .map((a) => a.name ?? a.value ?? a.id)
+      .filter((n): n is string => typeof n === "string")
+      .join(", ");
+    return {
+      ok: false,
+      error: `"${raw}" is not a valid value for "${field.name}". Allowed: ${names}.`,
+    };
+  }
+  return { ok: true, value: { id: match.id } };
+}
+
+/** Jira `schema.type` values that are an array/object of selectable options. */
+const OPTION_ITEM_TYPES = new Set(["option", "version", "component", "group"]);
+
+/** Coerce one rendered string value to the field's Jira type (or report why not). */
+export function coerceFieldValue(raw: string, field: JiraField): CoerceResult {
+  const type = field.schema?.type ?? "string";
+  const items = field.schema?.items;
+
+  switch (type) {
+    case "number": {
+      const n = Number(raw);
+      if (raw.trim() === "" || Number.isNaN(n)) {
+        return { ok: false, error: `"${field.name}" expects a number, got "${raw}".` };
+      }
+      return { ok: true, value: n };
+    }
+    case "array": {
+      // Accept a JSON array literal, otherwise treat the string as one element.
+      let elements: unknown[];
+      const trimmed = raw.trim();
+      if (trimmed.startsWith("[")) {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(trimmed);
+        } catch {
+          return { ok: false, error: `"${field.name}" expects a JSON array, got "${raw}".` };
+        }
+        elements = Array.isArray(parsed) ? parsed : [parsed];
+      } else {
+        elements = [raw];
+      }
+      if (items && OPTION_ITEM_TYPES.has(items)) {
+        const out: Array<{ id: string }> = [];
+        for (const element of elements) {
+          const r = toOption(String(element), field);
+          if (!r.ok) return r;
+          out.push(r.value);
+        }
+        return { ok: true, value: out };
+      }
+      if (items === "number") {
+        const nums = elements.map(Number);
+        if (nums.some((n) => Number.isNaN(n))) {
+          return { ok: false, error: `"${field.name}" expects an array of numbers, got "${raw}".` };
+        }
+        return { ok: true, value: nums };
+      }
+      return { ok: true, value: elements.map(String) };
+    }
+    case "option":
+    case "priority":
+    case "resolution": {
+      return toOption(raw, field);
+    }
+    // string / date / datetime / text / any / and unknown types: pass through.
+    default: {
+      return { ok: true, value: raw };
+    }
+  }
+}
+
+/**
+ * Coerce + validate every mapping against the live field metadata. Returns the
+ * Jira-shaped `additionalFields` object plus any validation errors (unknown field
+ * key, bad option value, type mismatch). The caller should fail the action when
+ * `errors` is non-empty rather than send a request Jira will reject.
+ */
+export function buildAdditionalFields({
+  mappings,
+  fields,
+}: {
+  mappings: FieldMapping[];
+  fields: JiraField[];
+}): { additionalFields: Record<string, unknown>; errors: string[] } {
+  const byKey = new Map(fields.map((f) => [f.key, f]));
+  const additionalFields: Record<string, unknown> = {};
+  const errors: string[] = [];
+  for (const mapping of mappings) {
+    const field = byKey.get(mapping.fieldKey);
+    if (!field) {
+      errors.push(
+        `Unknown Jira field "${mapping.fieldKey}" for this project/issue type.`,
+      );
+      continue;
+    }
+    const result = coerceFieldValue(mapping.value, field);
+    if (!result.ok) {
+      errors.push(result.error);
+      continue;
+    }
+    additionalFields[mapping.fieldKey] = result.value;
+  }
+  return { additionalFields, errors };
+}

--- a/plugins/integration-jira-backend/src/automations.ts
+++ b/plugins/integration-jira-backend/src/automations.ts
@@ -25,6 +25,7 @@ import { extractErrorMessage, qualifyAccessRuleId } from "@checkstack/common";
 import { jiraAccess, pluginMetadata } from "@checkstack/integration-jira-common";
 
 import { createJiraClientFromConfig } from "./jira-client";
+import { buildAdditionalFields } from "./additional-fields";
 import type { JiraConnectionConfig } from "./provider";
 import { JIRA_RESOLVERS, JIRA_PROVIDER_QUALIFIED_ID } from "./provider";
 
@@ -293,9 +294,26 @@ export function createJiraActions(): ActionDefinition<unknown, unknown>[] {
       }
       const { client, config: connConfig } = loaded;
       try {
-        const additionalFields: Record<string, unknown> = {};
-        for (const mapping of config.fieldMappings ?? []) {
-          additionalFields[mapping.fieldKey] = mapping.value;
+        // Coerce + validate the operator's field mappings against the live Jira
+        // field schema (the config value is always a string, but Jira fields are
+        // typed). This turns e.g. labels `["x"]` into a real array and rejects an
+        // unknown field key / bad option value with a clear error, instead of
+        // sending a malformed payload Jira rejects with an opaque 400.
+        const mappings = config.fieldMappings ?? [];
+        let additionalFields: Record<string, unknown> = {};
+        if (mappings.length > 0) {
+          const fieldMeta = await client.getFields(
+            config.projectKey,
+            config.issueTypeId,
+          );
+          const coerced = buildAdditionalFields({ mappings, fields: fieldMeta });
+          if (coerced.errors.length > 0) {
+            return {
+              success: false,
+              error: `Invalid additional field(s): ${coerced.errors.join(" ")}`,
+            };
+          }
+          additionalFields = coerced.additionalFields;
         }
         const result = await client.createIssue({
           projectKey: config.projectKey,

--- a/plugins/integration-jira-backend/src/jira-client.test.ts
+++ b/plugins/integration-jira-backend/src/jira-client.test.ts
@@ -206,6 +206,48 @@ describe("createJiraClient", () => {
     });
   });
 
+  describe("searchIssues endpoint (Cloud removed legacy /search; CHANGE-2046)", () => {
+    it("uses /rest/api/3/search/jql for cloud mode", async () => {
+      fetchFixture = setupFetchMock({ issues: [{ key: "SCRUM-1", fields: {} }] });
+
+      const client = createJiraClient({
+        authMode: "cloud",
+        baseUrl: "https://mycompany.atlassian.net",
+        email: "user@example.com",
+        apiToken: "token",
+        logger: testLogger,
+      });
+
+      const result = await client.searchIssues({ jql: "project = SCRUM" });
+
+      expect(fetchFixture.calls[0].url).toBe(
+        "https://mycompany.atlassian.net/rest/api/3/search/jql",
+      );
+      // The new endpoint returns no `total`; existence is derived from issues.
+      expect(result.found).toBe(true);
+      expect(result.count).toBe(1);
+    });
+
+    it("keeps the legacy /rest/api/2/search for datacenter (on-prem) mode", async () => {
+      fetchFixture = setupFetchMock({ total: 2, issues: [{ key: "OPS-1", fields: {} }] });
+
+      const client = createJiraClient({
+        authMode: "datacenter",
+        baseUrl: "https://jira.mycompany.com",
+        apiToken: "pat-token",
+        logger: testLogger,
+      });
+
+      const result = await client.searchIssues({ jql: "project = OPS" });
+
+      expect(fetchFixture.calls[0].url).toBe(
+        "https://jira.mycompany.com/rest/api/2/search",
+      );
+      // Data Center still reports `total`.
+      expect(result.count).toBe(2);
+    });
+  });
+
   describe("createIssue description format", () => {
     it("uses Atlassian Document Format for cloud mode", async () => {
       fetchFixture = setupFetchMock({

--- a/plugins/integration-jira-backend/src/jira-client.ts
+++ b/plugins/integration-jira-backend/src/jira-client.ts
@@ -318,6 +318,7 @@ export function createJiraClient(options: JiraClientOptions) {
           required: boolean;
           schema?: {
             type: string;
+            items?: string;
             system?: string;
             custom?: string;
             customId?: number;

--- a/plugins/integration-jira-backend/src/jira-client.ts
+++ b/plugins/integration-jira-backend/src/jira-client.ts
@@ -470,7 +470,14 @@ export function createJiraClient(options: JiraClientOptions) {
         }>;
       }
 
-      const result = await request<SearchResponse>("/search", {
+      // Jira Cloud DEPRECATED the legacy `/search` endpoint on 2024-05-01 and
+      // REMOVED it on 2025-05-01 (Atlassian CHANGE-2046); it now returns HTTP 410
+      // and requires `/search/jql`. The new endpoint is paginated via
+      // `nextPageToken` and returns NO `total`. Jira Data Center / Server (on-prem,
+      // which can be older) still serves the legacy `/search` and has no
+      // `/search/jql`, so choose the endpoint by auth mode.
+      const searchPath = authMode === "datacenter" ? "/search" : "/search/jql";
+      const result = await request<SearchResponse>(searchPath, {
         method: "POST",
         body: JSON.stringify({
           jql,
@@ -486,6 +493,8 @@ export function createJiraClient(options: JiraClientOptions) {
         status: issue.fields?.status?.name,
         summary: issue.fields?.summary,
       }));
+      // `/search/jql` (Cloud) returns no `total`, so existence is derived from the
+      // returned issues; Data Center's `/search` still provides `total`.
       const count = result.total ?? issues.length;
       return {
         found: count > 0,

--- a/plugins/integration-jira-backend/src/provider.ts
+++ b/plugins/integration-jira-backend/src/provider.ts
@@ -11,7 +11,34 @@ import type {
   GetConnectionOptionsParams,
 } from "@checkstack/integration-backend";
 import { pluginMetadata } from "@checkstack/integration-jira-common";
+import type { JiraField } from "@checkstack/integration-jira-common";
 import { createJiraClientFromConfig } from "./jira-client";
+
+/**
+ * Human-readable value TYPE for a Jira field, surfaced as the option's
+ * `description` so the model (and the editor) know how to format the value:
+ * e.g. `array of string (required)`, `number`, or `option; one of: High, Low`.
+ * Without this the model knows the field key but guesses the value shape (e.g.
+ * sends a bare string for `labels`, which Jira expects as an array).
+ */
+function describeFieldType(field: JiraField): string {
+  const parts: string[] = [];
+  const type = field.schema?.type;
+  if (type === "array") {
+    parts.push(field.schema?.items ? `array of ${field.schema.items}` : "array");
+  } else if (type) {
+    parts.push(type);
+  }
+  const allowed = (field.allowedValues ?? [])
+    .map((v) => v.name ?? v.value ?? v.id)
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
+  if (allowed.length > 0) {
+    const shown = allowed.slice(0, 8).join(", ");
+    parts.push(`one of: ${shown}${allowed.length > 8 ? ", ..." : ""}`);
+  }
+  if (field.required) parts.push("required");
+  return parts.join("; ") || "unknown type";
+}
 
 /**
  * Supported Jira authentication modes.
@@ -271,6 +298,9 @@ If a property is missing, the placeholder will be preserved in the output for de
               .map((f) => ({
                 value: f.key,
                 label: `${f.name}${f.required ? " *" : ""}`,
+                // Surface the field's value TYPE so the model formats the value
+                // correctly (e.g. labels = "array of string", not a bare string).
+                description: describeFieldType(f),
               }));
           }
 

--- a/plugins/integration-jira-common/src/schemas.ts
+++ b/plugins/integration-jira-common/src/schemas.ts
@@ -39,6 +39,8 @@ export const JiraFieldSchema = z.object({
   schema: z
     .object({
       type: z.string(),
+      /** Element type for `type: "array"` fields (e.g. "string" for labels). */
+      items: z.string().optional(),
       system: z.string().optional(),
       custom: z.string().optional(),
       customId: z.number().optional(),


### PR DESCRIPTION
## Summary

A focused E2E pass on the automation **AI Analyze** action (`automation.ai_analyze`) — driving the chat assistant to generate real automations and running them against synthetic data — surfaced a chain of production bugs. This branch fixes all of them, each with a regression test and changeset.

## What's in here

| Commit | Fix |
|--------|-----|
| `22de4402` | **ai_analyze structured output** now works on OpenAI-compatible providers. The provider drops the `responseFormat` JSON schema (`supportsStructuredOutputs: false`), so the schema is now embedded in the prompt, and the repair loop feeds back field-level validation errors + the rejected output, escalating on retry. |
| `90a9ffc9` | **Stop double-prefixing produced artifact types.** The action registry qualifies `produces` as `${pluginId}.${produces}`; actions that already qualified it (e.g. `automation.analysis`) produced `automation.automation.analysis`, so downstream `choose`/artifact reads silently missed. Fixed across 7 actions. |
| `51f50870` | **Jira `search_issues` off the removed Cloud `/search` endpoint** (HTTP 410 since 2025-05-01). Cloud → `/search/jql`; Datacenter/on-prem (older) → `/search`, differentiated by auth mode. |
| `67d78a20` | **template-engine** accepts the `not` keyword as prefix negation (previously only `!`). |
| `bb6d06dc` | **resolveActionOptions** can discover nested (array-item) resolver fields via dotted paths (e.g. `fieldMappings.fieldKey`). |
| `2998bb53` | Surface each Jira field's **value type** in the `create_issue` field-options list (e.g. "array of string", "number"). |
| `617edefb` | **Coerce + validate** `create_issue` field mappings against the live Jira schema (string → array/number/option), rejecting unknown keys / bad option values before the API call. |
| `a683181b` | `dev:auth` script to run the backend headless with dev-auth (E2E harness). |

## Testing

- Unit/regression tests added for every fix (structured-output repair, produces qualification, Jira search endpoint, `not` keyword, nested resolver fields, field coercion).
- Verified end-to-end against a live dev backend: the assistant autonomously discovered the nested `fieldMappings.fieldKey` resolver, coerced a `labels` value to a real array, and filed a Jira issue that the array-typed field accepted (a bare string would have 400'd — proof the coercion path ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
