### PR TITLE
feat(healthcheck): filter assignable health checks in the assignment editor

### DIFF
--- a/.changeset/healthcheck-assignment-filter.md
+++ b/.changeset/healthcheck-assignment-filter.md
@@ -1,0 +1,11 @@
+---
+"@checkstack/healthcheck-frontend": minor
+---
+
+Add a filter input to the "Available" section of the system ↔ healthcheck
+assignment editor.
+
+The assignment IDE tree's "Available" list now has a search box that filters
+assignable health checks by name or strategy-id tail (case-insensitive), with
+an empty-state message when the filter yields no matches. The one-click-to-assign
+interaction is unchanged.

--- a/core/healthcheck-frontend/src/components/assignments/AssignmentTree.tsx
+++ b/core/healthcheck-frontend/src/components/assignments/AssignmentTree.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import {
   Settings,
   Gauge,
@@ -7,8 +7,9 @@ import {
   Plus,
   Check,
   Bell,
+  Search,
 } from "lucide-react";
-import { IDETreeNode, IDETreeSection } from "@checkstack/ui";
+import { IDETreeNode, IDETreeSection, Input } from "@checkstack/ui";
 import { ExtensionSlot } from "@checkstack/frontend-api";
 import { AssignmentIDENodeSlot } from "../../slots";
 
@@ -48,6 +49,18 @@ export const AssignmentTree: React.FC<AssignmentTreeProps> = ({
   onToggleAssignment,
   isLocked,
 }) => {
+  const [availableQuery, setAvailableQuery] = useState("");
+  const filteredAvailable = useMemo(() => {
+    const q = availableQuery.trim().toLowerCase();
+    if (!q) return available;
+    return available.filter((c) => {
+      const strategyTail = c.strategyId.split(".").pop() ?? "";
+      return (
+        c.name.toLowerCase().includes(q) || strategyTail.toLowerCase().includes(q)
+      );
+    });
+  }, [available, availableQuery]);
+
   return (
     <div className="py-2">
       <IDETreeSection label="Assigned Health Checks" />
@@ -134,20 +147,39 @@ export const AssignmentTree: React.FC<AssignmentTreeProps> = ({
       {!isLocked && available.length > 0 && (
         <>
           <IDETreeSection label="Available" />
-          {available.map((config) => (
-            <button
-              key={config.id}
-              type="button"
-              onClick={() => onToggleAssignment(config.id, false)}
-              className="flex items-center gap-2 w-full px-3 py-2 pl-7 text-sm text-left transition-colors text-muted-foreground hover:text-foreground hover:bg-muted/50 border-l-2 border-transparent"
-            >
-              <Plus className="h-4 w-4 shrink-0" />
-              <span className="truncate flex-1">{config.name}</span>
-              <span className="text-[10px] text-muted-foreground shrink-0">
-                {config.strategyId.split(".").pop()}
-              </span>
-            </button>
-          ))}
+          <div className="px-3 pb-1">
+            <div className="flex items-center gap-2 rounded-md border border-input bg-surface-inset px-2 focus-within:ring-1 focus-within:ring-ring">
+              <Search className="pointer-events-none h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <Input
+                value={availableQuery}
+                onChange={(e) => setAvailableQuery(e.target.value)}
+                placeholder="Filter health checks…"
+                autoComplete="off"
+                aria-label="Filter available health checks"
+                className="h-7 border-0 bg-transparent px-0 text-xs focus-visible:ring-0 focus-visible:ring-offset-0"
+              />
+            </div>
+          </div>
+          {filteredAvailable.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-muted-foreground italic">
+              No matching health checks
+            </p>
+          ) : (
+            filteredAvailable.map((config) => (
+              <button
+                key={config.id}
+                type="button"
+                onClick={() => onToggleAssignment(config.id, false)}
+                className="flex items-center gap-2 w-full px-3 py-2 pl-7 text-sm text-left transition-colors text-muted-foreground hover:text-foreground hover:bg-muted/50 border-l-2 border-transparent"
+              >
+                <Plus className="h-4 w-4 shrink-0" />
+                <span className="truncate flex-1">{config.name}</span>
+                <span className="text-[10px] text-muted-foreground shrink-0">
+                  {config.strategyId.split(".").pop()}
+                </span>
+              </button>
+            ))
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
## What

Adds a search/filter input to the "Available" section of the system ↔ healthcheck assignment editor (the IDE tree sidebar), so users can filter assignable health checks by name or strategy-id tail.

## Why

The "assign new" list rendered every unassigned config as a flat button list with no search. With many configurations this is hard to scan and you have no way to narrow it down to the check you want to add.

## How

In `AssignmentTree.tsx`, the "Available" section now renders a search `Input` (with a `Search` icon, matching the existing `SystemMultiSelect` pattern in `core/status-page-frontend`) above the list. Typing filters by name **or** strategy-id tail, case-insensitive. An empty-state "No matching health checks" message shows when the filter yields nothing. The one-click-to-assign interaction (`onToggleAssignment(config.id, false)`) is unchanged — only the list is filtered, not the assignment flow.

Chose an inline filter over a popover combobox because the list lives in a tree sidebar where discoverability matters and hiding available items behind a popover click would be a regression.

## Notes

- No API/contract changes up to the page; `AssignmentTree` props are unchanged.
- Includes a changeset (`@checkstack/healthcheck-frontend`: minor).
- Lint and typecheck pass for `@checkstack/healthcheck-frontend`.