### PR TITLE
feat(ci): auto-generate CVE remediation PRs in Security Maintenance

### DIFF
--- a/.github/workflows/security-maintenance.yml
+++ b/.github/workflows/security-maintenance.yml
@@ -109,6 +109,16 @@ jobs:
           } > /tmp/cve-report.md
           echo "fixable_count=$fixable" >> "$GITHUB_OUTPUT"
 
+      # Hand the normalized findings to the `remediate` job (a separate, clean
+      # checkout) so override-pruning and auto-remediation never edit the same
+      # working tree and cross-contaminate their PRs.
+      - name: Upload findings
+        uses: actions/upload-artifact@v7
+        with:
+          name: security-vulns
+          path: /tmp/vulns.json
+          retention-days: 1
+
       # Re-resolve each managed override with it removed; prune any that the
       # graph no longer needs, then refresh the lockfile. Produces a working-
       # tree diff (package.json + manifest + bun.lock) only when something was
@@ -153,7 +163,9 @@ jobs:
         if: steps.prune.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # See the remediation PR step for why a non-GITHUB_TOKEN identity is
+          # needed for CI to run on the created PR.
+          token: ${{ secrets.SECURITY_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           branch: chore/security-maintenance
           base: main
           commit-message: "chore(security): prune redundant managed overrides"
@@ -218,3 +230,121 @@ jobs:
               });
               core.info('Created new CVE tracking issue');
             }
