### PR TITLE
feat(ui): searchable, stably-sorted system picker for maintenance/incident editors

### DIFF
--- a/.changeset/system-multi-select-sort-search.md
+++ b/.changeset/system-multi-select-sort-search.md
@@ -1,0 +1,19 @@
+---
+"@checkstack/ui": minor
+"@checkstack/maintenance-frontend": minor
+"@checkstack/incident-frontend": minor
+"@checkstack/status-page-frontend": minor
+---
+
+Add a searchable, stably-sorted system picker to maintenance and incident editors.
+
+The "Affected Systems" picker in the maintenance and incident editors was a
+plain inline checkbox list that was neither sorted nor searchable, so the
+order jumped between renders and finding a system in a large catalog meant
+scrolling. Both now use a shared `SystemMultiSelect` component that sorts
+systems by name (case-insensitive, natural numeric order) once per render and
+adds a substring search box, with a "{n} selected" count.
+
+`SystemMultiSelect` is now exported from `@checkstack/ui`. The status-page
+builder's inline duplicate of the same component is removed in favour of the
+shared one.

--- a/core/incident-frontend/src/components/IncidentEditor.tsx
+++ b/core/incident-frontend/src/components/IncidentEditor.tsx
@@ -32,6 +32,7 @@ import {
   Spinner,
   FormError,
   ConfirmationModal,
+  SystemMultiSelect,
   useUnsavedChanges,
 } from "@checkstack/ui";
 import { Plus, MessageSquare, AlertCircle } from "lucide-react";
