### PR TITLE
fix(security): remediate image-scan CVEs + fix CI Actions Cache + automate override/CVE maintenance

### DIFF
--- a/.changeset/smtp-nodemailer-9-security.md
+++ b/.changeset/smtp-nodemailer-9-security.md
@@ -1,0 +1,7 @@
+---
+"@checkstack/notification-smtp-backend": patch
+---
+
+Bump `nodemailer` from 8.x to 9.0.0 to remediate a vulnerability flagged in the
+production image scan. The API surface used by this plugin (`createTransport`,
+`Transporter`, `sendMail`) is unchanged, so there is no behavioral difference.

--- a/.github/actions/bun-install/action.yml
+++ b/.github/actions/bun-install/action.yml
@@ -1,0 +1,30 @@
+name: Setup Bun and install
+description: >-
+  Set up Bun and run a frozen-lockfile install with Bun's global package store
+  (~/.bun/install/cache) cached across runs. Replaces the repeated
+  "Setup Bun" + "Install Dependencies" step pair in every job.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+
+    # Cache Bun's GLOBAL package store, not node_modules. bun install still
+    # links the workspace, but the slow part — downloading + extracting every
+    # dependency tarball — is skipped on a hit. The key is pinned to bun.lock so
+    # an unchanged lockfile is an exact hit; restore-keys lets a changed lockfile
+    # warm-start from the previous store and only fetch the delta.
+    - name: Restore bun install cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.bun/install/cache
+        key: bun-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          bun-store-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Install Dependencies
+      shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,11 +37,6 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
       # Astro 6 hard-requires Node ≥ 22.12 at runtime. `bun run` defers to
       # the system `node` binary for shebang-based CLIs like astro, so the
       # runner's default (Node 20) makes the build fail with
@@ -52,8 +47,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/bun-install
 
       - name: Build Astro Starlight site
         run: bun run --filter '@checkstack/docs' build

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -374,27 +374,11 @@ jobs:
 
       # The external-plugin-lifecycle integration test drives a real browser to
       # assert @checkstack/ui's Monaco CodeEditor renders in the standalone dev
-      # server, so Chromium must be available.
-      #
-      # Pin to the EXACT playwright version resolved in bun.lock, and install
-      # the headless shell explicitly. Why both:
-      #  - @playwright/test / playwright are nested under the workspace packages
-      #    (core/create-checkstack-plugin, ...), NOT the repo-root node_modules.
-      #    A bare `bunx playwright` at the root therefore finds no local binary
-      #    and downloads playwright@latest; once npm's latest drifts past the
-      #    locked version it installs a DIFFERENT browser build, and the test's
-      #    locked @playwright/test can't find its expected binary
-      #    (chromium_headless_shell-<n>). Pinning to the lockfile version makes
-      #    the install deterministic and immune to new Playwright releases.
-      #  - Recent Playwright ships the headless binary that chromium.launch()
-      #    uses (chrome-headless-shell) as a SEPARATE component from `chromium`,
-      #    so it must be requested explicitly.
+      # server, so Chromium must be available. `playwright:install` pins the
+      # browser download to the bun.lock-resolved Playwright version and includes
+      # the headless shell — see scripts/install-playwright.ts for the why.
       - name: Install Playwright Chromium
-        run: |
-          set -euo pipefail
-          PW_VERSION="$(grep -oE '"playwright@[0-9][^"]*"' bun.lock | head -1 | sed -E 's/^"playwright@([^"]+)"$/\1/')"
-          echo "Installing Playwright browsers for pinned version: ${PW_VERSION:?could not resolve playwright version from bun.lock}"
-          bunx "playwright@${PW_VERSION}" install --with-deps chromium chromium-headless-shell
+        run: bun run playwright:install --with-deps
 
       - name: Run Integration Tests
         id: integration

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,13 +28,8 @@ jobs:
           # and the guard would degrade to a warn-and-skip.
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install Dependencies
-        run: bun install --frozen-lockfile
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/bun-install
 
       # The committed `@checkstack/sdk` package is generated from the per-plugin
       # contracts + the script-context helper builders. This guard fails when:
@@ -111,13 +106,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install Dependencies
-        run: bun install --frozen-lockfile
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/bun-install
 
       - name: Lint
         id: lint
@@ -148,13 +138,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install Dependencies
-        run: bun install --frozen-lockfile
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/bun-install
 
       # Guards against the dependency drift cleaned up in issue #245: the same
       # external dependency declared at divergent ranges across workspace
@@ -162,12 +147,27 @@ jobs:
       # into one lockfile). syncpack enforces a single shared range for the
       # unified set declared in `.syncpackrc.json`. Run `bun run deps:fix`
       # locally to auto-align, then `bun install`.
+      # Two gates share this job:
+      #  1. syncpack alignment (issue #245) — one shared range per external dep.
+      #  2. managed-override drift — every SECURITY override in package.json
+      #     `overrides`/`resolutions` is documented in
+      #     security/managed-overrides.json and still sits at/above its
+      #     safeFloor. Stops undocumented security pins (which rot silently)
+      #     from sneaking in. See scripts/audit-overrides.ts.
       - name: Check Dependency Alignment
         id: deps
         run: |
           set +e
-          bun run deps:check 2>&1 | tee /tmp/deps-output.txt
-          echo "exit_code=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
+          : > /tmp/deps-output.txt
+          rc=0
+          echo "── syncpack alignment ──" | tee -a /tmp/deps-output.txt
+          bun run deps:check 2>&1 | tee -a /tmp/deps-output.txt
+          [ "${PIPESTATUS[0]}" != "0" ] && rc=1
+          echo "" | tee -a /tmp/deps-output.txt
+          echo "── managed-override drift ──" | tee -a /tmp/deps-output.txt
+          bun run audit:overrides:check 2>&1 | tee -a /tmp/deps-output.txt
+          [ "${PIPESTATUS[0]}" != "0" ] && rc=1
+          echo "exit_code=$rc" >> $GITHUB_OUTPUT
 
       - name: Upload Output
         if: always()
@@ -197,13 +197,8 @@ jobs:
           # test ("resolves a real ref in this repo") fails.
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install Dependencies
-        run: bun install --frozen-lockfile
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/bun-install
 
       - name: Run Tests
         id: test
@@ -293,18 +288,13 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
           node-version: 22
 
-      - name: Install Dependencies
-        run: bun install --frozen-lockfile
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/bun-install
 
       # The external-plugin lifecycle test (#251 Phase 3) needs the CURRENT
       # tree's @checkstack/* packages served as PUBLISHED tarballs from a
@@ -419,6 +409,12 @@ jobs:
     name: Security
     if: github.head_ref != 'changeset-release/main' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    # `packages: read` lets the build pull the release-produced registry
+    # buildcache below. `contents: read` is the workflow default, restated
+    # because naming a job-level permissions block drops anything not listed.
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -430,36 +426,117 @@ jobs:
           # already check out with lfs: true for the same reason.)
           lfs: true
 
-      - name: Build Production Image
-        run: docker build -t checkstack-prod:latest .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-      - name: Trivy Image Scan
-        id: trivy-image
-        uses: aquasecurity/trivy-action@v0.36.0
+      # Best-effort login so the registry cache below is readable. Marked
+      # continue-on-error so a fork PR (whose GITHUB_TOKEN can't read packages)
+      # still builds — it just misses the cache and builds cold.
+      - name: Login to GitHub Container Registry
         continue-on-error: true
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Reuse the amd64 buildcache that release.yml publishes for the same
+      # Dockerfile — READ-ONLY (no cache-to), so PRs never write cache and the
+      # 10 GB Actions Cache budget is untouched. `load: true` puts the image in
+      # the local docker daemon so Trivy can scan it by tag. A cache miss (e.g.
+      # before the first release writes the tag) just builds cold; it never fails.
+      - name: Build Production Image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          tags: checkstack-prod:latest
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/checkstack:buildcache-linux-amd64
+
+      # TWO scans, both emitting JSON and NEVER failing on their own
+      # (exit-code 0): the gating decision is made in the evaluate step below.
+      #  - image: the runtime attack surface (OS packages + production deps).
+      #  - fs: the WHOLE dependency graph from bun.lock, INCLUDING
+      #    devDependencies that `bun install --production` strips from the
+      #    image. This fs scan is what closes the gap that let dev-only CVEs
+      #    (e.g. vite, postcss-selector-parser) stay invisible to the image
+      #    scan. We deliberately do NOT pass ignore-unfixed here so unfixed
+      #    findings are captured too, then surfaced as warnings (not failures).
+      - name: Trivy image scan (JSON)
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
           image-ref: checkstack-prod:latest
-          format: table
-          exit-code: "1"
-          ignore-unfixed: true
+          format: json
+          exit-code: "0"
           severity: CRITICAL,HIGH,MEDIUM
-          output: /tmp/trivy-image.txt
+          output: /tmp/trivy-image.json
 
-      - name: Aggregate Security Output
+      - name: Trivy filesystem scan (JSON)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: json
+          exit-code: "0"
+          severity: CRITICAL,HIGH,MEDIUM
+          output: /tmp/trivy-fs.json
+
+      # Gate policy:
+      #  - FIXABLE findings (a fixed version exists) FAIL the job — they are
+      #    actionable, so they must be remediated.
+      #  - UNFIXED findings (no upstream fix yet, e.g. the alpine openssl
+      #    CRITICAL or vite) are surfaced as ::warning:: annotations but DO
+      #    NOT fail. The daily security-maintenance workflow re-checks these
+      #    and auto-opens a remediation PR the moment a fix ships.
+      - name: Evaluate findings (fail on fixable, warn on unfixed)
         id: security
         run: |
+          set -euo pipefail
+          for f in /tmp/trivy-image.json /tmp/trivy-fs.json; do
+            [ -s "$f" ] || echo '{"Results":[]}' > "$f"
+          done
+
+          jq -s '
+            [ .[].Results[]?.Vulnerabilities[]?
+              | { id:.VulnerabilityID, pkg:.PkgName, installed:.InstalledVersion,
+                  fixed:(.FixedVersion // ""), sev:.Severity } ]
+            | unique_by(.id + "|" + .pkg + "|" + .installed)
+          ' /tmp/trivy-image.json /tmp/trivy-fs.json > /tmp/vulns.json
+
+          jq -r '[.[] | select(.fixed != "")]
+            | sort_by(.sev) | reverse[]
+            | "  [\(.sev)] \(.pkg) \(.installed) -> fixed in \(.fixed)  (\(.id))"' \
+            /tmp/vulns.json > /tmp/fixable.txt || true
+          jq -r '[.[] | select(.fixed == "")]
+            | sort_by(.sev) | reverse[]
+            | "  [\(.sev)] \(.pkg) \(.installed)  (\(.id)) — no upstream fix yet"' \
+            /tmp/vulns.json > /tmp/unfixed.txt || true
+
+          fixable_count=$(jq '[.[] | select(.fixed != "")] | length' /tmp/vulns.json)
+          unfixed_count=$(jq '[.[] | select(.fixed == "")] | length' /tmp/vulns.json)
+
           {
-            echo "🔎 Running Security Audit..."
+            echo "🔎 Security Audit (image + filesystem)"
             echo ""
-            echo "🐳 --- Image Scan ---"
-            cat /tmp/trivy-image.txt 2>/dev/null || echo "(no output produced)"
+            echo "❌ Fixable vulnerabilities ($fixable_count) — these fail the build:"
+            [ "$fixable_count" -gt 0 ] && cat /tmp/fixable.txt || echo "  (none)"
+            echo ""
+            echo "⚠️  Known unfixed vulnerabilities ($unfixed_count) — surfaced, not gated:"
+            [ "$unfixed_count" -gt 0 ] && cat /tmp/unfixed.txt || echo "  (none)"
           } > /tmp/security-output.txt
 
-          if [ "${{ steps.trivy-image.outcome }}" != "success" ]; then
-            echo "exit_code=1" >> $GITHUB_OUTPUT
+          # Surface each unfixed finding as a GitHub warning annotation.
+          while IFS= read -r line; do
+            [ -n "$line" ] && echo "::warning title=Unfixed vulnerability::${line# }"
+          done < /tmp/unfixed.txt
+
+          cat /tmp/security-output.txt
+          if [ "$fixable_count" -gt 0 ]; then
+            echo "exit_code=1" >> "$GITHUB_OUTPUT"
           else
-            echo "exit_code=0" >> $GITHUB_OUTPUT
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload Output
@@ -715,7 +792,7 @@ jobs:
                   output,
                   '```',
                   '',
-                  '**How to fix:** CI only enforces the image scan — run `bun run audit:image` locally to reproduce these vulnerabilities (requires building the production image). For a faster check without a Docker build, `bun run audit:security` runs a filesystem scan against your dependencies. Update the base image, runtime dependencies, or affected packages in `bun.lock` accordingly. All **CRITICAL** vulnerabilities must be resolved or ignored if they are confirmed false positives.',
+                  '**How to fix:** Only **fixable** findings (a patched version exists) fail the build; unfixed findings are surfaced as warnings, not gated. Run `bun run audit:image` (production image) and `bun run audit:security` (filesystem / full dependency graph incl. devDependencies) locally to reproduce. Bump the affected direct dependency, or for a transitive package add a documented entry to `security/managed-overrides.json` plus matching `overrides`/`resolutions` in `package.json` (then `bun install`). Re-run `bun run audit:overrides:check` to confirm the override is consistent.',
                   '',
                   '</details>',
                 ].join('\n'));

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -375,8 +375,26 @@ jobs:
       # The external-plugin-lifecycle integration test drives a real browser to
       # assert @checkstack/ui's Monaco CodeEditor renders in the standalone dev
       # server, so Chromium must be available.
+      #
+      # Pin to the EXACT playwright version resolved in bun.lock, and install
+      # the headless shell explicitly. Why both:
+      #  - @playwright/test / playwright are nested under the workspace packages
+      #    (core/create-checkstack-plugin, ...), NOT the repo-root node_modules.
+      #    A bare `bunx playwright` at the root therefore finds no local binary
+      #    and downloads playwright@latest; once npm's latest drifts past the
+      #    locked version it installs a DIFFERENT browser build, and the test's
+      #    locked @playwright/test can't find its expected binary
+      #    (chromium_headless_shell-<n>). Pinning to the lockfile version makes
+      #    the install deterministic and immune to new Playwright releases.
+      #  - Recent Playwright ships the headless binary that chromium.launch()
+      #    uses (chrome-headless-shell) as a SEPARATE component from `chromium`,
+      #    so it must be requested explicitly.
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: |
+          set -euo pipefail
+          PW_VERSION="$(grep -oE '"playwright@[0-9][^"]*"' bun.lock | head -1 | sed -E 's/^"playwright@([^"]+)"$/\1/')"
+          echo "Installing Playwright browsers for pinned version: ${PW_VERSION:?could not resolve playwright version from bun.lock}"
+          bunx "playwright@${PW_VERSION}" install --with-deps chromium chromium-headless-shell
 
       - name: Run Integration Tests
         id: integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install Dependencies
