### PR TITLE
feat: per-environment rollup, history, and anomaly baselines

### DIFF
--- a/.changeset/anomaly-baseline-per-env.md
+++ b/.changeset/anomaly-baseline-per-env.md
@@ -1,0 +1,73 @@
+---
+"@checkstack/anomaly-backend": minor
+"@checkstack/anomaly-common": minor
+"@checkstack/healthcheck-backend": minor
+"@checkstack/healthcheck-common": minor
+"@checkstack/healthcheck-frontend": minor
+---
+
+Anomaly baselines are now per-environment, so the env-scoped
+`HealthCheckDrawer` shows the clicked env's baseline (not a cross-env
+one). Closes the follow-up noted in `healthcheck-per-env-rollup`.
+
+## What changed
+
+- **`anomaly_baselines`** now carries a nullable `environment_id`
+  column, and its unique constraint grew to
+  `(systemId, configurationId, environmentId, fieldPath)` with
+  `NULLS NOT DISTINCT` — so there is exactly one baseline per
+  `(system, config, env, path)` tuple, and the env-less slice (`NULL`)
+  stays a single row (the pre-feature cross-env baseline, preserved as
+  the env-less row until the next analyzer tick rewrites per-env rows).
+  Existing rows backfill to `environment_id = NULL` with no data work.
+- **Baseline analyzer** (`jobs/baseline-analyzer.ts`) now fans out per
+  environment within each assignment: runs are grouped by
+  `environmentId` (null = env-less), stats are computed per env, and
+  the upsert targets the 4-tuple. The cache key gained an env segment
+  (`baseline:${config}:${system}:${env ?? "<none>"}:${path}`) and the
+  `ANOMALY_BASELINE_UPDATED` signal payload now carries `environmentId`.
+  Previously the analyzer computed one cross-env batch per assignment.
+- **Inline detector** (`detector.ts`) resolves the per-env baseline:
+  the lookup matches `environmentId` when present or `IS NULL` for the
+  env-less slice, and the cache key matches the analyzer's env segment.
+  `environmentId` is threaded from the `checkCompleted` hook (see
+  below); it defaults to `null` (env-less) so a caller that omits it
+  resolves the env-less baseline rather than failing.
+- **`getAnomalyBaselines` RPC** now accepts an optional
+  `environmentId: string | null` filter and surfaces `environmentId` on
+  every `AnomalyBaselineDto`. Tristate semantics, mirroring
+  `getHistory`: `undefined` → all envs (no predicate), `null` → env-less
+  slice (`IS NULL`), a string → that env. The service predicate is at
+  the DB layer.
+- **`HealthCheckDrawer`** threads `item.environmentId` (already on its
+  props) into the baselines query, so the drawer's anomaly overlay
+  resolves server-side to the clicked env's baseline only — matching the
+  env-scoping already applied to its history table and charts. The
+  latency chart tolerates the new field (it picks the single
+  `"latencyMs"` baseline, which the env filter guarantees is unique).
+- **`getRunsForAnalysis`** (healthcheck) now returns `environmentId`
+  on each run so the analyzer can group by env. Additive optional
+  field; only the analyzer consumes it.
+- **`checkCompleted` / `checkFailed` hooks** (healthcheck) now carry
+  `environmentId: string | null` on their payloads, sourced from the
+  per-env execution loop. Only the anomaly detector subscribes to
+  `checkCompleted` (it was updated); the failure-path emit (rollup
+  error) passes `null`.
+
+## Notes
+
+- Anomaly *rows* (`anomalies` table) remain cross-env by design in this
+  step — only baselines are env-scoped, matching the scoped task. A
+  detector run for env A and env B's normal value still share one
+  `(system, config, path)` anomaly row; env-scoping the anomalies table
+  is tracked as a separate follow-up so this change stays focused on
+  the drawer's baseline overlay.
+- The `checkCompleted` / `checkFailed` payload change is technically
+  breaking for hook subscribers that destructure the payload, but the
+  only in-tree subscriber (the anomaly plugin) was updated in lockstep.
+  External webhook subscribers receive an additional field and are not
+  affected unless they reject unknown keys (uncommon).
+- Migration `0006_sad_retro_girl.sql` drops + recreates the unique
+  constraint with `NULLS NOT DISTINCT` and adds the column. It applies
+  cleanly to fresh and already-populated DBs (existing NULL-env rows
+  remain unique under the new key).

--- a/.changeset/healthcheck-per-env-rollup.md
+++ b/.changeset/healthcheck-per-env-rollup.md
@@ -1,0 +1,107 @@
+---
+"@checkstack/healthcheck-backend": minor
+"@checkstack/healthcheck-common": minor
+"@checkstack/healthcheck-frontend": minor
+---
+
+Per-environment health semantics: rollup no longer masks sibling outages,
+and notifications + automation windows are env-scoped.
+
+## The bug
+
+When a `(system, configuration)` assignment fanned out to multiple
+environments and only some of them failed, the system rollup could
+read **healthy** (masking a permanently-failing env), or **flap**
+healthy↔degraded/unhealthy tick-by-tick whenever env insertion order
+drifted, because the rollup derivation flattened every env's runs into
+one `timestamp DESC` list and handed the interleaved list to the
+threshold evaluator. The default `consecutive` mode walks newest-first
+and breaks the streak on the first interleaving env, so the rollup
+collapsed to whichever single env's status the most recent run landed
+on. Each flap fired an escalation/recovery notification + a
+`system_health_changed` trigger event.
+
+## What changed
+
+- **`getSystemHealthStatus(systemId)` rollup** now groups the latest
+  run window by `environmentId`, evaluates the threshold window PER
+  ENVIRONMENT, and takes worst-wins across envs within each association
+  (unhealthy > degraded > healthy) before worst-wins across associations.
+  This is stable regardless of env insertion order or multi-pod racing.
+  For a single-env (or env-less-only) assignment this reduces to the
+  pre-existing flat-window behavior. Per-env and env-less slices
+  (`environmentId: string` / `null`) are unchanged.
+- **`getSystemHealthOverview`** now groups runs per `(configurationId,
+  environmentId)`, evaluates each env's slice on its own monotonic run
+  window, and worst-wins across envs — mirroring `getSystemHealthStatus`.
+  The response carries `environmentId` on every `recentRuns[]` entry,
+  and adds `perEnvironment[]` per check (one entry per env with its own
+  `status` and env-scoped `recentRuns`) so a frontend can render one
+  row per `(check, environment)` pair, surfacing per-env outages the
+  rollup intentionally hides in the aggregate view. The top-level
+  `recentRuns[]` and `status` keep their pre-existing shape for
+  backwards compatibility (single-env checks are unchanged).
+- **`HealthCheckSystemOverview`** (frontend) now flattens multi-env
+  assignments into one row per `(check, environment)` — each row carries
+  the check name, an env pill (resolved via the same
+  `getSystemEnvironments` query the drawer already uses), the per-env
+  status, sparkline, and last-run. With the "Failing"/"Healthy" filter
+  now scoped per env, a permanently-failing environment surfaces as its
+  own failing row beside its healthy sibling, instead of being masked by
+  the rollup's worst-wins / latest-wins. Single-env and env-less
+  assignments render the historical single row (no env pill). Clicking
+  any env row opens the check-level drawer, scoped to that env via the
+  server-side env filter on the queries below — the drawer's run
+  history table, charts, and tiles all see only the (check, environment)
+  pair the operator clicked, never a mixed-env pool.
+- **`getHistory`, `getDetailedHistory`, `getRunStats`,
+  `getAggregatedHistory`, and `getDetailedAggregatedHistory`** now accept
+  an optional `environmentId: string | null` input that filters
+  server-side at the DB layer (`environment_id = $X` for an env, `IS
+  NULL` for the env-less slice, no predicate when omitted). The drawer's
+  charts and Recent Runs table pass the clicked row's `environmentId`
+  so the pagination, totals, and buckets reflect only that env — a
+  client-side filter would double-paginate and miscount totals; the
+  filter is at the DB so the data is honest end-to-end. The aggregated
+  history applies the env filter to all three tiers the cross-tier
+  aggregation engine reads (raw `health_check_runs` + hourly and daily
+  `health_check_aggregates`), since both tables are env-keyed. Single-env
+  and env-less rows omit the filter, so historical callers are
+  unchanged.
+- **Anomaly baselines are NOT yet env-scoped** — `anomaly_baselines` is
+  keyed on `(systemId, configurationId, fieldPath)` with no
+  `environmentId` column, and the detector computes a single baseline
+  across all envs of an assignment. Scoping the drawer's anomaly overlay
+  per env needs a schema migration + a per-env detector rewrite, and is
+  tracked as a follow-up. The drawer continues to show the cross-env
+  baseline next to the (now env-scoped) history + charts.
+- **`system_health_changed` / `system_degraded` / `system_healthy`
+  triggers** now partition by `(systemId, environmentId)` instead of
+  the bare `systemId` when the trigger fires from a per-env change.
+  Two failing environments of one system now fire two distinct events
+  with independent flapping/dwell/dedup windows — operators can author
+  per-env automations and get per-env notifications. A bare rollup
+  transition (`environmentId` absent) partitions on `systemId` alone,
+  so existing recipes that read only `payload.systemId` keep working.
+- **`notifyStateChange`** now accepts `environmentId` +
+  `environmentName`. Per-env notifications get an env-qualified title
+  (`"System health critical (prod): ..."`) and body, and an
+  env-qualified collapse key (`systemHealthCollapseKey(systemId, envId)`)
+  so two failing envs render as two independent cards instead of
+  merging into one. Suppression checks (maintenance/incident) remain
+  system-scoped.
+
+## Notes
+
+- Each failing env now fires its own `system_health_changed` event with
+  its own partition — this is the documented migration away from the
+  bug-report flapping cadence into a per-env flap cadence. Operators
+  with existing `window:` / `dwell:` recipes on `system_health_changed`
+  may see different refire cadence per env (one flapping env no longer
+  drowns out its steady sibling). To opt back into the pooled
+  historical behavior, an automation recipe can override its own
+  `partitionBy: (p) => p.systemId`.
+- `SYSTEM_STATUS_CHANGED` remains rollup-only (one broadcast per tick
+  on the rollup status transition): it drives low-noise cache
+  invalidation for `SystemHealthBadge` and `DependencyBadge`, and the
+  per-env trigger events above already cover per-env automation needs.

--- a/core/anomaly-backend/drizzle/0006_sad_retro_girl.sql
+++ b/core/anomaly-backend/drizzle/0006_sad_retro_girl.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "anomaly_baselines" DROP CONSTRAINT "anomaly_baselines_unique_path";--> statement-breakpoint
+ALTER TABLE "anomaly_baselines" ADD COLUMN "environment_id" text;--> statement-breakpoint
+ALTER TABLE "anomaly_baselines" ADD CONSTRAINT "anomaly_baselines_unique_path" UNIQUE NULLS NOT DISTINCT("system_id","configuration_id","environment_id","field_path");

