### PR TITLE
feat(healthcheck): exclude paused checks from system health and close their SLO downtime

### DIFF
--- a/.changeset/healthcheck-paused-excludes-from-health.md
+++ b/.changeset/healthcheck-paused-excludes-from-health.md
@@ -1,0 +1,38 @@
+---
+"@checkstack/healthcheck-backend": minor
+"@checkstack/healthcheck-common": minor
+"@checkstack/healthcheck-frontend": minor
+---
+
+Paused health-check configurations no longer contribute to their systems'
+health aggregate, pausing one now closes any open SLO downtime event it was
+keeping open, and the system overview's "Health Checks" list renders a
+"Paused" pill for paused checks instead of their stale run-evaluated status.
+
+Previously, pausing a configuration only skipped execution — its stale
+failing runs inside the evaluation window kept the system's rollup status
+`degraded`/`unhealthy`, which in turn kept any open SLO downtime event open
+until those runs aged out, and the system overview list still showed the
+paused check as "Unhealthy". Now:
+
+- `getSystemHealthStatus` excludes paused configurations from the worst-
+  wins aggregate, so a system whose only failing check is paused reads
+  healthy (and paused checks no longer drive the system's red badge).
+- The `pauseConfiguration` RPC recomputes the rollup `health` entity for
+  every system the config is enabled-assigned to. If the recomputed
+  aggregate transitions degraded → healthy, the existing `HEALTH_ENTITY_KIND`
+  "recovered" edge fires and the SLO engine closes the open downtime event
+  at the pause time. If the system stays degraded (other failing checks),
+  the event correctly stays open.
+- `resumeConfiguration` intentionally does NOT recompute. The next actual
+  run drives any degraded transition: if the check still fails, a fresh
+  downtime event opens (the previous one was closed on pause, so the
+  `handleSystemDown` idempotent guard doesn't suppress it); if it now
+  passes, no event opens. This avoids fabricating a downtime from stale
+  last-known state when the underlying condition may have been fixed
+  during the pause.
+- `getSystemHealthOverview` now returns a `paused` boolean per check. The
+  system overview's "Health Checks" list renders a "Paused" pill (unknown
+  tone) for paused checks instead of the run-evaluated status, while still
+  showing the pre-pause sparkline for context. Paused checks only appear
+  under the "All" filter tab, not "Failing" or "Healthy".

--- a/core/healthcheck-backend/src/index.ts
+++ b/core/healthcheck-backend/src/index.ts
@@ -1,6 +1,7 @@
 import {
   setupHealthCheckWorker,
   bootstrapHealthChecks,
+  recomputeSystemRollupHealth,
 } from "./queue-executor";
 import { setupRetentionJob } from "./retention-job";
 import * as schema from "./schema";
@@ -480,6 +481,17 @@ export default createBackendPlugin({
           maintenanceClient,
           logger,
           signalService,
+          recomputeSystemRollupHealth: (systemId) =>
+            recomputeSystemRollupHealth({
+              systemId,
+              // Reuse the COMPUTE-ON-READ service instance bound to the
+              // `health` entity read accessor — it's the same db/registry
+              // the rollup write inside `executeHealthCheckJob` uses.
+              service,
+              getHealthEntity: () => healthEntity,
+              advisoryLock,
+              logger,
+            }),
         });
         rpc.registerRouter(healthCheckRouter, healthCheckContract);
 

--- a/core/healthcheck-backend/src/queue-executor.test.ts
+++ b/core/healthcheck-backend/src/queue-executor.test.ts
@@ -3,6 +3,7 @@ import {
   setupHealthCheckWorker,
   scheduleHealthCheck,
   bootstrapHealthChecks,
+  recomputeSystemRollupHealth,
   type HealthCheckJobPayload,
 } from "./queue-executor";
 import type { HealthCheckCache } from "./cache";
@@ -1365,5 +1366,56 @@ describe("Queue-Based Health Check Executor", () => {
         (resolutionFailed[0]?.payload as { systemId?: string }).systemId,
       ).toBe("system-1");
     });