-        run: bun install --frozen-lockfile
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/bun-install
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
@@ -153,8 +148,16 @@ jobs:
           # to the assembled manifest. Cache is scoped per image AND platform so
           # the two native builds never clobber each other's cache.
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.pair }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.pair }}
+          # Cache lives in the GHCR registry (a dedicated `buildcache-<platform>`
+          # tag per image+platform), NOT the GitHub Actions Cache. Rationale:
+          # `type=gha,mode=max` exported every intermediate layer of this
+          # multi-stage build for all 4 build variants on every release, churning
+          # ~5.6 GB of blobs. The Actions Cache has a hard 10 GB/repo cap, so those
+          # blobs evicted each other (and the useful tsgo cache) by LRU before they
+          # could ever be reused — paying the full export cost every run for a low
+          # hit rate. The registry cache has no such cap and survives between runs.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache-${{ matrix.pair }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache-${{ matrix.pair }},mode=max
 
       - name: Export digest
         run: |

--- a/.github/workflows/security-maintenance.yml
+++ b/.github/workflows/security-maintenance.yml
@@ -1,0 +1,209 @@
+name: Security Maintenance
+
+# Daily security hygiene that runs against the CURRENT main + the PUBLISHED
+# image, decoupled from PRs so newly-disclosed CVEs and newly-available fixes
+# surface even when nobody opens a PR. It does two things:
+#
+#   1. Override lifecycle — re-resolves every entry in
+#      security/managed-overrides.json with the override removed. Any override
+#      the graph no longer needs is auto-pruned and proposed as a PR.
+#
+#   2. Fix-available watch — scans the published image (OS + runtime) and the
+#      filesystem (full dependency graph, incl. devDependencies) and reports
+#      every FIXABLE finding. Unfixed findings (e.g. the alpine openssl
+#      CRITICAL, vite) flip into this list the moment upstream ships a fix, so
+#      a tracking issue is upserted to notify the maintainer. This is the
+#      "tell me when there's a fix" mechanism.
+
+on:
+  schedule:
+    # Daily at 06:00 UTC.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: security-maintenance
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  packages: read
+
+jobs:
+  maintain:
+    name: Audit overrides & watch for fixes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/bun-install
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Scan the PUBLISHED image (what is actually deployed / what the company
+      # scans) + the filesystem. exit-code 0: this job never fails on findings;
+      # it reports and opens PRs/issues instead.
+      - name: Trivy image scan (published)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: ghcr.io/${{ github.repository_owner }}/checkstack:latest
+          format: json
+          exit-code: "0"
+          severity: CRITICAL,HIGH,MEDIUM
+          output: /tmp/img.json
+
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: json
+          exit-code: "0"
+          severity: CRITICAL,HIGH,MEDIUM
+          output: /tmp/fs.json
+
+      - name: Build CVE report
+        id: cve
+        run: |
+          set -euo pipefail
+          for f in /tmp/img.json /tmp/fs.json; do
+            [ -s "$f" ] || echo '{"Results":[]}' > "$f"
+          done
+
+          jq -s '
+            [ .[].Results[]?.Vulnerabilities[]?
+              | { id:.VulnerabilityID, pkg:.PkgName, installed:.InstalledVersion,
+                  fixed:(.FixedVersion // ""), sev:.Severity } ]
+            | unique_by(.id + "|" + .pkg + "|" + .installed)
+          ' /tmp/img.json /tmp/fs.json > /tmp/vulns.json
+
+          fixable=$(jq '[.[] | select(.fixed != "")] | length' /tmp/vulns.json)
+          {
+            echo "### Fixable vulnerabilities (a patched version exists): ${fixable}"
+            echo ""
+            if [ "$fixable" -gt 0 ]; then
+              jq -r '[.[] | select(.fixed != "")] | sort_by(.sev) | reverse[]
+                | "- **\(.sev)** \`\(.pkg)\` \(.installed) → fixed in **\(.fixed)** (\(.id))"' /tmp/vulns.json
+            else
+              echo "_None._"
+            fi
+            echo ""
+            echo "<details><summary>Known unfixed (monitoring only)</summary>"
+            echo ""
+            jq -r '[.[] | select(.fixed == "")] | sort_by(.sev) | reverse[]
+              | "- \(.sev) \`\(.pkg)\` \(.installed) (\(.id))"' /tmp/vulns.json
+            echo ""
+            echo "</details>"
+          } > /tmp/cve-report.md
+          echo "fixable_count=$fixable" >> "$GITHUB_OUTPUT"
+
+      # Re-resolve each managed override with it removed; prune any that the
+      # graph no longer needs, then refresh the lockfile. Produces a working-
+      # tree diff (package.json + manifest + bun.lock) only when something was
+      # pruned — create-pull-request no-ops without a diff.
+      - name: Prune redundant overrides
+        id: prune
+        run: |
+          set -euo pipefail
+          bun run audit:overrides:redundant --json > /tmp/redundant.json || true
+          bun run audit:overrides:prune | tee /tmp/prune.txt
+          bun install
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compose PR body
+        if: steps.prune.outputs.changed == 'true'
+        run: |
+          {
+            echo "Automated by the daily **Security Maintenance** workflow."
+            echo ""
+            echo "## Redundant overrides removed"
+            echo ""
+            echo "These security overrides are no longer needed — the dependency graph"
+            echo "now resolves at/above their \`safeFloor\` without the pin:"
+            echo ""
+            sed 's/^/- /' /tmp/prune.txt | grep -i pruned || cat /tmp/prune.txt
+            echo ""
+            echo "## Current CVE state"
+            echo ""
+            cat /tmp/cve-report.md
+          } > /tmp/pr-body.md
+
+      - name: Open / update override-removal PR
+        if: steps.prune.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/security-maintenance
+          base: main
+          commit-message: "chore(security): prune redundant managed overrides"
+          title: "chore(security): prune redundant managed overrides"
+          body-path: /tmp/pr-body.md
+          labels: security-maintenance
+          delete-branch: true
+
+      # Surface fixable CVEs that need a human decision (version bumps can be
+      # breaking, so they are NOT auto-applied) via a single upserted issue.
+      - name: Upsert CVE tracking issue
+        if: steps.cve.outputs.fixable_count != '0'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('/tmp/cve-report.md', 'utf8');
+            const marker = '<!-- security-maintenance-cve -->';
+            const title = '🔒 Security: fixable vulnerabilities available';
+            const body = [
+              marker,
+              '',
+              'The daily Security Maintenance scan found vulnerabilities with an **available fix**.',
+              'Version bumps can be breaking, so they are not auto-applied — review and bump the',
+              'affected direct dependency, or add a documented entry to `security/managed-overrides.json`.',
+              '',
+              report,
+              '',
+              `_Last updated: run [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})._`,
+            ].join('\n');
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security-maintenance',
+              per_page: 100,
+            });
+            const hit = existing.find((i) => i.body && i.body.includes(marker));
+
+            if (hit) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: hit.number,
+                body,
+              });
+              core.info(`Updated issue #${hit.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['security-maintenance'],
+              });
+              core.info('Created new CVE tracking issue');
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ docs/.astro/
 
 # Local DB backups (pg_dump) — never commit
 backups/
+
+# Throwaway git worktrees created by scripts/audit-overrides.ts --redundant/--prune
+.audit-overrides-wt/

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "syncpack": "^15.3.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.59.3",
+        "zod": "^4.2.1",
       },
     },
     "core/about-common": {

--- a/bun.lock
+++ b/bun.lock
@@ -1797,7 +1797,7 @@
     },
     "core/sdk": {
       "name": "@checkstack/sdk",
-      "version": "0.109.1",
+      "version": "0.110.0",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/anomaly-common": "workspace:*",
@@ -2897,7 +2897,7 @@
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/notification-backend": "workspace:*",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "^9.0.0",
         "zod": "^4.2.1",
       },
       "devDependencies": {
@@ -3014,9 +3014,12 @@
     "drizzle-kit": ">=0.31.0 <1.0.0",
     "drizzle-orm": "^0.45.0",
     "esbuild": "^0.28.1",
+    "minimatch": "^10.2.5",
+    "postcss-selector-parser": "^7.1.4",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "uuid": "^14.0.0",
+    "ws": "^8.21.0",
     "yaml": "^2.9.0",
   },
   "packages": {
@@ -4564,8 +4567,6 @@
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
 
-    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
-
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
@@ -5328,7 +5329,7 @@
 
     "node-schedule": ["node-schedule@2.1.1", "", { "dependencies": { "cron-parser": "^4.2.0", "long-timeout": "0.1.1", "sorted-array-functions": "^1.3.0" } }, "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ=="],
 
-    "nodemailer": ["nodemailer@8.0.5", "", {}, "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="],
+    "nodemailer": ["nodemailer@9.0.0", "", {}, "sha512-tbPTid7d/p9jAA8CRZ3iomvrMaST0o6NYuY7v6JQZHpPRZ61mLFSPKYd7342NtOFuej9/+L48SOIxwfu2uDvtw=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
@@ -5454,7 +5455,7 @@
 
     "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
 
-    "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
+    "postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
@@ -6048,15 +6049,11 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@eslint/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
     "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@expressive-code/core/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
@@ -6174,8 +6171,6 @@
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
     "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "eslint-plugin-unicorn/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -6187,8 +6182,6 @@
     "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "happy-dom/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -6302,8 +6295,6 @@
 
     "vscode-json-languageservice/vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
-    "vscode-languageclient/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
-
     "vscode-languageclient/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "vscode-ws-jsonrpc/vscode-jsonrpc": ["vscode-jsonrpc@8.2.1", "", {}, "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ=="],
@@ -6326,11 +6317,7 @@
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
-
     "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "@expressive-code/core/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -6411,8 +6398,6 @@
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "eslint/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "mdast-util-gfm-table/mdast-util-to-markdown/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -6498,15 +6483,9 @@
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
-    "vscode-languageclient/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
-
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
@@ -6515,8 +6494,6 @@
     "@so-ric/colorspace/color/color-string/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
     "astro/vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "mdast-util-gfm-table/mdast-util-to-markdown/parse-entities/character-entities-legacy": ["character-entities-legacy@1.1.4", "", {}, "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="],
 
@@ -6589,8 +6566,6 @@
     "telegramify-markdown/unified/vfile/unist-util-stringify-position": ["unist-util-stringify-position@2.0.3", "", { "dependencies": { "@types/unist": "^2.0.2" } }, "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g=="],
 
     "telegramify-markdown/unified/vfile/vfile-message": ["vfile-message@2.0.4", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-stringify-position": "^2.0.0" } }, "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ=="],
-
-    "vscode-languageclient/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 

--- a/core/e2e/package.json
+++ b/core/e2e/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "scripts": {
-    "pretest:e2e": "bun run --filter @checkstack/frontend build && bun run --filter @checkstack/docs build",
+    "pretest:e2e": "bun run ../../scripts/install-playwright.ts && bun run --filter @checkstack/frontend build && bun run --filter @checkstack/docs build",
     "test:e2e": "bun --env-file=../../.env scripts/run-all.ts",
     "test:e2e:file": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "docker:build": "docker build -t checkstack-prod:latest .",
     "audit:security": "bun run scripts/audit-trivy.ts fs",
     "audit:image": "bun run scripts/audit-trivy.ts image",
+    "audit:overrides:check": "bun run scripts/audit-overrides.ts --check",
+    "audit:overrides:redundant": "bun run scripts/audit-overrides.ts --redundant",
     "changeset": "changeset",
     "version-packages": "bun run scripts/inject-release.ts && changeset version && bun install --lockfile-only && bun run scripts/generate-sdk.ts && bun run scripts/generate-docs-index.ts",
     "publish-packages": "bun run scripts/publish-packages.ts",
@@ -61,7 +63,10 @@
     "uuid": "^14.0.0",
     "yaml": "^2.9.0",
     "react": "19.2.7",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.7",
+    "ws": "^8.21.0",
+    "minimatch": "^10.2.5",
+    "postcss-selector-parser": "^7.1.4"
   },
   "resolutions": {
     "drizzle-orm": "^0.45.0",
@@ -71,6 +76,9 @@
     "uuid": "^14.0.0",
     "yaml": "^2.9.0",
     "react": "19.2.7",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.7",
+    "ws": "^8.21.0",
+    "minimatch": "^10.2.5",
+    "postcss-selector-parser": "^7.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "semver": "^7.8.1",
     "syncpack": "^15.3.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.59.3"
+    "typescript-eslint": "^8.59.3",
+    "zod": "^4.2.1"
   },
   "dependencies": {
     "@orpc/contract": "^1.14.4"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "audit:image": "bun run scripts/audit-trivy.ts image",
     "audit:overrides:check": "bun run scripts/audit-overrides.ts --check",
     "audit:overrides:redundant": "bun run scripts/audit-overrides.ts --redundant",
+    "playwright:install": "bun run scripts/install-playwright.ts",
     "changeset": "changeset",
     "version-packages": "bun run scripts/inject-release.ts && changeset version && bun install --lockfile-only && bun run scripts/generate-sdk.ts && bun run scripts/generate-docs-index.ts",
     "publish-packages": "bun run scripts/publish-packages.ts",

--- a/plugins/notification-smtp-backend/package.json
+++ b/plugins/notification-smtp-backend/package.json
@@ -18,7 +18,7 @@
     "@checkstack/backend-api": "workspace:*",
     "@checkstack/notification-backend": "workspace:*",
     "@checkstack/common": "workspace:*",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^9.0.0",
     "zod": "^4.2.1"
   },
   "devDependencies": {

--- a/scripts/audit-overrides.test.ts
+++ b/scripts/audit-overrides.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyPrune,
+  extractInstalledVersions,
+  findDrift,
+  isRedundant,
+  parseManifest,
+  type ManagedOverride,
+} from "./audit-overrides";
+
+const baseEntry: ManagedOverride = {
+  name: "ws",
+  pinned: "^8.21.0",
+  safeFloor: "8.21.0",
+  severity: "HIGH",
+  advisory: "Trivy 2026-06: ws < 8.21.0 (HIGH)",
+  reason: "transitive pull of 8.20.1",
+  addedAt: "2026-06-15",
+  removeWhen: "no consumer resolves below 8.21.0",
+};
+
+describe("parseManifest", () => {
+  test("parses a valid manifest and ignores meta keys", () => {
+    const raw = JSON.stringify({
+      $comment: "docs",
+      $schema: "./x.json",
+      overrides: [baseEntry],
+    });
+    const result = parseManifest({ raw });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("ws");
+  });
+
+  test("throws on a missing required field", () => {
+    const raw = JSON.stringify({ overrides: [{ name: "ws", pinned: "^8.21.0" }] });
+    expect(() => parseManifest({ raw })).toThrow();
+  });
+
+  test("throws on an invalid severity", () => {
+    const raw = JSON.stringify({
+      overrides: [{ ...baseEntry, severity: "SPICY" }],
+    });
+    expect(() => parseManifest({ raw })).toThrow();
+  });
+});
+
+describe("findDrift", () => {
+  test("no issues when manifest matches overrides and resolutions", () => {
+    const issues = findDrift({
+      manifest: [baseEntry],
+      overrides: { ws: "^8.21.0" },
+      resolutions: { ws: "^8.21.0" },
+    });
+    expect(issues).toEqual([]);
+  });
+
+  test("flags an override missing from package.json overrides", () => {
+    const issues = findDrift({
+      manifest: [baseEntry],
+      overrides: {},
+      resolutions: { ws: "^8.21.0" },
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.problem).toContain('missing from package.json "overrides"');
+  });
+
+  test("flags a mismatched pin between manifest and resolutions", () => {
+    const issues = findDrift({
+      manifest: [baseEntry],
+      overrides: { ws: "^8.21.0" },
+      resolutions: { ws: "^8.20.0" },
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.problem).toContain("resolutions");
+  });
+
+  test("flags a pinned range whose floor is below safeFloor", () => {
+    const issues = findDrift({
+      manifest: [{ ...baseEntry, pinned: ">=8.0.0" }],
+      overrides: { ws: ">=8.0.0" },
+      resolutions: { ws: ">=8.0.0" },
+    });
+    expect(issues.some((i) => i.problem.includes("below safeFloor"))).toBe(true);
+  });
+
+  test("ignores extra non-manifest overrides (intentional pins)", () => {
+    const issues = findDrift({
+      manifest: [baseEntry],
+      overrides: { ws: "^8.21.0", react: "19.2.7" },
+      resolutions: { ws: "^8.21.0", react: "19.2.7" },
+    });
+    expect(issues).toEqual([]);
+  });
+});
+
+describe("extractInstalledVersions", () => {
+  test("extracts direct and nested resolved versions, deduped", () => {
+    const lock = `
+      "ws": ["ws@8.21.0", "", {}, "sha512-aaa"],
+      "foo/ws": ["ws@8.21.0", "", {}, "sha512-bbb"],
+      "bar/ws": ["ws@8.20.1", "", {}, "sha512-ccc"],
+    `;
+    const versions = extractInstalledVersions({ lockfileText: lock, name: "ws" }).sort();
+    expect(versions).toEqual(["8.20.1", "8.21.0"]);
+  });
+
+  test("does not match a different package with the name as a suffix", () => {
+    const lock = `"y-ws": ["y-ws@1.0.0", "", {}, "sha512-zzz"],`;
+    expect(extractInstalledVersions({ lockfileText: lock, name: "ws" })).toEqual([]);
+  });
+
+  test("returns empty when the package is absent", () => {
+    expect(
+      extractInstalledVersions({ lockfileText: `"left-pad": ["left-pad@1.3.0"]`, name: "ws" }),
+    ).toEqual([]);
+  });
+
+  test("handles scoped package names", () => {
+    const lock = `"@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", {}, "sha512-q"],`;
+    expect(
+      extractInstalledVersions({ lockfileText: lock, name: "@grpc/proto-loader" }),
+    ).toEqual(["0.8.1"]);
+  });
+});
+
+describe("applyPrune", () => {
+  test("removes named entries from overrides, resolutions, and manifest only", () => {
+    const pkg = {
+      overrides: { ws: "^8.21.0", react: "19.2.7" },
+      resolutions: { ws: "^8.21.0", react: "19.2.7" },
+    };
+    const manifest = { overrides: [baseEntry, { ...baseEntry, name: "minimatch" }] };
+
+    const result = applyPrune({ names: ["ws"], pkg, manifest });
+
+    expect(result.pkg.overrides).toEqual({ react: "19.2.7" });
+    expect(result.pkg.resolutions).toEqual({ react: "19.2.7" });
+    expect(result.manifest.overrides.map((o) => o.name)).toEqual(["minimatch"]);
+  });
+
+  test("does not mutate the input objects", () => {
+    const pkg = { overrides: { ws: "^8.21.0" }, resolutions: { ws: "^8.21.0" } };
+    const manifest = { overrides: [baseEntry] };
+
+    applyPrune({ names: ["ws"], pkg, manifest });
+
+    expect(pkg.overrides.ws).toBe("^8.21.0");
+    expect(manifest.overrides).toHaveLength(1);
+  });
+
+  test("is a no-op for names that are not present", () => {
+    const pkg = { overrides: { ws: "^8.21.0" }, resolutions: { ws: "^8.21.0" } };
+    const manifest = { overrides: [baseEntry] };
+
+    const result = applyPrune({ names: ["nonexistent"], pkg, manifest });
+
+    expect(result.pkg.overrides).toEqual({ ws: "^8.21.0" });
+    expect(result.manifest.overrides).toHaveLength(1);
+  });
+});
+
+describe("isRedundant", () => {
+  test("redundant when every resolved copy is at/above the floor", () => {
+    expect(
+      isRedundant({ resolvedVersions: ["8.21.0", "8.22.0"], safeFloor: "8.21.0" }),
+    ).toBe(true);
+  });
+
+  test("not redundant when any resolved copy is below the floor", () => {
+    expect(
+      isRedundant({ resolvedVersions: ["8.21.0", "8.20.1"], safeFloor: "8.21.0" }),
+    ).toBe(false);
+  });
+
+  test("redundant when the package left the graph entirely", () => {
+    expect(isRedundant({ resolvedVersions: [], safeFloor: "8.21.0" })).toBe(true);
+  });
+});

--- a/scripts/audit-overrides.test.ts
+++ b/scripts/audit-overrides.test.ts
@@ -6,11 +6,12 @@ import {
   isRedundant,
   parseManifest,
   type ManagedOverride,
+  type ManagedOverrideMeta,
 } from "./audit-overrides";
 
-const baseEntry: ManagedOverride = {
-  name: "ws",
-  pinned: "^8.21.0",
+// Human-only metadata as it appears under a name key in the manifest (no
+// version - that lives in package.json).
+const baseMeta: ManagedOverrideMeta = {
   safeFloor: "8.21.0",
   severity: "HIGH",
   advisory: "Trivy 2026-06: ws < 8.21.0 (HIGH)",
@@ -19,33 +20,37 @@ const baseEntry: ManagedOverride = {
   removeWhen: "no consumer resolves below 8.21.0",
 };
 
+// The flat `{ name, ...meta }` shape parseManifest returns.
+const baseEntry: ManagedOverride = { name: "ws", ...baseMeta };
+
 describe("parseManifest", () => {
-  test("parses a valid manifest and ignores meta keys", () => {
+  test("parses a valid manifest, folds the name key in, ignores meta keys", () => {
     const raw = JSON.stringify({
       $comment: "docs",
       $schema: "./x.json",
-      overrides: [baseEntry],
+      overrides: { ws: baseMeta },
     });
     const result = parseManifest({ raw });
     expect(result).toHaveLength(1);
     expect(result[0]?.name).toBe("ws");
+    expect(result[0]?.safeFloor).toBe("8.21.0");
   });
 
   test("throws on a missing required field", () => {
-    const raw = JSON.stringify({ overrides: [{ name: "ws", pinned: "^8.21.0" }] });
+    const raw = JSON.stringify({ overrides: { ws: { safeFloor: "8.21.0" } } });
     expect(() => parseManifest({ raw })).toThrow();
   });
 
   test("throws on an invalid severity", () => {
     const raw = JSON.stringify({
-      overrides: [{ ...baseEntry, severity: "SPICY" }],
+      overrides: { ws: { ...baseMeta, severity: "SPICY" } },
     });
     expect(() => parseManifest({ raw })).toThrow();
   });
 });
 
 describe("findDrift", () => {
-  test("no issues when manifest matches overrides and resolutions", () => {
+  test("no issues when the name is present and identical in both blocks", () => {
     const issues = findDrift({
       manifest: [baseEntry],
       overrides: { ws: "^8.21.0" },
@@ -54,7 +59,7 @@ describe("findDrift", () => {
     expect(issues).toEqual([]);
   });
 
-  test("flags an override missing from package.json overrides", () => {
+  test("flags a documented override missing from package.json overrides", () => {
     const issues = findDrift({
       manifest: [baseEntry],
       overrides: {},
@@ -64,19 +69,19 @@ describe("findDrift", () => {
     expect(issues[0]?.problem).toContain('missing from package.json "overrides"');
   });
 
-  test("flags a mismatched pin between manifest and resolutions", () => {
+  test("flags overrides and resolutions pinning different ranges", () => {
     const issues = findDrift({
       manifest: [baseEntry],
       overrides: { ws: "^8.21.0" },
-      resolutions: { ws: "^8.20.0" },
+      resolutions: { ws: "^8.21.1" },
     });
     expect(issues).toHaveLength(1);
-    expect(issues[0]?.problem).toContain("resolutions");
+    expect(issues[0]?.problem).toContain("they must match");
   });
 
   test("flags a pinned range whose floor is below safeFloor", () => {
     const issues = findDrift({
-      manifest: [{ ...baseEntry, pinned: ">=8.0.0" }],
+      manifest: [baseEntry],
       overrides: { ws: ">=8.0.0" },
       resolutions: { ws: ">=8.0.0" },
     });
@@ -129,33 +134,33 @@ describe("applyPrune", () => {
       overrides: { ws: "^8.21.0", react: "19.2.7" },
       resolutions: { ws: "^8.21.0", react: "19.2.7" },
     };
-    const manifest = { overrides: [baseEntry, { ...baseEntry, name: "minimatch" }] };
+    const manifest = { overrides: { ws: baseMeta, minimatch: baseMeta } };
 
     const result = applyPrune({ names: ["ws"], pkg, manifest });
 
     expect(result.pkg.overrides).toEqual({ react: "19.2.7" });
     expect(result.pkg.resolutions).toEqual({ react: "19.2.7" });
-    expect(result.manifest.overrides.map((o) => o.name)).toEqual(["minimatch"]);
+    expect(Object.keys(result.manifest.overrides)).toEqual(["minimatch"]);
   });
 
   test("does not mutate the input objects", () => {
     const pkg = { overrides: { ws: "^8.21.0" }, resolutions: { ws: "^8.21.0" } };
-    const manifest = { overrides: [baseEntry] };
+    const manifest = { overrides: { ws: baseMeta } };
 
     applyPrune({ names: ["ws"], pkg, manifest });
 
     expect(pkg.overrides.ws).toBe("^8.21.0");
-    expect(manifest.overrides).toHaveLength(1);
+    expect(Object.keys(manifest.overrides)).toEqual(["ws"]);
   });
 
   test("is a no-op for names that are not present", () => {
     const pkg = { overrides: { ws: "^8.21.0" }, resolutions: { ws: "^8.21.0" } };
-    const manifest = { overrides: [baseEntry] };
+    const manifest = { overrides: { ws: baseMeta } };
 
     const result = applyPrune({ names: ["nonexistent"], pkg, manifest });
 
     expect(result.pkg.overrides).toEqual({ ws: "^8.21.0" });
-    expect(result.manifest.overrides).toHaveLength(1);
+    expect(Object.keys(result.manifest.overrides)).toEqual(["ws"]);
   });
 });
 

--- a/scripts/audit-overrides.test.ts
+++ b/scripts/audit-overrides.test.ts
@@ -5,12 +5,13 @@ import {
   findDrift,
   isRedundant,
   parseManifest,
+  type IntentionalPin,
   type ManagedOverride,
   type ManagedOverrideMeta,
 } from "./audit-overrides";
 
-// Human-only metadata as it appears under a name key in the manifest (no
-// version - that lives in package.json).
+// Human-only metadata as it appears under a name key in the `security` bucket
+// (no version - that lives in package.json).
 const baseMeta: ManagedOverrideMeta = {
   safeFloor: "8.21.0",
   severity: "HIGH",
@@ -20,79 +21,114 @@ const baseMeta: ManagedOverrideMeta = {
   removeWhen: "no consumer resolves below 8.21.0",
 };
 
-// The flat `{ name, ...meta }` shape parseManifest returns.
 const baseEntry: ManagedOverride = { name: "ws", ...baseMeta };
+const reactPin: IntentionalPin = {
+  name: "react",
+  reason: "single React across MFE",
+  addedAt: "2026-06-06",
+};
 
 describe("parseManifest", () => {
-  test("parses a valid manifest, folds the name key in, ignores meta keys", () => {
+  test("parses both buckets, folds the name key in, ignores meta keys", () => {
     const raw = JSON.stringify({
       $comment: "docs",
-      $schema: "./x.json",
-      overrides: { ws: baseMeta },
+      security: { ws: baseMeta },
+      intentional: { react: { reason: reactPin.reason, addedAt: reactPin.addedAt } },
     });
     const result = parseManifest({ raw });
-    expect(result).toHaveLength(1);
-    expect(result[0]?.name).toBe("ws");
-    expect(result[0]?.safeFloor).toBe("8.21.0");
+    expect(result.security).toHaveLength(1);
+    expect(result.security[0]?.name).toBe("ws");
+    expect(result.intentional).toHaveLength(1);
+    expect(result.intentional[0]?.name).toBe("react");
   });
 
-  test("throws on a missing required field", () => {
-    const raw = JSON.stringify({ overrides: { ws: { safeFloor: "8.21.0" } } });
+  test("throws when a security entry is missing a required field", () => {
+    const raw = JSON.stringify({
+      security: { ws: { safeFloor: "8.21.0" } },
+      intentional: {},
+    });
+    expect(() => parseManifest({ raw })).toThrow();
+  });
+
+  test("throws when an intentional entry is missing a reason", () => {
+    const raw = JSON.stringify({
+      security: {},
+      intentional: { react: { addedAt: "2026-06-06" } },
+    });
     expect(() => parseManifest({ raw })).toThrow();
   });
 
   test("throws on an invalid severity", () => {
     const raw = JSON.stringify({
-      overrides: { ws: { ...baseMeta, severity: "SPICY" } },
+      security: { ws: { ...baseMeta, severity: "SPICY" } },
+      intentional: {},
     });
     expect(() => parseManifest({ raw })).toThrow();
   });
 });
 
 describe("findDrift", () => {
-  test("no issues when the name is present and identical in both blocks", () => {
+  const ok = {
+    security: [baseEntry],
+    intentional: [reactPin],
+    overrides: { ws: "^8.21.0", react: "19.2.7" },
+    resolutions: { ws: "^8.21.0", react: "19.2.7" },
+  };
+
+  test("no issues when every override is documented and consistent", () => {
+    expect(findDrift(ok)).toEqual([]);
+  });
+
+  test("flags an override present in package.json but undocumented", () => {
     const issues = findDrift({
-      manifest: [baseEntry],
-      overrides: { ws: "^8.21.0" },
-      resolutions: { ws: "^8.21.0" },
+      ...ok,
+      overrides: { ...ok.overrides, lodash: "^4.17.21" },
+      resolutions: { ...ok.resolutions, lodash: "^4.17.21" },
     });
-    expect(issues).toEqual([]);
+    expect(issues.some((i) => i.name === "lodash" && i.problem.includes("undocumented"))).toBe(
+      true,
+    );
+  });
+
+  test("flags a name documented in BOTH buckets", () => {
+    const issues = findDrift({
+      ...ok,
+      security: [baseEntry],
+      intentional: [reactPin, { name: "ws", reason: "x", addedAt: "2026-06-15" }],
+    });
+    expect(issues.some((i) => i.name === "ws" && i.problem.includes("exactly one"))).toBe(true);
   });
 
   test("flags a documented override missing from package.json overrides", () => {
-    const issues = findDrift({
-      manifest: [baseEntry],
-      overrides: {},
-      resolutions: { ws: "^8.21.0" },
-    });
-    expect(issues).toHaveLength(1);
-    expect(issues[0]?.problem).toContain('missing from package.json "overrides"');
+    const issues = findDrift({ ...ok, overrides: { react: "19.2.7" } });
+    expect(issues.some((i) => i.problem.includes('missing from package.json "overrides"'))).toBe(
+      true,
+    );
   });
 
   test("flags overrides and resolutions pinning different ranges", () => {
     const issues = findDrift({
-      manifest: [baseEntry],
-      overrides: { ws: "^8.21.0" },
-      resolutions: { ws: "^8.21.1" },
+      ...ok,
+      resolutions: { ws: "^8.21.1", react: "19.2.7" },
     });
-    expect(issues).toHaveLength(1);
-    expect(issues[0]?.problem).toContain("they must match");
+    expect(issues.some((i) => i.problem.includes("they must match"))).toBe(true);
   });
 
-  test("flags a pinned range whose floor is below safeFloor", () => {
+  test("flags a SECURITY pin whose floor is below safeFloor", () => {
     const issues = findDrift({
-      manifest: [baseEntry],
-      overrides: { ws: ">=8.0.0" },
-      resolutions: { ws: ">=8.0.0" },
+      ...ok,
+      overrides: { ws: ">=8.0.0", react: "19.2.7" },
+      resolutions: { ws: ">=8.0.0", react: "19.2.7" },
     });
     expect(issues.some((i) => i.problem.includes("below safeFloor"))).toBe(true);
   });
 
-  test("ignores extra non-manifest overrides (intentional pins)", () => {
+  test("does NOT apply a floor check to intentional pins (any range is fine)", () => {
     const issues = findDrift({
-      manifest: [baseEntry],
-      overrides: { ws: "^8.21.0", react: "19.2.7" },
-      resolutions: { ws: "^8.21.0", react: "19.2.7" },
+      security: [],
+      intentional: [reactPin],
+      overrides: { react: "0.0.1" },
+      resolutions: { react: "0.0.1" },
     });
     expect(issues).toEqual([]);
   });
@@ -129,38 +165,43 @@ describe("extractInstalledVersions", () => {
 });
 
 describe("applyPrune", () => {
-  test("removes named entries from overrides, resolutions, and manifest only", () => {
+  test("removes named entries from package.json and the security bucket only", () => {
     const pkg = {
       overrides: { ws: "^8.21.0", react: "19.2.7" },
       resolutions: { ws: "^8.21.0", react: "19.2.7" },
     };
-    const manifest = { overrides: { ws: baseMeta, minimatch: baseMeta } };
+    const manifest = {
+      security: { ws: baseMeta, minimatch: baseMeta },
+      intentional: { react: { reason: "x", addedAt: "2026-06-06" } },
+    };
 
     const result = applyPrune({ names: ["ws"], pkg, manifest });
 
     expect(result.pkg.overrides).toEqual({ react: "19.2.7" });
     expect(result.pkg.resolutions).toEqual({ react: "19.2.7" });
-    expect(Object.keys(result.manifest.overrides)).toEqual(["minimatch"]);
+    expect(Object.keys(result.manifest.security)).toEqual(["minimatch"]);
+    // Intentional pins are never touched.
+    expect(result.manifest.intentional).toEqual({ react: { reason: "x", addedAt: "2026-06-06" } });
   });
 
   test("does not mutate the input objects", () => {
     const pkg = { overrides: { ws: "^8.21.0" }, resolutions: { ws: "^8.21.0" } };
-    const manifest = { overrides: { ws: baseMeta } };
+    const manifest = { security: { ws: baseMeta } };
 
     applyPrune({ names: ["ws"], pkg, manifest });
 
     expect(pkg.overrides.ws).toBe("^8.21.0");
-    expect(Object.keys(manifest.overrides)).toEqual(["ws"]);
+    expect(Object.keys(manifest.security)).toEqual(["ws"]);
   });
 
   test("is a no-op for names that are not present", () => {
     const pkg = { overrides: { ws: "^8.21.0" }, resolutions: { ws: "^8.21.0" } };
-    const manifest = { overrides: { ws: baseMeta } };
+    const manifest = { security: { ws: baseMeta } };
 
     const result = applyPrune({ names: ["nonexistent"], pkg, manifest });
 
     expect(result.pkg.overrides).toEqual({ ws: "^8.21.0" });
-    expect(Object.keys(result.manifest.overrides)).toEqual(["ws"]);
+    expect(Object.keys(result.manifest.security)).toEqual(["ws"]);
   });
 });
 

--- a/scripts/audit-overrides.ts
+++ b/scripts/audit-overrides.ts
@@ -39,9 +39,9 @@ const ROOT = path.resolve(import.meta.dirname, "..");
 const MANIFEST_PATH = path.join(ROOT, "security", "managed-overrides.json");
 const PKG_PATH = path.join(ROOT, "package.json");
 
-export const ManagedOverrideSchema = z.object({
-  name: z.string().min(1),
-  pinned: z.string().min(1),
+// Human-only metadata. The pinned VERSION is intentionally NOT here - it lives
+// in package.json `overrides`/`resolutions` (single source of truth).
+export const ManagedOverrideMetaSchema = z.object({
   safeFloor: z.string().min(1),
   severity: z.enum(["CRITICAL", "HIGH", "MEDIUM", "LOW"]),
   advisory: z.string().min(1),
@@ -51,16 +51,19 @@ export const ManagedOverrideSchema = z.object({
 });
 
 export const ManifestSchema = z.object({
-  overrides: z.array(ManagedOverrideSchema),
+  overrides: z.record(z.string().min(1), ManagedOverrideMetaSchema),
 });
 
-export type ManagedOverride = z.infer<typeof ManagedOverrideSchema>;
+export type ManagedOverrideMeta = z.infer<typeof ManagedOverrideMetaSchema>;
+export type ManagedOverride = ManagedOverrideMeta & { name: string };
 
 export function parseManifest({ raw }: { raw: string }): ManagedOverride[] {
-  // Strip the `$comment`/`$schema` meta keys before validation so the schema
-  // can stay strict about the override shape.
+  // `$comment`/`$schema` meta keys are ignored: z.record only validates the
+  // `overrides` map. The package name is the map KEY; we fold it back into each
+  // entry so callers keep a flat `{ name, ...meta }` shape.
   const parsed: unknown = JSON.parse(raw);
-  return ManifestSchema.parse(parsed).overrides;
+  const { overrides } = ManifestSchema.parse(parsed);
+  return Object.entries(overrides).map(([name, meta]) => ({ name, ...meta }));
 }
 
 export interface DriftIssue {
@@ -69,10 +72,12 @@ export interface DriftIssue {
 }
 
 /**
- * A managed override must be declared identically in BOTH `overrides` and
- * `resolutions` (this repo mirrors them), and its pinned range must not allow
- * anything below `safeFloor`. Extra package.json overrides that are NOT in the
- * manifest are intentional pins (react, drizzle, ...) and are ignored here.
+ * Each managed override must (a) be present in BOTH package.json `overrides`
+ * and `resolutions` (this repo mirrors them), declared identically, and (b)
+ * pin a range whose floor is at/above the recorded `safeFloor`. The pinned
+ * version is read from package.json - the manifest no longer stores it.
+ * Extra package.json overrides NOT in the manifest are intentional pins
+ * (react, drizzle, ...) and are ignored here.
  */
 export function findDrift({
   manifest,
@@ -92,44 +97,46 @@ export function findDrift({
     if (inOverrides === undefined) {
       issues.push({
         name: entry.name,
-        problem: `listed in managed-overrides.json but missing from package.json "overrides"`,
-      });
-    } else if (inOverrides !== entry.pinned) {
-      issues.push({
-        name: entry.name,
-        problem: `pinned "${entry.pinned}" in manifest but "${inOverrides}" in package.json "overrides"`,
+        problem: `documented in managed-overrides.json but missing from package.json "overrides"`,
       });
     }
-
     if (inResolutions === undefined) {
       issues.push({
         name: entry.name,
-        problem: `listed in managed-overrides.json but missing from package.json "resolutions"`,
+        problem: `documented in managed-overrides.json but missing from package.json "resolutions"`,
       });
-    } else if (inResolutions !== entry.pinned) {
+    }
+    if (
+      inOverrides !== undefined &&
+      inResolutions !== undefined &&
+      inOverrides !== inResolutions
+    ) {
       issues.push({
         name: entry.name,
-        problem: `pinned "${entry.pinned}" in manifest but "${inResolutions}" in package.json "resolutions"`,
+        problem: `"overrides" pins "${inOverrides}" but "resolutions" pins "${inResolutions}" — they must match`,
       });
     }
 
-    // The pinned range must not permit a version below the recorded safe floor.
-    const floor = semver.minVersion(entry.pinned);
-    if (!floor) {
-      issues.push({
-        name: entry.name,
-        problem: `pinned range "${entry.pinned}" is not a parseable semver range`,
-      });
-    } else if (!semver.valid(entry.safeFloor)) {
-      issues.push({
-        name: entry.name,
-        problem: `safeFloor "${entry.safeFloor}" is not a valid semver version`,
-      });
-    } else if (semver.lt(floor, entry.safeFloor)) {
-      issues.push({
-        name: entry.name,
-        problem: `pinned range "${entry.pinned}" allows ${floor.version}, below safeFloor ${entry.safeFloor}`,
-      });
+    // The pinned range (from package.json) must not permit a version below the
+    // recorded safe floor.
+    if (inOverrides !== undefined) {
+      const floor = semver.minVersion(inOverrides);
+      if (!floor) {
+        issues.push({
+          name: entry.name,
+          problem: `pinned range "${inOverrides}" is not a parseable semver range`,
+        });
+      } else if (!semver.valid(entry.safeFloor)) {
+        issues.push({
+          name: entry.name,
+          problem: `safeFloor "${entry.safeFloor}" is not a valid semver version`,
+        });
+      } else if (semver.lt(floor, entry.safeFloor)) {
+        issues.push({
+          name: entry.name,
+          problem: `pinned range "${inOverrides}" allows ${floor.version}, below safeFloor ${entry.safeFloor}`,
+        });
+      }
     }
   }
 
@@ -255,7 +262,7 @@ export function applyPrune({
     resolutions?: Record<string, string>;
     [k: string]: unknown;
   };
-  manifest: { overrides: ManagedOverride[]; [k: string]: unknown };
+  manifest: { overrides: Record<string, unknown>; [k: string]: unknown };
 }): { pkg: typeof pkg; manifest: typeof manifest } {
   const toRemove = new Set(names);
   const nextPkg = structuredClone(pkg);
@@ -265,9 +272,7 @@ export function applyPrune({
     for (const name of toRemove) delete block[name];
   }
   const nextManifest = structuredClone(manifest);
-  nextManifest.overrides = nextManifest.overrides.filter(
-    (o) => !toRemove.has(o.name),
-  );
+  for (const name of toRemove) delete nextManifest.overrides[name];
   return { pkg: nextPkg, manifest: nextManifest };
 }
 

--- a/scripts/audit-overrides.ts
+++ b/scripts/audit-overrides.ts
@@ -50,20 +50,38 @@ export const ManagedOverrideMetaSchema = z.object({
   removeWhen: z.string().min(1),
 });
 
+// Intentional, permanent pins (version alignment, singletons). Documented but
+// NEVER auto-pruned, so no safeFloor / advisory is required - just intent.
+export const IntentionalPinMetaSchema = z.object({
+  reason: z.string().min(1),
+  addedAt: z.string().min(1),
+});
+
 export const ManifestSchema = z.object({
-  overrides: z.record(z.string().min(1), ManagedOverrideMetaSchema),
+  security: z.record(z.string().min(1), ManagedOverrideMetaSchema),
+  intentional: z.record(z.string().min(1), IntentionalPinMetaSchema),
 });
 
 export type ManagedOverrideMeta = z.infer<typeof ManagedOverrideMetaSchema>;
 export type ManagedOverride = ManagedOverrideMeta & { name: string };
+export type IntentionalPinMeta = z.infer<typeof IntentionalPinMetaSchema>;
+export type IntentionalPin = IntentionalPinMeta & { name: string };
 
-export function parseManifest({ raw }: { raw: string }): ManagedOverride[] {
-  // `$comment`/`$schema` meta keys are ignored: z.record only validates the
-  // `overrides` map. The package name is the map KEY; we fold it back into each
-  // entry so callers keep a flat `{ name, ...meta }` shape.
+export interface ParsedManifest {
+  security: ManagedOverride[];
+  intentional: IntentionalPin[];
+}
+
+export function parseManifest({ raw }: { raw: string }): ParsedManifest {
+  // `$comment`/`$schema` meta keys are ignored: the schema only validates the
+  // `security`/`intentional` maps. The package name is each map's KEY; we fold
+  // it back into the entries so callers keep a flat `{ name, ...meta }` shape.
   const parsed: unknown = JSON.parse(raw);
-  const { overrides } = ManifestSchema.parse(parsed);
-  return Object.entries(overrides).map(([name, meta]) => ({ name, ...meta }));
+  const { security, intentional } = ManifestSchema.parse(parsed);
+  return {
+    security: Object.entries(security).map(([name, meta]) => ({ name, ...meta })),
+    intentional: Object.entries(intentional).map(([name, meta]) => ({ name, ...meta })),
+  };
 }
 
 export interface DriftIssue {
@@ -71,72 +89,110 @@ export interface DriftIssue {
   problem: string;
 }
 
-/**
- * Each managed override must (a) be present in BOTH package.json `overrides`
- * and `resolutions` (this repo mirrors them), declared identically, and (b)
- * pin a range whose floor is at/above the recorded `safeFloor`. The pinned
- * version is read from package.json - the manifest no longer stores it.
- * Extra package.json overrides NOT in the manifest are intentional pins
- * (react, drizzle, ...) and are ignored here.
- */
-export function findDrift({
-  manifest,
+// Every documented override must be present in BOTH `overrides` and
+// `resolutions` (this repo mirrors them), declared identically.
+function checkPresence({
+  name,
   overrides,
   resolutions,
 }: {
-  manifest: ManagedOverride[];
+  name: string;
   overrides: Record<string, string>;
   resolutions: Record<string, string>;
 }): DriftIssue[] {
   const issues: DriftIssue[] = [];
+  const inOverrides = overrides[name];
+  const inResolutions = resolutions[name];
 
-  for (const entry of manifest) {
+  if (inOverrides === undefined) {
+    issues.push({
+      name,
+      problem: `documented in managed-overrides.json but missing from package.json "overrides"`,
+    });
+  }
+  if (inResolutions === undefined) {
+    issues.push({
+      name,
+      problem: `documented in managed-overrides.json but missing from package.json "resolutions"`,
+    });
+  }
+  if (
+    inOverrides !== undefined &&
+    inResolutions !== undefined &&
+    inOverrides !== inResolutions
+  ) {
+    issues.push({
+      name,
+      problem: `"overrides" pins "${inOverrides}" but "resolutions" pins "${inResolutions}" — they must match`,
+    });
+  }
+  return issues;
+}
+
+/**
+ * Validates the manifest against package.json `overrides`/`resolutions`:
+ *  - every package.json override is documented in EXACTLY one bucket (no
+ *    undocumented pins, and none claimed as both security and intentional);
+ *  - security + intentional entries are present and identical in both blocks;
+ *  - each SECURITY pin's range floor is at/above its recorded `safeFloor`.
+ * The pinned version is read from package.json (single source of truth).
+ */
+export function findDrift({
+  security,
+  intentional,
+  overrides,
+  resolutions,
+}: {
+  security: ManagedOverride[];
+  intentional: IntentionalPin[];
+  overrides: Record<string, string>;
+  resolutions: Record<string, string>;
+}): DriftIssue[] {
+  const issues: DriftIssue[] = [];
+  const securityNames = new Set(security.map((e) => e.name));
+  const intentionalNames = new Set(intentional.map((e) => e.name));
+
+  // Completeness: every package.json override must be documented exactly once.
+  for (const name of Object.keys(overrides)) {
+    const inSec = securityNames.has(name);
+    const inInt = intentionalNames.has(name);
+    if (!inSec && !inInt) {
+      issues.push({
+        name,
+        problem: `override exists in package.json but is undocumented — add it to the "security" or "intentional" section of managed-overrides.json`,
+      });
+    } else if (inSec && inInt) {
+      issues.push({
+        name,
+        problem: `documented in BOTH "security" and "intentional" — it must be in exactly one`,
+      });
+    }
+  }
+
+  for (const entry of [...security, ...intentional]) {
+    issues.push(...checkPresence({ name: entry.name, overrides, resolutions }));
+  }
+
+  // Security pins additionally carry a safe floor the range must respect.
+  for (const entry of security) {
     const inOverrides = overrides[entry.name];
-    const inResolutions = resolutions[entry.name];
-
-    if (inOverrides === undefined) {
+    if (inOverrides === undefined) continue;
+    const floor = semver.minVersion(inOverrides);
+    if (!floor) {
       issues.push({
         name: entry.name,
-        problem: `documented in managed-overrides.json but missing from package.json "overrides"`,
+        problem: `pinned range "${inOverrides}" is not a parseable semver range`,
       });
-    }
-    if (inResolutions === undefined) {
+    } else if (!semver.valid(entry.safeFloor)) {
       issues.push({
         name: entry.name,
-        problem: `documented in managed-overrides.json but missing from package.json "resolutions"`,
+        problem: `safeFloor "${entry.safeFloor}" is not a valid semver version`,
       });
-    }
-    if (
-      inOverrides !== undefined &&
-      inResolutions !== undefined &&
-      inOverrides !== inResolutions
-    ) {
+    } else if (semver.lt(floor, entry.safeFloor)) {
       issues.push({
         name: entry.name,
-        problem: `"overrides" pins "${inOverrides}" but "resolutions" pins "${inResolutions}" — they must match`,
+        problem: `pinned range "${inOverrides}" allows ${floor.version}, below safeFloor ${entry.safeFloor}`,
       });
-    }
-
-    // The pinned range (from package.json) must not permit a version below the
-    // recorded safe floor.
-    if (inOverrides !== undefined) {
-      const floor = semver.minVersion(inOverrides);
-      if (!floor) {
-        issues.push({
-          name: entry.name,
-          problem: `pinned range "${inOverrides}" is not a parseable semver range`,
-        });
-      } else if (!semver.valid(entry.safeFloor)) {
-        issues.push({
-          name: entry.name,
-          problem: `safeFloor "${entry.safeFloor}" is not a valid semver version`,
-        });
-      } else if (semver.lt(floor, entry.safeFloor)) {
-        issues.push({
-          name: entry.name,
-          problem: `pinned range "${inOverrides}" allows ${floor.version}, below safeFloor ${entry.safeFloor}`,
-        });
-      }
     }
   }
 
@@ -248,8 +304,9 @@ async function simulateRemoval({
 
 /**
  * Remove a set of override names from a package.json-shaped object (both
- * `overrides` and `resolutions`) and from the managed-overrides manifest.
- * Pure: returns the new JSON strings; the caller writes them.
+ * `overrides` and `resolutions`) and from the manifest's `security` section
+ * (only security pins are ever pruned). Pure: returns the new objects; the
+ * caller writes them.
  */
 export function applyPrune({
   names,
@@ -262,7 +319,7 @@ export function applyPrune({
     resolutions?: Record<string, string>;
     [k: string]: unknown;
   };
-  manifest: { overrides: Record<string, unknown>; [k: string]: unknown };
+  manifest: { security: Record<string, unknown>; [k: string]: unknown };
 }): { pkg: typeof pkg; manifest: typeof manifest } {
   const toRemove = new Set(names);
   const nextPkg = structuredClone(pkg);
@@ -272,19 +329,22 @@ export function applyPrune({
     for (const name of toRemove) delete block[name];
   }
   const nextManifest = structuredClone(manifest);
-  for (const name of toRemove) delete nextManifest.overrides[name];
+  for (const name of toRemove) delete nextManifest.security[name];
   return { pkg: nextPkg, manifest: nextManifest };
 }
 
 async function runCheck(): Promise<void> {
-  const manifest = parseManifest({ raw: readFileSync(MANIFEST_PATH, "utf8") });
+  const { security, intentional } = parseManifest({
+    raw: readFileSync(MANIFEST_PATH, "utf8"),
+  });
   const pkg: {
     overrides?: Record<string, string>;
     resolutions?: Record<string, string>;
   } = JSON.parse(readFileSync(PKG_PATH, "utf8"));
 
   const issues = findDrift({
-    manifest,
+    security,
+    intentional,
     overrides: pkg.overrides ?? {},
     resolutions: pkg.resolutions ?? {},
   });
@@ -301,16 +361,16 @@ async function runCheck(): Promise<void> {
   }
 
   console.log(
-    `✓ ${manifest.length} managed security override(s) are documented and consistent.`,
+    `✓ ${security.length} security + ${intentional.length} intentional override(s) documented and consistent.`,
   );
 }
 
 async function runRedundant(): Promise<void> {
   const asJson = process.argv.includes("--json");
-  const manifest = parseManifest({ raw: readFileSync(MANIFEST_PATH, "utf8") });
+  const { security } = parseManifest({ raw: readFileSync(MANIFEST_PATH, "utf8") });
 
   const results: RedundancyResult[] = [];
-  for (const entry of manifest) {
+  for (const entry of security) {
     results.push(await simulateRemoval({ entry }));
   }
 
@@ -337,10 +397,10 @@ async function runRedundant(): Promise<void> {
 }
 
 async function runPrune(): Promise<void> {
-  const manifest = parseManifest({ raw: readFileSync(MANIFEST_PATH, "utf8") });
+  const { security } = parseManifest({ raw: readFileSync(MANIFEST_PATH, "utf8") });
 
   const redundantNames: string[] = [];
-  for (const entry of manifest) {
+  for (const entry of security) {
     const result = await simulateRemoval({ entry });
     if (result.redundant) redundantNames.push(entry.name);
   }

--- a/scripts/audit-overrides.ts
+++ b/scripts/audit-overrides.ts
@@ -1,0 +1,388 @@
+#!/usr/bin/env bun
+/**
+ * Security-override lifecycle auditor.
+ *
+ * Background: a `overrides`/`resolutions` entry that pins a transitive package
+ * to a fixed version is a stop-gap. Nothing tells you when it can be removed
+ * (every consumer updated, the graph now resolves safe on its own) - so they
+ * rot into dead weight or, worse, hold a package below a newer safe release.
+ * `security/managed-overrides.json` documents each SECURITY override; this
+ * script keeps that file honest and detects when an override is redundant.
+ *
+ * Modes:
+ *   --check
+ *       Drift guard (fast; runs in PR CI). Fails if a managed override is
+ *       missing/mismatched in package.json `overrides` or `resolutions`, or if
+ *       its pinned range floor sits below the recorded `safeFloor`.
+ *
+ *   --redundant [--json]
+ *       Re-resolution audit (heavy; runs in the daily security-maintenance
+ *       workflow). For each managed override it spins up a throwaway git
+ *       worktree, removes that single override, runs `bun install`, and reads
+ *       the resolved version(s) back from the worktree's bun.lock. If the graph
+ *       still lands at/above `safeFloor` WITHOUT the override, the override is
+ *       redundant and reported (as a removable candidate). `--json` emits a
+ *       machine-readable report for the workflow to turn into an auto-PR.
+ *
+ * The pure helpers (parseManifest/findDrift/extractInstalledVersions/
+ * isRedundant) are unit-tested in audit-overrides.test.ts; the worktree +
+ * install orchestration is exercised by the scheduled workflow.
+ */
+
+import { $ } from "bun";
+import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import semver from "semver";
+import { z } from "zod";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const MANIFEST_PATH = path.join(ROOT, "security", "managed-overrides.json");
+const PKG_PATH = path.join(ROOT, "package.json");
+
+export const ManagedOverrideSchema = z.object({
+  name: z.string().min(1),
+  pinned: z.string().min(1),
+  safeFloor: z.string().min(1),
+  severity: z.enum(["CRITICAL", "HIGH", "MEDIUM", "LOW"]),
+  advisory: z.string().min(1),
+  reason: z.string().min(1),
+  addedAt: z.string().min(1),
+  removeWhen: z.string().min(1),
+});
+
+export const ManifestSchema = z.object({
+  overrides: z.array(ManagedOverrideSchema),
+});
+
+export type ManagedOverride = z.infer<typeof ManagedOverrideSchema>;
+
+export function parseManifest({ raw }: { raw: string }): ManagedOverride[] {
+  // Strip the `$comment`/`$schema` meta keys before validation so the schema
+  // can stay strict about the override shape.
+  const parsed: unknown = JSON.parse(raw);
+  return ManifestSchema.parse(parsed).overrides;
+}
+
+export interface DriftIssue {
+  name: string;
+  problem: string;
+}
+
+/**
+ * A managed override must be declared identically in BOTH `overrides` and
+ * `resolutions` (this repo mirrors them), and its pinned range must not allow
+ * anything below `safeFloor`. Extra package.json overrides that are NOT in the
+ * manifest are intentional pins (react, drizzle, ...) and are ignored here.
+ */
+export function findDrift({
+  manifest,
+  overrides,
+  resolutions,
+}: {
+  manifest: ManagedOverride[];
+  overrides: Record<string, string>;
+  resolutions: Record<string, string>;
+}): DriftIssue[] {
+  const issues: DriftIssue[] = [];
+
+  for (const entry of manifest) {
+    const inOverrides = overrides[entry.name];
+    const inResolutions = resolutions[entry.name];
+
+    if (inOverrides === undefined) {
+      issues.push({
+        name: entry.name,
+        problem: `listed in managed-overrides.json but missing from package.json "overrides"`,
+      });
+    } else if (inOverrides !== entry.pinned) {
+      issues.push({
+        name: entry.name,
+        problem: `pinned "${entry.pinned}" in manifest but "${inOverrides}" in package.json "overrides"`,
+      });
+    }
+
+    if (inResolutions === undefined) {
+      issues.push({
+        name: entry.name,
+        problem: `listed in managed-overrides.json but missing from package.json "resolutions"`,
+      });
+    } else if (inResolutions !== entry.pinned) {
+      issues.push({
+        name: entry.name,
+        problem: `pinned "${entry.pinned}" in manifest but "${inResolutions}" in package.json "resolutions"`,
+      });
+    }
+
+    // The pinned range must not permit a version below the recorded safe floor.
+    const floor = semver.minVersion(entry.pinned);
+    if (!floor) {
+      issues.push({
+        name: entry.name,
+        problem: `pinned range "${entry.pinned}" is not a parseable semver range`,
+      });
+    } else if (!semver.valid(entry.safeFloor)) {
+      issues.push({
+        name: entry.name,
+        problem: `safeFloor "${entry.safeFloor}" is not a valid semver version`,
+      });
+    } else if (semver.lt(floor, entry.safeFloor)) {
+      issues.push({
+        name: entry.name,
+        problem: `pinned range "${entry.pinned}" allows ${floor.version}, below safeFloor ${entry.safeFloor}`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Extract every resolved version of `name` present in a bun text lockfile.
+ * bun.lock keys look like `"name@1.2.3"` and `"parent/name@1.2.3"`; we match
+ * the exact package name followed by `@<semver>` and ignore npm aliases
+ * (`name@npm:other@...`).
+ */
+export function extractInstalledVersions({
+  lockfileText,
+  name,
+}: {
+  lockfileText: string;
+  name: string;
+}): string[] {
+  const escaped = name.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  // Match `"name@1.2.3"` or `"some/scope/name@1.2.3"` (the leaf after the last
+  // slash is the package), capturing the version. Excludes `@npm:` aliases.
+  const re = new RegExp(
+    String.raw`"(?:[^"]*/)?${escaped}@(\d+\.\d+\.\d+[^"]*)"`,
+    "g",
+  );
+  const versions = new Set<string>();
+  for (const match of lockfileText.matchAll(re)) {
+    const version = match[1];
+    if (version && semver.valid(semver.coerce(version) ?? "")) {
+      const clean = semver.valid(version) ?? semver.coerce(version)?.version;
+      if (clean) versions.add(clean);
+    }
+  }
+  return [...versions];
+}
+
+/**
+ * An override is redundant when, with it removed, EVERY resolved copy still
+ * sits at/above the safe floor (nothing in the graph pulls a vulnerable
+ * version on its own). If no copy resolves at all, the package left the graph
+ * entirely - also redundant.
+ */
+export function isRedundant({
+  resolvedVersions,
+  safeFloor,
+}: {
+  resolvedVersions: string[];
+  safeFloor: string;
+}): boolean {
+  if (resolvedVersions.length === 0) return true;
+  return resolvedVersions.every((v) => semver.gte(v, safeFloor));
+}
+
+interface RedundancyResult {
+  name: string;
+  redundant: boolean;
+  resolvedWithout: string[];
+  safeFloor: string;
+}
+
+async function simulateRemoval({
+  entry,
+}: {
+  entry: ManagedOverride;
+}): Promise<RedundancyResult> {
+  const worktree = path.join(ROOT, ".audit-overrides-wt", entry.name);
+  rmSync(path.join(ROOT, ".audit-overrides-wt"), {
+    recursive: true,
+    force: true,
+  });
+
+  await $`git worktree add --detach --force ${worktree} HEAD`.quiet();
+  try {
+    const wtPkgPath = path.join(worktree, "package.json");
+    const pkg: {
+      overrides?: Record<string, string>;
+      resolutions?: Record<string, string>;
+    } = JSON.parse(readFileSync(wtPkgPath, "utf8"));
+    delete pkg.overrides?.[entry.name];
+    delete pkg.resolutions?.[entry.name];
+    writeFileSync(wtPkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+    // Plain (non-frozen) install so bun RE-RESOLVES the now-unpinned package
+    // and rewrites the worktree's bun.lock. `--no-save`/`--frozen-lockfile`
+    // would keep the old lockfile and we'd read the pre-removal versions.
+    await $`cd ${worktree} && bun install`.quiet().nothrow();
+
+    const lockfileText = readFileSync(path.join(worktree, "bun.lock"), "utf8");
+    const resolvedWithout = extractInstalledVersions({
+      lockfileText,
+      name: entry.name,
+    });
+
+    return {
+      name: entry.name,
+      redundant: isRedundant({ resolvedVersions: resolvedWithout, safeFloor: entry.safeFloor }),
+      resolvedWithout,
+      safeFloor: entry.safeFloor,
+    };
+  } finally {
+    await $`git worktree remove --force ${worktree}`.quiet().nothrow();
+    rmSync(path.join(ROOT, ".audit-overrides-wt"), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+/**
+ * Remove a set of override names from a package.json-shaped object (both
+ * `overrides` and `resolutions`) and from the managed-overrides manifest.
+ * Pure: returns the new JSON strings; the caller writes them.
+ */
+export function applyPrune({
+  names,
+  pkg,
+  manifest,
+}: {
+  names: string[];
+  pkg: {
+    overrides?: Record<string, string>;
+    resolutions?: Record<string, string>;
+    [k: string]: unknown;
+  };
+  manifest: { overrides: ManagedOverride[]; [k: string]: unknown };
+}): { pkg: typeof pkg; manifest: typeof manifest } {
+  const toRemove = new Set(names);
+  const nextPkg = structuredClone(pkg);
+  for (const key of ["overrides", "resolutions"] as const) {
+    const block = nextPkg[key];
+    if (!block) continue;
+    for (const name of toRemove) delete block[name];
+  }
+  const nextManifest = structuredClone(manifest);
+  nextManifest.overrides = nextManifest.overrides.filter(
+    (o) => !toRemove.has(o.name),
+  );
+  return { pkg: nextPkg, manifest: nextManifest };
+}
+
+async function runCheck(): Promise<void> {
+  const manifest = parseManifest({ raw: readFileSync(MANIFEST_PATH, "utf8") });
+  const pkg: {
+    overrides?: Record<string, string>;
+    resolutions?: Record<string, string>;
+  } = JSON.parse(readFileSync(PKG_PATH, "utf8"));
+
+  const issues = findDrift({
+    manifest,
+    overrides: pkg.overrides ?? {},
+    resolutions: pkg.resolutions ?? {},
+  });
+
+  if (issues.length > 0) {
+    console.error("❌ Managed-override drift detected:\n");
+    for (const issue of issues) {
+      console.error(`   - ${issue.name}: ${issue.problem}`);
+    }
+    console.error(
+      "\nFix package.json overrides/resolutions or security/managed-overrides.json so they agree.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ ${manifest.length} managed security override(s) are documented and consistent.`,
+  );
+}
+
+async function runRedundant(): Promise<void> {
+  const asJson = process.argv.includes("--json");
+  const manifest = parseManifest({ raw: readFileSync(MANIFEST_PATH, "utf8") });
+
+  const results: RedundancyResult[] = [];
+  for (const entry of manifest) {
+    results.push(await simulateRemoval({ entry }));
+  }
+
+  const redundant = results.filter((r) => r.redundant);
+
+  if (asJson) {
+    console.log(JSON.stringify({ redundant, all: results }, null, 2));
+    return;
+  }
+
+  if (redundant.length === 0) {
+    console.log("✓ All managed overrides are still required.");
+    return;
+  }
+
+  console.log(`Found ${redundant.length} redundant override(s) (safe to remove):\n`);
+  for (const r of redundant) {
+    const detail =
+      r.resolvedWithout.length === 0
+        ? "package no longer in the graph"
+        : `graph resolves ${r.resolvedWithout.join(", ")} >= ${r.safeFloor}`;
+    console.log(`   - ${r.name}: ${detail}`);
+  }
+}
+
+async function runPrune(): Promise<void> {
+  const manifest = parseManifest({ raw: readFileSync(MANIFEST_PATH, "utf8") });
+
+  const redundantNames: string[] = [];
+  for (const entry of manifest) {
+    const result = await simulateRemoval({ entry });
+    if (result.redundant) redundantNames.push(entry.name);
+  }
+
+  if (redundantNames.length === 0) {
+    console.log("✓ No redundant overrides to prune.");
+    return;
+  }
+
+  const pkg = JSON.parse(readFileSync(PKG_PATH, "utf8"));
+  const rawManifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const { pkg: nextPkg, manifest: nextManifest } = applyPrune({
+    names: redundantNames,
+    pkg,
+    manifest: rawManifest,
+  });
+
+  writeFileSync(PKG_PATH, `${JSON.stringify(nextPkg, null, 2)}\n`);
+  writeFileSync(MANIFEST_PATH, `${JSON.stringify(nextManifest, null, 2)}\n`);
+
+  console.log(`Pruned ${redundantNames.length} redundant override(s): ${redundantNames.join(", ")}`);
+  console.log("Run `bun install` to update the lockfile.");
+}
+
+if (import.meta.main) {
+  const mode = process.argv[2];
+  switch (mode) {
+  case "--check": {
+    await runCheck();
+  
+  break;
+  }
+  case "--redundant": {
+    await runRedundant();
+  
+  break;
+  }
+  case "--prune": {
+    await runPrune();
+  
+  break;
+  }
+  default: {
+    console.error(
+      "Usage: bun run scripts/audit-overrides.ts <--check | --redundant [--json] | --prune>",
+    );
+    process.exit(1);
+  }
+  }
+}