@@ -251,16 +252,9 @@ export const IncidentEditor: React.FC<Props> = ({
     if (isBlocked) cancelDiscard();
   };
 
-  const handleSystemToggle = (systemId: string) => {
-    setSelectedSystemIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(systemId)) {
-        next.delete(systemId);
-      } else {
-        next.add(systemId);
-      }
-      return next;
-    });
+  const handleSystemChange = (ids: string[]) => {
+    setTouched((prev) => ({ ...prev, systems: true }));
+    setSelectedSystemIds(new Set(ids));
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -385,46 +379,12 @@ export const IncidentEditor: React.FC<Props> = ({
               <Label id="systems-label" required>
                 Affected Systems
               </Label>
-              <div
-                role="group"
-                aria-labelledby="systems-label"
-                aria-invalid={Boolean(showError("systems"))}
-                aria-describedby={
-                  showError("systems") ? "systems-error" : undefined
-                }
-                className="max-h-36 overflow-y-auto border rounded-md bg-surface-inset p-3 space-y-2"
-              >
-                {systems.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
-                    No systems available
-                  </p>
-                ) : (
-                  systems.map((system) => (
-                    <div
-                      key={system.id}
-                      className="flex items-center space-x-2 p-2 rounded hover:bg-accent cursor-pointer"
-                      onClick={() => {
-                        setTouched((prev) => ({ ...prev, systems: true }));
-                        handleSystemToggle(system.id);
-                      }}
-                    >
-                      <Checkbox
-                        id={`system-${system.id}`}
-                        checked={selectedSystemIds.has(system.id)}
-                      />
-                      <Label
-                        htmlFor={`system-${system.id}`}
-                        className="cursor-pointer flex-1"
-                      >
-                        {system.name}
-                      </Label>
-                    </div>
-                  ))
-                )}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {selectedSystemIds.size} system(s) selected
-              </p>
+              <SystemMultiSelect
+                systems={systems}
+                selectedIds={[...selectedSystemIds]}
+                onChange={handleSystemChange}
+                labelledBy="systems-label"
+              />
               <FormError id="systems-error" className="text-xs">
                 {showError("systems")}
               </FormError>

--- a/core/maintenance-frontend/src/components/MaintenanceEditor.tsx
+++ b/core/maintenance-frontend/src/components/MaintenanceEditor.tsx
@@ -27,6 +27,7 @@ import {
   Spinner,
   FormError,
   ConfirmationModal,
+  SystemMultiSelect,
   useUnsavedChanges,
 } from "@checkstack/ui";
 import { Plus, MessageSquare, AlertCircle } from "lucide-react";
@@ -269,17 +270,9 @@ export const MaintenanceEditor: React.FC<Props> = ({
     if (isBlocked) cancelDiscard();
   };
 
-  const handleSystemToggle = (systemId: string) => {
+  const handleSystemChange = (ids: string[]) => {
     markTouched("systems");
-    setSelectedSystemIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(systemId)) {
-        next.delete(systemId);
-      } else {
-        next.add(systemId);
-      }
-      return next;
-    });
+    setSelectedSystemIds(new Set(ids));
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -437,35 +430,12 @@ export const MaintenanceEditor: React.FC<Props> = ({
                   <Label id={systemsLabelId} required>
                     Affected Systems
                   </Label>
-                  <div className="max-h-36 overflow-y-auto border rounded-md p-3 space-y-2">
-                    {systems.length === 0 ? (
-                      <p className="text-sm text-muted-foreground">
-                        No systems available
-                      </p>
-                    ) : (
-                      systems.map((system) => (
-                        <div
-                          key={system.id}
-                          className="flex items-center space-x-2 p-2 rounded hover:bg-accent cursor-pointer"
-                          onClick={() => handleSystemToggle(system.id)}
-                        >
-                          <Checkbox
-                            id={`system-${system.id}`}
-                            checked={selectedSystemIds.has(system.id)}
-                          />
-                          <Label
-                            htmlFor={`system-${system.id}`}
-                            className="cursor-pointer flex-1"
-                          >
-                            {system.name}
-                          </Label>
-                        </div>
-                      ))
-                    )}
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {selectedSystemIds.size} system(s) selected
-                  </p>
+                  <SystemMultiSelect
+                    systems={systems}
+                    selectedIds={[...selectedSystemIds]}
+                    onChange={handleSystemChange}
+                    labelledBy={systemsLabelId}
+                  />
                   <FormError>{systemsError}</FormError>
                 </div>
 

--- a/core/status-page-frontend/src/pages/StatusPageBuilderPage.tsx
+++ b/core/status-page-frontend/src/pages/StatusPageBuilderPage.tsx
@@ -8,7 +8,6 @@ import {
   Label,
   Textarea,
   Toggle,
-  Checkbox,
   Badge,
   LoadingSpinner,
   Select,
@@ -21,6 +20,7 @@ import {
   toastError,
   QueryErrorState,
   ConfirmationModal,
+  SystemMultiSelect,
 } from "@checkstack/ui";
 import {
   ArrowUp,
@@ -96,60 +96,6 @@ function defaultConfig(type: string): unknown {
 
 type SystemOption = { id: string; name: string };
 type GroupOption = { id: string; name: string };
-
-/** Searchable, counted multi-select of systems. */
-const SystemMultiSelect: React.FC<{
-  systems: SystemOption[];
-  selected: string[];
-  onChange: (ids: string[]) => void;
-}> = ({ systems, selected, onChange }) => {
-  const [query, setQuery] = useState("");
-  const set = new Set(selected);
-  const filtered = query
-    ? systems.filter((s) => s.name.toLowerCase().includes(query.toLowerCase()))
-    : systems;
-  const toggle = (id: string, on: boolean) => {
-    const next = new Set(selected);
-    if (on) next.add(id);
-    else next.delete(id);
-    onChange([...next]);
-  };
-  return (
-    <div className="space-y-1.5">
-      <div className="flex items-center justify-between gap-2">
-        <Input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search systems…"
-          className="h-8"
-        />
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {selected.length} selected
-        </span>
-      </div>
-      <div className="max-h-48 space-y-1 overflow-y-auto rounded-md border bg-surface-inset p-2">
-        {systems.length === 0 ? (
-          <p className="text-xs text-muted-foreground">No systems available.</p>
-        ) : filtered.length === 0 ? (
-          <p className="text-xs text-muted-foreground">No matches.</p>
-        ) : (
-          filtered.map((s) => (
-            <label
-              key={s.id}
-              className="flex cursor-pointer items-center gap-2 text-sm"
-            >
-              <Checkbox
-                checked={set.has(s.id)}
-                onCheckedChange={(c) => toggle(s.id, Boolean(c))}
-              />
-              {s.name}
-            </label>
-          ))
-        )}
-      </div>
-    </div>
-  );
-};
 
 /** Inline editor for a list of labelled links (the links widget config). */
 const LinksConfigEditor: React.FC<{
@@ -281,7 +227,7 @@ const BlockConfigEditor: React.FC<{
       return (
         <SystemMultiSelect
           systems={systems}
-          selected={(config.systemIds as string[]) ?? []}
+          selectedIds={(config.systemIds as string[]) ?? []}
           onChange={(ids) => set({ systemIds: ids })}
         />
       );
@@ -292,7 +238,7 @@ const BlockConfigEditor: React.FC<{
         <div className="space-y-3">
           <SystemMultiSelect
             systems={systems}
-            selected={(config.systemIds as string[]) ?? []}
+            selectedIds={(config.systemIds as string[]) ?? []}
             onChange={(ids) => set({ systemIds: ids })}
           />
           <EventFeedControls config={config} set={set} />
@@ -305,7 +251,7 @@ const BlockConfigEditor: React.FC<{
         <div className="space-y-2">
           <SystemMultiSelect
             systems={systems}
-            selected={items.map((i) => i.systemId)}
+            selectedIds={items.map((i) => i.systemId)}
             onChange={(ids) => set({ items: ids.map((systemId) => ({ systemId })) })}
           />
           <label className="flex items-center gap-2 text-sm">

--- a/core/ui/src/components/SystemMultiSelect.tsx
+++ b/core/ui/src/components/SystemMultiSelect.tsx
@@ -1,0 +1,116 @@
+import * as React from "react";
+import { cn } from "../utils";
+import { Input } from "./Input";
+import { Checkbox } from "./Checkbox";
+
+export interface SystemMultiSelectProps {
+  /** Systems to pick from. Sorted stably by name (case-insensitive). */
+  systems: Array<{ id: string; name: string }>;
+  /** Currently selected system ids. */
+  selectedIds: string[];
+  /** Emitted with the full new selection whenever a system is toggled. */
+  onChange: (ids: string[]) => void;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  noMatchText?: string;
+  /** Renders the "{n} selected" count line. Override to localise. */
+  countLabel?: (count: number) => string;
+  className?: string;
+  listClassName?: string;
+  /** id of the labelling element, surfaced via aria-labelledby on the list. */
+  labelledBy?: string;
+}
+
+const defaultCountLabel = (n: number) => `${n} system(s) selected`;
+
+/**
+ * Searchable, counted multi-select of systems. Sorts the options stably by
+ * name (case-insensitive) so the rendered list does not jump around between
+ * renders, and provides a substring filter to find systems quickly.
+ */
+export const SystemMultiSelect: React.FC<SystemMultiSelectProps> = ({
+  systems,
+  selectedIds,
+  onChange,
+  searchPlaceholder = "Search systems\u2026",
+  emptyText = "No systems available",
+  noMatchText = "No matches",
+  countLabel = defaultCountLabel,
+  className,
+  listClassName,
+  labelledBy,
+}) => {
+  const [query, setQuery] = React.useState("");
+
+  // Stable, case-insensitive sort by name. `numeric: true` keeps "system-2"
+  // before "system-10". useMemo avoids re-sorting on every keystroke.
+  const sorted = React.useMemo(
+    () =>
+      [...systems].toSorted((a, b) =>
+        a.name.localeCompare(b.name, undefined, {
+          numeric: true,
+          sensitivity: "base",
+        }),
+      ),
+    [systems],
+  );
+
+  const filtered = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return sorted;
+    return sorted.filter((s) => s.name.toLowerCase().includes(q));
+  }, [sorted, query]);
+
+  const selected = React.useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const toggle = (id: string, on: boolean) => {
+    const next = new Set(selected);
+    if (on) next.add(id);
+    else next.delete(id);
+    onChange([...next]);
+  };
+
+  return (
+    <div className={cn("space-y-1.5", className)}>
+      <div className="flex items-center justify-between gap-2">
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={searchPlaceholder}
+          className="h-8"
+          aria-label="Filter systems"
+        />
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {countLabel(selected.size)}
+        </span>
+      </div>
+      <div
+        role="group"
+        aria-labelledby={labelledBy}
+        className={cn(
+          "max-h-48 space-y-1 overflow-y-auto rounded-md border bg-surface-inset p-2",
+          listClassName,
+        )}
+      >
+        {systems.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{emptyText}</p>
+        ) : filtered.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{noMatchText}</p>
+        ) : (
+          filtered.map((s) => (
+            <label
+              key={s.id}
+              className="flex cursor-pointer items-center gap-2 text-sm"
+            >
+              <Checkbox
+                checked={selected.has(s.id)}
+                onCheckedChange={(c) => toggle(s.id, Boolean(c))}
+              />
+              {s.name}
+            </label>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};

--- a/core/ui/src/index.ts
+++ b/core/ui/src/index.ts
@@ -97,3 +97,4 @@ export * from "./components/CopyableValue";
 export * from "./hooks/useUnsavedChanges";
 export * from "./hooks/useKeptPrevious";
 export * from "./components/charts";
+export * from "./components/SystemMultiSelect";

--- a/plugins/healthcheck-script-backend/src/concurrency.test.ts
+++ b/plugins/healthcheck-script-backend/src/concurrency.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { readdir } from "node:fs/promises";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { InlineScriptCollector } from "./inline-script-collector";
 import { ScriptHealthCheckStrategy } from "./strategy";
 import type { ScriptTransportClient } from "./transport-client";
@@ -18,9 +19,31 @@ import type { ScriptTransportClient } from "./transport-client";
 const PARALLELISM = 20;
 const TMP_PREFIX = "checkstack-script-";
 
-async function countLeakedTmpDirs(): Promise<number> {
-  const entries = await readdir(tmpdir());
-  return entries.filter((name) => name.startsWith(TMP_PREFIX)).length;
+/**
+ * Create a throwaway base dir and a collector whose per-run scratch dirs are
+ * created *inside* it (via `resolutionRoot`). This isolates the leak check
+ * from every other test file that also spawns scripts into the shared
+ * `os.tmpdir()` — the main source of cross-file flakes. Returns the base dir
+ * (caller removes it) plus a `countLeaked()` that only counts dirs under it.
+ */
+async function isolatedScope(): Promise<{
+  collector: InlineScriptCollector;
+  countLeaked: () => Promise<number>;
+  cleanup: () => Promise<void>;
+}> {
+  const base = await mkdtemp(join(tmpdir(), "cs-concurrency-test-"));
+  const collector = new InlineScriptCollector(
+    undefined,
+    () => Promise.resolve({ mode: "ready" as const, root: base }),
+  );
+  return {
+    collector,
+    countLeaked: async () =>
+      (await readdir(base)).filter((n) => n.startsWith(TMP_PREFIX)).length,
+    cleanup: async () => {
+      await rm(base, { recursive: true, force: true });
+    },
+  };
 }
 
 const mockClient: ScriptTransportClient = {
@@ -68,8 +91,8 @@ describe("inline-script concurrency", () => {
   }, 60_000);
 
   it("cleans up temp dirs even when scripts throw", async () => {
-    const collector = new InlineScriptCollector();
-    const before = await countLeakedTmpDirs();
+    const { collector, countLeaked, cleanup } = await isolatedScope();
+    const before = await countLeaked();
 
     await Promise.all(
       Array.from({ length: PARALLELISM }, () =>
@@ -88,13 +111,14 @@ describe("inline-script concurrency", () => {
       ),
     );
 
-    const after = await countLeakedTmpDirs();
+    const after = await countLeaked();
     expect(after).toBe(before);
+    await cleanup();
   }, 60_000);
 
   it("cleans up temp dirs when scripts time out", async () => {
-    const collector = new InlineScriptCollector();
-    const before = await countLeakedTmpDirs();
+    const { collector, countLeaked, cleanup } = await isolatedScope();
+    const before = await countLeaked();
 
     await Promise.all(
       Array.from({ length: 5 }, () =>
@@ -114,8 +138,9 @@ describe("inline-script concurrency", () => {
     // the kernel can be slow to drop fds on macOS.
     await new Promise((r) => setTimeout(r, 100));
 
-    const after = await countLeakedTmpDirs();
+    const after = await countLeaked();
     expect(after).toBe(before);
+    await cleanup();
   }, 30_000);
 });
 


### PR DESCRIPTION
## What

The "Affected Systems" picker in the maintenance and incident editors was an unsorted, non-searchable inline checkbox list: the order jumped between renders and finding a system in a large catalog meant scrolling.

Both editors now use a shared `SystemMultiSelect` (exported from `@checkstack/ui`) that:
- sorts systems by name (case-insensitive, natural numeric order) once per render via `useMemo`, and
- adds a substring search box with a "{n} selected" count.

The status-page builder's local inline duplicate of the same component is removed in favour of the shared one (DRY).

## Changes
- `core/ui/src/components/SystemMultiSelect.tsx` (new) — the shared component, exported from `@checkstack/ui`.
- `MaintenanceEditor.tsx` / `IncidentEditor.tsx` — replaced the inline list with `<SystemMultiSelect>`.
- `StatusPageBuilderPage.tsx` — dropped the local `SystemMultiSelect` duplicate, imports the shared one.

## Test flake fix
`plugins/healthcheck-script-backend/src/concurrency.test.ts` had a cross-file flake: the two "cleans up temp dirs" tests counted `checkstack-script-*` entries in the shared `os.tmpdir()`, which races against every other test file that spawns scripts into the same dir. Each test now gets a dedicated `resolutionRoot` (via the collector's `getResolutionRoot` hook) and counts leaks only inside it, removing the race.

## Verification
- `bun run typecheck` ✓
- `bun run lint` ✓
- `bun run test` ✓ (full suite green; the previously-flaky timeout test ran clean across multiple reruns)