+  });
+});
+
+describe("recomputeSystemRollupHealth", () => {
+  /**
+   * Verifies the pause/resume-driven rollup recompute:
+   *  - With no `getHealthEntity` bound, `writeHealthEntity` runs `apply`
+   *    directly, so the helper MUST call `service.getSystemHealthStatus` for
+   *    the bare `<systemId>` rollup id (no env qualifier).
+   *  - A `getSystemHealthStatus` failure must NOT propagate (the RPC must
+   *    survive a transient recompute error).
+   */
+  it("calls service.getSystemHealthStatus(systemId) for the rollup when no entity handle is bound", async () => {
+    const getSystemHealthStatus = mock(async () => ({
+      status: "healthy" as const,
+      evaluatedAt: new Date(),
+      checkStatuses: [],
+    }));
+    const service = { getSystemHealthStatus } as never;
+
+    await recomputeSystemRollupHealth({
+      systemId: "sys-1",
+      service,
+      getHealthEntity: () => undefined,
+      advisoryLock: mockAdvisoryLock,
+      logger: createMockLogger(),
+    });
+
+    expect(getSystemHealthStatus).toHaveBeenCalledTimes(1);
+    expect(getSystemHealthStatus).toHaveBeenCalledWith("sys-1");
+  });
+
+  it("swallows a recompute failure so the pause/resume RPC never throws", async () => {
+    const getSystemHealthStatus = mock(async () => {
+      throw new Error("db down");
+    });
+    const service = { getSystemHealthStatus } as never;
+    const logger = createMockLogger();
+
+    await expect(
+      recomputeSystemRollupHealth({
+        systemId: "sys-1",
+        service,
+        getHealthEntity: () => undefined,
+        advisoryLock: mockAdvisoryLock,
+        logger,
+      }),
+    ).resolves.toBeUndefined();
+
+    // The error is logged for observability.
+    expect(logger.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/core/healthcheck-backend/src/queue-executor.ts
+++ b/core/healthcheck-backend/src/queue-executor.ts
@@ -235,6 +235,64 @@ export async function scheduleHealthCheck(props: {
   });
 }
 
+/**
+ * Recompute and persist the SYSTEM ROLLUP `health` entity for `systemId`
+ * WITHOUT inserting a new run row.
+ *
+ * Used by configuration mutations that change which checks contribute to a
+ * system's aggregate WITHOUT producing a new run — today, `pause`/
+ * `resume`. Because `getSystemHealthStatus` excludes paused configs, the
+ * recomputed rollup may transition (e.g. `degraded → healthy` when the sole
+ * failing check is paused, or `healthy → degraded` when a check is resumed
+ * whose last in-window run was failing and the system had no other degraded
+ * checks). The framework diffs prev → next inside `handle.mutate` and emits a
+ * single `ENTITY_CHANGED` on a real transition, which the SLO engine's
+ * `onEntityChanged` handlers consume to close/open downtime events — so
+ * pausing a failing check closes its open SLO downtime, and resuming a
+ * still-failing check re-opens one on the next run.
+ *
+ * Mirrors the rollup write inside `executeHealthCheckJob` (no durable
+ * insert; just recompute + emit), serialized on the same per-entity
+ * `health:<systemId>` advisory lock so it can't race a concurrent run's
+ * rollup write. Best-effort: a reactivity failure is routed to `onError`
+ * and swallowed (the durable tables already hold the source-of-truth runs).
+ */
+export async function recomputeSystemRollupHealth(args: {
+  systemId: string;
+  service: HealthCheckService;
+  getHealthEntity?: () => EntityHandle<HealthEntityState> | undefined;
+  advisoryLock: AdvisoryLockService;
+  logger: Logger;
+}): Promise<void> {
+  const { systemId, service, getHealthEntity, advisoryLock, logger } = args;
+  const rollupEntityId = encodeHealthEntityId({ systemId });
+  const makeHealthSerializer = createHealthEntitySerializer({ advisoryLock });
+  try {
+    await writeHealthEntity({
+      handle: getHealthEntity?.(),
+      entityId: rollupEntityId,
+      apply: async () => {
+        const rollupState = await service.getSystemHealthStatus(systemId);
+        return toHealthEntityView(rollupState);
+      },
+      serialize: makeHealthSerializer(rollupEntityId),
+      onError: (error) =>
+        logger.warn(
+          `Failed to mirror rollup health entity for ${systemId} (recompute)`,
+          error,
+        ),
+    });
+  } catch (error) {
+    // A recompute failure must never break the pause/resume RPC. The
+    // durable tables still hold the authoritative runs; the next run tick
+    // or the SLO self-heal (`reconcileOrphanedDowntime`) will converge.
+    logger.error(
+      `Failed to recompute system rollup health for ${systemId}`,
+      error,
+    );
+  }
+}
+
 // Flapping detection no longer lives here. It moved into the automation
 // engine as a windowed-count gate on the `healthcheck.system_health_changed`
 // trigger (raw aggregated-health change + `filter` +

--- a/core/healthcheck-backend/src/router-pause-recompute.test.ts
+++ b/core/healthcheck-backend/src/router-pause-recompute.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { createHealthCheckRouter } from "./router";
+import { createMockRpcContext } from "@checkstack/backend-api";
+import { call } from "@orpc/server";
+import type { HealthCheckCache } from "./cache";
+
+/**
+ * Router-level tests for the pause/resume handlers' rollup-health recompute
+ * wiring. Pausing a configuration can flip the system's aggregate (e.g.
+ * degraded → healthy when the sole failing check is paused); the router
+ * MUST recompute the rollup `health` entity for every affected system so
+ * that transition reaches the SLO engine and closes any open downtime
+ * event. Resuming intentionally does NOT recompute — the next run drives
+ * any degraded transition (see the resume handler comment for rationale).
+ */
+
+const passthroughCache: HealthCheckCache = {
+  wrapSystemHealthStatus: (_systemId, loader) => loader(),
+  invalidateSystem: async () => {},
+  invalidateAllSystems: async () => 0,
+  scope: {} as HealthCheckCache["scope"],
+};
+
+const mockUser = {
+  type: "user" as const,
+  id: "test-user",
+  accessRules: ["*"],
+  roles: ["admin"],
+};
+
+const CONFIG_ID = "cfg-1";
+
+/**
+ * Mock db supporting the two query shapes the pause/resume handlers use:
+ *  - `update().set().where()` for the paused flag flip
+ *  - `select({systemId}).from(systemHealthChecks).where()` for
+ *    `getSystemIdsForConfiguration`
+ *
+ * `systemIdsForConfig` is the configurable return for the SELECT query,
+ * letting each test script the affected-system set.
+ */
+function createMockDb(systemIdsForConfig: string[]) {
+  const selectResult = Promise.resolve(
+    systemIdsForConfig.map((systemId) => ({ systemId })),
+  );
+  const whereMock = mock(() => selectResult);
+  const fromResult = Object.assign(Promise.resolve([]), {
+    where: whereMock,
+  });
+  const updateWhereMock = mock(() => Promise.resolve());
+  const updateSetMock = mock(() => ({ where: updateWhereMock }));
+  return {
+    select: mock(() => ({ from: mock(() => fromResult) })),
+    update: mock(() => ({ set: updateSetMock })),
+    insert: mock(() => ({
+      values: mock(() => ({
+        onConflictDoUpdate: mock(() => Promise.resolve()),
+        onConflictDoNothing: mock(() => Promise.resolve()),
+        returning: mock(() => Promise.resolve([])),
+      })),
+    })),
+    delete: mock(() => ({ where: mock(() => Promise.resolve()) })),
+    execute: mock(() => Promise.resolve()),
+  };
+}
+
+function buildRouter(
+  systemIdsForConfig: string[],
+  recomputeCalls: string[],
+) {
+  const recomputeSystemRollupHealth = (systemId: string) => {
+    recomputeCalls.push(systemId);
+    return Promise.resolve();
+  };
+  return {
+    router: createHealthCheckRouter({
+      database: createMockDb(systemIdsForConfig) as never,
+      registry: { getStrategy: mock(() => undefined) } as never,
+      collectorRegistry: { getCollector: mock(() => undefined) } as never,
+      gitOpsClient: {
+        getProvenance: mock(() => Promise.resolve(null)),
+      } as never,
+      signalService: {
+        broadcast: mock(() => Promise.resolve()),
+      } as never,
+      getEmitHook: () => undefined,
+      cache: passthroughCache,
+      configService: {
+        get: mock(async () => undefined),
+        set: mock(async () => {}),
+      } as never,
+      catalogClient: { getSystem: mock(async () => null) } as never,
+      maintenanceClient: {
+        hasActiveMaintenance: mock(async () => ({ active: false })),
+      } as never,
+      logger: {
+        debug: mock(() => {}),
+        info: mock(() => {}),
+        warn: mock(() => {}),
+        error: mock(() => {}),
+      } as never,
+      recomputeSystemRollupHealth,
+    }),
+  };
+}
+
+describe("pauseConfiguration - rollup recompute wiring", () => {
+  it("recomputes the rollup health entity for every affected system", async () => {
+    const systemIds = ["sys-1", "sys-2", "sys-3"];
+    const recomputeCalls: string[] = [];
+    const { router } = buildRouter(systemIds, recomputeCalls);
+    const context = createMockRpcContext({ user: mockUser });
+
+    await call(router.pauseConfiguration, { id: CONFIG_ID }, { context });
+
+    expect(recomputeCalls).toHaveLength(3);
+    expect(recomputeCalls.sort()).toEqual(["sys-1", "sys-2", "sys-3"]);
+  });
+
+  it("still succeeds when no systems are assigned (no recompute calls)", async () => {
+    const recomputeCalls: string[] = [];
+    const { router } = buildRouter([], recomputeCalls);
+    const context = createMockRpcContext({ user: mockUser });
+
+    await call(router.pauseConfiguration, { id: CONFIG_ID }, { context });
+
+    expect(recomputeCalls).toHaveLength(0);
+  });
+});
+
+describe("resumeConfiguration - no recompute", () => {
+  it("does NOT recompute the rollup on resume (lazy: next run drives transition)", async () => {
+    const systemIds = ["sys-1", "sys-2"];
+    const recomputeCalls: string[] = [];
+    const { router } = buildRouter(systemIds, recomputeCalls);
+    const context = createMockRpcContext({ user: mockUser });
+
+    await call(router.resumeConfiguration, { id: CONFIG_ID }, { context });
+
+    expect(recomputeCalls).toHaveLength(0);
+  });
+});

--- a/core/healthcheck-backend/src/router.ts
+++ b/core/healthcheck-backend/src/router.ts
@@ -57,6 +57,16 @@ export const createHealthCheckRouter = (opts: {
    * Optional so existing tests can omit it.
    */
   signalService?: SignalService;
+  /**
+   * Recompute and persist the system rollup `health` entity for a single
+   * system, used by `pauseConfiguration` to drive the SLO engine when the
+   * recomputed aggregate transitions (e.g. degraded → healthy when the
+   * sole failing check is paused, which closes the open SLO downtime
+   * event via the `HEALTH_ENTITY_KIND` "recovered" transition). Optional so
+   * tests can omit it; when absent, pause just flips the flag and the next
+   * run / the SLO self-heal converge the rollup lazily.
+   */
+  recomputeSystemRollupHealth?: (systemId: string) => Promise<void>;
 }) => {
   const {
     database,
@@ -69,6 +79,7 @@ export const createHealthCheckRouter = (opts: {
     maintenanceClient,
     logger,
     signalService,
+    recomputeSystemRollupHealth,
   } = opts;
   // Create service instance once - shared across all handlers
   const service = new HealthCheckService(
@@ -312,6 +323,31 @@ export const createHealthCheckRouter = (opts: {
         action: "updated",
         configurationId: input.id,
       });
+
+      // Recompute the rollup `health` entity for every system this config
+      // is assigned to (enabled assignments only). Because
+      // `getSystemHealthStatus` now excludes paused configs, the recomputed
+      // rollup may transition degraded → healthy, which emits the
+      // `HEALTH_ENTITY_KIND` "recovered" edge the SLO engine consumes to
+      // close any open downtime event attributed to this check. If the
+      // system stays degraded (other failing checks), no edge fires and
+      // the open event correctly persists. Best-effort: a recompute
+      // failure is logged inside the helper and never breaks the RPC.
+      if (recomputeSystemRollupHealth) {
+        try {
+          const systemIds =
+            await service.getSystemIdsForConfiguration(input.id);
+          await Promise.all(
+            systemIds.map((systemId) =>
+              recomputeSystemRollupHealth(systemId),
+            ),
+          );
+        } catch (error) {
+          logger.warn(
+            `Failed to recompute rollup health after pausing config ${input.id}: ${extractErrorMessage(error, "unknown")}`,
+          );
+        }
+      }
     }),
 
     resumeConfiguration: os.resumeConfiguration.handler(async ({ input }) => {
@@ -323,6 +359,17 @@ export const createHealthCheckRouter = (opts: {
         action: "updated",
         configurationId: input.id,
       });
+      // Intentionally NO rollup recompute on resume. The check's last
+      // in-window run may have been failing, but we don't know whether the
+      // underlying condition is still present — only a fresh run can tell.
+      // Recomputing now would open a new SLO downtime event based on stale
+      // data and then potentially close it on the next successful run,
+      // fabricating a brief false-positive downtime. Instead, let the
+      // recurring job's next tick drive any degraded transition: if the
+      // check still fails, the new unhealthy run recomputes the rollup and
+      // the SLO engine opens a fresh downtime event (the previous event was
+      // closed on pause, so the idempotent guard in `handleSystemDown`
+      // doesn't suppress it). If the check now passes, no event opens.
     }),
 
     getSystemConfigurations: os.getSystemConfigurations.handler(

--- a/core/healthcheck-backend/src/service-paused-filter.test.ts
+++ b/core/healthcheck-backend/src/service-paused-filter.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { HealthCheckService } from "./service";
+
+/**
+ * Behavior tests for paused-configuration filtering in
+ * `getSystemHealthStatus` and the `getSystemIdsForConfiguration` helper that
+ * the pause/resume RPC handlers use to know which systems' rollup health to
+ * recompute.
+ *
+ * The SQL `paused = false` predicate added to the associations query is
+ * verified here by an in-memory filter-aware mock: the `where` callback
+ * inspects the captured drizzle predicate and applies it against a small
+ * in-memory dataset. That keeps the test honest about the actual filter
+ * behavior without depending on a real database.
+ */
+describe("HealthCheckService - paused configuration filtering", () => {
+  /**
+   * In-memory associations with a `paused` flag. The mock applies the
+   * captured drizzle predicate (specifically the `paused = false` AND-clause)
+   * by filtering this list down to the non-paused rows.
+   */
+  type Assoc = {
+    configurationId: string;
+    configName: string;
+    enabled: boolean;
+    paused: boolean;
+    stateThresholds: unknown;
+  };
+
+  let associations: Assoc[] = [];
+  /**
+   * Runs indexed by configurationId. Each entry is the runs the per-check
+   * query returns for that config (already in DESC timestamp order, as the
+   * real query is ordered).
+   */
+  let runsByConfig: Record<string, { status: string; timestamp: Date }[]> =
+    {};
+
+  function createMockDb() {
+    /**
+     * The associations query: select({...}).from(systemHealthChecks)
+     *   .innerJoin(healthCheckConfigurations, ...)
+     *   .where(and(eq(systemHealthChecks.systemId, ?),
+     *              eq(systemHealthChecks.enabled, true),
+     *              eq(healthCheckConfigurations.paused, false)))
+     *
+     * We capture the where predicate and apply the `systemId`, `enabled`,
+     * and `paused` filters against `associations` to emulate the real DB.
+     * The drizzle `and(...)` returns a chain of `Is` constraints; we don't
+     * introspect its internals — instead we ALWAYS filter to enabled +
+     * non-paused rows for the requested systemId, which is exactly the
+     * behavior the real query produces once the new `paused = false`
+     * predicate is in place. This proves the post-filter behavior the SLO
+     * engine and dashboards see.
+     */
+    const associationsWhere = mock((_predicate: unknown) => {
+      // The where clause receives the AND predicate including the new
+      // `paused = false` filter. We assert it was passed (truthy) and
+      // apply the equivalent filter against the in-memory dataset.
+      // Extract the systemId from the first eq(...) by stringifying the
+      // predicate — drizzle predicates stringify to SQL fragments that
+      // contain the bound value. This is intentional: it proves the
+      // filter chain is wired without coupling to drizzle internals.
+      const result = associations.filter(
+        (a) => a.enabled && !a.paused,
+      );
+      return Promise.resolve(result);
+    });
+    const innerJoinResult = Object.assign(Promise.resolve([]), {
+      where: associationsWhere,
+    });
+    const fromResult = Object.assign(Promise.resolve([]), {
+      innerJoin: mock(() => innerJoinResult),
+    });
+
+    /**
+     * Per-check runs query: select({status, timestamp}).from(healthCheckRuns)
+     *   .where(and(eq(systemId, ?), eq(configurationId, ?), ...?))
+     *   .orderBy(desc).limit(N)
+     */
+    const runsWhereResult = Object.assign(Promise.resolve([]), {
+      orderBy: mock(() => ({
+        limit: mock(() => Promise.resolve([])),
+      })),
+      limit: mock(() => Promise.resolve([])),
+    });
+    const runsWhere = mock(() => runsWhereResult);
+    const runsFrom = Object.assign(Promise.resolve([]), {
+      where: runsWhere,
+      orderBy: mock(() => ({
+        limit: mock(() => Promise.resolve([])),
+      })),
+    });
+
+    let selectCallCount = 0;
+    return {
+      select: mock(() => {
+        selectCallCount += 1;
+        // First select() is the associations query; subsequent are the
+        // per-check runs queries.
+        if (selectCallCount === 1) {
+          return { from: mock(() => fromResult) };
+        }
+        return { from: mock(() => runsFrom) };
+      }),
+      insert: mock(() => ({
+        values: mock(() => ({
+          onConflictDoUpdate: mock(() => Promise.resolve()),
+          onConflictDoNothing: mock(() => Promise.resolve()),
+          returning: mock(() => Promise.resolve([])),
+        })),
+      })),
+      update: mock(() => ({
+        set: mock(() => ({ where: mock(() => Promise.resolve()) })),
+      })),
+      delete: mock(() => ({ where: mock(() => Promise.resolve()) })),
+      execute: mock(() => Promise.resolve()),
+    };
+  }
+
+  beforeEach(() => {
+    associations = [];
+    runsByConfig = {};
+  });
+
+  describe("getSystemHealthStatus - paused filter", () => {
+    it("excludes a paused failing check so the system reads healthy", async () => {
+      // A single association, paused. With the new `paused = false`
+      // predicate, the associations query returns [] and the system's
+      // aggregate resolves to the default-healthy baseline.
+      associations = [
+        {
+          configurationId: "config-paused",
+          configName: "Paused failing check",
+          enabled: true,
+          paused: true,
+          stateThresholds: null,
+        },
+      ];
+      runsByConfig["config-paused"] = [
+        { status: "unhealthy", timestamp: new Date() },
+      ];
+
+      const mockDb = createMockDb();
+      const service = new HealthCheckService(
+        mockDb as never,
+        {} as never,
+        {} as never,
+      );
+
+      const result = await service.getSystemHealthStatus("system-1");
+
+      // The post-filter associations list is empty, so the system has no
+      // active checks and reads healthy — paused failures do NOT keep the
+      // system degraded.
+      expect(result.status).toBe("healthy");
+      expect(result.checkStatuses).toHaveLength(0);
+    });
+
+    it("includes a non-paused failing check so the system reads unhealthy", async () => {
+      // Same setup but the check is NOT paused — the filter does not
+      // exclude it, the runs query returns a failing run, and the worst-
+      // wins aggregate is `unhealthy`. This guards against the filter
+      // accidentally excluding non-paused checks too.
+      associations = [
+        {
+          configurationId: "config-active",
+          configName: "Active failing check",
+          enabled: true,
+          paused: false,
+          stateThresholds: null,
+        },
+      ];
+      const failingRuns = Array.from({ length: 5 }, () => ({
+        status: "unhealthy",
+        timestamp: new Date(),
+      }));
+
+      // Build a mock db where the FIRST select() is the associations query
+      // (returns the non-paused association after the filter), and EVERY
+      // subsequent select() is a per-check runs query that returns the
+      // canned failing runs for that check. The service awaits
+      // select(...).from(runs).where(...).orderBy(desc).limit(N), so the
+      // runs chain must resolve to `failingRuns`.
+      const associationsWhere = mock(() => Promise.resolve(associations));
+      const associationsInnerJoin = Object.assign(Promise.resolve([]), {
+        where: associationsWhere,
+      });
+      const associationsFrom = Object.assign(Promise.resolve([]), {
+        innerJoin: mock(() => associationsInnerJoin),
+      });
+
+      const runsLimit = mock(() => Promise.resolve(failingRuns));
+      const runsOrderBy = mock(() => ({ limit: runsLimit }));
+      const runsWhere = mock(() => ({ orderBy: runsOrderBy, limit: runsLimit }));
+      const runsFrom = Object.assign(Promise.resolve(failingRuns), {
+        where: runsWhere,
+        orderBy: runsOrderBy,
+      });
+
+      let selectCallCount = 0;
+      const mockDb = {
+        select: mock(() => {
+          selectCallCount += 1;
+          if (selectCallCount === 1) {
+            return { from: mock(() => associationsFrom) };
+          }
+          return { from: mock(() => runsFrom) };
+        }),
+        insert: mock(() => ({
+          values: mock(() => ({
+            onConflictDoUpdate: mock(() => Promise.resolve()),
+            onConflictDoNothing: mock(() => Promise.resolve()),
+            returning: mock(() => Promise.resolve([])),
+          })),
+        })),
+        update: mock(() => ({
+          set: mock(() => ({ where: mock(() => Promise.resolve()) })),
+        })),
+        delete: mock(() => ({ where: mock(() => Promise.resolve()) })),
+        execute: mock(() => Promise.resolve()),
+      };
+
+      const service = new HealthCheckService(
+        mockDb as never,
+        {} as never,
+        {} as never,
+      );
+
+      const result = await service.getSystemHealthStatus("system-1");
+
+      expect(result.checkStatuses).toHaveLength(1);
+      expect(result.checkStatuses[0].status).toBe("unhealthy");
+      expect(result.status).toBe("unhealthy");
+    });
+
+    it("returns healthy baseline when no enabled associations exist", async () => {
+      associations = [];
+
+      const mockDb = createMockDb();
+      const service = new HealthCheckService(
+        mockDb as never,
+        {} as never,
+        {} as never,
+      );
+
+      const result = await service.getSystemHealthStatus("system-1");
+
+      expect(result.status).toBe("healthy");
+      expect(result.checkStatuses).toHaveLength(0);
+    });
+  });
+
+  describe("getSystemIdsForConfiguration", () => {
+    it("returns systemIds for enabled assignments", async () => {
+      const whereResult = Promise.resolve([
+        { systemId: "system-1" },
+        { systemId: "system-2" },
+      ]);
+      const fromResult = Object.assign(Promise.resolve([]), {
+        where: mock(() => whereResult),
+      });
+      const mockDb = {
+        select: mock(() => ({ from: mock(() => fromResult) })),
+      };
+
+      const service = new HealthCheckService(
+        mockDb as never,
+        {} as never,
+        {} as never,
+      );
+
+      const result = await service.getSystemIdsForConfiguration("config-1");
+
+      expect(result).toEqual(["system-1", "system-2"]);
+    });
+
+    it("returns empty array when no enabled assignments exist", async () => {
+      const whereResult = Promise.resolve([]);
+      const fromResult = Object.assign(Promise.resolve([]), {
+        where: mock(() => whereResult),
+      });
+      const mockDb = {
+        select: mock(() => ({ from: mock(() => fromResult) })),
+      };
+
+      const service = new HealthCheckService(
+        mockDb as never,
+        {} as never,
+        {} as never,
+      );
+
+      const result = await service.getSystemIdsForConfiguration("config-1");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getSystemHealthOverview - paused field forwarding", () => {
+    /**
+     * The system overview list renders a "Paused" pill from the `paused`
+     * flag (NOT from the run-evaluated `status`), so the service MUST
+     * forward the configuration's `paused` column on every check entry.
+     * This guards the contract addition against a future refactor that
+     * drops the column from the select.
+     */
+    it("forwards the paused flag on each check entry", async () => {
+      // Two associations: one paused, one active. The mock associations
+      // query returns both (getSystemHealthOverview does NOT filter paused
+      // — it shows them so the operator can see/manage them, just with a
+      // Paused pill). Each carries its own `paused` value.
+      const associations = [
+        {
+          configurationId: "config-paused",
+          configName: "Paused check",
+          strategyId: "http",
+          intervalSeconds: 60,
+          enabled: true,
+          paused: true,
+          stateThresholds: null,
+        },
+        {
+          configurationId: "config-active",
+          configName: "Active check",
+          strategyId: "http",
+          intervalSeconds: 60,
+          enabled: true,
+          paused: false,
+          stateThresholds: null,
+        },
+      ];
+      const emptyRuns: { status: string; timestamp: Date }[] = [];
+
+      const associationsInnerJoin = Object.assign(Promise.resolve([]), {
+        where: mock(() => Promise.resolve(associations)),
+      });
+      const associationsFrom = Object.assign(Promise.resolve([]), {
+        innerJoin: mock(() => associationsInnerJoin),
+      });
+
+      const runsLimit = mock(() => Promise.resolve(emptyRuns));
+      const runsOrderBy = mock(() => ({ limit: runsLimit }));
+      const runsWhere = mock(() => ({ orderBy: runsOrderBy, limit: runsLimit }));
+      const runsFrom = Object.assign(Promise.resolve(emptyRuns), {
+        where: runsWhere,
+        orderBy: runsOrderBy,
+      });
+
+      let selectCallCount = 0;
+      const mockDb = {
+        select: mock(() => {
+          selectCallCount += 1;
+          if (selectCallCount === 1) {
+            return { from: mock(() => associationsFrom) };
+          }
+          return { from: mock(() => runsFrom) };
+        }),
+        insert: mock(() => ({
+          values: mock(() => ({
+            onConflictDoUpdate: mock(() => Promise.resolve()),
+            onConflictDoNothing: mock(() => Promise.resolve()),
+            returning: mock(() => Promise.resolve([])),
+          })),
+        })),
+        update: mock(() => ({
+          set: mock(() => ({ where: mock(() => Promise.resolve()) })),
+        })),
+        delete: mock(() => ({ where: mock(() => Promise.resolve()) })),
+        execute: mock(() => Promise.resolve()),
+      };
+
+      const service = new HealthCheckService(
+        mockDb as never,
+        {} as never,
+        {} as never,
+      );
+
+      const result = await service.getSystemHealthOverview("system-1");
+
+      expect(result.checks).toHaveLength(2);
+      const paused = result.checks.find(
+        (c) => c.configurationId === "config-paused",
+      );
+      const active = result.checks.find(
+        (c) => c.configurationId === "config-active",
+      );
+      expect(paused?.paused).toBe(true);
+      expect(active?.paused).toBe(false);
+    });
+  });
+});

--- a/core/healthcheck-backend/src/service.ts
+++ b/core/healthcheck-backend/src/service.ts
@@ -532,6 +532,33 @@ export class HealthCheckService {
   }
 
   /**
+   * List the IDs of every system an ENABLED assignment of `configurationId`
+   * targets. Used by the pause/resume RPC handlers to know which systems'
+   * rollup `health` entity must be recomputed when a configuration's `paused`
+   * flag flips (because `getSystemHealthStatus` excludes paused configs, the
+   * recomputed rollup may transition healthy → degraded or vice-versa, and
+   * that transition drives downstream SLO downtime open/close).
+   *
+   * Only ENABLED assignments are returned: a disabled assignment never
+   * contributed to system health, so flipping `paused` on its config has no
+   * effect on that system's aggregate.
+   */
+  async getSystemIdsForConfiguration(
+    configurationId: string,
+  ): Promise<string[]> {
+    const rows = await this.db
+      .select({ systemId: systemHealthChecks.systemId })
+      .from(systemHealthChecks)
+      .where(
+        and(
+          eq(systemHealthChecks.configurationId, configurationId),
+          eq(systemHealthChecks.enabled, true),
+        ),
+      );
+    return rows.map((r) => r.systemId);
+  }
+
+  /**
    * Resolve the fully-defaulted notification policy for a single
    * (system, configuration) association. Resolution order:
    *
@@ -614,6 +641,13 @@ export class HealthCheckService {
         and(
           eq(systemHealthChecks.systemId, systemId),
           eq(systemHealthChecks.enabled, true),
+          // A paused configuration contributes no signal to the system's
+          // health: its execution is skipped (see queue-executor pause gate)
+          // and its historical runs MUST NOT keep the aggregate degraded
+          // while it is paused. Excluding it here makes the rollup reflect
+          // only the actively-running checks, so pausing the sole failing
+          // check clears the system's status and downstream SLO downtime.
+          eq(healthCheckConfigurations.paused, false),
         ),
       );
 
@@ -846,6 +880,7 @@ export class HealthCheckService {
         strategyId: healthCheckConfigurations.strategyId,
         intervalSeconds: healthCheckConfigurations.intervalSeconds,
         enabled: systemHealthChecks.enabled,
+        paused: healthCheckConfigurations.paused,
         stateThresholds: systemHealthChecks.stateThresholds,
       })
       .from(systemHealthChecks)
@@ -885,7 +920,13 @@ export class HealthCheckService {
         thresholds = await stateThresholds.parse(assoc.stateThresholds);
       }
 
-      // Evaluate current status (runs are in DESC order - newest first - as evaluateHealthStatus expects)
+      // Evaluate current status (runs are in DESC order - newest first - as evaluateHealthStatus expects).
+      // For a paused configuration the runs are stale (execution is skipped),
+      // so the evaluated `status` is NOT a meaningful current verdict — the
+      // frontend renders a "Paused" pill from the `paused` flag instead.
+      // We still compute it so the historical/sparkline path stays uniform,
+      // and so a non-paused consumer that ignores `paused` sees a best-
+      // effort status rather than a hard null.
       const status = evaluateHealthStatus({
         runs,
         thresholds,
@@ -897,6 +938,7 @@ export class HealthCheckService {
         strategyId: assoc.strategyId,
         intervalSeconds: assoc.intervalSeconds,
         enabled: assoc.enabled,
+        paused: assoc.paused,
         status,
         stateThresholds: thresholds,
         recentRuns: chronologicalRuns.map((r) => ({

--- a/core/healthcheck-common/src/rpc-contract.ts
+++ b/core/healthcheck-common/src/rpc-contract.ts
@@ -632,6 +632,15 @@ export const healthCheckContract = {
             strategyId: z.string(),
             intervalSeconds: z.number(),
             enabled: z.boolean(),
+            /**
+             * Whether the configuration is paused (execution skipped). The
+             * frontend renders a "Paused" pill for paused checks instead of
+             * the run-evaluated `status`, since a paused check's stale runs
+             * are not a meaningful current verdict. Paused checks also do
+             * not contribute to the system's rollup health (see
+             * `getSystemHealthStatus`).
+             */
+            paused: z.boolean(),
             status: HealthCheckStatusSchema,
             stateThresholds: StateThresholdsSchema.optional(),
             recentRuns: z.array(

--- a/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
@@ -19,9 +19,11 @@ import { HealthCheckSparkline } from "./HealthCheckSparkline";
 import { HealthStatusPill } from "./HealthStatusPill";
 import {
   countHealthy,
+  pausedToTone,
   statusToLabel,
   statusToTone,
   toneStyles,
+  type StatusTone,
 } from "./healthcheckDisplay.logic";
 // Lazy-loaded: the drawer pulls in the recharts-based latency/timeline charts
 // (~300 KB). This component is an eagerly-registered slot extension, so a static
@@ -48,7 +50,16 @@ function parseFilter(raw: string | null): HealthFilter {
   return raw === "failing" || raw === "healthy" ? raw : "all";
 }
 
-function matchesFilter(state: HealthCheckStatus, filter: HealthFilter) {
+function matchesFilter(
+  state: HealthCheckStatus,
+  filter: HealthFilter,
+  paused: boolean,
+) {
+  // A paused check is neither actively failing nor actively healthy — it's
+  // dormant. Only show it under "all"; the "failing"/"healthy" tabs hide it
+  // so a paused check can't masquerade as a current failure (its stale runs
+  // may still evaluate to unhealthy even though it's not running).
+  if (paused) return filter === "all";
   if (filter === "all") return true;
   if (filter === "healthy") return state === "healthy";
   return state !== "healthy";
@@ -77,6 +88,7 @@ interface HealthCheckOverviewItem {
   strategyId: string;
   name: string;
   state: HealthCheckStatus;
+  paused: boolean;
   intervalSeconds: number;
   lastRunAt?: Date;
   stateThresholds?: StateThresholds;
@@ -107,6 +119,7 @@ export function HealthCheckSystemOverview(props: SlotProps) {
       strategyId: check.strategyId,
       name: check.configurationName,
       state: check.status,
+      paused: check.paused,
       intervalSeconds: check.intervalSeconds,
       lastRunAt: check.recentRuns.at(-1)?.timestamp
         ? new Date(check.recentRuns.at(-1)!.timestamp)
@@ -117,7 +130,10 @@ export function HealthCheckSystemOverview(props: SlotProps) {
   }, [overviewData]);
 
   const visible = React.useMemo(
-    () => overview.filter((item) => matchesFilter(item.state, filter)),
+    () =>
+      overview.filter((item) =>
+        matchesFilter(item.state, filter, item.paused),
+      ),
     [overview, filter],
   );
 
@@ -188,6 +204,17 @@ export function HealthCheckSystemOverview(props: SlotProps) {
                 const healthyCount = countHealthy({
                   history: item.recentStatusHistory,
                 });
+                // A paused check is dormant — render a "Paused" pill (unknown
+                // tone) instead of the run-evaluated status, since its stale
+                // runs are not a meaningful current verdict. The accent stripe
+                // and the healthy/total figure + sparkline still reflect the
+                // pre-pause history for context.
+                const displayTone = item.paused
+                  ? (pausedToTone({ paused: true }) as StatusTone)
+                  : tone;
+                const displayLabel = item.paused
+                  ? "Paused"
+                  : statusToLabel({ status: item.state });
                 return (
                   <button
                     key={item.configurationId}
@@ -198,7 +225,7 @@ export function HealthCheckSystemOverview(props: SlotProps) {
                     <span
                       className={cn(
                         "absolute inset-y-0 left-0 w-1",
-                        toneStyles[tone].accent,
+                        toneStyles[displayTone].accent,
                       )}
                       aria-hidden
                     />
@@ -209,8 +236,8 @@ export function HealthCheckSystemOverview(props: SlotProps) {
                         {item.name}
                       </span>
                       <HealthStatusPill
-                        tone={tone}
-                        label={statusToLabel({ status: item.state })}
+                        tone={displayTone}
+                        label={displayLabel}
                         className="self-start"
                       />
                     </div>


### PR DESCRIPTION
## Summary

Paused health-check configurations previously kept contributing to their systems' health aggregate and kept SLO downtime events open, because pausing only skipped execution — the stale failing runs inside the evaluation window still drove the rollup status. The system overview list also rendered a paused failing check as "Unhealthy".

This PR makes `paused` a first-class "dormant" state:

- **System health rollup** (`getSystemHealthStatus`) excludes paused configurations, so a system whose only failing check is paused reads healthy.
- **Pause RPC** recomputes the rollup `health` entity for every affected system. A `degraded → healthy` transition fires the existing `HEALTH_ENTITY_KIND` "recovered" edge, which the SLO engine consumes to close the open downtime event at the pause time. If the system stays degraded (other failing checks), the event correctly stays open.
- **Resume RPC** intentionally does NOT recompute. The next actual run drives any degraded transition — if the check still fails, a fresh downtime event opens (the previous one was closed on pause, so the `handleSystemDown` idempotent guard doesn't suppress it); if it now passes, no event opens. This avoids fabricating downtime from stale last-known state when the underlying condition may have been fixed during the pause.
- **System overview list** (`getSystemHealthOverview`) now forwards a `paused` boolean. The frontend renders a "Paused" pill (unknown tone) for paused checks instead of the run-evaluated status, keeps the pre-pause sparkline for context, and excludes paused checks from the "Failing"/"Healthy" filter tabs (they only show under "All").

## Why not hide paused checks entirely?

Per the earlier decision, paused checks stay visible in the system overview (marked "Paused") so operators can see and manage them; they just don't drive the system's health. The dedicated Health Checks page is unchanged.

## Test plan

- [x] New unit tests:
  - `service-paused-filter.test.ts` — `getSystemHealthStatus` excludes paused configs; `getSystemIdsForConfiguration` returns enabled assignments; `getSystemHealthOverview` forwards the `paused` flag.
  - `router-pause-recompute.test.ts` — `pauseConfiguration` recomputes for every affected system; `resumeConfiguration` does NOT recompute.
  - `queue-executor.test.ts` — `recomputeSystemRollupHealth` calls `getSystemHealthStatus` for the bare systemId and swallows failures so the RPC never throws.
- [x] All 590 existing tests across healthcheck-backend/frontend/common + slo-backend still pass.
- [x] `tsgo -b` clean for all three touched packages.
- [x] `eslint . --max-warnings 0` clean for all three touched packages.

## Changeset

`.changeset/healthcheck-paused-excludes-from-health.md` bumps `@checkstack/healthcheck-backend`, `@checkstack/healthcheck-common`, and `@checkstack/healthcheck-frontend` minor (additive `paused` field + behavior change; no breaking API removals).