--- a/scripts/install-playwright.test.ts
+++ b/scripts/install-playwright.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { resolvePlaywrightVersion } from "./install-playwright";
+
+describe("resolvePlaywrightVersion", () => {
+  test("extracts the single resolved playwright version", () => {
+    const lock = `
+      "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" } }, "sha512-a"],
+      "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" } }, "sha512-b"],
+      "playwright-core": ["playwright-core@1.60.0", "", {}, "sha512-c"],
+    `;
+    expect(resolvePlaywrightVersion({ lockfileText: lock })).toBe("1.60.0");
+  });
+
+  test("does not confuse playwright-core or @playwright/test for playwright", () => {
+    const lock = `
+      "@playwright/test": ["@playwright/test@1.55.0", "", {}, "sha512-a"],
+      "playwright-core": ["playwright-core@1.55.0", "", {}, "sha512-c"],
+    `;
+    expect(() => resolvePlaywrightVersion({ lockfileText: lock })).toThrow(
+      /Could not find a resolved/,
+    );
+  });
+
+  test("throws when the graph resolved more than one playwright version", () => {
+    const lock = `
+      "a/playwright": ["playwright@1.60.0", "", {}, "sha512-b"],
+      "b/playwright": ["playwright@1.59.0", "", {}, "sha512-d"],
+    `;
+    expect(() => resolvePlaywrightVersion({ lockfileText: lock })).toThrow(
+      /multiple playwright versions/,
+    );
+  });
+
+  test("dedupes identical versions appearing under multiple parents", () => {
+    const lock = `
+      "playwright": ["playwright@1.60.0", "", {}, "sha512-b"],
+      "x/playwright": ["playwright@1.60.0", "", {}, "sha512-e"],
+    `;
+    expect(resolvePlaywrightVersion({ lockfileText: lock })).toBe("1.60.0");
+  });
+});