--- a/core/anomaly-backend/drizzle/meta/0006_snapshot.json
+++ b/core/anomaly-backend/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,426 @@
+{
+  "id": "befb837b-78d8-4845-8b00-133b91250ab1",
+  "prevId": "845d6dfb-760a-47da-820b-6357758651ca",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.anomalies": {
+      "name": "anomalies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "anomaly_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'spike'"
+        },
+        "state": {
+          "name": "state",
+          "type": "anomaly_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "anomaly_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baseline_value": {
+          "name": "baseline_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline_std_dev": {
+          "name": "baseline_std_dev",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviation": {
+          "name": "deviation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspicious_run_count": {
+          "name": "suspicious_run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmation_threshold": {
+          "name": "confirmation_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovered_at": {
+          "name": "recovered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_value": {
+          "name": "suppressed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_baseline": {
+          "name": "suppressed_baseline",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_assignments": {
+      "name": "anomaly_assignments",
+      "schema": "",
+      "columns": {
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "anomaly_assignments_pk": {
+          "name": "anomaly_assignments_pk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "system_id",
+            "configuration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_baselines": {
+      "name": "anomaly_baselines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean": {
+          "name": "mean",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "std_dev": {
+          "name": "std_dev",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trend_slope": {
+          "name": "trend_slope",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dominant_value": {
+          "name": "dominant_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dominant_ratio": {
+          "name": "dominant_ratio",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "anomaly_baselines_unique_path": {
+          "name": "anomaly_baselines_unique_path",
+          "nullsNotDistinct": true,
+          "columns": [
+            "system_id",
+            "configuration_id",
+            "environment_id",
+            "field_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_configurations": {
+      "name": "anomaly_configurations",
+      "schema": "",
+      "columns": {
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_notification_mutes": {
+      "name": "anomaly_notification_mutes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_at": {
+          "name": "muted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anomaly_notification_mutes_user_idx": {
+          "name": "anomaly_notification_mutes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anomaly_notification_mutes_system_idx": {
+          "name": "anomaly_notification_mutes_system_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anomaly_notification_mutes_user_id_system_id_field_path_pk": {
+          "name": "anomaly_notification_mutes_user_id_system_id_field_path_pk",
+          "columns": [
+            "user_id",
+            "system_id",
+            "field_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.anomaly_direction": {
+      "name": "anomaly_direction",
+      "schema": "public",
+      "values": [
+        "above",
+        "below",
+        "changed"
+      ]
+    },
+    "public.anomaly_kind": {
+      "name": "anomaly_kind",
+      "schema": "public",
+      "values": [
+        "spike",
+        "drift"
+      ]
+    },
+    "public.anomaly_state": {
+      "name": "anomaly_state",
+      "schema": "public",
+      "values": [
+        "suspicious",
+        "anomaly",
+        "recovered"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/core/anomaly-backend/drizzle/meta/_journal.json
+++ b/core/anomaly-backend/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1780347895517,
       "tag": "0005_cute_blonde_phantom",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782855759107,
+      "tag": "0006_sad_retro_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/core/anomaly-backend/src/detector.test.ts
+++ b/core/anomaly-backend/src/detector.test.ts
@@ -216,7 +216,7 @@ const createMockCollectorRegistry = (): CollectorRegistry => {
 const systemId = "sys-1";
 const configurationId = "config-1";
 const timestamp = new Date().toISOString();
-const cacheKeyPrefix = `baseline:${configurationId}:${systemId}:collectors.http.request.responseTimeMs`;
+const cacheKeyPrefix = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.responseTimeMs`;
 
 const anomalousResult = {
   "uuid-1": {
@@ -298,7 +298,7 @@ describe("Anomaly Detector — processCheckCompleted", () => {
 
   test("creates suspicious anomaly for dominance drift", async () => {
     const baseline = createBaseline({ dominantValue: "OK", dominantRatio: 0.95 });
-    const cacheKey = `baseline:${configurationId}:${systemId}:collectors.http.request.statusText`;
+    const cacheKey = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.statusText`;
     const cache = createMockCache(new Map([[cacheKey, baseline]]));
     const db = createMockDb();
     
@@ -538,8 +538,8 @@ describe("Anomaly Detector — processCheckCompleted", () => {
 
   test("correctly builds field paths from collector results", async () => {
     const baseline = createBaseline();
-    const path1 = `baseline:${configurationId}:${systemId}:collectors.http.request.responseTimeMs`;
-    const path2 = `baseline:${configurationId}:${systemId}:collectors.http.request.statusCode`;
+    const path1 = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.responseTimeMs`;
+    const path2 = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.statusCode`;
     const cache = createMockCache(new Map([[path1, baseline], [path2, baseline]]));
 
     await processCheckCompleted({
@@ -603,7 +603,7 @@ describe("Anomaly Detector — processCheckCompleted", () => {
 
   test("resolves higher-is-better direction from schema (value below mean is anomalous)", async () => {
     const baseline = createBaseline({ mean: 99, stdDev: 1 });
-    const cacheKey = `baseline:${configurationId}:${systemId}:collectors.http.request.availability`;
+    const cacheKey = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.availability`;
     const cache = createMockCache(new Map([[cacheKey, baseline]]));
     const db = createMockDb();
 
@@ -629,7 +629,7 @@ describe("Anomaly Detector — processCheckCompleted", () => {
 
   test("higher-is-better ignores values above the mean", async () => {
     const baseline = createBaseline({ mean: 95, stdDev: 1 });
-    const cacheKey = `baseline:${configurationId}:${systemId}:collectors.http.request.availability`;
+    const cacheKey = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.availability`;
     const cache = createMockCache(new Map([[cacheKey, baseline]]));
     const db = createMockDb();
 
@@ -651,7 +651,7 @@ describe("Anomaly Detector — processCheckCompleted", () => {
 
   test("resolves deviation direction (value far from mean in either direction is anomalous)", async () => {
     const baseline = createBaseline({ mean: 200, stdDev: 5 });
-    const cacheKey = `baseline:${configurationId}:${systemId}:collectors.http.request.statusCode`;
+    const cacheKey = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.statusCode`;
     const cache = createMockCache(new Map([[cacheKey, baseline]]));
     const db = createMockDb();
 
@@ -674,7 +674,7 @@ describe("Anomaly Detector — processCheckCompleted", () => {
 
   test("skips fields where schema has anomaly-enabled: false and config has no direction", async () => {
     const baseline = createBaseline({ mean: 100, stdDev: 10 });
-    const cacheKey = `baseline:${configurationId}:${systemId}:collectors.http.request.bodyText`;
+    const cacheKey = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.bodyText`;
     const cache = createMockCache(new Map([[cacheKey, baseline]]));
     const db = createMockDb();
 
@@ -1087,5 +1087,78 @@ describe("Anomaly Detector — processCheckCompleted", () => {
     expect(db._updateCalls[0]).toMatchObject({ state: "anomaly" });
     // The failure was logged at warn level
     expect(logger.warn).toHaveBeenCalled();
+  });
+
+  // ─── Environment scoping ──────────────────────────────────────────────
+  //
+  // Regression guard: when a run carries `environmentId`, the detector must
+  // resolve the per-env baseline — the cache key gains an env segment and the
+  // env-less (`<none>`) key is NOT consulted. This locks the analyzer↔detector
+  // cache-key contract: a per-env baseline never shadows (or is shadowed by)
+  // the env-less slice.
+
+  test("uses env-scoped cache key when environmentId is provided", async () => {
+    const baseline = createBaseline();
+    const envBaselineFromDb = {
+      mean: baseline.mean,
+      stdDev: baseline.stdDev,
+      trendSlope: baseline.trendSlope,
+      sampleCount: baseline.sampleCount,
+      computedAt: new Date(baseline.computedAt),
+      dominantValue: null,
+      dominantRatio: null,
+      environmentId: "env-prod",
+    };
+    const db = createMockDb({ baselineFromDb: envBaselineFromDb });
+    const cache = createMockCache(new Map()); // empty → forces DB lookup
+
+    await processCheckCompleted({
+      ...baseProps,
+      latencyMs: 50,
+      environmentId: "env-prod",
+      result: anomalousResult,
+      db: db as never,
+      cache,
+      logger: createMockLogger() as never,
+      catalogClient: createMockCatalogClient() as never,
+      notificationClient: createMockNotificationClient() as never,
+    });
+
+    // The cache lookup must carry the env segment, NOT the env-less `<none>`.
+    const expectedKey = `baseline:${configurationId}:${systemId}:env-prod:collectors.http.request.responseTimeMs`;
+    const envLessKey = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.responseTimeMs`;
+    expect(cache.get).toHaveBeenCalledWith(expectedKey);
+    expect(cache.get).not.toHaveBeenCalledWith(envLessKey);
+    // After the DB hit, the env-scoped baseline is written back under the
+    // same env-scoped key.
+    expect(cache.set).toHaveBeenCalledWith(
+      expectedKey,
+      expect.objectContaining({ mean: baseline.mean }),
+      expect.any(Number),
+    );
+  });
+
+  test("falls back to env-less (<none>) cache key when environmentId is null", async () => {
+    const baseline = createBaseline();
+    const envKey = `baseline:${configurationId}:${systemId}:env-prod:collectors.http.request.responseTimeMs`;
+    const envLessKey = `baseline:${configurationId}:${systemId}:<none>:collectors.http.request.responseTimeMs`;
+    // Seed ONLY the env-less slice; the per-env key is absent. A null env run
+    // must read the env-less baseline, never the per-env one.
+    const cache = createMockCache(new Map([[envLessKey, baseline]]));
+
+    await processCheckCompleted({
+      ...baseProps,
+      latencyMs: 50,
+      environmentId: null,
+      result: anomalousResult,
+      db: createMockDb() as never,
+      cache,
+      logger: createMockLogger() as never,
+      catalogClient: createMockCatalogClient() as never,
+      notificationClient: createMockNotificationClient() as never,
+    });
+
+    expect(cache.get).toHaveBeenCalledWith(envLessKey);
+    expect(cache.get).not.toHaveBeenCalledWith(envKey);
   });
 });

--- a/core/anomaly-backend/src/detector.ts
+++ b/core/anomaly-backend/src/detector.ts
@@ -1,7 +1,7 @@
 import type { SafeDatabase } from "@checkstack/backend-api";
 import type { CacheProvider } from "@checkstack/cache-api";
 import * as schema from "./schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 import {
   computeThresholds,
   isAnomalous,
@@ -38,6 +38,7 @@ export async function processCheckCompleted({
   latencyMs: _latencyMs,
   result,
   timestamp: _timestamp,
+  environmentId = null,
   db,
   cache,
   routerCache,
@@ -53,6 +54,15 @@ export async function processCheckCompleted({
   latencyMs: number | undefined;
   result: Record<string, unknown> | undefined;
   timestamp: string;
+  /**
+   * Environment the run was executed for. null = the env-less slice (no
+   * environment membership). Threads through from the `checkCompleted` hook so
+   * the baseline lookup resolves the per-env baseline instead of a cross-env
+   * one — mirroring the analyzer's per-env upsert key. Optional only so legacy
+   * callers/tests that omit it resolve the env-less slice rather than failing —
+   * production always threads the hook payload.
+   */
+  environmentId?: string | null;
   db: SafeDatabase<typeof schema>;
   cache: CacheProvider;
   routerCache?: {
@@ -127,10 +137,21 @@ export async function processCheckCompleted({
 
   // Check each field
   for (const { path, value, collectorId, fieldName } of fieldsToCheck) {
-    const cacheKey = `baseline:${configurationId}:${systemId}:${path}`;
+    // Cache key mirrors the analyzer's, including the env slice, so a per-env
+    // baseline never shadows another env's cached entry. The env-less slice
+    // uses "<none>" (matches the analyzer's cache key).
+    const envSegment = environmentId ?? "<none>";
+    const cacheKey = `baseline:${configurationId}:${systemId}:${envSegment}:${path}`;
     let baseline = await cache.get<FieldBaseline>(cacheKey);
 
     if (!baseline) {
+      // Resolve the per-env baseline: match environmentId when present, or the
+      // env-less (NULL) slice otherwise. `nullsNotDistinct()` on the unique
+      // constraint guarantees exactly one env-less row per path.
+      const envPredicate =
+        environmentId === null
+          ? isNull(schema.anomalyBaselines.environmentId)
+          : eq(schema.anomalyBaselines.environmentId, environmentId);
       const [dbBaseline] = await db
         .select()
         .from(schema.anomalyBaselines)
@@ -138,6 +159,7 @@ export async function processCheckCompleted({
           and(
             eq(schema.anomalyBaselines.systemId, systemId),
             eq(schema.anomalyBaselines.configurationId, configurationId),
+            envPredicate,
             eq(schema.anomalyBaselines.fieldPath, path),
           ),
         )

--- a/core/anomaly-backend/src/jobs/baseline-analyzer.ts
+++ b/core/anomaly-backend/src/jobs/baseline-analyzer.ts
@@ -62,7 +62,8 @@ export async function setupBaselineAnalyzerJob({
       });
 
       for (const assignment of activeAssignments) {
-        // Per-assignment configuration is fetched once and reused per field.
+        // Per-assignment configuration is fetched once and reused across
+        // every per-environment fan-out within this assignment.
         let templateConfig;
         let assignmentConfig;
         try {
@@ -83,159 +84,174 @@ export async function setupBaselineAnalyzerJob({
           );
         }
 
-        const fieldValues: Record<string, (string | boolean | number)[]> = {};
-        const fieldCollectorIds: Record<string, string> = {};
-        const fieldNames: Record<string, string> = {};
+        // Fan out per environment so each env gets its own baseline. `null`
+        // is the env-less slice (no environment membership) — preserved as a
+        // distinct group so the pre-feature cross-env baseline survives as the
+        // env-less row. Maps preserve insertion order, and getRunsForAnalysis
+        // returns runs DESC by timestamp, so the first env we encounter leads
+        // the iteration; ordering across envs is not significant.
+        const runsByEnv = groupRunsByEnvironment(assignment.runs);
 
-        // `getRunsForAnalysis` returns runs in DESCENDING timestamp order.
-        // Iterate in reverse so per-field arrays end up chronologically ascending —
-        // a property the regression slope relies on.
-        for (let i = assignment.runs.length - 1; i >= 0; i--) {
-          const row = assignment.runs[i];
-          if (!row.result) continue;
+        for (const [environmentId, envRuns] of runsByEnv) {
+          const fieldValues: Record<string, (string | boolean | number)[]> = {};
+          const fieldCollectorIds: Record<string, string> = {};
+          const fieldNames: Record<string, string> = {};
 
-          const result = row.result as HealthCheckRunResult;
+          // `getRunsForAnalysis` returns runs in DESCENDING timestamp order.
+          // Iterate in reverse so per-field arrays end up chronologically
+          // ascending — a property the regression slope relies on.
+          for (let i = envRuns.length - 1; i >= 0; i--) {
+            const row = envRuns[i];
+            if (!row.result) continue;
 
-          if (typeof result.latencyMs === "number") {
-            const fullPath = "latencyMs";
-            if (!fieldValues[fullPath]) fieldValues[fullPath] = [];
-            fieldValues[fullPath].push(result.latencyMs);
-          }
+            const result = row.result as HealthCheckRunResult;
 
-          const collectors = result.metadata?.collectors;
-          if (!collectors) continue;
-
-          for (const collectorData of Object.values(collectors)) {
-            if (typeof collectorData !== "object" || collectorData === null) continue;
-            const data = collectorData as Record<string, unknown>;
-            const realCollectorId = data._collectorId;
-            if (typeof realCollectorId !== "string") continue;
-
-            for (const [fieldName, value] of Object.entries(data)) {
-              if (fieldName === "_collectorId" || fieldName.startsWith("_")) continue;
-              if (
-                typeof value !== "number" &&
-                typeof value !== "string" &&
-                typeof value !== "boolean"
-              ) {
-                continue;
-              }
-              const fullPath = `collectors.${realCollectorId}.${fieldName}`;
+            if (typeof result.latencyMs === "number") {
+              const fullPath = "latencyMs";
               if (!fieldValues[fullPath]) fieldValues[fullPath] = [];
-              fieldValues[fullPath].push(value);
-              fieldCollectorIds[fullPath] = realCollectorId;
-              fieldNames[fullPath] = fieldName;
+              fieldValues[fullPath].push(result.latencyMs);
+            }
+
+            const collectors = result.metadata?.collectors;
+            if (!collectors) continue;
+
+            for (const collectorData of Object.values(collectors)) {
+              if (typeof collectorData !== "object" || collectorData === null) continue;
+              const data = collectorData as Record<string, unknown>;
+              const realCollectorId = data._collectorId;
+              if (typeof realCollectorId !== "string") continue;
+
+              for (const [fieldName, value] of Object.entries(data)) {
+                if (fieldName === "_collectorId" || fieldName.startsWith("_")) continue;
+                if (
+                  typeof value !== "number" &&
+                  typeof value !== "string" &&
+                  typeof value !== "boolean"
+                ) {
+                  continue;
+                }
+                const fullPath = `collectors.${realCollectorId}.${fieldName}`;
+                if (!fieldValues[fullPath]) fieldValues[fullPath] = [];
+                fieldValues[fullPath].push(value);
+                fieldCollectorIds[fullPath] = realCollectorId;
+                fieldNames[fullPath] = fieldName;
+              }
             }
           }
-        }
 
-        for (const [path, values] of Object.entries(fieldValues)) {
-          if (values.length < MIN_BASELINE_SAMPLES) continue;
+          for (const [path, values] of Object.entries(fieldValues)) {
+            if (values.length < MIN_BASELINE_SAMPLES) continue;
 
-          let mean = 0;
-          let stdDev = 0;
-          let trendSlope = 0;
-          let dominantValue: string | undefined;
-          let dominantRatio: number | undefined;
+            let mean = 0;
+            let stdDev = 0;
+            let trendSlope = 0;
+            let dominantValue: string | undefined;
+            let dominantRatio: number | undefined;
 
-          if (typeof values[0] === "number") {
-            const numValues = values as number[];
-            mean = computeMean(numValues);
-            stdDev = computeStdDev(numValues);
-            trendSlope = computeLinearRegressionSlope(numValues);
-          }
+            if (typeof values[0] === "number") {
+              const numValues = values as number[];
+              mean = computeMean(numValues);
+              stdDev = computeStdDev(numValues);
+              trendSlope = computeLinearRegressionSlope(numValues);
+            }
 
-          const dom = computeDominance(values);
-          if (dom.dominantValue !== undefined) {
-            dominantValue = String(dom.dominantValue);
-            dominantRatio = dom.dominantRatio;
-          }
+            const dom = computeDominance(values);
+            if (dom.dominantValue !== undefined) {
+              dominantValue = String(dom.dominantValue);
+              dominantRatio = dom.dominantRatio;
+            }
 
-          const baseline = {
-            mean,
-            stdDev,
-            trendSlope,
-            dominantValue,
-            dominantRatio,
-            sampleCount: values.length,
-            computedAt: new Date(),
-          };
+            const baseline = {
+              mean,
+              stdDev,
+              trendSlope,
+              dominantValue,
+              dominantRatio,
+              sampleCount: values.length,
+              computedAt: new Date(),
+            };
 
-          await db
-            .insert(schema.anomalyBaselines)
-            .values({
-              systemId: assignment.systemId,
-              configurationId: assignment.configurationId,
-              fieldPath: path,
+            await db
+              .insert(schema.anomalyBaselines)
+              .values({
+                systemId: assignment.systemId,
+                configurationId: assignment.configurationId,
+                environmentId,
+                fieldPath: path,
+                ...baseline,
+              })
+              .onConflictDoUpdate({
+                target: [
+                  schema.anomalyBaselines.systemId,
+                  schema.anomalyBaselines.configurationId,
+                  schema.anomalyBaselines.environmentId,
+                  schema.anomalyBaselines.fieldPath,
+                ],
+                set: baseline,
+              });
+
+            // Cache key mirrors the detector's lookup, including the env slice
+            // so a per-env baseline never shadows another env's cached entry.
+            const cacheKey = `baseline:${assignment.configurationId}:${assignment.systemId}:${environmentId ?? "<none>"}:${path}`;
+            await cache.set(
+              cacheKey,
+              { ...baseline, computedAt: baseline.computedAt.toISOString() },
+              1000 * 60 * 60 * 24,
+            );
+
+            if (signalService && typeof values[0] === "number") {
+              await signalService.broadcast(ANOMALY_BASELINE_UPDATED, {
+                systemId: assignment.systemId,
+                configurationId: assignment.configurationId,
+                environmentId,
+                fieldPath: path,
+                mean: baseline.mean,
+                stdDev: baseline.stdDev,
+                sampleCount: baseline.sampleCount,
+              });
+            }
+
+            // Drift evaluation runs only for numeric fields scoped to a collector
+            // (the path layout `collectors.${id}.${field}`). Run-level fields like
+            // `latencyMs` are skipped because we have no schema-declared direction
+            // for them.
+            if (typeof values[0] !== "number") continue;
+            const collectorId = fieldCollectorIds[path];
+            const fieldName = fieldNames[path];
+            if (!collectorId || !fieldName) continue;
+
+            const schemaInfo = lookupSchemaInfo({
+              collectorRegistry,
+              collectorId,
+              fieldName,
+            });
+
+            const baselineDto: FieldBaseline = {
               ...baseline,
-            })
-            .onConflictDoUpdate({
-              target: [
-                schema.anomalyBaselines.systemId,
-                schema.anomalyBaselines.configurationId,
-                schema.anomalyBaselines.fieldPath,
-              ],
-              set: baseline,
-            });
+              computedAt: baseline.computedAt.toISOString(),
+            };
 
-          const cacheKey = `baseline:${assignment.configurationId}:${assignment.systemId}:${path}`;
-          await cache.set(
-            cacheKey,
-            { ...baseline, computedAt: baseline.computedAt.toISOString() },
-            1000 * 60 * 60 * 24,
-          );
-
-          if (signalService && typeof values[0] === "number") {
-            await signalService.broadcast(ANOMALY_BASELINE_UPDATED, {
+            await evaluateDrift({
+              db,
+              logger,
+              catalogClient,
+              notificationClient,
+              signalService,
               systemId: assignment.systemId,
               configurationId: assignment.configurationId,
               fieldPath: path,
-              mean: baseline.mean,
-              stdDev: baseline.stdDev,
-              sampleCount: baseline.sampleCount,
+              baseline: baselineDto,
+              schemaDirection: schemaInfo.direction,
+              schemaSensitivity: schemaInfo.sensitivity,
+              schemaConfirmationWindow: schemaInfo.confirmationWindow,
+              schemaDriftEnabled: schemaInfo.driftEnabled,
+              schemaDriftThreshold: schemaInfo.driftThreshold,
+              schemaMinAbsoluteDelta: schemaInfo.minAbsoluteDelta,
+              schemaMinRelativeDelta: schemaInfo.minRelativeDelta,
+              templateConfig,
+              assignmentConfig,
             });
           }
-
-          // Drift evaluation runs only for numeric fields scoped to a collector
-          // (the path layout `collectors.${id}.${field}`). Run-level fields like
-          // `latencyMs` are skipped because we have no schema-declared direction
-          // for them.
-          if (typeof values[0] !== "number") continue;
-          const collectorId = fieldCollectorIds[path];
-          const fieldName = fieldNames[path];
-          if (!collectorId || !fieldName) continue;
-
-          const schemaInfo = lookupSchemaInfo({
-            collectorRegistry,
-            collectorId,
-            fieldName,
-          });
-
-          const baselineDto: FieldBaseline = {
-            ...baseline,
-            computedAt: baseline.computedAt.toISOString(),
-          };
-
-          await evaluateDrift({
-            db,
-            logger,
-            catalogClient,
-            notificationClient,
-            signalService,
-            systemId: assignment.systemId,
-            configurationId: assignment.configurationId,
-            fieldPath: path,
-            baseline: baselineDto,
-            schemaDirection: schemaInfo.direction,
-            schemaSensitivity: schemaInfo.sensitivity,
-            schemaConfirmationWindow: schemaInfo.confirmationWindow,
-            schemaDriftEnabled: schemaInfo.driftEnabled,
-            schemaDriftThreshold: schemaInfo.driftThreshold,
-            schemaMinAbsoluteDelta: schemaInfo.minAbsoluteDelta,
-            schemaMinRelativeDelta: schemaInfo.minRelativeDelta,
-            templateConfig,
-            assignmentConfig,
-          });
         }
       }
 
@@ -266,6 +282,37 @@ interface SchemaInfo {
   driftThreshold?: number;
   minAbsoluteDelta?: number;
   minRelativeDelta?: number;
+}
+
+/**
+ * Partition an assignment's runs by `environmentId` so each environment gets
+ * its own baseline. `null` (env-less slice) is kept as a distinct key — the
+ * pre-feature cross-env baseline survives as the env-less row. A `Map` preserves
+ * the first-seen order of environments; ordering across envs is not
+ * significant (each env's stats are computed independently), only the
+ * chronological order of runs *within* an env group matters, and that is
+ * preserved by appending in the same DESC order the upstream query returned.
+ */
+function groupRunsByEnvironment(
+  runs: Array<{ result?: unknown; environmentId: string | null }>,
+): Map<
+  string | null,
+  Array<{ result?: unknown; environmentId: string | null }>
+> {
+  const groups = new Map<
+    string | null,
+    Array<{ result?: unknown; environmentId: string | null }>
+  >();
+  for (const run of runs) {
+    const key = run.environmentId ?? null;
+    let bucket = groups.get(key);
+    if (!bucket) {
+      bucket = [];
+      groups.set(key, bucket);
+    }
+    bucket.push(run);
+  }
+  return groups;
 }
 
 function lookupSchemaInfo({

--- a/core/anomaly-backend/src/schema.ts
+++ b/core/anomaly-backend/src/schema.ts
@@ -74,6 +74,14 @@ export const anomalyBaselines = pgTable("anomaly_baselines", {
   id: uuid("id").primaryKey().defaultRandom(),
   systemId: text("system_id").notNull(),
   configurationId: uuid("configuration_id").notNull(),
+  /**
+   * Environment this baseline was computed for (per-environment fan-out).
+   * null = the env-less slice (the pre-feature cross-env baseline), mirroring
+   * `health_check_runs.environmentId`. `nullsNotDistinct()` on the unique
+   * constraint below means "one baseline per (system, config, null env, path)"
+   * — so the env-less slice stays a single row.
+   */
+  environmentId: text("environment_id"),
   fieldPath: text("field_path").notNull(),
   mean: doublePrecision("mean").notNull(),
   stdDev: doublePrecision("std_dev").notNull(),
@@ -83,11 +91,9 @@ export const anomalyBaselines = pgTable("anomaly_baselines", {
   dominantValue: text("dominant_value"),
   dominantRatio: doublePrecision("dominant_ratio"),
 }, (t) => ({
-  uniquePath: unique("anomaly_baselines_unique_path").on(
-    t.systemId,
-    t.configurationId,
-    t.fieldPath
-  )
+  uniquePath: unique("anomaly_baselines_unique_path")
+    .on(t.systemId, t.configurationId, t.environmentId, t.fieldPath)
+    .nullsNotDistinct(),
 }));
 
 export const anomalyConfigurations = pgTable("anomaly_configurations", {

--- a/core/anomaly-backend/src/service.ts
+++ b/core/anomaly-backend/src/service.ts
@@ -212,19 +212,37 @@ export class AnomalyService {
   async getAnomalyBaselines(params: {
     systemId: string;
     configurationId: string;
+    /**
+     * Optional environment filter. Mirrors the proc input tristate:
+     * - `undefined` → no env predicate (return every env for this
+     *   system+config, e.g. the single-env rollup drawer or non-scoped
+     *   callers).
+     * - `null` → only the env-less slice (environment_id IS NULL).
+     * - a string → only that environment's baselines.
+     */
+    environmentId?: string | null;
   }) {
+    const conditions = [
+      eq(schema.anomalyBaselines.systemId, params.systemId),
+      eq(schema.anomalyBaselines.configurationId, params.configurationId),
+    ];
+
+    if (params.environmentId !== undefined) {
+      conditions.push(
+        params.environmentId === null
+          ? isNull(schema.anomalyBaselines.environmentId)
+          : eq(schema.anomalyBaselines.environmentId, params.environmentId),
+      );
+    }
+
     const results = await this.db
       .select()
       .from(schema.anomalyBaselines)
-      .where(
-        and(
-          eq(schema.anomalyBaselines.systemId, params.systemId),
-          eq(schema.anomalyBaselines.configurationId, params.configurationId),
-        ),
-      );
+      .where(and(...conditions));
 
     return results.map((r) => ({
       ...r,
+      environmentId: r.environmentId,
       computedAt: r.computedAt.toISOString(),
     }));
   }

--- a/core/anomaly-common/src/index.ts
+++ b/core/anomaly-common/src/index.ts
@@ -31,6 +31,13 @@ export const ANOMALY_BASELINE_UPDATED = createSignal({
   payloadSchema: z.object({
     systemId: z.string(),
     configurationId: z.string(),
+    /**
+     * Environment the recomputed baseline belongs to. null = the env-less
+     * slice (no environment membership). Subscribers that only key on
+     * (system, config, fieldPath) keep working; env-aware subscribers can
+     * now scope their refetch.
+     */
+    environmentId: z.string().nullable(),
     fieldPath: z.string(),
     mean: z.number(),
     stdDev: z.number(),

--- a/core/anomaly-common/src/rpc-contract.ts
+++ b/core/anomaly-common/src/rpc-contract.ts
@@ -33,6 +33,12 @@ export const AnomalyBaselineDtoSchema = z.object({
   id: z.string(),
   systemId: z.string(),
   configurationId: z.string(),
+  /**
+   * Environment this baseline was computed for. null = the env-less slice (no
+   * environment membership). Surfaced so the frontend can keep the env-scoped
+   * drawer's chart on the clicked env's baseline only.
+   */
+  environmentId: z.string().nullable(),
   fieldPath: z.string(),
   mean: z.number(),
   stdDev: z.number(),
@@ -107,6 +113,15 @@ export const anomalyContract = {
     .input(z.object({
       systemId: z.string(),
       configurationId: z.string(),
+      /**
+       * Optional environment filter, mirroring the HealthCheckDrawer's
+       * `item.environmentId` semantics:
+       * - `undefined` (omitted) → return baselines for ALL environments
+       *   (the single-env rollup row, or any caller that isn't env-scoped).
+       * - `null` → only the env-less slice (environment_id IS NULL).
+       * - a string → only that environment's baselines.
+       */
+      environmentId: z.string().nullish(),
     }))
     .output(z.array(AnomalyBaselineDtoSchema)),
 

--- a/core/healthcheck-backend/src/automations.test.ts
+++ b/core/healthcheck-backend/src/automations.test.ts
@@ -67,7 +67,7 @@ describe("healthcheck triggers", () => {
   });
 
 
-  it("extracts systemId as the contextKey on all three", () => {
+  it("extracts systemId as the contextKey on all three (bare rollup, no environmentId)", () => {
     const degradedOrChanged = {
       systemId: "sys-1",
       previousStatus: "healthy",
@@ -88,6 +88,48 @@ describe("healthcheck triggers", () => {
     expect(systemHealthChangedTrigger.contextKey?.(degradedOrChanged)).toBe(
       "sys-1",
     );
+  });
+
+  it("partitions the contextKey per-(system, environment) when environmentId is present", () => {
+    // Per-env partition: two failing envs of one system share a SYSTEM
+    // but NOT a flapping/dwell/dedup window — automations get N distinct
+    // `system_health_changed` events with independent partitions. The bare
+    // rollup change (no environmentId) keys on the bare systemId alone so
+    // existing recipes keep working.
+    const prodSpread = {
+      systemId: "sys-1",
+      environmentId: "prod",
+      previousStatus: "healthy",
+      newStatus: "unhealthy",
+      healthyChecks: 1,
+      totalChecks: 2,
+      timestamp: "2026-05-29T11:00:00Z",
+    } as const;
+    const stagingSpread = {
+      ...prodSpread,
+      environmentId: "staging",
+    } as const;
+    const rollup = {
+      systemId: "sys-1",
+      previousStatus: "degraded",
+      newStatus: "unhealthy",
+      healthyChecks: 1,
+      totalChecks: 2,
+      timestamp: "2026-05-29T11:00:00Z",
+    } as const;
+
+    expect(systemHealthChangedTrigger.contextKey?.(prodSpread)).toBe(
+      "sys-1::prod",
+    );
+    expect(systemHealthChangedTrigger.contextKey?.(stagingSpread)).toBe(
+      "sys-1::staging",
+    );
+    // Rollup stays system-scoped.
+    expect(systemHealthChangedTrigger.contextKey?.(rollup)).toBe("sys-1");
+    // The directional triggers use the SAME partition function (they share
+    // the schema's { systemId, environmentId? } fields by structural type).
+    expect(systemDegradedTrigger.contextKey?.(prodSpread)).toBe("sys-1::prod");
+    expect(systemHealthyTrigger.contextKey?.(prodSpread)).toBe("sys-1::prod");
   });
 });
 

--- a/core/healthcheck-backend/src/automations.ts
+++ b/core/healthcheck-backend/src/automations.ts
@@ -90,6 +90,24 @@ const checkFailedPayloadSchema = z.object({
 
 // ─── Triggers ──────────────────────────────────────────────────────────
 
+// Per-(system, environment) partition key for all entity-driven system-health
+// triggers. Carrying `environmentId` here — NOT just on the payload — makes
+// the automation engine's dwell / flapping / dedup windows partition per-env:
+// one environment flapping doesn't get drowned out by the steady sibling,
+// and N failing envs fire N distinct `system_health_changed` events with
+// independent partitions (see the changeset "Make healthcheck triggers
+// env-scoped"). `payload.systemId` stays the bare systemId, so existing
+// recipes that read only `systemId` keep working. A bare rollup change
+// (per `environmentId = null`) partitions on the bare systemId alone —
+// the historical system-scoped window. The three trigger payloads all
+// expose `{ systemId, environmentId? }`, so the partition function is shared
+// via an inline closure that's structural-compatible with each.
+function systemHealthPartitionKey<
+  P extends { systemId: string; environmentId?: string },
+>(p: P): string {
+  return p.environmentId ? `${p.systemId}::${p.environmentId}` : p.systemId;
+}
+
 export const systemDegradedTrigger: TriggerDefinition<
   z.infer<typeof systemDegradedPayloadSchema>
 > = {
@@ -105,7 +123,8 @@ export const systemDegradedTrigger: TriggerDefinition<
   setup: makeEntityDrivenTriggerSetup<
     z.infer<typeof systemDegradedPayloadSchema>
   >(),
-  contextKey: (p) => p.systemId,
+  // Per-(system, env); bare systemId for the rollup change (env-less).
+  contextKey: (p) => systemHealthPartitionKey(p),
   contextKeyLabel: "system",
 };
 
@@ -122,7 +141,7 @@ export const systemHealthyTrigger: TriggerDefinition<
   setup: makeEntityDrivenTriggerSetup<
     z.infer<typeof systemHealthyPayloadSchema>
   >(),
-  contextKey: (p) => p.systemId,
+  contextKey: (p) => systemHealthPartitionKey(p),
   contextKeyLabel: "system",
 };
 
@@ -140,7 +159,7 @@ export const systemHealthChangedTrigger: TriggerDefinition<
   setup: makeEntityDrivenTriggerSetup<
     z.infer<typeof systemHealthChangedPayloadSchema>
   >(),
-  contextKey: (p) => p.systemId,
+  contextKey: (p) => systemHealthPartitionKey(p),
   contextKeyLabel: "system",
 };
 

--- a/core/healthcheck-backend/src/hooks.ts
+++ b/core/healthcheck-backend/src/hooks.ts
@@ -46,6 +46,12 @@ export const healthCheckHooks = {
     latencyMs: number | undefined;
     result: Record<string, unknown> | undefined;
     timestamp: string;
+    /**
+     * Environment the run was executed for. null = the env-less slice (no
+     * environment membership). Forwarded by the anomaly plugin so its inline
+     * detector resolves the per-env baseline rather than a cross-env one.
+     */
+    environmentId: string | null;
   }>("healthcheck.check.completed"),
 
   /**
@@ -64,5 +70,6 @@ export const healthCheckHooks = {
     latencyMs: number | undefined;
     result: Record<string, unknown> | undefined;
     timestamp: string;
+    environmentId: string | null;
   }>("healthcheck.check.failed"),
 } as const;

--- a/core/healthcheck-backend/src/queue-executor.ts
+++ b/core/healthcheck-backend/src/queue-executor.ts
@@ -142,6 +142,7 @@ async function emitCheckCompletedHook({
   status,
   latencyMs,
   result,
+  environmentId,
 }: {
   getEmitHook: () => EmitHookFn | undefined;
   systemId: string;
@@ -149,6 +150,7 @@ async function emitCheckCompletedHook({
   status: string;
   latencyMs: number | undefined;
   result: Record<string, unknown> | undefined;
+  environmentId: string | null;
 }): Promise<void> {
   const emitHook = getEmitHook();
   if (!emitHook) return;
@@ -160,6 +162,7 @@ async function emitCheckCompletedHook({
     latencyMs,
     result,
     timestamp,
+    environmentId,
   });
   // Narrow follow-up — informational for automation triggers; the
   // auto-incident pipeline still runs on its own thresholds.
@@ -171,6 +174,7 @@ async function emitCheckCompletedHook({
       latencyMs,
       result,
       timestamp,
+      environmentId,
     });
   }
 }
@@ -321,6 +325,21 @@ async function notifyStateChange(props: {
   configurationId: string;
   previousStatus: HealthCheckStatus;
   newStatus: HealthCheckStatus;
+  /**
+   * The environment this transition is scoped to. `null` (or `undefined`)
+   * means the rollout transition (the system rollup). A concrete string means
+   * the per-env slice — the body and collapse key are env-qualified so two
+   * failing envs don't merge into one card (see the changeset "Make
+   * healthcheck triggers env-scoped").
+   */
+  environmentId?: string | null;
+  /**
+   * Human-readable env name, included in the title/body. Best-effort: when
+   * absent (e.g. catastrophic job failure before env resolution) the message
+   * falls back to the bare system name. Resolution happens before the call
+   * site, so no extra catalog RPC here.
+   */
+  environmentName?: string;
   service: HealthCheckService;
   catalogClient: CatalogClient;
   notificationClient: NotificationClient;
@@ -334,6 +353,8 @@ async function notifyStateChange(props: {
     configurationId,
     previousStatus,
     newStatus,
+    environmentId,
+    environmentName,
     service,
     catalogClient,
     notificationClient,
@@ -341,6 +362,9 @@ async function notifyStateChange(props: {
     incidentClient,
     logger,
   } = props;
+
+  const envScoped = typeof environmentId === "string";
+  const envSuffix = envScoped && environmentName ? ` (${environmentName})` : "";
 
   const transition = classifyTransition(previousStatus, newStatus);
   if (transition === "none") {
@@ -411,19 +435,23 @@ async function notifyStateChange(props: {
   let importance: "info" | "warning" | "critical";
 
   if (transition === "recovery") {
-    title = `System health restored: ${systemName}`;
-    body =
-      `All health checks for **${systemName}** are now passing. The system has returned to normal operation.`;
+    title = `System health restored${envSuffix}: ${systemName}`;
+    body = envScoped
+      ? `Health checks for **${systemName}** in environment **${environmentName ?? environmentId}** are now passing. The system has returned to normal operation in that environment.`
+      : `All health checks for **${systemName}** are now passing. The system has returned to normal operation.`;
     importance = "info";
   } else if (newStatus === "unhealthy") {
-    title = `System health critical: ${systemName}`;
-    body = `Health checks indicate **${systemName}** is unhealthy and may be down.`;
+    title = `System health critical${envSuffix}: ${systemName}`;
+    body = envScoped
+      ? `Health checks indicate **${systemName}** is unhealthy in environment **${environmentName ?? environmentId}** and may be down in that environment.`
+      : `Health checks indicate **${systemName}** is unhealthy and may be down.`;
     importance = "critical";
   } else {
     // degraded — either an escalation from healthy or a partial recovery
-    title = `System health degraded: ${systemName}`;
-    body =
-      `Some health checks for **${systemName}** are failing. The system may be experiencing issues.`;
+    title = `System health degraded${envSuffix}: ${systemName}`;
+    body = envScoped
+      ? `Some health checks for **${systemName}** in environment **${environmentName ?? environmentId}** are failing. That environment may be experiencing issues.`
+      : `Some health checks for **${systemName}** are failing. The system may be experiencing issues.`;
     importance = "warning";
   }
 
@@ -449,7 +477,14 @@ async function notifyStateChange(props: {
       body,
       importance,
       action: { label: actionLabel, url: actionUrl },
-      collapseKey: systemHealthCollapseKey(systemId),
+      // Env-qualified collapse key so two failing envs of one system generate
+      // two independent notification cards (one per env) instead of merging
+      // -> operators see all env outages. The system-rollup transition
+      // (`environmentId === null`/undefined) keys on the bare systemId and
+      // therefore reuses the pre-existing single-card identity.
+      collapseKey: envScoped
+        ? systemHealthCollapseKey(systemId, environmentId)
+        : systemHealthCollapseKey(systemId),
       subjects: [
         createSystemSubject({
           id: systemId,
@@ -1071,6 +1106,8 @@ async function executeHealthCheckJob(props: {
           configurationId: configId,
           previousStatus,
           newStatus: newState.status,
+          environmentId,
+          environmentName: environment?.name,
           service,
           catalogClient,
           maintenanceClient,
@@ -1189,6 +1226,7 @@ async function executeHealthCheckJob(props: {
       status: result.status,
       latencyMs: result.latencyMs,
       result: (result.metadata?.collectors as Record<string, unknown>) ?? undefined,
+      environmentId,
     });
 
     if (newState.status !== previousStatus) {
@@ -1210,6 +1248,8 @@ async function executeHealthCheckJob(props: {
         configurationId: configId,
         previousStatus,
         newStatus: newState.status,
+        environmentId,
+        environmentName: environment?.name,
         service,
         catalogClient,
         maintenanceClient,
@@ -1415,6 +1455,7 @@ async function executeHealthCheckJob(props: {
       status: "unhealthy",
       latencyMs: undefined,
       result: undefined,
+      environmentId: null,
     });
 
     if (newState.status !== previousStatus) {

--- a/core/healthcheck-backend/src/service-env-filter.test.ts
+++ b/core/healthcheck-backend/src/service-env-filter.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, mock } from "bun:test";
+import { HealthCheckService } from "./service";
+
+/**
+ * Regression coverage for the server-side `environmentId` predicate added
+ * to `getHistory`, `getRunStats`, `getDetailedHistory`, and
+ * `getAggregatedHistory` so the per-(check, environment) views in the
+ * `HealthCheckDrawer` see only the env the operator clicked — not a
+ * mixed-env pool filtered client-side. A client-side filter would double-
+ * paginate, miscount totals, and ship rows the backend didn't return; the
+ * filter MUST be at the DB so the pagination + total are honest.
+ *
+ * Verified by capturing the predicate each query method passes to
+ * drizzle's `where(...)` and checking the bound value is present in the
+ * predicate's SQL-string form (drizzle SQL nodes stringify to SQL
+ * fragments that include their bindings — the same convention used by
+ * `service-paused-filter.test.ts`).
+ */
+describe("HealthCheckService env filter on per-env queries", () => {
+  /** Drizzle SQL nodes don't stringify to readable SQL, but they expose a
+   * `queryChunks` array (or a `SQL<...>` wrapper) whose leaves carry the
+   * bound params and column names. `containsString` recursively walks any
+   * captured predicate — `eq(healthCheckRuns.environmentId, "prod")`
+   * carries `"prod"` and `"environment_id"` inside its `queryChunks` —
+   * and a composition via `and(...)` carries them in the top-level
+   * chunks. We piggyback on this internal structure the same way drizzle
+   * itself does at query serialization, so the assertion proves the
+   * binding made it into the predicate object the service handed the
+   * query builder. */
+  function containsString(v: unknown, needle: string): boolean {
+    return containsStringInner(v, needle, new Set());
+  }
+  function containsStringInner(
+    v: unknown,
+    needle: string,
+    seen: Set<unknown>,
+  ): boolean {
+    if (typeof v === "string") return v.includes(needle);
+    if (v === null || typeof v !== "object" || seen.has(v)) return false;
+    seen.add(v);
+    if (Array.isArray(v)) return v.some((x) => containsStringInner(x, needle, seen));
+    // Visit every enumerable key + symbol — drizzle keeps bound params
+    // and column names on `queryChunks` and nested column descriptors.
+    const record = v as Record<PropertyKey, unknown>;
+    return Object.getOwnPropertyNames(record)
+      .some((key) =>
+        containsStringInner(record[key], needle, seen),
+      ) || Object.getOwnPropertySymbols(record).some((sym) =>
+        containsStringInner(record[sym], needle, seen),
+      );
+  }
+
+  /** Extracts every string-leaf reachable from a predicate. Used for
+   * focused assertions like "the env column appears as IS NULL, not EQ". */
+  function allStrings(v: unknown, seen = new Set<unknown>()): string[] {
+    if (typeof v === "string") return [v];
+    if (v === null || typeof v !== "object" || seen.has(v)) return [];
+    seen.add(v);
+    if (Array.isArray(v)) return v.flatMap((x) => allStrings(x, seen));
+    const record = v as Record<PropertyKey, unknown>;
+    return Object.getOwnPropertyNames(record)
+      .flatMap((key) => allStrings(record[key], seen))
+      .concat(Object.getOwnPropertySymbols(record).flatMap((sym) => allStrings(record[sym], seen)));
+  }
+
+  /**
+   * Build the `db.select(...)` chain. Returns a builder object the service
+   * awaits; methods are no-ops that return `self` so the chain
+   * terminates. `where(predicate)` records the predicate for inspection.
+   * Each captured table is indexed by call order — the service's per-
+   * method structure (which selects queries, in which order) is stable so
+   * the calling test can read captured predicates by index.
+   */
+  function makeChainable(returnValue: unknown[] = []) {
+    const whereCalls: unknown[] = [];
+    // Promise that also exposes the query builder chain. `await` of this
+    // object returns the resolved value (an array, iterable); builder
+    // methods attached so `.where(...).orderBy(...).limit(...)` chains
+    // terminate in the same thenable.
+    type Chain = Promise<unknown[]> & {
+      where: (predicate: unknown) => Chain;
+      orderBy: () => Chain;
+      limit: () => Chain;
+      offset: () => Chain;
+      innerJoin: () => Chain;
+    };
+    const chain = Object.assign(Promise.resolve(returnValue), {
+      where: mock((predicate: unknown) => {
+        whereCalls.push(predicate);
+        return chain;
+      }),
+      orderBy: mock(() => chain),
+      limit: mock(() => chain),
+      offset: mock(() => chain),
+      innerJoin: mock(() => chain),
+    }) as Chain;
+    return { chain, whereCalls };
+  }
+
+  function buildDb(runsReturn: unknown[] = []) {
+    const runsChain = makeChainable(runsReturn);
+    const aggregatesChain = makeChainable(runsReturn);
+    const configChain = makeChainable([{ id: "cfg-1", strategyId: "http" }]);
+
+    // The service's `select().from(table)` — route every `from()` to one
+    // of our chained builders. Order matters per-method; the test reads it
+    // back via the returned `captures` lists.
+    const selectCallCount = { n: 0 };
+    const db = {
+      select: mock(() => {
+        selectCallCount.n += 1;
+        return {
+          from: mock((_table?: unknown) => {
+            // `healthCheckConfigurations` is the first select in
+            // `getAggregatedHistory`. We dispatch on call order: 1 → config,
+            // since the others go through table selects below. For simpler
+            // methods these are not distinguished, but practice confirms
+            // the captured predicate array captures env-id semantics
+            // regardless.
+            return runsChain.chain;
+          }),
+          // `getRunStats` uses a column projection: `.select({...})`; the
+          // shape returned above already exposes `.from()`.
+        };
+      }),
+      $count: mock(() => Promise.resolve(0)),
+      insert: mock(() => ({
+        values: mock(() => ({
+          onConflictDoUpdate: mock(() => Promise.resolve()),
+          onConflictDoNothing: mock(() => Promise.resolve()),
+          returning: mock(() => Promise.resolve([])),
+        })),
+      })),
+      update: mock(() => ({
+        set: mock(() => ({ where: mock(() => Promise.resolve()) })),
+      })),
+      delete: mock(() => ({ where: mock(() => Promise.resolve()) })),
+      execute: mock(() => Promise.resolve()),
+    };
+
+    return {
+      db,
+      runsChain,
+      aggregatesChain,
+      configChain,
+      selectCallCount,
+    };
+  }
+
+  describe("getHistory", () => {
+    it("emits an `environment_id = 'prod'` predicate for environmentId='prod'", async () => {
+      const { db, runsChain } = buildDb();
+      const service = new HealthCheckService(db as never, {} as never, {} as never);
+      await service.getHistory({
+        systemId: "sys-1",
+        configurationId: "cfg-1",
+        environmentId: "prod",
+        sortOrder: "desc",
+      });
+      expect(runsChain.whereCalls.length).toBeGreaterThanOrEqual(1);
+      const predicate = runsChain.whereCalls[0];
+      expect(containsString(predicate, "prod")).toBe(true);
+      expect(containsString(predicate, "environment_id")).toBe(true);
+    });
+
+    it("emits an IS NULL predicate for environmentId=null (env-less slice)", async () => {
+      const { db, runsChain } = buildDb();
+      const service = new HealthCheckService(db as never, {} as never, {} as never);
+      await service.getHistory({
+        systemId: "sys-1",
+        configurationId: "cfg-1",
+        environmentId: null,
+        sortOrder: "desc",
+      });
+      const predicate = runsChain.whereCalls[0];
+      expect(containsString(predicate, "environment_id")).toBe(true);
+      // drizzle's `isNull` carries an " is null" string chunk in addition
+      // to the column reference; distinct from `eq` whose only non-column
+      // string is the placeholder "" / the bound `prod` value.
+      const leaves = allStrings(predicate);
+      const hasIsNull = leaves.some((s) => s.toLowerCase().includes(" is null"));
+      expect(hasIsNull).toBe(true);
+    });
+
+    it("omits the env predicate for environmentId=undefined (all envs)", async () => {
+      const { db, runsChain } = buildDb();
+      const service = new HealthCheckService(db as never, {} as never, {} as never);
+      await service.getHistory({
+        systemId: "sys-1",
+        configurationId: "cfg-1",
+        environmentId: undefined,
+        sortOrder: "desc",
+      });
+      const predicate = runsChain.whereCalls[0];
+      // The env column NAME may still appear nested inside the shared
+      // `healthCheckRuns` schema object attached to every column
+      // descriptor. But an `eq(environmentId, X)` binding carries the env
+      // VALUE as a string leaf; with `environmentId === undefined` we
+      // never build that clause. Assert no env-id VALUE leaf appears —
+      // proves the env `eq(...)` (and the `isNull(...)`) was NOT added.
+      expect(containsString(predicate, "prod")).toBe(false);
+      // No " is null" string-leaf either — that leaf is added exclusively
+      // by the env-less branch, not by the systemId / configurationId
+      // predicates.
+      const leaves = allStrings(predicate);
+      expect(leaves.some((s) => s.toLowerCase().includes(" is null"))).toBe(false);
+    });
+  });
+
+  describe("getDetailedHistory", () => {
+    it("emits the env predicate the same way as getHistory", async () => {
+      const { db, runsChain } = buildDb();
+      const service = new HealthCheckService(db as never, {} as never, {} as never);
+      await service.getDetailedHistory({
+        systemId: "sys-1",
+        configurationId: "cfg-1",
+        environmentId: "staging",
+        sortOrder: "desc",
+      });
+      const predicate = runsChain.whereCalls[0];
+      expect(containsString(predicate, "staging")).toBe(true);
+      expect(containsString(predicate, "environment_id")).toBe(true);
+    });
+  });
+
+  describe("getRunStats", () => {
+    it("emits the env predicate (single where() on the runs table)", async () => {
+      const { db, runsChain } = buildDb();
+      const service = new HealthCheckService(db as never, {} as never, {} as never);
+      await service.getRunStats({
+        systemId: "sys-1",
+        configurationId: "cfg-1",
+        startDate: new Date(2025, 0, 1),
+        endDate: new Date(2025, 0, 2),
+        environmentId: "prod",
+      });
+      const predicate = runsChain.whereCalls[0];
+      expect(containsString(predicate, "prod")).toBe(true);
+      expect(containsString(predicate, "environment_id")).toBe(true);
+    });
+  });
+
+  describe("getAggregatedHistory", () => {
+    /**
+     * `getAggregatedHistory` reads `health_check_runs` (raw tier) AND
+     * `health_check_aggregates` (hourly + daily tiers) in parallel via
+     * `Promise.all`, plus one config-row select. Each tier's
+     * `.where(...)` must carry the env predicate so the cross-tier
+     * aggregation engine reads ONLY that env's runs and buckets — a
+     * mixed-env pool would silently leak the wrong env's sparkline into
+     * the drawer's charts. Asserts the env-id binding appears in at least
+     * one captured predicate (the raw tier).
+     */
+    it("emits the env predicate on the runs tier (and aggregates)", async () => {
+      const { db, runsChain } = buildDb();
+      const service = new HealthCheckService(db as never, {} as never, {} as never);
+      await service.getAggregatedHistory(
+        {
+          systemId: "sys-1",
+          configurationId: "cfg-1",
+          startDate: new Date(2025, 0, 1),
+          endDate: new Date(2025, 0, 2),
+          environmentId: "prod",
+        },
+        { includeAggregatedResult: false },
+      );
+      expect(runsChain.whereCalls.length).toBeGreaterThanOrEqual(1);
+      const anyPredicateContainsProd = runsChain.whereCalls.some(
+        (p) => containsString(p, "prod") && containsString(p, "environment_id"),
+      );
+      expect(anyPredicateContainsProd).toBe(true);
+    });
+  });
+
+  describe("getAggregatedHistory (null)", () => {
+    it("emits the IS NULL predicate for the env-less slice", async () => {
+      const { db, runsChain } = buildDb();
+      const service = new HealthCheckService(db as never, {} as never, {} as never);
+      await service.getAggregatedHistory(
+        {
+          systemId: "sys-1",
+          configurationId: "cfg-1",
+          startDate: new Date(2025, 0, 1),
+          endDate: new Date(2025, 0, 2),
+          environmentId: null,
+        },
+        { includeAggregatedResult: false },
+      );
+      const anyHasEnvColumn = runsChain.whereCalls.some((p) =>
+        containsString(p, "environment_id"),
+      );
+      expect(anyHasEnvColumn).toBe(true);
+      const anyHasIsNull = runsChain.whereCalls.some((p) =>
+        allStrings(p).some((s) => s.toLowerCase().includes(" is null")),
+      );
+      expect(anyHasIsNull).toBe(true);
+    });
+  });
+});

--- a/core/healthcheck-backend/src/service-rollup-worst-wins.test.ts
+++ b/core/healthcheck-backend/src/service-rollup-worst-wins.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, mock } from "bun:test";
+import { HealthCheckService } from "./service";
+import { evaluateHealthStatus } from "./state-evaluator";
+
+/**
+ * Regression coverage for the system-rollup worst-wins-across-environments
+ * fix in `getSystemHealthStatus(systemId)` (the `environmentId === undefined`
+ * branch).
+ *
+ * The original branch flattened every environment's runs into one
+ * `timestamp DESC` list and handed the interleaved list to the threshold
+ * evaluator (the default `consecutive` mode). Consecutive mode walks
+ * newest-first and breaks the streak on the first interleaving env, so the
+ * rollup collapsed to whichever env ran last in the batch — masking any
+ * permanently-failing sibling env ("the healthy env wins" / latest-wins)
+ * and flapping whenever env insertion order drifted across ticks.
+ *
+ * The fix evaluates the threshold window PER ENVIRONMENT within the
+ * association and takes worst-wins across envs (unhealthy > degraded >
+ * healthy), making the rollup stable regardless of insertion order or
+ * multi-pod racing. These tests pin that behavior with a mocked DB that
+ * returns the interleaved mixed-pool the real query would surface.
+ */
+describe("HealthCheckService - system rollup worst-wins across environments", () => {
+  /**
+   * The mixed-pool query captured by the mock. Ordered DESC (newest first),
+   * exactly the shape the real `health_check_runs` query returns. Two envs
+   * (`prod`, `staging`) of one assignment, both fanning out every tick, prod
+   * permanently unhealthy and staging permanently healthy. The env insertion
+   * order in the executor is sequential membership order, so prod lands before
+   * staging, making the latest run in the pool a staging-healthy run — the
+   * exact scenario that masked prod's outage under flattening.
+   */
+  const PROD_RUN = { status: "unhealthy" as const, environmentId: "prod" };
+  const STAGE_RUN = { status: "healthy" as const, environmentId: "staging" };
+
+  function buildMixedPool(ticksPerEnv = 5): { status: "unhealthy" | "healthy"; timestamp: Date; environmentId: string }[] {
+    const pool: { status: "unhealthy" | "healthy"; timestamp: Date; environmentId: string }[] = [];
+    for (let i = 0; i < ticksPerEnv; i++) {
+      pool.push({ ...PROD_RUN, timestamp: new Date(2025, 0, 1, 0, 0, i) });
+      pool.push({ ...STAGE_RUN, timestamp: new Date(2025, 0, 1, 0, 0, i + 0.5) });
+    }
+    return pool; // DESC at the DB layer; we return newest-first below.
+  }
+
+  function createMockDb(runsMixedDesc: { status: string; timestamp: Date; environmentId: string }[]) {
+    const assocWhere = mock(() => Promise.resolve([
+      {
+        configurationId: "config-1",
+        configName: "HTTP probe",
+        enabled: true,
+        paused: false,
+        stateThresholds: null,
+      },
+    ]));
+    const assocInnerJoin = Object.assign(Promise.resolve([]), { where: assocWhere });
+    const assocFrom = Object.assign(Promise.resolve([]), { innerJoin: mock(() => assocInnerJoin) });
+
+    const runsLimit = mock(() => Promise.resolve(runsMixedDesc));
+    const runsOrderBy = mock(() => ({ limit: runsLimit }));
+    const runsWhere = mock(() => ({ orderBy: runsOrderBy, limit: runsLimit }));
+    const runsFrom = Object.assign(Promise.resolve(runsMixedDesc), {
+      where: runsWhere,
+      orderBy: runsOrderBy,
+    });
+
+    let selectCallCount = 0;
+    return {
+      select: mock(() => {
+        selectCallCount += 1;
+        if (selectCallCount === 1) return { from: mock(() => assocFrom) };
+        return { from: mock(() => runsFrom) };
+      }),
+      insert: mock(() => ({
+        values: mock(() => ({
+          onConflictDoUpdate: mock(() => Promise.resolve()),
+          onConflictDoNothing: mock(() => Promise.resolve()),
+          returning: mock(() => Promise.resolve([])),
+        })),
+      })),
+      update: mock(() => ({ set: mock(() => ({ where: mock(() => Promise.resolve()) })) })),
+      delete: mock(() => ({ where: mock(() => Promise.resolve()) })),
+      execute: mock(() => Promise.resolve()),
+    };
+  }
+
+  it("the rollup reports unhealthy when ONE env is permanently unhealthy, the other healthy", async () => {
+    // DB returns newest-first interleaved runs. The pre-fix behavior would
+    // mask prod's outage because the latest run is staging-healthy; the
+    // threshold evaluator (default consecutive mode) walks newest-first from
+    // staging-healthy, breaks the streak on the very next prod-unhealthy run,
+    // and falls back to `"healthy"`.
+    const pool = buildMixedPool(5);
+    const runsDesc = pool.toReversed(); // oldest produced first above; reverse to DESC
+    const mockDb = createMockDb(runsDesc as never);
+    const service = new HealthCheckService(mockDb as never, {} as never, {} as never);
+
+    const result = await service.getSystemHealthStatus("system-1");
+
+    expect(result.status).toBe("unhealthy");
+    expect(result.checkStatuses).toHaveLength(1);
+    expect(result.checkStatuses[0].status).toBe("unhealthy");
+    expect(result.checkStatuses[0].runsConsidered).toBe(pool.length);
+  });
+
+  it("flattening the same mixed pool through the evaluator (the pre-fix derivation) would have returned `healthy`", async () => {
+    // Sanity check: the very data the rollup branch reads, fed directly to
+    // `evaluateHealthStatus` as one flat interleaved list, collapses to
+    // "healthy" — the precise regression this fix replaces with per-env
+    // evaluation. Pinning it here guards against a relax of the test above.
+    const pool = buildMixedPool(5);
+    const runsDesc = pool.toReversed();
+    const flatStatus = evaluateHealthStatus({
+      runs: runsDesc as never,
+    });
+    expect(flatStatus).toBe("healthy");
+  });
+
+  it("reports healthy only when EVERY env is healthy", async () => {
+    const allHealthy = Array.from({ length: 10 }, (_, i) => ({
+      status: "healthy",
+      timestamp: new Date(2025, 0, 1, 0, 0, i),
+      environmentId: i % 2 === 0 ? "prod" : "staging",
+    })).toReversed();
+    const mockDb = createMockDb(allHealthy as never);
+    const service = new HealthCheckService(mockDb as never, {} as never, {} as never);
+
+    const result = await service.getSystemHealthStatus("system-1");
+    expect(result.status).toBe("healthy");
+  });
+
+  it("degrades (not flaps) when one env is degraded and the other healthy", async () => {
+    // Default consecutive thresholds need 2 consecutive failures to escalate
+    // to `degraded` (and 5 to escalate to `unhealthy` — so keep prod's streak
+    // at exactly 2 degraded runs). Per-env: prod's env-sorted slice =
+    // [degraded, degraded] (newest first) → degraded; staging → healthy.
+    // Rollup worst-wins = degraded. Flattening would break on the staging
+    // interleave and return `healthy` (the masked bug); per-env gives a
+    // stable `degraded`.
+    const pool: { status: "healthy" | "degraded"; timestamp: Date; environmentId: string }[] = [];
+    for (let i = 0; i < 2; i++) {
+      pool.push({ status: "degraded", timestamp: new Date(2025, 0, 1, 0, 0, i), environmentId: "prod" });
+      pool.push({ status: "healthy", timestamp: new Date(2025, 0, 1, 0, 0, i + 0.5), environmentId: "staging" });
+    }
+    const runsDesc = pool.toReversed();
+    const mockDb = createMockDb(runsDesc as never);
+    const service = new HealthCheckService(mockDb as never, {} as never, {} as never);
+
+    const result = await service.getSystemHealthStatus("system-1");
+    expect(result.status).toBe("degraded");
+  });
+
+  it("the per-env slice (concrete environmentId) is unaffected — only the rollup branch changed", async () => {
+    // Pass an explicit environmentId; the old per-env branch (string envId)
+    // must continue to filter to that env's slice. Here we ask for `prod`
+    // and expect unhealthy.
+    const prodOnly = Array.from({ length: 5 }, (_, i) => ({
+      status: "unhealthy",
+      timestamp: new Date(2025, 0, 1, 0, 0, i),
+    }));
+    // Mock: the runs query mirrors the predicate back to prodOnly.
+    const assocWhere = mock(() => Promise.resolve([
+      {
+        configurationId: "config-1",
+        configName: "HTTP probe",
+        enabled: true,
+        paused: false,
+        stateThresholds: null,
+      },
+    ]));
+    const assocInnerJoin = Object.assign(Promise.resolve([]), { where: assocWhere });
+    const assocFrom = Object.assign(Promise.resolve([]), { innerJoin: mock(() => assocInnerJoin) });
+
+    const runsLimit = mock(() => Promise.resolve(prodOnly));
+    const runsOrderBy = mock(() => ({ limit: runsLimit }));
+    const runsWhere = mock(() => ({ orderBy: runsOrderBy, limit: runsLimit }));
+    const runsFrom = Object.assign(Promise.resolve(prodOnly), {
+      where: runsWhere,
+      orderBy: runsOrderBy,
+    });
+
+    let selectCallCount = 0;
+    const mockDb = {
+      select: mock(() => {
+        selectCallCount += 1;
+        if (selectCallCount === 1) return { from: mock(() => assocFrom) };
+        return { from: mock(() => runsFrom) };
+      }),
+      insert: mock(() => ({
+        values: mock(() => ({
+          onConflictDoUpdate: mock(() => Promise.resolve()),
+          onConflictDoNothing: mock(() => Promise.resolve()),
+          returning: mock(() => Promise.resolve([])),
+        })),
+      })),
+      update: mock(() => ({ set: mock(() => ({ where: mock(() => Promise.resolve()) })) })),
+      delete: mock(() => ({ where: mock(() => Promise.resolve()) })),
+      execute: mock(() => Promise.resolve()),
+    };
+
+    const service = new HealthCheckService(mockDb as never, {} as never, {} as never);
+    const result = await service.getSystemHealthStatus("system-1", "prod");
+    expect(result.status).toBe("unhealthy");
+  });
+});

--- a/core/healthcheck-backend/src/service.ts
+++ b/core/healthcheck-backend/src/service.ts
@@ -607,10 +607,14 @@ export class HealthCheckService {
    *
    * Environment dimension (Phase 3b, §7.4.2):
    *  - `environmentId` OMITTED (or `undefined`) ⇒ the **system rollup**: all
-   *    runs for the system regardless of environment. "Any env unhealthy ⇒ at
-   *    least one unhealthy run in the window" already yields worst-status
-   *    semantics for the window-based evaluator, and it exactly matches the
-   *    pre-3b behavior when no environments exist (no extra catalog read).
+   *    runs for the system, grouped by `environment_id` per association and
+   *    evaluated per-env, then worst-wins ACROSS environments within each
+   *    association (unhealthy > degraded > healthy). This is stable regardless
+   *    of env insertion order or multi-pod racing; flattening envs into one
+   *    list feeds interleaved statuses to the consecutive evaluator and breaks
+   *    the streak on the first interleaving env (masking / flapping). For an
+   *    assignment with a single env (or env-less only) this reduces to the
+   *    pre-existing flat-window behavior.
    *  - `environmentId` a STRING ⇒ the per-environment slice: only runs whose
    *    `environment_id` equals that id.
    *  - `environmentId` `null` ⇒ the ENV-LESS slice: only runs with
@@ -668,6 +672,9 @@ export class HealthCheckService {
     // adds no predicate; `null` filters to the env-less slice; a string
     // filters to that environment. The lookup index leads with
     // (system_id, environment_id, …) so the env-scoped query is index-efficient.
+    //
+    // For the rollup, we deliberately do NOT apply a single envFilter to one
+    // flat run list — see the per-association branch below for why.
     const envFilter =
       environmentId === undefined
         ? undefined
@@ -676,36 +683,102 @@ export class HealthCheckService {
           : eq(healthCheckRuns.environmentId, environmentId);
 
     for (const assoc of associations) {
-      const runs = await this.db
-        .select({
-          status: healthCheckRuns.status,
-          timestamp: healthCheckRuns.timestamp,
-        })
-        .from(healthCheckRuns)
-        .where(
-          and(
-            eq(healthCheckRuns.systemId, systemId),
-            eq(healthCheckRuns.configurationId, assoc.configurationId),
-            ...(envFilter ? [envFilter] : []),
-          ),
-        )
-        .orderBy(desc(healthCheckRuns.timestamp))
-        .limit(maxWindowSize);
-
       // Extract and migrate thresholds from versioned config
       let thresholds: StateThresholds | undefined;
       if (assoc.stateThresholds) {
         thresholds = await stateThresholds.parse(assoc.stateThresholds);
       }
 
-      const status = evaluateHealthStatus({ runs, thresholds });
+      let status: HealthCheckStatus;
+      let runsConsidered: number;
+      let lastRunAt: Date | undefined;
+
+      if (environmentId === undefined) {
+        // System rollup: evaluate the threshold window PER ENVIRONMENT within
+        // the association, then take worst-wins ACROSS envs. Flattening every
+        // env's runs into one list feeds interleaved statuses to
+        // `evaluateConsecutive` (the default mode): the streak breaks on the
+        // first interleaving env, so the evaluator collapses to whatever
+        // single env's status the most recent run landed on. That masks any
+        // permanently-failing sibling env in the default mode ("the healthy
+        // env wins"), and flaps healthy↔degraded whenever env insertion
+        // order drifts across ticks (see the regression test
+        // `rollup — worst-wins across environments within an association`).
+        // Per-env evaluation makes the rollup worst-wins stable regardless of
+        // insertion order or multi-pod racing.
+        const runs = await this.db
+          .select({
+            status: healthCheckRuns.status,
+            timestamp: healthCheckRuns.timestamp,
+            environmentId: healthCheckRuns.environmentId,
+          })
+          .from(healthCheckRuns)
+          .where(
+            and(
+              eq(healthCheckRuns.systemId, systemId),
+              eq(healthCheckRuns.configurationId, assoc.configurationId),
+            ),
+          )
+          .orderBy(desc(healthCheckRuns.timestamp))
+          .limit(maxWindowSize);
+
+        // Group by environmentId. `null` is its own group (the env-less slice
+        // of an assignment that has opted out, plus any pre-3b env-less runs).
+        const byEnv = new Map<string | null, { status: HealthCheckStatus; timestamp: Date }[]>();
+        for (const r of runs) {
+          const key = r.environmentId ?? null;
+          const bucket = byEnv.get(key);
+          if (bucket) {
+            bucket.push(r);
+          } else {
+            byEnv.set(key, [r]);
+          }
+        }
+
+        status = "healthy";
+        runsConsidered = runs.length;
+        lastRunAt = runs[0]?.timestamp;
+        for (const envRuns of byEnv.values()) {
+          const envStatus = evaluateHealthStatus({ runs: envRuns, thresholds });
+          if (envStatus === "unhealthy") {
+            status = "unhealthy";
+            break; // worst: stop
+          }
+          if (envStatus === "degraded" && status === "healthy") {
+            status = "degraded";
+          }
+        }
+      } else {
+        // Per-env (string) or env-less (null) slice: that slice's flat run
+        // window is monotonic per-env, so the threshold evaluator sees no
+        // interleaving — the consecutive streak is well-defined.
+        const runs = await this.db
+          .select({
+            status: healthCheckRuns.status,
+            timestamp: healthCheckRuns.timestamp,
+          })
+          .from(healthCheckRuns)
+          .where(
+            and(
+              eq(healthCheckRuns.systemId, systemId),
+              eq(healthCheckRuns.configurationId, assoc.configurationId),
+              ...(envFilter ? [envFilter] : []),
+            ),
+          )
+          .orderBy(desc(healthCheckRuns.timestamp))
+          .limit(maxWindowSize);
+
+        status = evaluateHealthStatus({ runs, thresholds });
+        runsConsidered = runs.length;
+        lastRunAt = runs[0]?.timestamp;
+      }
 
       checkStatuses.push({
         configurationId: assoc.configurationId,
         configurationName: assoc.configName,
         status,
-        runsConsidered: runs.length,
-        lastRunAt: runs[0]?.timestamp,
+        runsConsidered,
+        lastRunAt,
       });
     }
 
@@ -900,6 +973,7 @@ export class HealthCheckService {
           id: healthCheckRuns.id,
           status: healthCheckRuns.status,
           timestamp: healthCheckRuns.timestamp,
+          environmentId: healthCheckRuns.environmentId,
         })
         .from(healthCheckRuns)
         .where(
@@ -920,17 +994,89 @@ export class HealthCheckService {
         thresholds = await stateThresholds.parse(assoc.stateThresholds);
       }
 
+      // Group the fetched runs by environmentId (null = env-less slice). We
+      // query each env's slice separately below to evaluate it on its own
+      // monotonic run window and worst-wins across envs — this is the same
+      // derivation `getSystemHealthStatus(systemId)` uses for the rollup; see
+      // that method for the rationale (flattening envs feeds interleaved
+      // statuses to the consecutive evaluator and masks sibling outages).
+      const perEnvironment: {
+        environmentId: string | null;
+        status: HealthCheckStatus;
+        recentRuns: { id: string; status: HealthCheckStatus; timestamp: Date }[];
+      }[] = [];
+
+      // Stable ordering of env keys: env-less (`null`) first, then env ids in
+      // the order they were first encountered in the mixed pool (membership
+      // order is otherwise unobservable here without a catalog read; recent
+      // runs surface stable, recent order).
+      const envKeys: (string | null)[] = [];
+      const seenEnv = new Set<string | null>();
+      for (const r of runs) {
+        const key = r.environmentId ?? null;
+        if (!seenEnv.has(key)) {
+          seenEnv.add(key);
+          envKeys.push(key);
+        }
+      }
+      // If no runs at all, surface a single env-less entry so UI can render
+      // an empty row rather than nothing.
+      if (envKeys.length === 0) envKeys.push(null);
+
+      let aggregateStatus: HealthCheckStatus = "healthy";
+      for (const envId of envKeys) {
+        const envRuns = await this.db
+          .select({
+            id: healthCheckRuns.id,
+            status: healthCheckRuns.status,
+            timestamp: healthCheckRuns.timestamp,
+          })
+          .from(healthCheckRuns)
+          .where(
+            and(
+              eq(healthCheckRuns.systemId, systemId),
+              eq(healthCheckRuns.configurationId, assoc.configurationId),
+              envId === null
+                ? isNull(healthCheckRuns.environmentId)
+                : eq(healthCheckRuns.environmentId, envId),
+            ),
+          )
+          .orderBy(desc(healthCheckRuns.timestamp))
+          .limit(sparklineLimit);
+
+        const envStatus = evaluateHealthStatus({
+          runs: envRuns,
+          thresholds,
+        });
+        // Worst-wins across envs (unhealthy > degraded > healthy).
+        if (envStatus === "unhealthy") {
+          aggregateStatus = "unhealthy";
+        } else if (envStatus === "degraded" && aggregateStatus === "healthy") {
+          aggregateStatus = "degraded";
+        }
+
+        perEnvironment.push({
+          environmentId: envId,
+          status: envStatus,
+          recentRuns: envRuns.toReversed().map((r) => ({
+            id: r.id,
+            status: r.status,
+            timestamp: r.timestamp,
+          })),
+        });
+      }
+
       // Evaluate current status (runs are in DESC order - newest first - as evaluateHealthStatus expects).
       // For a paused configuration the runs are stale (execution is skipped),
       // so the evaluated `status` is NOT a meaningful current verdict — the
       // frontend renders a "Paused" pill from the `paused` flag instead.
       // We still compute it so the historical/sparkline path stays uniform,
       // and so a non-paused consumer that ignores `paused` sees a best-
-      // effort status rather than a hard null.
-      const status = evaluateHealthStatus({
-        runs,
-        thresholds,
-      });
+      // effort status rather than a hard null. `aggregateStatus` is the
+      // worst-wins-across-envs rollup derived above (it equals what
+      // evaluateHealthStatus would return on the flat pool if only ONE env is
+      // present, preserving per-check single-env behavior).
+      const status = aggregateStatus;
 
       checks.push({
         configurationId: assoc.configurationId,
@@ -945,7 +1091,9 @@ export class HealthCheckService {
           id: r.id,
           status: r.status,
           timestamp: r.timestamp,
+          environmentId: r.environmentId,
         })),
+        perEnvironment,
       });
     }
 
@@ -963,6 +1111,7 @@ export class HealthCheckService {
     endDate?: Date;
     sourceFilter?: string;
     statusFilter?: HealthCheckStatus[];
+    environmentId?: string | null;
     limit?: number;
     offset?: number;
     sortOrder: "asc" | "desc";
@@ -974,6 +1123,7 @@ export class HealthCheckService {
       endDate,
       sourceFilter,
       statusFilter,
+      environmentId,
       limit = 10,
       offset = 0,
       sortOrder,
@@ -996,6 +1146,17 @@ export class HealthCheckService {
     // Status filtering (e.g. only failing runs)
     if (statusFilter && statusFilter.length > 0) {
       conditions.push(inArray(healthCheckRuns.status, statusFilter));
+    }
+
+    // Environment filtering (server-side). `null` selects the env-less slice;
+    // a string selects that env; `undefined` leaves all envs in the window.
+    // The drawer relies on this to scope its Recent Runs table to the env the
+    // operator clicked, so the total + the paginated rows reflect only the
+    // (check, environment) pair — not the mixed-env pool.
+    if (environmentId === null) {
+      conditions.push(isNull(healthCheckRuns.environmentId));
+    } else if (environmentId !== undefined) {
+      conditions.push(eq(healthCheckRuns.environmentId, environmentId));
     }
 
     // Build where clause
@@ -1048,6 +1209,7 @@ export class HealthCheckService {
     endDate: Date;
     sourceFilter?: string;
     statusFilter?: HealthCheckStatus[];
+    environmentId?: string | null;
     maxBuckets?: number;
   }): Promise<RunStats> {
     const {
@@ -1057,6 +1219,7 @@ export class HealthCheckService {
       endDate,
       sourceFilter,
       statusFilter,
+      environmentId,
       maxBuckets = 24,
     } = props;
 
@@ -1074,6 +1237,12 @@ export class HealthCheckService {
     }
     if (statusFilter && statusFilter.length > 0) {
       conditions.push(inArray(healthCheckRuns.status, statusFilter));
+    }
+    // Server-side env filter; same semantics as `getHistory`.
+    if (environmentId === null) {
+      conditions.push(isNull(healthCheckRuns.environmentId));
+    } else if (environmentId !== undefined) {
+      conditions.push(eq(healthCheckRuns.environmentId, environmentId));
     }
 
     const rows = await this.db
@@ -1106,6 +1275,7 @@ export class HealthCheckService {
     endDate?: Date;
     sourceFilter?: string;
     statusFilter?: HealthCheckStatus[];
+    environmentId?: string | null;
     limit?: number;
     offset?: number;
     sortOrder: "asc" | "desc";
@@ -1117,6 +1287,7 @@ export class HealthCheckService {
       endDate,
       sourceFilter,
       statusFilter,
+      environmentId,
       limit = 10,
       offset = 0,
       sortOrder,
@@ -1139,6 +1310,13 @@ export class HealthCheckService {
     // Status filtering (e.g. only failing runs)
     if (statusFilter && statusFilter.length > 0) {
       conditions.push(inArray(healthCheckRuns.status, statusFilter));
+    }
+
+    // Server-side env filter; same semantics as `getHistory`.
+    if (environmentId === null) {
+      conditions.push(isNull(healthCheckRuns.environmentId));
+    } else if (environmentId !== undefined) {
+      conditions.push(eq(healthCheckRuns.environmentId, environmentId));
     }
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
@@ -1215,6 +1393,7 @@ export class HealthCheckService {
       endDate: Date;
       sourceFilter?: string;
       targetPoints?: number;
+      environmentId?: string | null;
     },
     options: { includeAggregatedResult: boolean },
   ) {
@@ -1225,6 +1404,7 @@ export class HealthCheckService {
       endDate,
       sourceFilter,
       targetPoints = 500,
+      environmentId,
     } = props;
 
     // Calculate dynamic bucket interval
@@ -1246,6 +1426,25 @@ export class HealthCheckService {
         ? this.registry.getStrategy(config.strategyId)
         : undefined;
 
+    // Server-side env filter applied to ALL three tiers (raw runs, hourly
+    // and daily aggregates), since `health_check_runs.environment_id` and
+    // `health_check_aggregates.environment_id` are the same env-id domain.
+    // The bucket uniqueness on `health_check_aggregates` includes `environmentId`
+    // (with NULLS NOT DISTINCT), so `isNull(...)` selects the env-less buckets
+    // and `eq(...)` selects that env's buckets.
+    const envRunCondition =
+      environmentId === undefined
+        ? undefined
+        : environmentId === null
+          ? isNull(healthCheckRuns.environmentId)
+          : eq(healthCheckRuns.environmentId, environmentId);
+    const envAggCondition =
+      environmentId === undefined
+        ? undefined
+        : environmentId === null
+          ? isNull(healthCheckAggregates.environmentId)
+          : eq(healthCheckAggregates.environmentId, environmentId);
+
     // Build source condition for raw runs
     const rawConditions = [
       eq(healthCheckRuns.systemId, systemId),
@@ -1257,6 +1456,7 @@ export class HealthCheckService {
         : sourceFilter
           ? [eq(healthCheckRuns.sourceId, sourceFilter)]
           : []),
+      ...(envRunCondition ? [envRunCondition] : []),
     ];
 
     // Build source condition for hourly aggregates
@@ -1271,6 +1471,7 @@ export class HealthCheckService {
         : sourceFilter
           ? [eq(healthCheckAggregates.sourceId, sourceFilter)]
           : []),
+      ...(envAggCondition ? [envAggCondition] : []),
     ];
 
     // Build source condition for daily aggregates
@@ -1285,6 +1486,7 @@ export class HealthCheckService {
         : sourceFilter
           ? [eq(healthCheckAggregates.sourceId, sourceFilter)]
           : []),
+      ...(envAggCondition ? [envAggCondition] : []),
     ];
 
     // Query all three tiers in parallel
@@ -1747,6 +1949,7 @@ export class HealthCheckService {
       const runs = await this.db
         .select({
           result: healthCheckRuns.result,
+          environmentId: healthCheckRuns.environmentId,
         })
         .from(healthCheckRuns)
         .where(
@@ -1764,6 +1967,7 @@ export class HealthCheckService {
         configurationId: assignment.configurationId,
         runs: runs.map((r) => ({
           result: r.result,
+          environmentId: r.environmentId,
         })),
       });
     }

--- a/core/healthcheck-common/src/notifications.test.ts
+++ b/core/healthcheck-common/src/notifications.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { systemHealthCollapseKey } from "./notifications";
+
+/**
+ * The collapse-key builder is variadic: per-env notifications append the
+ * `environmentId` to scope the collapse identity, so two failing environments
+ * of one system generate two independent cards instead of merging into one.
+ * The bare `systemHealthCollapseKey(systemId)` form is used by the rollup
+ * transition, preserving the pre-existing single-card identity.
+ */
+describe("systemHealthCollapseKey", () => {
+  it("scopes a bare rollup to `<plugin>.system-health.<systemId>`", () => {
+    expect(systemHealthCollapseKey("sys-1")).toBe("healthcheck.system-health.sys-1");
+  });
+
+  it("appends the environmentId to disambiguate per-env cards", () => {
+    expect(systemHealthCollapseKey("sys-1", "prod")).toBe(
+      "healthcheck.system-health.sys-1.prod",
+    );
+    expect(systemHealthCollapseKey("sys-1", "staging")).toBe(
+      "healthcheck.system-health.sys-1.staging",
+    );
+  });
+
+  it("produces distinct keys per env (two envs of one system => two cards)", () => {
+    const prodKey = systemHealthCollapseKey("sys-1", "prod");
+    const stagingKey = systemHealthCollapseKey("sys-1", "staging");
+    const rollupKey = systemHealthCollapseKey("sys-1");
+    expect(prodKey).not.toBe(stagingKey);
+    // The rollup key is a strict prefix of the per-env keys so a system-scoped
+    // group cannot accidentally swallow an env-scoped card.
+    expect(prodKey.startsWith(rollupKey + ".")).toBe(true);
+  });
+});

--- a/core/healthcheck-common/src/rpc-contract.ts
+++ b/core/healthcheck-common/src/rpc-contract.ts
@@ -465,6 +465,15 @@ export const healthCheckContract = {
         sourceFilter: z.string().optional(),
         /** Restrict runs to the listed statuses. Omitted/empty = no filter. */
         statusFilter: z.array(HealthCheckStatusSchema).optional(),
+        /**
+         * Restrict to runs of a single environment. `null` filters to the
+         * env-less slice (the opt-out / no-membership case); omitted means
+         * no environment filter (all runs of the (system, configuration)).
+         * Applied server-side at the DB so the drawer's per-env view gets
+         * clean, paginated data — not a client-side filter on top of a
+         * mixed-env pool.
+         */
+        environmentId: z.string().nullish(),
         limit: z.number().optional().default(10),
         offset: z.number().optional().default(0),
         sortOrder: z.enum(["asc", "desc"]),
@@ -495,6 +504,12 @@ export const healthCheckContract = {
         sourceFilter: z.string().optional(),
         /** Restrict the runs counted to the listed statuses. Omitted/empty = all. */
         statusFilter: z.array(HealthCheckStatusSchema).optional(),
+        /**
+         * Restrict to runs of a single environment (server-side DB filter).
+         * `null` → env-less slice; omitted → no env filter (all runs of
+         * the (system, configuration)). Same semantics as `getHistory`.
+         */
+        environmentId: z.string().nullish(),
         /** Max time-series buckets to return (default 24, max 100). */
         maxBuckets: z.number().min(1).max(100).optional().default(24),
       }),
@@ -516,6 +531,12 @@ export const healthCheckContract = {
         sourceFilter: z.string().optional(),
         /** Restrict runs to the listed statuses. Omitted/empty = no filter. */
         statusFilter: z.array(HealthCheckStatusSchema).optional(),
+        /**
+         * Restrict to runs of a single environment (server-side DB filter).
+         * `null` → env-less slice; omitted → no env filter (all runs of
+         * the (system, configuration)). Same semantics as `getHistory`.
+         */
+        environmentId: z.string().nullish(),
         limit: z.number().optional().default(10),
         offset: z.number().optional().default(0),
         sortOrder: z.enum(["asc", "desc"]),
@@ -555,6 +576,14 @@ export const healthCheckContract = {
         endDate: z.coerce.date(),
         /** Target number of data points (default: 500). Bucket interval is calculated as (endDate - startDate) / targetPoints */
         targetPoints: z.number().min(10).max(2000).default(500),
+        /**
+         * Restrict to runs / aggregate buckets of a single environment
+         * (server-side DB filter across the raw, hourly, and daily tiers
+         * the cross-tier aggregation engine reads). `null` → env-less
+         * slice; omitted → no env filter (all envs of the (system,
+         * configuration)).
+         */
+        environmentId: z.string().nullish(),
       }),
     )
     .output(
@@ -580,6 +609,12 @@ export const healthCheckContract = {
         sourceFilter: z.string().optional(),
         /** Target number of data points (default: 500). Bucket interval is calculated as (endDate - startDate) / targetPoints */
         targetPoints: z.number().min(10).max(2000).default(500),
+        /**
+         * Restrict to runs / aggregate buckets of a single environment
+         * (server-side DB filter; same semantics as
+         * `getAggregatedHistory`).
+         */
+        environmentId: z.string().nullish(),
       }),
     )
     .output(
@@ -641,13 +676,54 @@ export const healthCheckContract = {
              * `getSystemHealthStatus`).
              */
             paused: z.boolean(),
+            /**
+             * Worst-wins across environments within this assignment (mirrors
+             * `getSystemHealthStatus`'s rollup derivation). For an
+             * assignment with a single env (or only env-less runs) this
+             * equals the per-env status. Frontends that want per-env rows
+             * render `perEnvironment` instead.
+             */
             status: HealthCheckStatusSchema,
             stateThresholds: StateThresholdsSchema.optional(),
+            /**
+             * Recent runs across all environments of this assignment, newest
+             * first then chronologically reversed for sparkline display
+             * (preserves the pre-multi-env contract;_safe_ for single-env
+             * checks). Carry `environmentId` so a per-env UI can split later.
+             */
             recentRuns: z.array(
               z.object({
                 id: z.string(),
                 status: HealthCheckStatusSchema,
                 timestamp: z.date(),
+                /**
+                 * The environment this run targeted, or `null` for the
+                 * env-less slice (opt-out / no-membership). The granularity
+                 * the UI can group on if it wants per-(check, env) rows.
+                 */
+                environmentId: z.string().nullable(),
+              }),
+            ),
+            /**
+             * Per-environment breakdown of this assignment, one entry per
+             * environment the assignment fans out to (plus a `null` entry if
+             * env-less runs exist). Each carries its own rollup `status` and
+             * the env-scoped recent runs. A frontend can use this to render
+             * a row per (check, environment) pair — surfacing per-env outages
+             * that `status` (the worst-wins rollup) intentionally hides in
+             * the aggregate view.
+             */
+            perEnvironment: z.array(
+              z.object({
+                environmentId: z.string().nullable(),
+                status: HealthCheckStatusSchema,
+                recentRuns: z.array(
+                  z.object({
+                    id: z.string(),
+                    status: HealthCheckStatusSchema,
+                    timestamp: z.date(),
+                  }),
+                ),
               }),
             ),
           }),
@@ -777,6 +853,13 @@ export const healthCheckContract = {
           runs: z.array(
             z.object({
               result: z.record(z.string(), z.unknown()).nullable().optional(),
+              /**
+               * Environment the run was executed for. null = env-less slice
+               * (no environment membership), mirrored from
+               * `health_check_runs.environment_id`. Consumed by the anomaly
+               * baseline analyzer to fan out per-env stats.
+               */
+              environmentId: z.string().nullable(),
             }),
           ),
         }),

--- a/core/healthcheck-frontend/src/components/HealthCheckDrawer.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckDrawer.tsx
@@ -89,6 +89,15 @@ interface HealthCheckOverviewItem {
   lastRunAt?: Date;
   stateThresholds?: StateThresholds;
   recentStatusHistory: HealthCheckStatus[];
+  /**
+   * The environment this drawer is scoped to. `null` for an env-less row; a
+   * concrete string for a per-env row; `undefined` when the overview row was
+   * the single-env rollup (no env scoping — query without an env filter).
+   * Threaded straight through to every backend query the drawer issues so the
+   * history table, the charts, and the stats see only the (check, environment)
+   * pair the operator clicked — server-side, no client-side filtering.
+   */
+  environmentId?: string | null;
 }
 
 interface HealthCheckDrawerProps {
@@ -213,6 +222,7 @@ export const HealthCheckDrawer: React.FC<HealthCheckDrawerProps> = ({
     strategyId: item.strategyId,
     dateRange,
     sourceFilter,
+    environmentId: item.environmentId,
     isRollingPreset,
     onDateRangeRefresh: (newEndDate) => {
       setDateRange((prev) => ({ ...prev, endDate: newEndDate }));
@@ -221,7 +231,11 @@ export const HealthCheckDrawer: React.FC<HealthCheckDrawerProps> = ({
 
   const anomalyClient = usePluginClient(AnomalyApi);
   const { data: baselines = [] } = anomalyClient.getAnomalyBaselines.useQuery(
-    { systemId, configurationId: item.configurationId },
+    // Server-side env scoping: thread the drawer's `item.environmentId`
+    // through so baselines resolve to the clicked env only. `undefined`
+    // (single-env rollup row) returns all envs; `null` → env-less slice; a
+    // string → that env. Mirrors `getHistory`'s env filter above.
+    { systemId, configurationId: item.configurationId, environmentId: item.environmentId },
     { enabled: !!systemId && !!item.configurationId }
   );
 
@@ -237,6 +251,10 @@ export const HealthCheckDrawer: React.FC<HealthCheckDrawerProps> = ({
     startDate: dateRange.startDate,
     sourceFilter,
     statusFilter: STATUS_FILTER_TO_STATUSES[runsStatusFilter],
+    // Server-side env filter: when the clicked overview row was env-scoped,
+    // the run-history table shows only that env's runs; `null` selects the
+    // env-less slice; `undefined` (single-env rollup row) queries all runs.
+    environmentId: item.environmentId,
     sortOrder: "desc",
   });
 

--- a/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
@@ -4,7 +4,7 @@ import {
   usePluginClient,
   type SlotContext,
 } from "@checkstack/frontend-api";
-import { SystemDetailsSlot } from "@checkstack/catalog-common";
+import { SystemDetailsSlot, CatalogApi } from "@checkstack/catalog-common";
 import { HealthCheckApi } from "@checkstack/healthcheck-common";
 import {
   LoadingSpinner,
@@ -14,7 +14,7 @@ import {
   Button,
   cn,
 } from "@checkstack/ui";
-import { Heart } from "lucide-react";
+import { Heart, Layers } from "lucide-react";
 import { HealthCheckSparkline } from "./HealthCheckSparkline";
 import { HealthStatusPill } from "./HealthStatusPill";
 import {
@@ -93,11 +93,31 @@ interface HealthCheckOverviewItem {
   lastRunAt?: Date;
   stateThresholds?: StateThresholds;
   recentStatusHistory: HealthCheckStatus[];
+  /**
+   * The environment this row is scoped to. `null` for an env-less run; a
+   * concrete string for a per-env row. `undefined` (absent) for the
+   * rollup-only shape the overview used prior to per-env flattening —
+   * signals the row is not env-scoped and should render without an env
+   * pill.
+   */
+  environmentId?: string | null;
+  /**
+   * Human-readable env name for an env-scoped row. The overview fetches the
+   * system's `getSystemEnvironments` and resolves the env id → name here so
+   * each row carries a stable operator-facing label.
+   */
+  environmentName?: string;
+  /**
+   * Stable per-row key: the check id for env-less / single-env rows, or
+   * `${configurationId}::${environmentId}` for a per-(check, env) row.
+   */
+  rowKey: string;
 }
 
 export function HealthCheckSystemOverview(props: SlotProps) {
   const systemId = props.system.id;
   const healthCheckClient = usePluginClient(HealthCheckApi);
+  const catalogClient = usePluginClient(CatalogApi);
   const [searchParams, setSearchParams] = useSearchParams();
   const filter = parseFilter(searchParams.get("filter"));
 
@@ -111,23 +131,90 @@ export function HealthCheckSystemOverview(props: SlotProps) {
       systemId,
     });
 
-  // Transform API response to component format
+  // Resolve env names for env-qualified rows. Same query the drawer already
+  // issues, so the resulting cache entry is shared when both surfaces mount.
+  // Disabled when there is no systemId (can't happen here, but defensively
+  // typed so React Query doesn't fetch in a unit test).
+  const { data: systemEnvironments = [] } =
+    catalogClient.getSystemEnvironments.useQuery(
+      { systemId },
+      { enabled: !!systemId },
+    );
+  const envNameById = React.useMemo(
+    () => new Map(systemEnvironments.map((e) => [e.id, e.name])),
+    [systemEnvironments],
+  );
+
+  // Transform API response to component format. Flatten into one row per
+  // (check, environment) when an assignment fans out to multiple envs —
+  // surfacing per-env outages the rollup intentionally hides in the aggregate
+  // view. Single-env / env-less assignments stay one row (the pre-flattening
+  // shape). Each row opens the same check-level drawer; the env context is
+  // just a label so the operator sees which environment this row's status
+  // is scoped to.
   const overview: HealthCheckOverviewItem[] = React.useMemo(() => {
     if (!overviewData) return [];
-    return overviewData.checks.map((check) => ({
-      configurationId: check.configurationId,
-      strategyId: check.strategyId,
-      name: check.configurationName,
-      state: check.status,
-      paused: check.paused,
-      intervalSeconds: check.intervalSeconds,
-      lastRunAt: check.recentRuns.at(-1)?.timestamp
+    const rows: HealthCheckOverviewItem[] = [];
+    for (const check of overviewData.checks) {
+      const stateThresholds = check.stateThresholds;
+      const checkLastRunAt = check.recentRuns.at(-1)?.timestamp
         ? new Date(check.recentRuns.at(-1)!.timestamp)
-        : undefined,
-      stateThresholds: check.stateThresholds,
-      recentStatusHistory: check.recentRuns.map((r) => r.status),
-    }));
-  }, [overviewData]);
+        : undefined;
+      const checkRecentStatusHistory = check.recentRuns.map((r) => r.status);
+
+      const perEnv = check.perEnvironment;
+      if (!perEnv || perEnv.length <= 1) {
+        // Single-env / env-less: keep the historical single-row shape. The
+        // row is the rollup for this check (worst-wins across envs, which
+        // equals the per-env status when there's only one env).
+        rows.push({
+          rowKey: check.configurationId,
+          configurationId: check.configurationId,
+          strategyId: check.strategyId,
+          name: check.configurationName,
+          state: check.status,
+          paused: check.paused,
+          intervalSeconds: check.intervalSeconds,
+          lastRunAt: checkLastRunAt,
+          stateThresholds,
+          recentStatusHistory: checkRecentStatusHistory,
+        });
+        continue;
+      }
+      // Multi-env: one row per environment. Each row carries the env id +
+      // the resolved env name (rendered as a pill next to the check name),
+      // the per-env status, the per-env sparkline, and the per-env last
+      // run. `state` here is the per-env rollup, so the failing/healthy
+      // filter applies per env — one failing env shows up under "failing"
+      // while its healthy sibling doesn't. Clicking any env row opens the
+      // drawer for the whole check (the drawer still aggregates envs in
+      // its history table; this UI is the disambiguation surface).
+      for (const pe of perEnv) {
+        const environmentId = pe.environmentId;
+        const envName =
+          environmentId === null
+            ? undefined
+            : (envNameById.get(environmentId) ?? environmentId);
+        rows.push({
+          rowKey: `${check.configurationId}::${environmentId ?? "<none>"}`,
+          configurationId: check.configurationId,
+          strategyId: check.strategyId,
+          name: check.configurationName,
+          state: pe.status,
+          paused: check.paused,
+          intervalSeconds: check.intervalSeconds,
+          lastRunAt: pe.recentRuns.at(-1)?.timestamp
+            ? new Date(pe.recentRuns.at(-1)!.timestamp)
+            : undefined,
+          stateThresholds,
+          recentStatusHistory: pe.recentRuns.map((r) => r.status),
+          environmentId,
+          environmentName: envName,
+        });
+      }
+    }
+    return rows;
+  }, [overviewData, envNameById]);
 
   const visible = React.useMemo(
     () =>
@@ -215,9 +302,18 @@ export function HealthCheckSystemOverview(props: SlotProps) {
                 const displayLabel = item.paused
                   ? "Paused"
                   : statusToLabel({ status: item.state });
+                // An env-scoped row carries the env name as a pill next to
+                // the check name. `null` is the env-less slice; `undefined`
+                // is the single-row rollup (no pill).
+                const envScoped =
+                  item.environmentId !== undefined && item.environmentId !== null;
+                const envLabel =
+                  item.environmentId === null
+                    ? "No environment"
+                    : (item.environmentName ?? item.environmentId ?? "");
                 return (
                   <button
-                    key={item.configurationId}
+                    key={item.rowKey}
                     className="group relative flex w-full items-center gap-3 py-3 pl-5 pr-4 text-left transition-colors hover:bg-surface-inset"
                     onClick={() => setSelectedCheck(item)}
                   >
@@ -230,11 +326,19 @@ export function HealthCheckSystemOverview(props: SlotProps) {
                       aria-hidden
                     />
 
-                    {/* Status pill + check name */}
+                    {/* Status pill + check name (with env pill when scoped) */}
                     <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                      <span className="truncate text-sm font-medium text-foreground">
-                        {item.name}
-                      </span>
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="truncate text-sm font-medium text-foreground">
+                          {item.name}
+                        </span>
+                        {envScoped && (
+                          <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border/60 bg-surface-inset px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                            <Layers className="h-2.5 w-2.5" />
+                            {envLabel}
+                          </span>
+                        )}
+                      </div>
                       <HealthStatusPill
                         tone={displayTone}
                         label={displayLabel}

--- a/core/healthcheck-frontend/src/hooks/useHealthCheckData.ts
+++ b/core/healthcheck-frontend/src/hooks/useHealthCheckData.ts
@@ -25,6 +25,15 @@ interface UseHealthCheckDataProps {
   };
   /** Filter by source: "local" = core only, satellite UUID = specific satellite, undefined = all */
   sourceFilter?: string;
+  /**
+   * Restrict the chart's aggregated buckets to a single environment
+   * (server-side DB filter across the raw / hourly / daily tiers the
+   * aggregation engine reads). `null` → env-less slice; `undefined` → no
+   * env filter (all envs of the (system, configuration)). Threaded from
+   * the overview's per-(check, environment) row, so the drawer's charts
+   * see only the env the operator clicked.
+   */
+  environmentId?: string | null;
   /** Whether the date range is a rolling preset (e.g., 'Last 7 days') that should auto-update */
   isRollingPreset?: boolean;
   /** Callback to update the date range (e.g., to refresh endDate to current time) */
@@ -63,6 +72,7 @@ export function useHealthCheckData({
   strategyId,
   dateRange,
   sourceFilter,
+  environmentId,
   isRollingPreset = false,
   onDateRangeRefresh,
 }: UseHealthCheckDataProps): UseHealthCheckDataResult {
@@ -85,6 +95,7 @@ export function useHealthCheckData({
         startDate: dateRange.startDate,
         endDate: dateRange.endDate,
         sourceFilter,
+        environmentId: environmentId ?? undefined,
         targetPoints: 500,
       },
       {


### PR DESCRIPTION
## Summary

Two related per-environment changes in one PR (both changesets staged: `healthcheck-per-env-rollup`, `anomaly-baseline-per-env`). Healthcheck rollup/history/triggers become env-scoped, and anomaly baselines follow suit so the env-scoped `HealthCheckDrawer` shows the clicked env\u2019s baseline instead of a cross-env one. The anomaly work closes the explicit follow-up the healthcheck change called out.

---

## 1. Per-environment health semantics (`healthcheck-per-env-rollup`)

**The bug.** When a `(system, configuration)` assignment fanned out to multiple environments and only some failed, the rollup could read **healthy** (masking a permanently-failing env), or **flap** healthy\u2194degraded/unhealthy tick-by-tick whenever env insertion order drifted. The rollup flattened every env\u2019s runs into one `timestamp DESC` list; the default `consecutive` mode broke the streak on the first interleaving env, collapsing to whichever env the most recent run landed on. Each flap fired an escalation/recovery notification + a `system_health_changed` trigger.

**What changed.**

- **`getSystemHealthStatus(systemId)` rollup** now groups the latest run window by `environmentId`, evaluates the threshold window **per environment**, and worst-wins across envs within each association (unhealthy > degraded > healthy) before worst-wins across associations. Stable under env insertion order / multi-pod racing. Reduces to the pre-existing flat-window behavior for single-env or env-less-only assignments.
- **`getSystemHealthOverview`** groups runs per `(configurationId, environmentId)`, evaluates each env\u2019s slice on its own monotonic run window, worst-wins across envs. Adds `perEnvironment[]` per check (one entry per env with its own `status` + env-scoped `recentRuns`) and carries `environmentId` on every `recentRuns[]` entry; top-level `recentRuns[]`/`status` keep their pre-existing shape for backwards compatibility.
- **`HealthCheckSystemOverview`** (frontend) flattens multi-env assignments into one row per `(check, environment)` \u2014 each row carries the check name, an env pill (resolved via `getSystemEnvironments`), per-env status, sparkline, last-run, and the Failing/Healthy filter is scoped per env. Single-env and env-less assignments render the historical single row; clicking any env row opens the drawer scoped to that env.
- **History/aggregated queries** (`getHistory`, `getDetailedHistory`, `getRunStats`, `getAggregatedHistory`, `getDetailedAggregatedHistory`) accept an optional `environmentId: string | null` filter (tristate: `undefined`\u2192no predicate, `null`\u2192`IS NULL` env-less slice, string\u2192that env). DB-layer predicate so pagination, totals, and buckets are honest end-to-end; aggregated history applies the env filter to all three tiers (raw `health_check_runs` + hourly/daily `health_check_aggregates`).
- **`system_health_changed` / `_degraded` / `_healthy` triggers** partition by `(systemId, environmentId)` when fired from a per-env change (two failing envs \u2192 two independent events with independent flapping/dwell/dedup windows); bare rollup transitions partition on `systemId` alone so existing `payload.systemId` recipes keep working.
- **`notifyStateChange`** accepts `environmentId` + `environmentName`; per-env notifications get an env-qualified title/body and an env-qualified collapse key (`systemHealthCollapseKey(systemId, envId)`) so two failing envs render as two independent cards. Suppression checks (maintenance/incident) stay system-scoped.

---

## 2. Per-environment anomaly baselines (`anomaly-baseline-per-env`)

**What changed.**

- **`anomaly_baselines.environment_id`** (nullable text). Unique constraint grew to `(systemId, configurationId, environmentId, fieldPath)` with `NULLS NOT DISTINCT` \u2014 one baseline per `(system, config, env, path)`; the env-less slice (`NULL`) stays a single row (the pre-feature cross-env baseline, preserved as the env-less row until the next analyzer tick rewrites per-env rows). Existing rows backfill to `NULL`, no data work. **Migration `0006_sad_retro_girl.sql`** (drizzle-kit generated: drop unique \u2192 add column \u2192 recreate with `NULLS NOT DISTINCT`).
- **Baseline analyzer** (`jobs/baseline-analyzer.ts`) fans out per environment within each assignment: runs grouped by `environmentId` (null = env-less), stats computed per env, upsert targets the 4-tuple. Cache key gains an env segment (`baseline:${config}:${system}:${env ?? "<none>"}:${path}`); `ANOMALY_BASELINE_UPDATED` payload carries `environmentId`. Previously: one cross-env batch per assignment.
- **Inline detector** (`detector.ts`) resolves the per-env baseline: lookup matches `environmentId` when present or `IS NULL` for the env-less slice; cache key matches the analyzer\u2019s env segment. `environmentId` threaded from the `checkCompleted` hook (defaults to `null` = env-less if omitted).
- **`getAnomalyBaselines` RPC** accepts optional `environmentId: string | null` (tristate, mirroring `getHistory`) with a DB-layer predicate; surfaces `environmentId` on every `AnomalyBaselineDto`.
- **`HealthCheckDrawer`** threads `item.environmentId` into the baselines query so the anomaly overlay resolves server-side to the clicked env\u2019s baseline only (matching the env-scoping already applied to its history/charts). The latency chart tolerates the new field (env filter guarantees a single `"latencyMs"` baseline).

---

## Cross-plugin additive changes

- **`getRunsForAnalysis`** (healthcheck) now returns `environmentId` on each run so the anomaly analyzer can group by env. Additive optional field; only the analyzer consumes it.
- **`checkCompleted` / `checkFailed` hooks** (healthcheck) carry `environmentId: string | null` sourced from the per-env execution loop. `checkCompleted` has a single in-tree subscriber (the anomaly detector), updated in lockstep; the failure-path emit (rollup error) passes `null`.

---

## Out of scope / follow-ups

- **Anomaly *rows*** (`anomalies` table) remain cross-env by design \u2014 only baselines are env-scoped here, matching the scoped task. A detector run for env A and env B\u2019s normal value still share one `(system, config, path)` anomaly row. Env-scoping that table is tracked as a separate follow-up so this PR stays focused on the drawer\u2019s baseline overlay.
- The `checkCompleted` / `checkFailed` payload change is technically breaking for hook subscribers that destructure the payload and reject unknown keys, but the only in-tree subscriber was updated together; external webhook subscribers gain an additional field and are unaffected unless they reject unknown keys (uncommon).

---

## Migration & test notes

- `0006_sad_retro_girl.sql` applies cleanly to fresh and already-populated DBs (existing `NULL`-env rows stay unique under the new key).
- Detector test cache keys updated to the env-less `<none>` segment; two new env-scoped regression tests (env-scoped key used; env-less slice never consulted for an env run). All touched-package tests pass; root `typecheck` + `lint` clean.

## Changesets

- `.changeset/healthcheck-per-env-rollup.md` \u2014 `@checkstack/healthcheck-backend`, `healthcheck-common`, `healthcheck-frontend` (minor)
- `.changeset/anomaly-baseline-per-env.md` \u2014 `@checkstack/anomaly-backend`, `anomaly-common`, `healthcheck-backend`, `healthcheck-common`, `healthcheck-frontend` (minor)