### PR TITLE
fix(ci): repair the failing daily Security Maintenance workflow

### DIFF
--- a/.github/workflows/security-maintenance.yml
+++ b/.github/workflows/security-maintenance.yml
@@ -95,7 +95,7 @@ jobs:
             echo ""
             if [ "$fixable" -gt 0 ]; then
               jq -r '[.[] | select(.fixed != "")] | sort_by(.sev) | reverse[]
-                | "- **\(.sev)** \`\(.pkg)\` \(.installed) → fixed in **\(.fixed)** (\(.id))"' /tmp/vulns.json
+                | "- **\(.sev)** `\(.pkg)` \(.installed) → fixed in **\(.fixed)** (\(.id))"' /tmp/vulns.json
             else
               echo "_None._"
             fi
@@ -103,7 +103,7 @@ jobs:
             echo "<details><summary>Known unfixed (monitoring only)</summary>"
             echo ""
             jq -r '[.[] | select(.fixed == "")] | sort_by(.sev) | reverse[]
-              | "- \(.sev) \`\(.pkg)\` \(.installed) (\(.id))"' /tmp/vulns.json
+              | "- \(.sev) `\(.pkg)` \(.installed) (\(.id))"' /tmp/vulns.json
             echo ""
             echo "</details>"
           } > /tmp/cve-report.md

--- a/.github/workflows/security-maintenance.yml
+++ b/.github/workflows/security-maintenance.yml
@@ -119,11 +119,13 @@ jobs:
           set -euo pipefail
           bun run audit:overrides:redundant --json > /tmp/redundant.json || true
           bun run audit:overrides:prune | tee /tmp/prune.txt
-          bun install
-          # Only the files the prune actually rewrites count as a change. Scope
-          # the check to them so unrelated working-tree noise (e.g. the Trivy DB
-          # the scans download into .cache/) can never trigger a spurious PR.
-          if [ -n "$(git status --porcelain -- package.json bun.lock security/managed-overrides.json)" ]; then
+          # The prune rewrites ONLY package.json + the manifest (never bun.lock).
+          # If neither changed, nothing was pruned — do NOT run `bun install`,
+          # because bun re-serializes bun.lock even on a no-op ("Saved lockfile"),
+          # which would otherwise open a spurious lockfile-only PR every day.
+          # Trivy's .cache/ DB is gitignored and out of scope here regardless.
+          if [ -n "$(git status --porcelain -- package.json security/managed-overrides.json)" ]; then
+            bun install
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/security-maintenance.yml
+++ b/.github/workflows/security-maintenance.yml
@@ -120,7 +120,10 @@ jobs:
           bun run audit:overrides:redundant --json > /tmp/redundant.json || true
           bun run audit:overrides:prune | tee /tmp/prune.txt
           bun install
-          if [ -n "$(git status --porcelain)" ]; then
+          # Only the files the prune actually rewrites count as a change. Scope
+          # the check to them so unrelated working-tree noise (e.g. the Trivy DB
+          # the scans download into .cache/) can never trigger a spurious PR.
+          if [ -n "$(git status --porcelain -- package.json bun.lock security/managed-overrides.json)" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -156,6 +159,12 @@ jobs:
           body-path: /tmp/pr-body.md
           labels: security-maintenance
           delete-branch: true
+          # Commit ONLY the files the prune rewrites — never the Trivy DB or any
+          # other untracked working-tree artifact.
+          add-paths: |
+            package.json
+            bun.lock
+            security/managed-overrides.json
 
       # Surface fixable CVEs that need a human decision (version bumps can be
       # breaking, so they are NOT auto-applied) via a single upserted issue.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ backups/
 
 # Throwaway git worktrees created by scripts/audit-overrides.ts --redundant/--prune
 .audit-overrides-wt/
+
+# Trivy downloads its ~1GB vulnerability DB here during CI scans; it must never
+# pollute `git status` or get committed (it exceeds GitHub's 100MB push limit).
+.cache/

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "audit:image": "bun run scripts/audit-trivy.ts image",
     "audit:overrides:check": "bun run scripts/audit-overrides.ts --check",
     "audit:overrides:redundant": "bun run scripts/audit-overrides.ts --redundant",
+    "audit:overrides:prune": "bun run scripts/audit-overrides.ts --prune",
     "playwright:install": "bun run scripts/install-playwright.ts",
     "changeset": "changeset",
     "version-packages": "bun run scripts/inject-release.ts && changeset version && bun install --lockfile-only && bun run scripts/generate-sdk.ts && bun run scripts/generate-docs-index.ts",


### PR DESCRIPTION
The daily **Security Maintenance** workflow had been failing every run since it
landed. It died at the first broken step, which masked three further bugs behind
it. Each was found and fixed by dispatching the workflow on this branch
(`workflow_dispatch --ref`) and reading the real run, repeating until green.

## Bugs fixed (in the order they surfaced)

1. **`Build CVE report` — invalid jq escape.** The jq programs escaped markdown
   backticks as `` \` ``, which is not a valid jq string escape, so jq aborted
   with `Invalid escape` before producing any report. Backticks are already
   literal inside a bash single-quoted jq program, so they're now written plain.

2. **`Prune redundant overrides` — missing npm script.** The step calls
   `bun run audit:overrides:prune`, but only the `:check` and `:redundant`
   aliases existed (the script's `--prune` mode was already implemented). Added
   the alias.

3. **`Open PR` — committed the 1GB Trivy DB.** The Trivy scans download their
   ~1GB vuln DB into `.cache/trivy/` in the workspace. That untracked dir made
   `git status` dirty and `create-pull-request` tried to commit it, blowing
   GitHub's 100MB push limit. Guards: gitignore `.cache/`, scope the change
   check to the files the prune rewrites, and `add-paths` so the PR only ever
   commits `package.json` / `bun.lock` / the manifest.

4. **Spurious daily PR.** `bun install` re-serializes `bun.lock` even on a no-op
   ("Saved lockfile"), so running it unconditionally after the prune opened a
   `bun.lock`-only PR every day. Now `bun install` runs (and a change is flagged)
   only when the prune actually rewrote `package.json` or the manifest.

## Verification

Dispatched on this branch repeatedly until green. Final steady-state run
(nothing to prune): **all steps pass**, `Compose PR body` / `Open PR` correctly
**skipped**, and the single CVE tracking issue (#346) is updated in place — no
duplicate issues, no junk PR. A spurious PR opened during debugging (#345) was
closed and its branch deleted.

> [!NOTE]
> One latent item not triggered day-to-day: when the prune *does* find a
> redundant override and `create-pull-request` opens a real PR, the repo setting
> **Settings → Actions → "Allow GitHub Actions to create and approve pull
> requests"** must be enabled, or that step will fail. It isn't exercised on a
> normal (nothing-to-prune) day, so the daily run stays green regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