--- a/scripts/install-playwright.ts
+++ b/scripts/install-playwright.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env bun
+/**
+ * Install Playwright browsers pinned to the EXACT version resolved in bun.lock.
+ *
+ * Why this exists: `@playwright/test`/`playwright` are nested under the
+ * workspace packages, not the repo-root node_modules, so a bare
+ * `bunx playwright install` at the root finds no local binary and downloads
+ * `playwright@latest` from npm. The moment npm's latest drifts past the locked
+ * version it installs a DIFFERENT browser build, and the tests' locked
+ * `@playwright/test` then can't find their expected binary
+ * (`chromium_headless_shell-<n>`). Pinning the install to the lockfile version
+ * makes it deterministic and immune to new Playwright releases. We also install
+ * `chromium-headless-shell` by default because recent Playwright ships the
+ * binary `chromium.launch()` uses as a SEPARATE component from `chromium`.
+ *
+ * Usage:
+ *   bun run scripts/install-playwright.ts                       # chromium + headless shell
+ *   bun run scripts/install-playwright.ts --with-deps           # + OS deps (CI/Linux)
+ *   bun run scripts/install-playwright.ts firefox webkit        # explicit browser set
+ *
+ * Any non-flag argument is treated as a browser name and overrides the default
+ * set. `--with-deps` is forwarded to `playwright install`.
+ */
+
+import { $ } from "bun";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const LOCKFILE_PATH = path.join(ROOT, "bun.lock");
+const DEFAULT_BROWSERS = ["chromium", "chromium-headless-shell"];
+
+/**
+ * Extract the single resolved `playwright` version from a bun text lockfile.
+ * bun.lock entries look like `"playwright": ["playwright@1.60.0", ...]`; we
+ * match the leaf package (not `playwright-core` / `@playwright/test`). Throws
+ * if absent, or if the graph resolved more than one distinct version (which a
+ * pinned install could not represent unambiguously).
+ */
+export function resolvePlaywrightVersion({
+  lockfileText,
+}: {
+  lockfileText: string;
+}): string {
+  const versions = new Set<string>();
+  for (const match of lockfileText.matchAll(/"playwright@(\d[^"]*)"/g)) {
+    const version = match[1];
+    if (version) versions.add(version);
+  }
+  if (versions.size === 0) {
+    throw new Error("Could not find a resolved `playwright` version in bun.lock");
+  }
+  if (versions.size > 1) {
+    throw new Error(
+      `bun.lock resolved multiple playwright versions (${[...versions].join(", ")}); align them before pinning the browser install`,
+    );
+  }
+  return [...versions][0]!;
+}
+
+function parseArgs({ argv }: { argv: string[] }): {
+  browsers: string[];
+  withDeps: boolean;
+} {
+  const withDeps = argv.includes("--with-deps");
+  const browsers = argv.filter((a) => !a.startsWith("--"));
+  return {
+    browsers: browsers.length > 0 ? browsers : DEFAULT_BROWSERS,
+    withDeps,
+  };
+}
+
+if (import.meta.main) {
+  const version = resolvePlaywrightVersion({
+    lockfileText: readFileSync(LOCKFILE_PATH, "utf8"),
+  });
+  const { browsers, withDeps } = parseArgs({ argv: process.argv.slice(2) });
+
+  console.log(
+    `Installing Playwright browsers for pinned version ${version}: ${browsers.join(", ")}${withDeps ? " (--with-deps)" : ""}`,
+  );
+
+  const args = [
+    `playwright@${version}`,
+    "install",
+    ...(withDeps ? ["--with-deps"] : []),
+    ...browsers,
+  ];
+  await $`bunx ${args}`;
+}