+
+      # When nothing is fixable anymore (e.g. after a remediation PR merged),
+      # close the tracking issue so it doesn't linger showing stale CVEs. The
+      # `Closes #N` in the remediation PR usually handles this on merge; this is
+      # the backstop for the case where the issue outlived its findings.
+      - name: Close tracking issue when clear
+        if: steps.cve.outputs.fixable_count == '0'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const marker = '<!-- security-maintenance-cve -->';
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security-maintenance',
+              per_page: 100,
+            });
+            for (const issue of open.filter((i) => i.body && i.body.includes(marker))) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'No fixable vulnerabilities remain — closing automatically.',
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+              core.info(`Closed tracking issue #${issue.number}`);
+            }
+
+  # Auto-remediate fixable findings into a CI-gated PR. Runs in its OWN clean
+  # checkout (separate from `maintain`) so it never shares a working tree with
+  # the override-prune step and can't cross-contaminate the two PRs. This
+  # GENERATES, never merges: the PR must pass full CI (typecheck/lint/test/build
+  # + the Security gate) before a human merges it. The remediator never makes an
+  # automatic major bump (the proto-loader trap); major-only fixes are listed in
+  # the PR body for manual handling.
+  remediate:
+    name: Auto-remediate fixable vulnerabilities
+    needs: maintain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/bun-install
+
+      - name: Download findings
+        uses: actions/download-artifact@v8
+        with:
+          name: security-vulns
+          path: /tmp
+
+      - name: Plan & apply remediations
+        id: remediate
+        run: |
+          set -euo pipefail
+          bun run security:remediate /tmp/vulns.json
+          # Scope the change check to the files the remediator rewrites (same
+          # rationale as the prune step): root + workspace manifests (range
+          # bumps), the lockfile, the override manifest, and the changeset.
+          if [ -n "$(git status --porcelain -- package.json 'core/*/package.json' 'plugins/*/package.json' bun.lock security/managed-overrides.json .changeset/auto-security-remediation.md)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Auto-close the CVE tracking issue when THIS PR remediates everything (no
+      # major-only findings remain for a human). `Closes #N` in the body closes
+      # the issue the moment the PR merges to main.
+      - name: Link tracking issue for closure
+        if: steps.remediate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "$(jq 'length' /tmp/remediation-manual.json)" = "0" ]; then
+            num=$(gh issue list --label security-maintenance --state open --json number,body \
+              --jq 'map(select(.body | contains("<!-- security-maintenance-cve -->")))[0].number // empty')
+            if [ -n "$num" ]; then
+              printf '\nCloses #%s\n' "$num" >> /tmp/remediation-summary.md
+              echo "Will close tracking issue #$num on merge."
+            fi
+          fi
+
+      - name: Open / update remediation PR
+        if: steps.remediate.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # A non-GITHUB_TOKEN identity is REQUIRED for the PR's CI to run:
+          # GitHub does not trigger workflows on PRs opened by GITHUB_TOKEN (they
+          # land in `action_required`). Create a SECURITY_BOT_TOKEN secret (a
+          # fine-grained PAT or GitHub App token with contents+pull-requests
+          # write, plus workflows) so the auto-PR is CI-gated end to end; until
+          # then it falls back to GITHUB_TOKEN and a maintainer must "Approve and
+          # run" the checks manually.
+          token: ${{ secrets.SECURITY_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: chore/security-remediation
+          base: main
+          commit-message: "fix(security): auto-remediate fixable vulnerabilities"
+          title: "fix(security): auto-remediate fixable vulnerabilities"
+          body-path: /tmp/remediation-summary.md
+          labels: security-maintenance
+          delete-branch: true
+          # Range-bumps edit workspace manifests too, so commit those alongside
+          # the root/lockfile/override/changeset files — never anything else.
+          add-paths: |
+            package.json
+            core/*/package.json
+            plugins/*/package.json
+            bun.lock
+            security/managed-overrides.json
+            .changeset/auto-security-remediation.md

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "audit:overrides:check": "bun run scripts/audit-overrides.ts --check",
     "audit:overrides:redundant": "bun run scripts/audit-overrides.ts --redundant",
     "audit:overrides:prune": "bun run scripts/audit-overrides.ts --prune",
+    "security:remediate": "bun run scripts/remediate-vulns.ts",
     "playwright:install": "bun run scripts/install-playwright.ts",
     "changeset": "changeset",
     "version-packages": "bun run scripts/inject-release.ts && changeset version && bun install --lockfile-only && bun run scripts/generate-sdk.ts && bun run scripts/generate-docs-index.ts",

--- a/scripts/remediate-vulns.test.ts
+++ b/scripts/remediate-vulns.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, test } from "bun:test";
+import {
+  collectChangesetPackages,
+  computeRangeBumpEdits,
+  mergeSecurityEntry,
+  parseFixedList,
+  pickInMajorFix,
+  planAll,
+  renderChangeset,
+  toManifestSeverity,
+  type Declaration,
+  type Finding,
+  type Plan,
+  type SecurityEntry,
+} from "./remediate-vulns";
+
+const EMPTY = { directlyDeclared: new Set<string>(), securityOverrides: new Set<string>(), intentionalOverrides: new Set<string>() };
+
+const f = (over: Partial<Finding>): Finding => ({
+  id: "CVE-X",
+  pkg: "p",
+  installed: "1.0.0",
+  fixed: "1.0.1",
+  sev: "MEDIUM",
+  ...over,
+});
+
+describe("parseFixedList", () => {
+  test("splits a comma list and drops invalid entries", () => {
+    expect(parseFixedList("7.6.1, 8.4.1")).toEqual(["7.6.1", "8.4.1"]);
+    expect(parseFixedList("3.4.7")).toEqual(["3.4.7"]);
+    expect(parseFixedList("")).toEqual([]);
+    expect(parseFixedList("not-a-version, 1.2.3")).toEqual(["1.2.3"]);
+  });
+});
+
+describe("pickInMajorFix", () => {
+  test("picks the lowest in-major fix above installed", () => {
+    expect(pickInMajorFix({ installed: "7.5.8", fixedVersions: ["7.6.1", "8.4.1"] })).toBe("7.6.1");
+  });
+
+  test("returns null when the only fixes are a higher major (no auto major bump)", () => {
+    expect(pickInMajorFix({ installed: "7.5.8", fixedVersions: ["8.4.1"] })).toBeNull();
+  });
+
+  test("ignores fixes at or below installed", () => {
+    expect(pickInMajorFix({ installed: "3.4.7", fixedVersions: ["3.4.6", "3.4.7"] })).toBeNull();
+  });
+
+  test("prefers the lowest of several in-major fixes", () => {
+    expect(
+      pickInMajorFix({ installed: "4.12.23", fixedVersions: ["4.13.0", "4.12.25"] }),
+    ).toBe("4.12.25");
+  });
+});
+
+describe("planAll", () => {
+  test("directly-declared dep -> range-bump (regardless of whether the range allows it)", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [f({ pkg: "hono", installed: "4.12.23", fixed: "4.12.25", sev: "HIGH" })],
+      directlyDeclared: new Set(["hono"]),
+    });
+    expect(plan.rangeBumps).toHaveLength(1);
+    expect(plan.rangeBumps[0]).toMatchObject({ pkg: "hono", action: "range-bump", target: "4.12.25" });
+    expect(plan.overrides).toEqual([]);
+  });
+
+  test("directly-declared dep with an OUT-OF-RANGE fix is still a range-bump (closes the gap)", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [f({ pkg: "x", installed: "1.2.0", fixed: "1.5.0", sev: "HIGH" })],
+      directlyDeclared: new Set(["x"]),
+    });
+    expect(plan.rangeBumps[0]).toMatchObject({ pkg: "x", action: "range-bump", target: "1.5.0" });
+    expect(plan.overrides).toEqual([]);
+  });
+
+  test("transitive dep -> override", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [f({ pkg: "undici", installed: "7.24.7", fixed: "7.28.0, 8.5.0", sev: "HIGH" })],
+    });
+    expect(plan.overrides).toHaveLength(1);
+    expect(plan.overrides[0]).toMatchObject({ pkg: "undici", action: "override", target: "7.28.0" });
+  });
+
+  test("security-override (transitive) -> override-bump only", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [
+        f({ pkg: "dompurify", installed: "3.4.3", fixed: "3.4.6", id: "CVE-A" }),
+        f({ pkg: "dompurify", installed: "3.4.3", fixed: "3.4.11", id: "CVE-B" }),
+        f({ pkg: "dompurify", installed: "3.4.3", fixed: "3.4.7", id: "CVE-C" }),
+      ],
+      securityOverrides: new Set(["dompurify"]),
+    });
+    expect(plan.overrides).toHaveLength(1);
+    // target = highest of the per-advisory minimums so all are cleared
+    expect(plan.overrides[0]).toMatchObject({ pkg: "dompurify", action: "override-bump", target: "3.4.11" });
+    expect(plan.overrides[0]).toHaveProperty("advisory", "CVE-A, CVE-B, CVE-C");
+    expect(plan.rangeBumps).toEqual([]);
+  });
+
+  test("security-override AND directly-declared -> BOTH override-bump and range-bump", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [f({ pkg: "dual", installed: "1.0.0", fixed: "1.0.5", sev: "HIGH" })],
+      directlyDeclared: new Set(["dual"]),
+      securityOverrides: new Set(["dual"]),
+    });
+    expect(plan.overrides[0]).toMatchObject({ pkg: "dual", action: "override-bump" });
+    expect(plan.rangeBumps[0]).toMatchObject({ pkg: "dual", action: "range-bump" });
+  });
+
+  test("an INTENTIONAL pin (react/drizzle) -> manual, never auto-bumped", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [f({ pkg: "react", installed: "19.2.7", fixed: "19.2.9", sev: "HIGH" })],
+      directlyDeclared: new Set(["react"]),
+      intentionalOverrides: new Set(["react"]),
+    });
+    expect(plan.manual).toHaveLength(1);
+    expect(plan.manual[0]).toMatchObject({ pkg: "react", action: "manual" });
+    expect(plan.rangeBumps).toEqual([]);
+    expect(plan.overrides).toEqual([]);
+  });
+
+  test("only a major-version fix available -> manual", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [f({ pkg: "protobufjs", installed: "7.5.8", fixed: "8.4.1", sev: "HIGH" })],
+    });
+    expect(plan.manual).toHaveLength(1);
+    expect(plan.manual[0]).toMatchObject({ pkg: "protobufjs", action: "manual" });
+    expect(plan.overrides).toEqual([]);
+  });
+
+  test("one advisory needing a major bump forces the whole package to manual", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [
+        f({ pkg: "p", installed: "7.5.8", fixed: "7.6.1", id: "A" }),
+        f({ pkg: "p", installed: "7.5.8", fixed: "8.0.0", id: "B" }),
+      ],
+      directlyDeclared: new Set(["p"]),
+    });
+    expect(plan.manual).toHaveLength(1);
+    expect(plan.rangeBumps).toEqual([]);
+    expect(plan.overrides).toEqual([]);
+  });
+
+  test("skips findings with no fix and dedupes per package", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [
+        f({ pkg: "openssl", installed: "3.5.6", fixed: "", sev: "CRITICAL" }),
+        f({ pkg: "undici", installed: "7.24.7", fixed: "7.28.0", id: "A" }),
+        f({ pkg: "undici", installed: "7.24.7", fixed: "7.28.0", id: "B" }),
+      ],
+    });
+    expect(plan.rangeBumps).toEqual([]);
+    expect(plan.overrides).toHaveLength(1);
+    expect(plan.overrides[0]).toHaveProperty("advisory", "A, B");
+  });
+
+  test("takes max severity across a package's advisories", () => {
+    const plan = planAll({
+      ...EMPTY,
+      findings: [
+        f({ pkg: "undici", installed: "7.24.7", fixed: "7.28.0", sev: "MEDIUM", id: "A" }),
+        f({ pkg: "undici", installed: "7.24.7", fixed: "7.28.0", sev: "HIGH", id: "B" }),
+      ],
+    });
+    expect(plan.overrides[0]).toMatchObject({ severity: "HIGH" });
+  });
+});
+
+describe("toManifestSeverity", () => {
+  test("passes canonical levels through, clamps anything else to MEDIUM", () => {
+    expect(toManifestSeverity("CRITICAL")).toBe("CRITICAL");
+    expect(toManifestSeverity("LOW")).toBe("LOW");
+    expect(toManifestSeverity("UNKNOWN")).toBe("MEDIUM");
+    expect(toManifestSeverity("")).toBe("MEDIUM");
+  });
+});
+
+describe("mergeSecurityEntry", () => {
+  const args = { target: "3.4.11", severity: "MEDIUM", advisory: "CVE-NEW", reason: "auto", today: "2026-06-19" };
+
+  test("builds a fully-documented entry when none exists, normalizing severity", () => {
+    const { entry, floor } = mergeSecurityEntry({ ...args, severity: "UNKNOWN", existing: undefined });
+    expect(floor).toBe("3.4.11");
+    expect(entry).toMatchObject({ safeFloor: "3.4.11", severity: "MEDIUM", advisory: "CVE-NEW", addedAt: "2026-06-19" });
+  });
+
+  test("preserves curated metadata and RAISES the floor for an existing entry", () => {
+    const existing: SecurityEntry = {
+      safeFloor: "3.4.6",
+      severity: "HIGH",
+      advisory: "CURATED",
+      reason: "curated reason",
+      addedAt: "2026-01-01",
+      removeWhen: "when x",
+    };
+    const { entry, floor } = mergeSecurityEntry({ ...args, existing });
+    expect(floor).toBe("3.4.11");
+    expect(entry).toEqual({ ...existing, safeFloor: "3.4.11" });
+  });
+
+  test("never LOWERS an existing floor", () => {
+    const existing: SecurityEntry = {
+      safeFloor: "3.4.20",
+      severity: "HIGH",
+      advisory: "CURATED",
+      reason: "r",
+      addedAt: "2026-01-01",
+      removeWhen: "w",
+    };
+    const { entry, floor } = mergeSecurityEntry({ ...args, target: "3.4.11", existing });
+    expect(floor).toBe("3.4.20");
+    expect(entry.safeFloor).toBe("3.4.20");
+  });
+});
+
+describe("computeRangeBumpEdits", () => {
+  test("emits one edit per declaration site (across files and blocks)", () => {
+    const edits = computeRangeBumpEdits({
+      rangeBumps: [
+        { pkg: "hono", action: "range-bump", installed: "4.12.23", target: "4.12.25", severity: "HIGH", advisory: "X" },
+      ],
+      declarationsByDep: {
+        hono: [
+          { file: "core/backend/package.json", block: "dependencies", pkgName: "@checkstack/backend", isPrivate: false },
+          { file: "core/backend-api/package.json", block: "peerDependencies", pkgName: "@checkstack/backend-api", isPrivate: false },
+        ],
+      },
+    });
+    expect(edits).toEqual([
+      { file: "core/backend/package.json", block: "dependencies", name: "hono", range: "^4.12.25" },
+      { file: "core/backend-api/package.json", block: "peerDependencies", name: "hono", range: "^4.12.25" },
+    ]);
+  });
+});
+
+const planWith = (over: Partial<Plan>): Plan => ({
+  rangeBumps: [],
+  overrides: [],
+  manual: [],
+  ...over,
+});
+
+const decl = (pkgName: string, isPrivate = false): Declaration => ({
+  file: "core/x/package.json",
+  block: "dependencies",
+  pkgName,
+  isPrivate,
+});
+
+describe("collectChangesetPackages", () => {
+  test("bumps the publishable packages a range-bump edited (not transitive overrides)", () => {
+    const plan = planWith({
+      rangeBumps: [
+        { pkg: "hono", action: "range-bump", installed: "4.12.23", target: "4.12.25", severity: "HIGH", advisory: "X" },
+      ],
+      overrides: [
+        { pkg: "undici", action: "override", installed: "7.24.7", target: "7.28.0", severity: "HIGH", advisory: "Y" },
+      ],
+    });
+    const pkgs = collectChangesetPackages({
+      plan,
+      declarationsByDep: {
+        hono: [decl("@checkstack/backend"), decl("@checkstack/auth-backend")],
+        undici: [],
+      },
+      fallbackPackage: "@checkstack/backend",
+    });
+    expect(pkgs).toEqual(["@checkstack/auth-backend", "@checkstack/backend"]);
+  });
+
+  test("excludes private packages from the changeset", () => {
+    const plan = planWith({
+      rangeBumps: [
+        { pkg: "hono", action: "range-bump", installed: "4.12.23", target: "4.12.25", severity: "HIGH", advisory: "X" },
+      ],
+    });
+    const pkgs = collectChangesetPackages({
+      plan,
+      declarationsByDep: { hono: [decl("@checkstack/e2e", true), decl("@checkstack/backend")] },
+      fallbackPackage: "@checkstack/backend",
+    });
+    expect(pkgs).toEqual(["@checkstack/backend"]);
+  });
+
+  test("falls back to the platform package when only transitive overrides changed", () => {
+    const plan = planWith({
+      overrides: [
+        { pkg: "protobufjs", action: "override", installed: "7.5.8", target: "7.6.3", severity: "HIGH", advisory: "Z" },
+      ],
+    });
+    const pkgs = collectChangesetPackages({
+      plan,
+      declarationsByDep: { protobufjs: [] },
+      fallbackPackage: "@checkstack/backend",
+    });
+    expect(pkgs).toEqual(["@checkstack/backend"]);
+  });
+
+  test("returns nothing when there is nothing to remediate", () => {
+    expect(
+      collectChangesetPackages({
+        plan: planWith({ manual: [{ pkg: "x", action: "manual", installed: "8.0.0", severity: "HIGH", reason: "major only" }] }),
+        declarationsByDep: {},
+        fallbackPackage: "@checkstack/backend",
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("renderChangeset", () => {
+  test("emits patch frontmatter + a bullet per applied fix", () => {
+    const plan = planWith({
+      rangeBumps: [
+        { pkg: "hono", action: "range-bump", installed: "4.12.23", target: "4.12.25", severity: "HIGH", advisory: "CVE-1" },
+      ],
+    });
+    const md = renderChangeset({ packages: ["@checkstack/backend"], plan });
+    expect(md).toContain('"@checkstack/backend": patch');
+    expect(md).toContain("- `hono` 4.12.23 → 4.12.25 (CVE-1)");
+    expect(md.startsWith("---\n")).toBe(true);
+  });
+});

--- a/scripts/remediate-vulns.ts
+++ b/scripts/remediate-vulns.ts
@@ -1,0 +1,540 @@
+#!/usr/bin/env bun
+/**
+ * Auto-remediate FIXABLE vulnerabilities found by the Security Maintenance scan.
+ *
+ * Reads the combined Trivy findings the workflow's "Build CVE report" step writes
+ * (`[{ id, pkg, installed, fixed, sev }]`, where `fixed` may be a comma list like
+ * "7.6.1, 8.4.1"). For each affected package it picks the lowest fixed version
+ * WITHIN THE INSTALLED MAJOR — never an automatic major bump, which is the
+ * `@grpc/proto-loader` trap (forcing protobufjs 8 breaks a consumer pinned to
+ * ^7) — that satisfies every advisory for that package, then applies the
+ * least-invasive fix:
+ *   - a package already pinned by a managed override -> raise the override;
+ *   - a direct dependency whose declared range already allows the fix
+ *     -> `bun update <pkg>` (just refresh the lockfile);
+ *   - otherwise (tight range, or transitive) -> add a documented managed
+ *     override forcing the fixed version.
+ * Packages whose ONLY fix is a major bump are reported as "manual" and left for
+ * a human (a major bump can break consumers in ways unit tests don't catch).
+ *
+ * Auto-GENERATE, never auto-MERGE: the changes go into a PR that must pass the
+ * full CI (typecheck/lint/test/build + the Security gate) before a human merges.
+ *
+ * Modes:
+ *   <vulns.json>              apply remediations, write summaries, refresh lockfile
+ *   <vulns.json> --dry-run    plan only; print the plan, change nothing
+ */
+
+import { Glob } from "bun";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import semver from "semver";
+import { z } from "zod";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const PKG_PATH = path.join(ROOT, "package.json");
+const MANIFEST_PATH = path.join(ROOT, "security", "managed-overrides.json");
+// Stable name so re-runs overwrite the same changeset (the PR branch is recreated
+// each run anyway).
+const CHANGESET_PATH = path.join(ROOT, ".changeset", "auto-security-remediation.md");
+// When a round touches ONLY transitive deps (no publishable package declares
+// them), bump this package so a release still ships the image rebuild that
+// carries the override fixes.
+const FALLBACK_RELEASE_PACKAGE = "@checkstack/backend";
+
+const SEVERITY_RANK: Record<string, number> = {
+  LOW: 0,
+  MEDIUM: 1,
+  HIGH: 2,
+  CRITICAL: 3,
+};
+
+// The dependency blocks a range can live in. `as const` so members narrow to a
+// union (used to index a manifest without a cast).
+const DEP_BLOCKS = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
+type DepBlock = (typeof DEP_BLOCKS)[number];
+
+// A partial view of a package.json. JSON.parse keeps every other field at
+// runtime (so write-back is lossless); this just types the bits we touch, so
+// `manifest[block]` indexes without a cast.
+interface PkgManifest {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  overrides?: Record<string, string>;
+  resolutions?: Record<string, string>;
+}
+
+const MANIFEST_SEVERITIES = ["CRITICAL", "HIGH", "MEDIUM", "LOW"] as const;
+
+/** Trivy can emit "UNKNOWN"; the managed-overrides manifest only allows the four
+ *  canonical levels, so clamp anything else to MEDIUM (don't under-rate). */
+export function toManifestSeverity(sev: string): (typeof MANIFEST_SEVERITIES)[number] {
+  for (const s of MANIFEST_SEVERITIES) if (s === sev) return s;
+  return "MEDIUM";
+}
+
+export interface SecurityEntry {
+  safeFloor: string;
+  severity: string;
+  advisory: string;
+  reason: string;
+  addedAt: string;
+  removeWhen: string;
+}
+
+/**
+ * Merge a remediation into a `security` manifest entry. For a NEW entry, build a
+ * fully-documented one. For an EXISTING (curated) entry, preserve its human
+ * fields (severity, advisory, reason) and only RAISE the floor — never lower it,
+ * never clobber the curation. Returns the entry plus the floor the override
+ * range should use.
+ */
+export function mergeSecurityEntry({
+  existing,
+  target,
+  severity,
+  advisory,
+  reason,
+  today,
+}: {
+  existing: SecurityEntry | undefined;
+  target: string;
+  severity: string;
+  advisory: string;
+  reason: string;
+  today: string;
+}): { entry: SecurityEntry; floor: string } {
+  if (!existing) {
+    const entry: SecurityEntry = {
+      safeFloor: target,
+      severity: toManifestSeverity(severity),
+      advisory,
+      reason,
+      addedAt: today,
+      removeWhen: `No dependency resolves below ${target} without this override.`,
+    };
+    return { entry, floor: target };
+  }
+  // Raise the floor to the higher of the two; keep the curated metadata.
+  const floor = semver.gt(target, existing.safeFloor) ? target : existing.safeFloor;
+  return { entry: { ...existing, safeFloor: floor }, floor };
+}
+
+export const FindingSchema = z.object({
+  id: z.string(),
+  pkg: z.string(),
+  installed: z.string(),
+  fixed: z.string(),
+  sev: z.string(),
+});
+export type Finding = z.infer<typeof FindingSchema>;
+
+export const VulnsSchema = z.array(FindingSchema);
+
+/** Split Trivy's `FixedVersion` ("7.6.1, 8.4.1") into clean semver strings. */
+export function parseFixedList(fixed: string): string[] {
+  return fixed
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0 && semver.valid(v) !== null);
+}
+
+/**
+ * Lowest fixed version in the SAME major as `installed` and strictly greater
+ * than it. Returns null when the only fixes are in a higher major (an auto
+ * major bump we refuse to make).
+ */
+export function pickInMajorFix({
+  installed,
+  fixedVersions,
+}: {
+  installed: string;
+  fixedVersions: string[];
+}): string | null {
+  const inst = semver.valid(semver.coerce(installed) ?? "");
+  if (!inst) return null;
+  const major = semver.major(inst);
+  const candidates = fixedVersions
+    .filter((v) => semver.valid(v) && semver.major(v) === major && semver.gt(v, inst))
+    .toSorted(semver.compare);
+  return candidates[0] ?? null;
+}
+
+export type Remediation =
+  | {
+      // range-bump: dep is directly declared in workspace package.json(s) — bump
+      //   its declared range so the PUBLISHED package carries the fix and our
+      //   lockfile re-resolves (closes the out-of-range gap; keeps syncpack
+      //   consistent because every declaration is bumped together).
+      // override / override-bump: dep is transitive (or already overridden) —
+      //   pin it in the root overrides for our image; npm consumers self-heal.
+      pkg: string;
+      action: "range-bump" | "override" | "override-bump";
+      installed: string;
+      target: string;
+      severity: string;
+      advisory: string;
+    }
+  | { pkg: string; action: "manual"; installed: string; reason: string; severity: string };
+
+export interface Plan {
+  rangeBumps: Remediation[];
+  overrides: Remediation[];
+  manual: Remediation[];
+}
+
+function maxSeverity(severities: string[]): string {
+  let best = severities[0] ?? "MEDIUM";
+  for (const s of severities) {
+    if ((SEVERITY_RANK[s] ?? -1) > (SEVERITY_RANK[best] ?? -1)) best = s;
+  }
+  return best;
+}
+
+/**
+ * Group findings by package and decide one remediation per package.
+ * - `directlyDeclared`: declared as a dependency of some workspace package, so a
+ *   fix belongs in their manifests (range-bump).
+ * - `securityOverrides`: already pinned via a MANAGED SECURITY override
+ *   (override-bump — raise the floor).
+ * - `intentionalOverrides`: pinned deliberately (react singleton, drizzle
+ *   alignment). Auto-bumping would fight the intent, so route to MANUAL.
+ * A dep can be both a security override AND directly declared — then we do both
+ * (raise the override for our image AND bump the published range for consumers).
+ */
+export function planAll({
+  findings,
+  directlyDeclared,
+  securityOverrides,
+  intentionalOverrides,
+}: {
+  findings: Finding[];
+  directlyDeclared: Set<string>;
+  securityOverrides: Set<string>;
+  intentionalOverrides: Set<string>;
+}): Plan {
+  const byPkg = new Map<string, Finding[]>();
+  for (const f of findings) {
+    if (f.fixed.trim().length === 0) continue;
+    const list = byPkg.get(f.pkg) ?? [];
+    list.push(f);
+    byPkg.set(f.pkg, list);
+  }
+
+  const plan: Plan = { rangeBumps: [], overrides: [], manual: [] };
+
+  for (const [pkg, group] of [...byPkg.entries()].toSorted()) {
+    // Use the lowest installed copy so the fix covers every occurrence.
+    const installed = group
+      .map((f) => f.installed)
+      .toSorted(semver.compare)[0]!;
+    const severity = maxSeverity(group.map((f) => f.sev));
+    const advisory = [...new Set(group.map((f) => f.id))].toSorted().join(", ");
+
+    // Each advisory needs its own in-major fix; the package target is the
+    // highest of those minimums so it clears them all. If ANY advisory has no
+    // in-major fix, the package can't be fully fixed without a major bump.
+    // A deliberate, non-security pin (react, drizzle, ...) — never auto-bump.
+    if (intentionalOverrides.has(pkg)) {
+      plan.manual.push({
+        pkg,
+        action: "manual",
+        installed,
+        severity,
+        reason: "pinned intentionally (not a security override) — bump manually if appropriate",
+      });
+      continue;
+    }
+
+    const perCve = group.map((f) =>
+      pickInMajorFix({ installed, fixedVersions: parseFixedList(f.fixed) }),
+    );
+    if (perCve.includes(null)) {
+      plan.manual.push({
+        pkg,
+        action: "manual",
+        installed,
+        severity,
+        reason: "only a major-version fix is available — bump manually",
+      });
+      continue;
+    }
+    const inMajorTargets = perCve.filter((v): v is string => v !== null);
+    const target = inMajorTargets.toSorted(semver.compare).at(-1)!;
+
+    const isSecurityOverride = securityOverrides.has(pkg);
+    const isDeclared = directlyDeclared.has(pkg);
+    if (isSecurityOverride) {
+      plan.overrides.push({ pkg, action: "override-bump", installed, target, severity, advisory });
+    }
+    if (isDeclared) {
+      plan.rangeBumps.push({ pkg, action: "range-bump", installed, target, severity, advisory });
+    }
+    if (!isSecurityOverride && !isDeclared) {
+      plan.overrides.push({ pkg, action: "override", installed, target, severity, advisory });
+    }
+  }
+
+  return plan;
+}
+
+export interface Declaration {
+  file: string;
+  block: DepBlock;
+  pkgName: string;
+  isPrivate: boolean;
+}
+
+export interface RangeEdit {
+  file: string;
+  block: DepBlock;
+  name: string;
+  range: string;
+}
+
+/**
+ * The concrete (file, block, name, range) edits a set of range-bumps implies —
+ * one per declaration site so EVERY manifest/block is moved together (the bit
+ * that keeps syncpack's unified groups consistent). Pure, so it's unit-tested.
+ */
+export function computeRangeBumpEdits({
+  rangeBumps,
+  declarationsByDep,
+}: {
+  rangeBumps: Remediation[];
+  declarationsByDep: Record<string, Declaration[]>;
+}): RangeEdit[] {
+  const edits: RangeEdit[] = [];
+  for (const r of rangeBumps) {
+    if (r.action !== "range-bump") continue;
+    for (const d of declarationsByDep[r.pkg] ?? []) {
+      edits.push({ file: d.file, block: d.block, name: r.pkg, range: `^${r.target}` });
+    }
+  }
+  return edits;
+}
+
+/**
+ * Publishable packages to bump in the remediation changeset: every publishable
+ * workspace package whose manifest we range-bumped (its declared dep changed, so
+ * its published artifact carries the fix). If a round is all-overrides (no
+ * manifest changed), fall back to a single platform package so a release still
+ * ships the image rebuild that carries the override fixes.
+ */
+export function collectChangesetPackages({
+  plan,
+  declarationsByDep,
+  fallbackPackage,
+}: {
+  plan: Plan;
+  declarationsByDep: Record<string, Declaration[]>;
+  fallbackPackage: string;
+}): string[] {
+  const names = new Set<string>();
+  for (const r of plan.rangeBumps) {
+    for (const d of declarationsByDep[r.pkg] ?? []) {
+      if (!d.isPrivate) names.add(d.pkgName);
+    }
+  }
+  if (names.size === 0 && [...plan.rangeBumps, ...plan.overrides].length > 0) {
+    names.add(fallbackPackage);
+  }
+  return [...names].toSorted();
+}
+
+/** A changeset (patch, per the BETA never-major rule) documenting the fixes. */
+export function renderChangeset({ packages, plan }: { packages: string[]; plan: Plan }): string {
+  const frontmatter = packages.map((p) => `"${p}": patch`).join("\n");
+  const bullets = [...plan.rangeBumps, ...plan.overrides]
+    .filter((r) => r.action !== "manual")
+    .map((r) => `- \`${r.pkg}\` ${r.installed} → ${r.target} (${r.advisory})`);
+  return [
+    "---",
+    frontmatter,
+    "---",
+    "",
+    "Security: auto-remediated fixable vulnerabilities flagged by the daily scan.",
+    "",
+    ...bullets,
+    "",
+  ].join("\n");
+}
+
+// ---- orchestration (not unit-tested; exercised by the workflow) ----
+
+/**
+ * Every place each external dependency is declared across the workspace, over
+ * all four dependency blocks — a range-bump must touch ALL of them (especially
+ * peerDependencies) to keep syncpack's unified groups consistent.
+ */
+function readWorkspaceDeclarations(): Record<string, Declaration[]> {
+  const byDep: Record<string, Declaration[]> = {};
+  const glob = new Glob("{core,plugins}/*/package.json");
+  for (const file of [...glob.scanSync(ROOT), "package.json"]) {
+    const pkg: PkgManifest & { name?: string; private?: boolean } = JSON.parse(
+      readFileSync(path.join(ROOT, file), "utf8"),
+    );
+    for (const block of DEP_BLOCKS) {
+      for (const [name, range] of Object.entries(pkg[block] ?? {})) {
+        if (range.startsWith("workspace:")) continue;
+        (byDep[name] ??= []).push({
+          file,
+          block,
+          pkgName: pkg.name ?? file,
+          isPrivate: pkg.private === true,
+        });
+      }
+    }
+  }
+  return byDep;
+}
+
+function renderSummary(plan: Plan): string {
+  const lines: string[] = ["Automated by the daily **Security Maintenance** workflow.", ""];
+  if (plan.rangeBumps.length > 0) {
+    lines.push("## Direct dependency range bumps", "");
+    for (const r of plan.rangeBumps) {
+      if (r.action === "manual") continue;
+      lines.push(`- **${r.severity}** \`${r.pkg}\` ${r.installed} → ^${r.target} (${r.advisory})`);
+    }
+    lines.push("");
+  }
+  if (plan.overrides.length > 0) {
+    lines.push("## Managed security overrides", "");
+    for (const r of plan.overrides) {
+      if (r.action === "manual") continue;
+      const verb = r.action === "override-bump" ? "raised to" : "pinned to";
+      lines.push(`- **${r.severity}** \`${r.pkg}\` ${r.installed} → ${verb} ^${r.target} (${r.advisory})`);
+    }
+    lines.push("");
+  }
+  if (plan.manual.length > 0) {
+    lines.push("## Needs manual attention (major-version fix only)", "");
+    for (const r of plan.manual) {
+      if (r.action !== "manual") continue;
+      lines.push(`- **${r.severity}** \`${r.pkg}\` ${r.installed}: ${r.reason}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const vulnsPath = process.argv[2];
+  const dryRun = process.argv.includes("--dry-run");
+  if (!vulnsPath) {
+    console.error("Usage: bun run scripts/remediate-vulns.ts <vulns.json> [--dry-run]");
+    process.exit(1);
+  }
+
+  const findings = VulnsSchema.parse(JSON.parse(readFileSync(vulnsPath, "utf8")));
+  const pkg: PkgManifest = JSON.parse(readFileSync(PKG_PATH, "utf8"));
+  const manifest: {
+    security: Record<string, SecurityEntry>;
+    intentional?: Record<string, unknown>;
+    [k: string]: unknown;
+  } = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+
+  const declarationsByDep = readWorkspaceDeclarations();
+  const plan = planAll({
+    findings,
+    directlyDeclared: new Set(Object.keys(declarationsByDep)),
+    securityOverrides: new Set(Object.keys(manifest.security)),
+    intentionalOverrides: new Set(Object.keys(manifest.intentional ?? {})),
+  });
+
+  const changesetPackages = collectChangesetPackages({
+    plan,
+    declarationsByDep,
+    fallbackPackage: FALLBACK_RELEASE_PACKAGE,
+  });
+
+  const summary = renderSummary(plan);
+  writeFileSync("/tmp/remediation-summary.md", `${summary}\n`);
+  writeFileSync("/tmp/remediation-manual.json", JSON.stringify(plan.manual, null, 2));
+  console.log(summary);
+  if (changesetPackages.length > 0) {
+    console.log(`Changeset (patch) will bump: ${changesetPackages.join(", ")}`);
+  }
+
+  if (dryRun) {
+    console.log("\n(dry-run: no files changed)");
+    return;
+  }
+
+  // Edit every affected package.json through one shared cache (root included, so
+  // range-bumps and override edits to it never clobber each other). Only files
+  // actually modified are written, to avoid spurious reformatting diffs.
+  const parsed = new Map<string, PkgManifest>([["package.json", pkg]]);
+  const dirtyFiles = new Set<string>();
+  const loadJson = (rel: string): PkgManifest => {
+    let json = parsed.get(rel);
+    if (!json) {
+      json = JSON.parse(readFileSync(path.join(ROOT, rel), "utf8"));
+      parsed.set(rel, json);
+    }
+    return json;
+  };
+
+  // 1. Range-bumps: raise the declared range in EVERY owning manifest/block so
+  //    the published package carries the fix and syncpack stays consistent.
+  for (const e of computeRangeBumpEdits({ rangeBumps: plan.rangeBumps, declarationsByDep })) {
+    (loadJson(e.file)[e.block] ??= {})[e.name] = e.range;
+    dirtyFiles.add(e.file);
+  }
+
+  // 2. Overrides: pin transitive deps in the root overrides + document them in
+  //    the security manifest (preserving any existing curation; never lowering
+  //    a floor or overwriting a higher recorded severity).
+  const today = new Date().toISOString().slice(0, 10);
+  let manifestDirty = false;
+  for (const r of plan.overrides) {
+    if (r.action === "manual") continue;
+    const { entry, floor } = mergeSecurityEntry({
+      existing: manifest.security[r.pkg],
+      target: r.target,
+      severity: r.severity,
+      advisory: r.advisory,
+      reason: `Auto-remediated by Security Maintenance: ${r.pkg} ${r.installed} had fixable advisories; pinned to the fixed ${semver.major(r.target)}.x line.`,
+      today,
+    });
+    const range = `^${floor}`;
+    pkg.overrides ??= {};
+    pkg.resolutions ??= {};
+    // Already covered at/above this floor — no change, no churn.
+    if (pkg.overrides[r.pkg] === range && pkg.resolutions[r.pkg] === range) continue;
+    pkg.overrides[r.pkg] = range;
+    pkg.resolutions[r.pkg] = range;
+    manifest.security[r.pkg] = entry;
+    dirtyFiles.add("package.json");
+    manifestDirty = true;
+  }
+
+  if (dirtyFiles.size === 0) {
+    console.log("Nothing to apply (all findings already covered or manual).");
+    return;
+  }
+
+  for (const rel of dirtyFiles) {
+    writeFileSync(path.join(ROOT, rel), `${JSON.stringify(parsed.get(rel), null, 2)}\n`);
+  }
+  if (manifestDirty) {
+    writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+  }
+  // A changeset so the release pipeline versions + publishes the affected
+  // packages and rebuilds the Docker image — without it the fixes never ship.
+  if (changesetPackages.length > 0) {
+    writeFileSync(CHANGESET_PATH, renderChangeset({ packages: changesetPackages, plan }));
+  }
+
+  // Re-resolve: range-bumps force bumped deps onto the new floor, overrides are
+  // materialized. No `bun update` — running it at the root rewrites root
+  // package.json (adds the dep) and breaks syncpack's unified groups.
+  await Bun.$`bun install`.cwd(ROOT);
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
Extends the daily **Security Maintenance** workflow to turn fixable Trivy findings into a single **CI-gated remediation PR** — it *generates*, never merges; a human reviews and merges after CI proves it.

## How it decides (per package)

Always the **lowest fixed version within the installed major** — never an automatic major bump (the `@grpc/proto-loader` trap). Then the least-invasive fix:

| Case | Action |
|---|---|
| Directly-declared workspace dep | **Bump its declared range in every owning manifest + block** (incl. `peerDependencies`) → the published package carries the fix, our lockfile re-resolves, and syncpack's unified groups stay consistent |
| Already a managed security override | **Raise the override**, preserving the curated manifest entry, never lowering a recorded `safeFloor` |
| Purely transitive dep | **Add a documented root override** (npm consumers self-heal via ranges) |
| Intentional pin (react/drizzle) or major-only fix | **Left for a human** (listed as "manual") |

No `bun update` — running it at the root pollutes the root manifest and breaks syncpack (that was the `Deps`-check failure).

## Also handles the full lifecycle

- **Changeset** bumping the publishable packages whose manifests changed (fallback to `@checkstack/backend` for all-transitive rounds), so a release actually ships the fix (incl. the Docker image rebuild).
- **Closes the CVE tracking issue** on merge (`Closes #N`) when nothing is left manual; the daily job also closes it when nothing is fixable.
- Both PR-creating steps use `SECURITY_BOT_TOKEN || GITHUB_TOKEN` so the auto-PR's CI runs.

## Quality

- `scripts/remediate-vulns.ts` pure logic (version selection, planning, changeset selection, security-entry merge, range-edit computation) is **unit-tested — 25 tests**.
- Verified end-to-end in a clean worktree against the live findings: hono `^4.12.25` across 7 backends, nodemailer `^9.0.1`, dompurify/protobufjs/undici via overrides; **`syncpack lint` ✓, override-drift ✓**, curated entries preserved, every package resolves to its fixed version.
- A code-review pass was run; its blockers/important findings are incorporated (preserve curated entries, never lower a floor, normalize Trivy severities, route intentional pins to manual, skip no-op rounds, remove all `as` casts).

## Required follow-up (one-time, by a maintainer)

Create a **`SECURITY_BOT_TOKEN`** secret (fine-grained PAT or GitHub App token with `contents:write` + `pull-requests:write` + `workflows`). Without it the auto-PR is still created but its CI sits in "Approve and run" — GitHub doesn't trigger workflows on `GITHUB_TOKEN`-created PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
