### PR TITLE
fix(ci): repair the failing daily Security Maintenance workflow

### DIFF
--- a/.github/workflows/security-maintenance.yml
+++ b/.github/workflows/security-maintenance.yml
@@ -95,7 +95,7 @@ jobs:
             echo ""
             if [ "$fixable" -gt 0 ]; then
               jq -r '[.[] | select(.fixed != "")] | sort_by(.sev) | reverse[]
-                | "- **\(.sev)** \`\(.pkg)\` \(.installed) → fixed in **\(.fixed)** (\(.id))"' /tmp/vulns.json
+                | "- **\(.sev)** `\(.pkg)` \(.installed) → fixed in **\(.fixed)** (\(.id))"' /tmp/vulns.json
             else
               echo "_None._"
             fi
@@ -103,7 +103,7 @@ jobs:
             echo "<details><summary>Known unfixed (monitoring only)</summary>"
             echo ""
             jq -r '[.[] | select(.fixed == "")] | sort_by(.sev) | reverse[]
-              | "- \(.sev) \`\(.pkg)\` \(.installed) (\(.id))"' /tmp/vulns.json
+              | "- \(.sev) `\(.pkg)` \(.installed) (\(.id))"' /tmp/vulns.json
             echo ""
             echo "</details>"
           } > /tmp/cve-report.md
@@ -119,8 +119,13 @@ jobs:
           set -euo pipefail
           bun run audit:overrides:redundant --json > /tmp/redundant.json || true
           bun run audit:overrides:prune | tee /tmp/prune.txt
-          bun install
-          if [ -n "$(git status --porcelain)" ]; then
+          # The prune rewrites ONLY package.json + the manifest (never bun.lock).
+          # If neither changed, nothing was pruned — do NOT run `bun install`,
+          # because bun re-serializes bun.lock even on a no-op ("Saved lockfile"),
+          # which would otherwise open a spurious lockfile-only PR every day.
+          # Trivy's .cache/ DB is gitignored and out of scope here regardless.
+          if [ -n "$(git status --porcelain -- package.json security/managed-overrides.json)" ]; then
+            bun install
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -156,6 +161,12 @@ jobs:
           body-path: /tmp/pr-body.md
           labels: security-maintenance
           delete-branch: true
+          # Commit ONLY the files the prune rewrites — never the Trivy DB or any
+          # other untracked working-tree artifact.
+          add-paths: |
+            package.json
+            bun.lock
+            security/managed-overrides.json
 
       # Surface fixable CVEs that need a human decision (version bumps can be
       # breaking, so they are NOT auto-applied) via a single upserted issue.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ backups/
 
 # Throwaway git worktrees created by scripts/audit-overrides.ts --redundant/--prune
 .audit-overrides-wt/
+
+# Trivy downloads its ~1GB vulnerability DB here during CI scans; it must never
+# pollute `git status` or get committed (it exceeds GitHub's 100MB push limit).
+.cache/

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "audit:image": "bun run scripts/audit-trivy.ts image",
     "audit:overrides:check": "bun run scripts/audit-overrides.ts --check",
     "audit:overrides:redundant": "bun run scripts/audit-overrides.ts --redundant",
+    "audit:overrides:prune": "bun run scripts/audit-overrides.ts --prune",
     "playwright:install": "bun run scripts/install-playwright.ts",
     "changeset": "changeset",
     "version-packages": "bun run scripts/inject-release.ts && changeset version && bun install --lockfile-only && bun run scripts/generate-sdk.ts && bun run scripts/generate-docs-index.ts",


### PR DESCRIPTION
The daily **Security Maintenance** workflow has been failing every run. The
first broken step masked three further bugs behind it; each was found by
dispatching the workflow (`workflow_dispatch`) and reading the real run,
repeating until green.

## Bugs fixed

1. **`Build CVE report` — invalid jq escape.** The jq programs escaped markdown
   backticks as `` \` ``, which is not a valid jq string escape, so jq aborted
   with `Invalid escape`. Backticks are already literal inside a bash
   single-quoted jq program, so they're now written plain.
2. **`Prune redundant overrides` — missing npm script.** The step calls
   `bun run audit:overrides:prune`, but only `:check` and `:redundant` aliases
   existed (the script's `--prune` mode was already implemented). Added the alias.
3. **`Open PR` — committed the ~1GB Trivy DB.** The Trivy scans download their
   vuln DB into `.cache/trivy/`, making `git status` dirty; `create-pull-request`
   then tried to commit it and blew GitHub's 100MB push limit. Guards: gitignore
   `.cache/`, scope the change check to the files the prune rewrites, and
   `add-paths` so the PR only ever commits `package.json` / `bun.lock` / the
   manifest.
4. **Spurious daily PR.** `bun install` re-serializes `bun.lock` even on a no-op
   ("Saved lockfile"), so running it unconditionally opened a `bun.lock`-only PR
   every day. Now `bun install` runs (and a change is flagged) only when the
   prune actually rewrote `package.json` or the manifest.

## Verification

Dispatched on the branch repeatedly until green. Final steady-state run (nothing
to prune): **all steps pass**, `Compose PR body` / `Open PR` correctly skipped,
and the single CVE tracking issue is updated in place — no duplicate issues, no
junk PR.

> [!IMPORTANT]
> This PR's **own Security gate will fail**, but NOT because of these changes:
> the daily scan has surfaced 11 real, newly-disclosed fixable CVEs on `main`
> (hono / dompurify / protobufjs). Any PR fails the fail-on-fixable gate right
> now. Those need separate remediation (not included here) — happy to do it on
> your go-ahead.

> [!NOTE]
> Latent: when the prune *does* find a redundant override and opens a real PR,
> the repo setting **Settings → Actions → "Allow GitHub Actions to create and
> approve pull requests"** must be enabled, or that step fails. It isn't
> exercised on a normal (nothing-to-prune) day, so the daily run stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