--- a/security/managed-overrides.json
+++ b/security/managed-overrides.json
@@ -1,0 +1,35 @@
+{
+  "$comment": "Source of truth for SECURITY dependency overrides (transitive version pins added to remediate a vulnerability). Intentional, permanent pins (e.g. react, drizzle-orm) are NOT tracked here - only stop-gaps that should be removed once the dependency graph naturally resolves to a safe version. The daily security-maintenance workflow re-validates each entry by removing it, re-resolving, and checking whether the graph still lands at/above `safeFloor`; redundant entries are auto-PR'd for removal. `audit:overrides:check` (PR CI) keeps this file and package.json `overrides`/`resolutions` in sync. See scripts/audit-overrides.ts.",
+  "overrides": [
+    {
+      "name": "ws",
+      "pinned": "^8.21.0",
+      "safeFloor": "8.21.0",
+      "severity": "HIGH",
+      "advisory": "Trivy image scan 2026-06: ws < 8.21.0 (HIGH)",
+      "reason": "A transitive consumer pulled ws 8.20.1 into the production image; 8.21.0 is the first fixed release.",
+      "addedAt": "2026-06-15",
+      "removeWhen": "No dependency resolves ws below 8.21.0 without this override."
+    },
+    {
+      "name": "minimatch",
+      "pinned": "^10.2.5",
+      "safeFloor": "10.2.5",
+      "severity": "HIGH",
+      "advisory": "Trivy image scan 2026-06: minimatch 5.1.9 (HIGH)",
+      "reason": "monaco-languageclient -> vscode-languageclient@9.0.1 pins minimatch ^5.1.0, pulling the vulnerable 5.1.9 into the bundled Monaco editor. 10.x is the fixed line; the matching API used (minimatch(path, pattern)) is unchanged.",
+      "addedAt": "2026-06-15",
+      "removeWhen": "vscode-languageclient (via monaco-languageclient) widens its minimatch range to a fixed release, or no dependency resolves minimatch below 10.2.5."
+    },
+    {
+      "name": "postcss-selector-parser",
+      "pinned": "^7.1.4",
+      "safeFloor": "7.1.4",
+      "severity": "MEDIUM",
+      "advisory": "Trivy fs scan 2026-06: postcss-selector-parser 6.1.2 (MEDIUM)",
+      "reason": "Transitive build-tooling dependency (postcss) pulled 6.1.2; 7.1.4 is the fixed release. Build-time only (not in the production runtime image).",
+      "addedAt": "2026-06-15",
+      "removeWhen": "No dependency resolves postcss-selector-parser below 7.1.4 without this override."
+    }
+  ]
+}

