### PR TITLE
feat(healthcheck): search, filter, and sort the Health Checks overview

### DIFF
--- a/.changeset/healthcheck-overview-search-filter.md
+++ b/.changeset/healthcheck-overview-search-filter.md
@@ -1,0 +1,15 @@
+---
+"@checkstack/healthcheck-frontend": minor
+---
+
+Add search, filters, and name sorting to the Health Checks overview.
+
+The "Health Checks" config page now ships a toolbar with a name search, a
+strategy filter, an active/paused status filter, and a "show all assigned to
+system X" filter. Results are sorted by name (case-insensitive). Filter state
+is held in URL params (shareable links) and debounced for smooth typing.
+
+Because a health-check configuration carries no system field of its own (the
+assignment is a separate entity), the system filter resolves the assigned
+config id set for the selected system via `getSystemConfigurations` and
+intersects it with the loaded configurations.

--- a/core/healthcheck-frontend/src/components/HealthCheckListToolbar.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckListToolbar.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import {
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Button,
+} from "@checkstack/ui";
+import { Search, X } from "lucide-react";
+import type { HealthCheckStrategyDto } from "@checkstack/healthcheck-common";
+import {
+  StatusFilterSchema,
+  type HealthCheckListState,
+  type StatusFilter,
+} from "./healthCheckListState.logic";
+
+/**
+ * Sentinel "all" value for the `Select` filters. Radix `Select` items cannot
+ * carry an empty-string value, so a non-empty token stands in for "no filter".
+ * (Same convention as `CatalogBrowseToolbar`.)
+ */
+const ALL = "__all__";
+
+const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
+  { value: "all", label: "All statuses" },
+  { value: "active", label: "Active" },
+  { value: "paused", label: "Paused" },
+];
+
+export interface HealthCheckListToolbarProps {
+  state: HealthCheckListState;
+  onQueryChange: (query: string) => void;
+  onStrategyChange: (strategyId: string | null) => void;
+  onStatusChange: (status: StatusFilter) => void;
+  onSystemChange: (systemId: string | null) => void;
+  onClearFilters: () => void;
+  strategies: HealthCheckStrategyDto[];
+  systems: { id: string; name: string }[];
+  /**
+   * `true` while the assigned-config-ids query for the selected system is
+   * loading. Used to hint the system filter is resolving (no separate affordance
+   * is rendered; the list itself shows nothing until the set resolves).
+   */
+  systemAssignmentsLoading?: boolean;
+  /** Whether any filter is currently active (drives the clear-filters button). */
+  hasActiveFilter: boolean;
+}
+
+/**
+ * Health-check overview toolbar: search by name + strategy/status/system
+ * filters + a clear-filters button. Pure controlled component — all state is
+ * lifted to the page via `useHealthCheckListState`.
+ *
+ * Mirrors the catalog browse toolbar layout
+ * (`core/catalog-frontend/src/components/browse/CatalogBrowseToolbar.tsx`).
+ */
+export const HealthCheckListToolbar: React.FC<HealthCheckListToolbarProps> = ({
+  state,
+  onQueryChange,
+  onStrategyChange,
+  onStatusChange,
+  onSystemChange,
+  onClearFilters,
+  strategies,
+  systems,
+  systemAssignmentsLoading = false,
+  hasActiveFilter,
+}) => {
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-center">
+      <div className="relative flex-1 min-w-[12rem]">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <Input
+          type="search"
+          value={state.query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="Search health checks"
+          aria-label="Search health checks"
+          className="pl-9"
+        />
+      </div>
+
+      <Select
+        value={state.strategyId ?? ALL}
+        onValueChange={(value) =>
+          onStrategyChange(value === ALL ? null : value)
+        }
+      >
+        <SelectTrigger className="md:w-48" aria-label="Filter by strategy">
+          <SelectValue placeholder="All strategies" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>All strategies</SelectItem>
+          {strategies.map((s) => (
+            <SelectItem key={s.id} value={s.id}>
+              {s.displayName}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={state.status}
+        onValueChange={(value) => onStatusChange(StatusFilterSchema.parse(value))}
+      >
+        <SelectTrigger className="md:w-40" aria-label="Filter by status">
+          <SelectValue placeholder="All statuses" />
+        </SelectTrigger>
+        <SelectContent>
+          {STATUS_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={state.systemId ?? ALL}
+        onValueChange={(value) => onSystemChange(value === ALL ? null : value)}
+      >
+        <SelectTrigger
+          className="md:w-52"
+          aria-label="Filter by assigned system"
+          title={
+            systemAssignmentsLoading
+              ? "Loading assignments…"
+              : "Show checks assigned to a system"
+          }
+        >
+          <SelectValue placeholder="All systems" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>All systems</SelectItem>
+          {systems.map((sys) => (
+            <SelectItem key={sys.id} value={sys.id}>
+              {sys.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {hasActiveFilter && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClearFilters}
+          className="text-muted-foreground"
+        >
+          <X className="mr-1 h-4 w-4" /> Clear
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/core/healthcheck-frontend/src/components/healthCheckListState.logic.test.ts
+++ b/core/healthcheck-frontend/src/components/healthCheckListState.logic.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, test } from "bun:test";
+import type { HealthCheckConfiguration } from "@checkstack/healthcheck-common";
+import {
+  DEFAULT_HEALTHCHECK_LIST_STATE,
+  HEALTHCHECK_LIST_PARAM,
+  filterAndSortHealthChecks,
+  hasActiveHealthCheckFilter,
+  parseHealthCheckListState,
+  serializeHealthCheckListState,
+} from "./healthCheckListState.logic";
+
+/** Minimal factory for a HealthCheckConfiguration with sensible defaults. */
+function makeConfig(
+  overrides: Partial<HealthCheckConfiguration> = {},
+): HealthCheckConfiguration {
+  return {
+    id: overrides.id ?? "c1",
+    name: overrides.name ?? "API check",
+    strategyId: overrides.strategyId ?? "http",
+    config: overrides.config ?? {},
+    intervalSeconds: overrides.intervalSeconds ?? 30,
+    collectors: overrides.collectors,
+    paused: overrides.paused ?? false,
+    createdAt: overrides.createdAt ?? new Date("2024-01-01"),
+    updatedAt: overrides.updatedAt ?? new Date("2024-01-02"),
+  };
+}
+
+function makeParams(
+  entries: Record<string, string>,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(entries)) params.set(k, v);
+  return params;
+}
+
+describe("parseHealthCheckListState", () => {
+  test("empty params yield defaults", () => {
+    expect(parseHealthCheckListState(new URLSearchParams())).toEqual(
+      DEFAULT_HEALTHCHECK_LIST_STATE,
+    );
+  });
+
+  test("parses all params", () => {
+    const params = makeParams({
+      [HEALTHCHECK_LIST_PARAM.query]: "api",
+      [HEALTHCHECK_LIST_PARAM.strategy]: "http",
+      [HEALTHCHECK_LIST_PARAM.status]: "paused",
+      [HEALTHCHECK_LIST_PARAM.system]: "sys-1",
+    });
+    expect(parseHealthCheckListState(params)).toEqual({
+      query: "api",
+      strategyId: "http",
+      status: "paused",
+      systemId: "sys-1",
+    });
+  });
+
+  test("empty strategy/system strings resolve to null", () => {
+    const params = makeParams({
+      [HEALTHCHECK_LIST_PARAM.strategy]: "",
+      [HEALTHCHECK_LIST_PARAM.system]: "",
+    });
+    const state = parseHealthCheckListState(params);
+    expect(state.strategyId).toBeNull();
+    expect(state.systemId).toBeNull();
+  });
+
+  test("invalid status falls back to all", () => {
+    const params = makeParams({ [HEALTHCHECK_LIST_PARAM.status]: "bogus" });
+    expect(parseHealthCheckListState(params).status).toBe("all");
+  });
+});
+
+describe("serializeHealthCheckListState", () => {
+  test("default state serializes to all-empty (clean URL)", () => {
+    const serialized = serializeHealthCheckListState(
+      DEFAULT_HEALTHCHECK_LIST_STATE,
+    );
+    for (const value of Object.values(serialized)) {
+      expect(value).toBe("");
+    }
+  });
+
+  test("round-trips a populated state", () => {
+    const state = {
+      query: "api",
+      strategyId: "http",
+      status: "paused" as const,
+      systemId: "sys-1",
+    };
+    const serialized = serializeHealthCheckListState(state);
+    expect(
+      parseHealthCheckListState(makeParams(serialized)),
+    ).toEqual(state);
+  });
+
+  test("default status serializes to empty (omitted from URL)", () => {
+    const serialized = serializeHealthCheckListState({
+      query: "",
+      strategyId: null,
+      status: "all",
+      systemId: null,
+    });
+    expect(serialized[HEALTHCHECK_LIST_PARAM.status]).toBe("");
+  });
+});
+
+describe("filterAndSortHealthChecks", () => {
+  const configs = [
+    makeConfig({ id: "c1", name: "Beta check", strategyId: "http", paused: false }),
+    makeConfig({ id: "c2", name: "alpha check", strategyId: "tcp", paused: true }),
+    makeConfig({ id: "c3", name: "Gamma probe", strategyId: "http", paused: false }),
+  ];
+
+  test("sorts by name case-insensitively", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: DEFAULT_HEALTHCHECK_LIST_STATE,
+    });
+    expect(result.map((c) => c.name)).toEqual([
+      "alpha check",
+      "Beta check",
+      "Gamma probe",
+    ]);
+  });
+
+  test("query filters by name substring (case-insensitive)", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: { ...DEFAULT_HEALTHCHECK_LIST_STATE, query: "BET" },
+    });
+    expect(result.map((c) => c.id)).toEqual(["c1"]);
+  });
+
+  test("strategy filter narrows to a single strategy", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: { ...DEFAULT_HEALTHCHECK_LIST_STATE, strategyId: "http" },
+    });
+    expect(result.map((c) => c.id).sort()).toEqual(["c1", "c3"]);
+  });
+
+  test("status=active returns only non-paused", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: { ...DEFAULT_HEALTHCHECK_LIST_STATE, status: "active" },
+    });
+    expect(result.map((c) => c.paused)).toEqual([false, false]);
+  });
+
+  test("status=paused returns only paused", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: { ...DEFAULT_HEALTHCHECK_LIST_STATE, status: "paused" },
+    });
+    expect(result.map((c) => c.id)).toEqual(["c2"]);
+  });
+
+  test("system filter intersects with assigned config ids", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: {
+        ...DEFAULT_HEALTHCHECK_LIST_STATE,
+        systemId: "sys-1",
+      },
+      assignedConfigIds: new Set(["c2", "c3"]),
+    });
+    expect(result.map((c) => c.id).sort()).toEqual(["c2", "c3"]);
+  });
+
+  test("system filter shows nothing while assigned ids are loading (undefined)", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: {
+        ...DEFAULT_HEALTHCHECK_LIST_STATE,
+        systemId: "sys-1",
+      },
+      assignedConfigIds: undefined,
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("system filter with empty assigned set shows nothing", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: {
+        ...DEFAULT_HEALTHCHECK_LIST_STATE,
+        systemId: "sys-1",
+      },
+      assignedConfigIds: new Set<string>(),
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("filters compose (AND): query + strategy + status + system", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: {
+        query: "gam",
+        strategyId: "http",
+        status: "active",
+        systemId: "sys-1",
+      },
+      assignedConfigIds: new Set(["c1", "c3"]),
+    });
+    expect(result.map((c) => c.id)).toEqual(["c3"]);
+  });
+
+  test("empty query string does not filter", () => {
+    const result = filterAndSortHealthChecks({
+      configurations: configs,
+      state: { ...DEFAULT_HEALTHCHECK_LIST_STATE, query: "" },
+    });
+    expect(result).toHaveLength(3);
+  });
+});
+
+describe("hasActiveHealthCheckFilter", () => {
+  test("default state has no active filter", () => {
+    expect(hasActiveHealthCheckFilter(DEFAULT_HEALTHCHECK_LIST_STATE)).toBe(
+      false,
+    );
+  });
+
+  test("query alone is an active filter", () => {
+    expect(
+      hasActiveHealthCheckFilter({
+        ...DEFAULT_HEALTHCHECK_LIST_STATE,
+        query: "x",
+      }),
+    ).toBe(true);
+  });
+
+  test("whitespace-only query is not an active filter", () => {
+    expect(
+      hasActiveHealthCheckFilter({
+        ...DEFAULT_HEALTHCHECK_LIST_STATE,
+        query: "   ",
+      }),
+    ).toBe(false);
+  });
+
+  test("any single dimension counts as active", () => {
+    expect(
+      hasActiveHealthCheckFilter({
+        ...DEFAULT_HEALTHCHECK_LIST_STATE,
+        strategyId: "http",
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveHealthCheckFilter({
+        ...DEFAULT_HEALTHCHECK_LIST_STATE,
+        status: "paused",
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveHealthCheckFilter({
+        ...DEFAULT_HEALTHCHECK_LIST_STATE,
+        systemId: "sys-1",
+      }),
+    ).toBe(true);
+  });
+});

--- a/core/healthcheck-frontend/src/components/healthCheckListState.logic.ts
+++ b/core/healthcheck-frontend/src/components/healthCheckListState.logic.ts
@@ -1,0 +1,183 @@
+import { z } from "zod";
+import type { HealthCheckConfiguration } from "@checkstack/healthcheck-common";
+
+/**
+ * Health-check overview list view state — DOM-free serialise/parse/filter/sort
+ * logic for the "Health Checks" config page. All list state (search query,
+ * strategy / status / system filters) is ephemeral UI state held in URL params
+ * so a shared link reopens the same view. This module owns the single source
+ * of truth for the param names and their defaults; the React hook
+ * (`useHealthCheckListState`) is a thin wrapper over these pure functions.
+ *
+ * Mirrors the catalog browse state pattern (see
+ * `core/catalog-frontend/src/components/browse/browseState.logic.ts`) so the
+ * two list surfaces share the same conventions.
+ */
+
+/** URL param keys used by the health-check list view. Centralised to avoid typos. */
+export const HEALTHCHECK_LIST_PARAM = {
+  query: "q",
+  strategy: "strategy",
+  status: "status",
+  system: "system",
+} as const;
+
+/**
+ * Status filter values. The list shows Active vs Paused (derived from
+ * `config.paused`); there is no run-level health status on this surface.
+ */
+export const StatusFilterSchema = z.enum(["all", "active", "paused"]);
+export type StatusFilter = z.infer<typeof StatusFilterSchema>;
+
+/** The fully-parsed health-check list view state. */
+export interface HealthCheckListState {
+  /** Free-text search over the configuration name. */
+  query: string;
+  /** Narrow to a single strategy id, or `null` for "all strategies". */
+  strategyId: string | null;
+  /** Active/paused filter. */
+  status: StatusFilter;
+  /**
+   * Narrow to checks assigned to a specific system id, or `null` for
+   * "all systems". A configuration has no `systemId` field of its own; the
+   * assignment is a separate entity, so the caller resolves the set of
+   * assigned configuration ids for the selected system and passes it to
+   * {@link filterAndSortHealthChecks} via `assignedConfigIds`.
+   */
+  systemId: string | null;
+}
+
+/** Default state when no params are present. */
+export const DEFAULT_HEALTHCHECK_LIST_STATE: HealthCheckListState = {
+  query: "",
+  strategyId: null,
+  status: "all",
+  systemId: null,
+};
+
+/**
+ * Parse health-check list state from a `URLSearchParams`-like reader. Invalid
+ * or absent values fall back to defaults so a hand-edited URL never throws.
+ */
+export function parseHealthCheckListState(params: {
+  get: (key: string) => string | null;
+}): HealthCheckListState {
+  const query = params.get(HEALTHCHECK_LIST_PARAM.query) ?? "";
+  const strategy = params.get(HEALTHCHECK_LIST_PARAM.strategy);
+  const system = params.get(HEALTHCHECK_LIST_PARAM.system);
+
+  const statusRaw = params.get(HEALTHCHECK_LIST_PARAM.status);
+  const status = StatusFilterSchema.safeParse(statusRaw);
+
+  return {
+    query,
+    strategyId: strategy && strategy.length > 0 ? strategy : null,
+    status: status.success ? status.data : DEFAULT_HEALTHCHECK_LIST_STATE.status,
+    systemId: system && system.length > 0 ? system : null,
+  };
+}
+
+/**
+ * Compute the param mutations to apply for a given list state. Returns a map
+ * of param key → value where an empty string means "delete this param" (so the
+ * URL stays clean and a default state produces no params at all). The React
+ * hook applies these against the live `URLSearchParams`.
+ */
+export function serializeHealthCheckListState(
+  state: HealthCheckListState,
+): Record<string, string> {
+  return {
+    [HEALTHCHECK_LIST_PARAM.query]: state.query,
+    [HEALTHCHECK_LIST_PARAM.strategy]: state.strategyId ?? "",
+    [HEALTHCHECK_LIST_PARAM.status]:
+      state.status === DEFAULT_HEALTHCHECK_LIST_STATE.status ? "" : state.status,
+    [HEALTHCHECK_LIST_PARAM.system]: state.systemId ?? "",
+  };
+}
+
+/** Case-insensitive substring match, null-safe. */
+function matchesText(haystack: string, needle: string): boolean {
+  if (!needle) return true;
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+/** Does a configuration pass the status filter? */
+function matchesStatus(
+  config: HealthCheckConfiguration,
+  status: StatusFilter,
+): boolean {
+  if (status === "all") return true;
+  if (status === "active") return !config.paused;
+  return config.paused;
+}
+
+/**
+ * Filter and sort health-check configurations for the overview list.
+ *
+ * - `query` matches the configuration name (case-insensitive substring).
+ * - `strategyId` narrows to a single strategy (exact id match).
+ * - `status` filters active vs paused.
+ * - `systemId` narrows to checks assigned to a system. Since a configuration
+ *   carries no system field, the caller resolves the assigned config id set
+ *   for the selected system and passes it as `assignedConfigIds`; when the
+ *   system filter is active (`systemId` set) only configs whose id appears in
+ *   that set survive. `assignedConfigIds` may be `undefined` while the
+ *   assignment query is still loading — in that case nothing is shown until
+ *   the set resolves (avoids a flash of unfiltered rows).
+ * - Results are sorted by name (case-insensitive, locale-aware) so the list
+ *   reads predictably regardless of insertion order.
+ */
+export function filterAndSortHealthChecks({
+  configurations,
+  state,
+  assignedConfigIds,
+}: {
+  configurations: HealthCheckConfiguration[];
+  state: HealthCheckListState;
+  /**
+   * Config ids assigned to the selected system. Resolved by the caller from
+   * `getSystemConfigurations({ systemId })` when `state.systemId` is set;
+   * `undefined` while that query is still loading, `null` when no system
+   * filter is active.
+   */
+  assignedConfigIds?: Set<string> | null;
+}): HealthCheckConfiguration[] {
+  const systemFilterActive = state.systemId !== null;
+
+  const filtered = configurations.filter((config) => {
+    if (!matchesText(config.name, state.query)) return false;
+    if (state.strategyId !== null && config.strategyId !== state.strategyId)
+      return false;
+    if (!matchesStatus(config, state.status)) return false;
+    if (systemFilterActive) {
+      const ids = assignedConfigIds;
+      // While the assignment set is loading (`undefined`), show nothing rather
+      // than the unfiltered superset — avoids a misleading flash of all checks.
+      // A resolved set (`null` shouldn't happen while the filter is active, but
+      // is treated as "no matches" defensively) gates each config by id.
+      if (!ids) return false;
+      if (!ids.has(config.id)) return false;
+    }
+    return true;
+  });
+
+  return filtered.toSorted((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  );
+}
+
+/**
+ * `true` when any filter is active (query / strategy / status / system). Used
+ * by the page to decide whether an empty list is "filtered to empty" (show a
+ * clear-filters affordance) vs a genuinely empty catalog.
+ */
+export function hasActiveHealthCheckFilter(
+  state: HealthCheckListState,
+): boolean {
+  return (
+    state.query.trim().length > 0 ||
+    state.strategyId !== null ||
+    state.status !== "all" ||
+    state.systemId !== null
+  );
+}

--- a/core/healthcheck-frontend/src/hooks/useDebouncedValue.ts
+++ b/core/healthcheck-frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,22 @@
+import React from "react";
+
+/**
+ * Return `value` debounced by `delayMs`: the returned value only updates after
+ * `value` has stopped changing for `delayMs`. Used to throttle the live
+ * health-check search so a fast typist doesn't re-filter the list on every
+ * keystroke.
+ *
+ * Copied (not imported) from catalog-frontend per the code-style guide —
+ * there is no shared `useDebounce` in `@checkstack/ui` yet, and adding one
+ * unilaterally is out of scope.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = React.useState(value);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/core/healthcheck-frontend/src/hooks/useHealthCheckListState.ts
+++ b/core/healthcheck-frontend/src/hooks/useHealthCheckListState.ts
@@ -1,0 +1,102 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  parseHealthCheckListState,
+  serializeHealthCheckListState,
+  type HealthCheckListState,
+  type StatusFilter,
+} from "../components/healthCheckListState.logic";
+import { useDebouncedValue } from "./useDebouncedValue";
+
+const QUERY_DEBOUNCE_MS = 150;
+
+export interface HealthCheckListStateApi {
+  /** Live state reflecting the URL (query updates immediately for the input). */
+  state: HealthCheckListState;
+  /** Query debounced for filtering, so typing stays smooth on large lists. */
+  debouncedQuery: string;
+  setQuery: (query: string) => void;
+  setStrategy: (strategyId: string | null) => void;
+  setStatus: (status: StatusFilter) => void;
+  setSystem: (systemId: string | null) => void;
+  /** Clear every filter (query/strategy/status/system). */
+  clearFilters: () => void;
+}
+
+/**
+ * Bridge between the health-check list URL params and the page. All
+ * persistence logic lives in `healthCheckListState.logic.ts` (DOM-free,
+ * tested); this hook only wires it to `useSearchParams` and adds query
+ * debouncing.
+ *
+ * Mirrors `useCatalogBrowseState` from catalog-frontend.
+ */
+export function useHealthCheckListState(): HealthCheckListStateApi {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const state = useMemo(
+    () => parseHealthCheckListState(searchParams),
+    [searchParams],
+  );
+
+  const debouncedQuery = useDebouncedValue(state.query, QUERY_DEBOUNCE_MS);
+
+  const commit = useCallback(
+    (next: HealthCheckListState) => {
+      const serialized = serializeHealthCheckListState(next);
+      setSearchParams(
+        (prev) => {
+          const updated = new URLSearchParams(prev);
+          for (const [key, value] of Object.entries(serialized)) {
+            if (value.length > 0) {
+              updated.set(key, value);
+            } else {
+              updated.delete(key);
+            }
+          }
+          return updated;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setQuery = useCallback(
+    (query: string) => commit({ ...state, query }),
+    [commit, state],
+  );
+  const setStrategy = useCallback(
+    (strategyId: string | null) => commit({ ...state, strategyId }),
+    [commit, state],
+  );
+  const setStatus = useCallback(
+    (status: StatusFilter) => commit({ ...state, status }),
+    [commit, state],
+  );
+  const setSystem = useCallback(
+    (systemId: string | null) => commit({ ...state, systemId }),
+    [commit, state],
+  );
+  const clearFilters = useCallback(
+    () =>
+      commit({
+        ...state,
+        query: "",
+        strategyId: null,
+        status: "all",
+        systemId: null,
+      }),
+    [commit, state],
+  );
+
+  return {
+    state,
+    debouncedQuery,
+    setQuery,
+    setStrategy,
+    setStatus,
+    setSystem,
+    clearFilters,
+  };
+}

--- a/core/healthcheck-frontend/src/pages/HealthCheckConfigPage.tsx
+++ b/core/healthcheck-frontend/src/pages/HealthCheckConfigPage.tsx
@@ -14,11 +14,18 @@ import {
   healthCheckAccess,
   pluginMetadata as healthcheckPluginMetadata,
 } from "@checkstack/healthcheck-common";
+import { CatalogApi } from "@checkstack/catalog-common";
 import { Tip, TipBanner } from "@checkstack/tips-frontend";
 import {
   HealthCheckList,
   HealthCheckListSkeleton,
 } from "../components/HealthCheckList";
+import { HealthCheckListToolbar } from "../components/HealthCheckListToolbar";
+import {
+  filterAndSortHealthChecks,
+  hasActiveHealthCheckFilter,
+} from "../components/healthCheckListState.logic";
+import { useHealthCheckListState } from "../hooks/useHealthCheckListState";
 import { FirstCheckWizard } from "../components/FirstCheckWizard";
 import {
   Button,
@@ -65,11 +72,21 @@ type ConfigurationsQueryData = {
 
 const HealthCheckConfigPageContent = () => {
   const healthCheckClient = usePluginClient(HealthCheckApi);
+  const catalogClient = usePluginClient(CatalogApi);
   const queryClient = useQueryClient();
   const accessApi = useApi(accessApiRef);
   const toast = useToast();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const {
+    state: listState,
+    debouncedQuery,
+    setQuery,
+    setStrategy,
+    setStatus,
+    setSystem,
+    clearFilters,
+  } = useHealthCheckListState();
   const { allowed: canRead, loading: accessLoading } = accessApi.useAccess(
     healthCheckAccess.configuration.read,
   );
@@ -107,7 +124,57 @@ const HealthCheckConfigPageContent = () => {
     {},
   );
 
-  const configurations = configurationsData?.configurations ?? [];
+  const configurations = useMemo(
+    () => configurationsData?.configurations ?? [],
+    [configurationsData],
+  );
+
+  // Systems list for the "assigned to system X" filter. Lazily loaded: the
+  // query is only enabled once the user has read access AND there are
+  // configurations to filter, so a fresh install with no checks doesn't ping
+  // the catalog backend.
+  const systemsQuery = catalogClient.getSystems.useQuery(
+    {},
+    { enabled: canRead && configurations.length > 0 },
+  );
+  const systems = systemsQuery.data?.systems ?? [];
+
+  // When a system filter is active, resolve the set of config ids assigned to
+  // that system via `getSystemConfigurations`. A configuration carries no
+  // system field of its own — the assignment is a separate entity — so the
+  // filter intersects this id set with the loaded configurations. `undefined`
+  // while loading (the filter logic shows nothing until the set resolves, to
+  // avoid a flash of the unfiltered superset).
+  const systemFilterActive = listState.systemId !== null;
+  const systemConfigsQuery =
+    healthCheckClient.getSystemConfigurations.useQuery(
+      { systemId: listState.systemId ?? "" },
+      { enabled: systemFilterActive },
+    );
+  const assignedConfigIds = useMemo((): Set<string> | null | undefined => {
+    if (!systemFilterActive) return null;
+    if (systemConfigsQuery.isLoading) return;
+    return new Set((systemConfigsQuery.data ?? []).map((c) => c.id));
+  }, [
+    systemFilterActive,
+    systemConfigsQuery.isLoading,
+    systemConfigsQuery.data,
+  ]);
+
+  const filteredConfigurations = useMemo(
+    () =>
+      filterAndSortHealthChecks({
+        configurations,
+        state: { ...listState, query: debouncedQuery },
+        assignedConfigIds,
+      }),
+    [configurations, listState, debouncedQuery, assignedConfigIds],
+  );
+
+  const hasActiveFilter = hasActiveHealthCheckFilter({
+    ...listState,
+    query: debouncedQuery,
+  });
 
   // Handle ?action=create URL parameter (from command palette)
   useEffect(() => {
@@ -314,15 +381,48 @@ const HealthCheckConfigPageContent = () => {
           }
         />
       ) : (
-        <HealthCheckList
-          configurations={configurations}
-          strategies={strategies}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-          onPause={(id) => pauseMutation.mutate({ id })}
-          onResume={(id) => resumeMutation.mutate({ id })}
-          canManage={canManage}
-        />
+        <div className="flex flex-col gap-4">
+          <HealthCheckListToolbar
+            state={listState}
+            onQueryChange={setQuery}
+            onStrategyChange={setStrategy}
+            onStatusChange={setStatus}
+            onSystemChange={setSystem}
+            onClearFilters={clearFilters}
+            strategies={strategies}
+            systems={systems}
+            systemAssignmentsLoading={
+              systemFilterActive && systemConfigsQuery.isLoading
+            }
+            hasActiveFilter={hasActiveFilter}
+          />
+
+          {systemFilterActive && systemConfigsQuery.isLoading ? (
+            <HealthCheckListSkeleton />
+          ) : filteredConfigurations.length === 0 ? (
+            <ListEmptyState
+              resource="health checks"
+              description="No health checks match the current search or filters."
+              actions={
+                hasActiveFilter ? (
+                  <Button variant="outline" onClick={clearFilters}>
+                    Clear filters
+                  </Button>
+                ) : undefined
+              }
+            />
+          ) : (
+            <HealthCheckList
+              configurations={filteredConfigurations}
+              strategies={strategies}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+              onPause={(id) => pauseMutation.mutate({ id })}
+              onResume={(id) => resumeMutation.mutate({ id })}
+              canManage={canManage}
+            />
+          )}
+        </div>
       )}
 
       <ConfirmationModal


### PR DESCRIPTION
## What

The **Health Checks** overview (config page) now has a toolbar with search, filters, and name sorting.

- **Search** by name (case-insensitive substring, debounced 150ms)
- **Strategy** dropdown
- **Status**: All / Active / Paused
- **System**: "show all assigned to system X" — selects a system and narrows the list to checks assigned to it
- Results are **sorted by name** (locale-aware, case-insensitive)
- Filter state lives in URL params (`q`, `strategy`, `status`, `system`) for shareable links

## Why

Operators could not locate a specific check among many, nor answer "which checks are watching system X?". The list rendered in insertion order with no way to narrow it.

## How

Because a health-check configuration carries no `system` field of its own (the assignment is a separate entity), the system filter resolves the assigned config id set for the selected system via `getSystemConfigurations({ systemId })` and intersects it with the loaded configurations. While that set is loading the list shows nothing (skeleton) to avoid a misleading flash of the unfiltered superset.

Mirrors the catalog browse pattern so the two list surfaces share conventions:
- Pure, DOM-free parse/serialize/filter/sort logic (`healthCheckListState.logic.ts`) — tested
- URL-synced state hook (`useHealthCheckListState`) + debounce hook (`useDebouncedValue`, copied per the code-style guide — no shared one in `@checkstack/ui`)
- Toolbar layout matching `CatalogBrowseToolbar`

## Files

- `components/healthCheckListState.logic.ts` — pure filter/sort/parse/serialize
- `components/healthCheckListState.logic.test.ts` — 21 unit tests
- `hooks/useDebouncedValue.ts` — debounce hook
- `hooks/useHealthCheckListState.ts` — URL state bridge
- `components/HealthCheckListToolbar.tsx` — toolbar UI
- `pages/HealthCheckConfigPage.tsx` — wires toolbar + lazy systems/assignments fetch + filtered/sorted list

## Verification

- `bun run typecheck` — passes
- `bun run lint` (`--max-warnings 0`) — passes
- `bun test` — 55/55 pass (21 new)

## Changeset

`@checkstack/healthcheck-frontend` — minor