--- a/security/managed-overrides.json
+++ b/security/managed-overrides.json
@@ -1,9 +1,7 @@
 {
-  "$comment": "Source of truth for SECURITY dependency overrides (transitive version pins added to remediate a vulnerability). Intentional, permanent pins (e.g. react, drizzle-orm) are NOT tracked here - only stop-gaps that should be removed once the dependency graph naturally resolves to a safe version. The daily security-maintenance workflow re-validates each entry by removing it, re-resolving, and checking whether the graph still lands at/above `safeFloor`; redundant entries are auto-PR'd for removal. `audit:overrides:check` (PR CI) keeps this file and package.json `overrides`/`resolutions` in sync. See scripts/audit-overrides.ts.",
-  "overrides": [
-    {
-      "name": "ws",
-      "pinned": "^8.21.0",
+  "$comment": "Human-only metadata for SECURITY dependency overrides (transitive pins added to remediate a vulnerability). The PINNED VERSION is NOT stored here - package.json `overrides`/`resolutions` is the single source of truth for that; this file only records why each pin exists and the minimum safe version. Keyed by package name. Intentional, permanent pins (react, drizzle-orm, ...) are NOT listed here, so the daily security-maintenance workflow never tries to prune them. `audit:overrides:check` (PR CI) verifies every key still has a matching override whose floor >= safeFloor; the daily job removes entries the graph no longer needs. See scripts/audit-overrides.ts.",
+  "overrides": {
+    "ws": {
       "safeFloor": "8.21.0",
       "severity": "HIGH",
       "advisory": "Trivy image scan 2026-06: ws < 8.21.0 (HIGH)",
@@ -11,9 +9,7 @@
       "addedAt": "2026-06-15",
       "removeWhen": "No dependency resolves ws below 8.21.0 without this override."
     },
-    {
-      "name": "minimatch",
-      "pinned": "^10.2.5",
+    "minimatch": {
       "safeFloor": "10.2.5",
       "severity": "HIGH",
       "advisory": "Trivy image scan 2026-06: minimatch 5.1.9 (HIGH)",
@@ -21,9 +17,7 @@
       "addedAt": "2026-06-15",
       "removeWhen": "vscode-languageclient (via monaco-languageclient) widens its minimatch range to a fixed release, or no dependency resolves minimatch below 10.2.5."
     },
-    {
-      "name": "postcss-selector-parser",
-      "pinned": "^7.1.4",
+    "postcss-selector-parser": {
       "safeFloor": "7.1.4",
       "severity": "MEDIUM",
       "advisory": "Trivy fs scan 2026-06: postcss-selector-parser 6.1.2 (MEDIUM)",
@@ -31,5 +25,5 @@
       "addedAt": "2026-06-15",
       "removeWhen": "No dependency resolves postcss-selector-parser below 7.1.4 without this override."
     }
-  ]
+  }
 }

--- a/security/managed-overrides.json
+++ b/security/managed-overrides.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Human-only metadata for SECURITY dependency overrides (transitive pins added to remediate a vulnerability). The PINNED VERSION is NOT stored here - package.json `overrides`/`resolutions` is the single source of truth for that; this file only records why each pin exists and the minimum safe version. Keyed by package name. Intentional, permanent pins (react, drizzle-orm, ...) are NOT listed here, so the daily security-maintenance workflow never tries to prune them. `audit:overrides:check` (PR CI) verifies every key still has a matching override whose floor >= safeFloor; the daily job removes entries the graph no longer needs. See scripts/audit-overrides.ts.",
-  "overrides": {
+  "$comment": "Registry of ALL package.json `overrides`/`resolutions`, split by intent. `security` = transitive pins added to remediate a vulnerability; the daily security-maintenance workflow re-resolves each and auto-prunes any the graph no longer needs (so they MUST carry a safeFloor). `intentional` = deliberate, permanent pins (version alignment, singletons) that are documented but NEVER auto-removed. The pinned VERSION is not stored here - package.json is the single source of truth; this file only records intent. `audit:overrides:check` (PR CI) requires every package.json override to appear in exactly one bucket, that security floors are >= safeFloor, and that overrides==resolutions. See scripts/audit-overrides.ts.",
+  "security": {
     "ws": {
       "safeFloor": "8.21.0",
       "severity": "HIGH",
@@ -24,6 +24,56 @@
       "reason": "Transitive build-tooling dependency (postcss) pulled 6.1.2; 7.1.4 is the fixed release. Build-time only (not in the production runtime image).",
       "addedAt": "2026-06-15",
       "removeWhen": "No dependency resolves postcss-selector-parser below 7.1.4 without this override."
+    },
+    "dompurify": {
+      "safeFloor": "3.4.3",
+      "severity": "MEDIUM",
+      "advisory": "Added in #210 (extend Trivy scope to MEDIUM and bump vulnerable deps): DOMPurify sanitizer-bypass class.",
+      "reason": "DOMPurify is the HTML sanitizer; 3.4.3 is the pinned fixed release. Confirm the exact advisory ID from #210 if refining.",
+      "addedAt": "2026-05-13",
+      "removeWhen": "No dependency resolves dompurify below 3.4.3 without this override."
+    },
+    "esbuild": {
+      "safeFloor": "0.28.1",
+      "severity": "MEDIUM",
+      "advisory": "esbuild dev-server request-exposure class; pinned to the patched 0.28.x line.",
+      "reason": "Forces every consumer onto a non-vulnerable esbuild line. Confirm the exact advisory ID if refining.",
+      "addedAt": "2026-06-14",
+      "removeWhen": "No dependency resolves esbuild below 0.28.1 without this override."
+    },
+    "uuid": {
+      "safeFloor": "14.0.0",
+      "severity": "MEDIUM",
+      "advisory": "Added in #210 (extend Trivy scope to MEDIUM and bump vulnerable deps).",
+      "reason": "Pins uuid to the 14.x fixed line. Confirm the exact advisory ID from #210 if refining.",
+      "addedAt": "2026-05-13",
+      "removeWhen": "No dependency resolves uuid below 14.0.0 without this override."
+    },
+    "yaml": {
+      "safeFloor": "2.9.0",
+      "severity": "MEDIUM",
+      "advisory": "Pinned to the non-vulnerable yaml 2.9.x line.",
+      "reason": "Forces every consumer onto a fixed yaml release. Confirm the exact advisory ID if refining.",
+      "addedAt": "2026-06-06",
+      "removeWhen": "No dependency resolves yaml below 2.9.0 without this override."
+    }
+  },
+  "intentional": {
+    "react": {
+      "reason": "Exact single React version across the workspace - Module Federation requires one React instance shared by host and remotes.",
+      "addedAt": "2026-06-06"
+    },
+    "react-dom": {
+      "reason": "Pinned with react to keep a single ReactDOM instance (MFE singleton).",
+      "addedAt": "2026-06-06"
+    },
+    "drizzle-orm": {
+      "reason": "Aligned to a single Drizzle ORM version across the workspace.",
+      "addedAt": "2026-04-16"
+    },
+    "drizzle-kit": {
+      "reason": "Pinned below 1.0 to a drizzle-kit range compatible with the pinned drizzle-orm.",
+      "addedAt": "2026-04-30"
     }
   }
 }


### PR DESCRIPTION
## Summary

Three related fixes in one branch: the CI Actions Cache, the CVEs your company's image scan flagged, and the security-scanning gaps that let CI miss them — plus daily automation so neither drifts back. Also hardens the Playwright browser install in CI.

## 1. CI Actions Cache (was net-negative)

The Actions Cache sat **over GitHub's 10 GB cap (10.4 GB / 449 entries)**, so it self-evicted by LRU every run. The budget was dominated by Docker `type=gha,mode=max` layers (5.6 GB) re-exported on every release for near-zero reuse, starving the one useful cache (tsgo, 31 MB). `bun install` was never cached at all.

- **Docker cache → GHCR registry** (`type=registry`) instead of `type=gha`. Frees ~5.6 GB, no eviction war. The PR security image build reuses it **read-only**.
- **`bun install` cached** via a shared composite action (`.github/actions/bun-install`) wired into all 7 install sites (pr-checks ×5, release, deploy-docs).
- The 375 orphaned `buildkit-blob` + 24 `buildkit-index` caches purged. Cache now ~4.9 GB / live entries only.

## 2. CVE remediation (your company image scan)

Why CI missed them: `--ignore-unfixed` dropped the unfixed ones; the scan only covered the **pruned production image** (devDependencies absent); and it ran **only on PRs**, never re-scanning the published image as new CVEs land.

| Finding | Action |
|---|---|
| ws 8.20.1 (HIGH) | override → `^8.21.0` ✅ |
| minimatch 5.1.9 (HIGH) | override → `^10.2.5` ✅ (frontend build verified) |
| postcss-selector-parser 6.1.2 (MED) | override → `^7.1.4` ✅ |
| nodemailer 8.0.5 (MED) | bump → `^9.0.0` ✅ |
| protobufjs 7.5.8 (MED) | **no fix** — `@grpc/proto-loader` (even latest) hard-pins `protobufjs ^7`; forcing v8 would break grpc at runtime. Surfaced as warning. |
| vite 8.0.16 (HIGH) | **no fix** — already latest. Warning. |
| alpine openssl 3.5.6-r0 (CRIT) | **no fix** — Alpine hasn't shipped it; `apk upgrade` already runs. Warning. |

## 3. Security scanning + automation

- PR security job now runs **both an image and a filesystem** Trivy scan, **gates on FIXABLE** findings and **warns (not fails) on unfixed** ones. The fs scan closes the dev-dependency blind spot (vite/postcss-selector-parser).
- **`security/managed-overrides.json`** is now the registry of **every** `package.json` override, split by intent (keyed by name; the pinned version lives only in `package.json`):
  - **`security`** (prunable, carries `safeFloor`): ws, minimatch, postcss-selector-parser, dompurify, esbuild, uuid, yaml.
  - **`intentional`** (documented, reason-only, **never** auto-removed): react, react-dom, drizzle-orm, drizzle-kit.
- **`scripts/audit-overrides.ts`** (+21 unit tests): a drift gate in the PR `deps` job that enforces **completeness** (every override documented in exactly one bucket — no undocumented pins), `overrides == resolutions`, and security pin floor ≥ `safeFloor`; plus a `--redundant`/`--prune` re-resolution audit that only ever touches the `security` bucket.
- **`.github/workflows/security-maintenance.yml`** (daily): re-resolves each **security** override and **auto-opens/updates a single PR** (fixed branch `chore/security-maintenance` — reused, never duplicated per day) pruning redundant ones; scans the published image + fs and **upserts one tracking issue** the moment a previously-unfixed CVE gains a fix. Intentional pins are never pruned.

## 4. Playwright browser install (Integration job was failing)

A bare `bunx playwright install` ran in the Integration job. `@playwright/test`/`playwright` are nested under the workspace packages, not the repo root, so `bunx` found no local binary and downloaded `playwright@latest`; once npm's latest drifted past the locked **1.60.0** it installed a mismatched browser build and the test couldn't find `chromium_headless_shell-1223` (deterministic failure, no lockfile change).

- **`scripts/install-playwright.ts`** (+4 unit tests) + **`playwright:install`** root script: resolve the exact `playwright` version from `bun.lock` and `bunx playwright@<locked> install`, including the now-separate `chromium-headless-shell`. Single source of truth, immune to new Playwright releases.
- The PR Integration job and `core/e2e`'s `pretest:e2e` both use it, so neither CI nor local e2e can hit the version skew.

## Verification

- `bun run typecheck` ✅, `bun run lint` ✅
- `bun test scripts/audit-overrides.test.ts` ✅ (21/21), `bun test scripts/install-playwright.test.ts` ✅ (4/4)
- `bun run audit:overrides:check` ✅ (7 security + 4 intentional overrides documented and consistent)
- `bun run --filter @checkstack/frontend build` ✅ (validates minimatch 10 in the Monaco bundle)
- `bun run audit:overrides:redundant` run live ✅ (all 3 new overrides correctly reported still-required)
- Full PR check run green: Typecheck, Lint, Deps, Test, **Integration**, Security, Report.

## Notes

- Changeset added for `@checkstack/notification-smtp-backend` (nodemailer bump). The override / CI / automation changes are root-level infra (no package source change), so they carry no per-package changeset by design.
- `zod` added to root `devDependencies` — the root-level `scripts/audit-overrides.ts` imports it, and CI's frozen install won't rely on hoisting (this fixed the initial Deps/Test failures).
- For esbuild/uuid/yaml the `safeFloor` is set to the current pin floor with provenance-based `advisory` text (origin PRs/commits) rather than invented CVE IDs; each carries a "confirm the exact advisory if refining" note.
- `core/auth-frontend`'s `test:e2e` still assumes browsers are pre-installed; it can call `bun run playwright:install` too if you want it fully symmetric (left untouched — not wired into CI).
- First post-merge release builds the new registry buildcache cold once.
- The daily workflow pulls the published `ghcr.io/.../checkstack:latest`; its first real run should be triggered manually (`workflow_dispatch`) to confirm registry auth + Trivy DB before relying on the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
