### PR TITLE
feat(notification-frontend): copyable error when a channel test fails

### DIFF
--- a/.changeset/notification-test-error-copyable.md
+++ b/.changeset/notification-test-error-copyable.md
@@ -1,0 +1,12 @@
+---
+"@checkstack/notification-frontend": patch
+---
+
+Show a copyable error when a notification channel test fails. Testing a
+configured channel returned `{ success, error }`, but the frontend discarded
+the result - a failed test cleared the spinner and gave no feedback, so
+operators had to open the browser network console to see why. The channel card
+now surfaces the full error inline in a dismissible callout with a copy button
+(and a success toast on a passing test). The message is shown untruncated,
+unlike toasts which cap at ~100 characters, so the actual transport error is
+readable and shareable.

--- a/core/notification-frontend/src/components/UserChannelCard.tsx
+++ b/core/notification-frontend/src/components/UserChannelCard.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronUp,
   Send,
+  AlertCircle,
 } from "lucide-react";
 import {
   Card,
@@ -17,8 +18,18 @@ import {
   DynamicIcon,
   MarkdownBlock,
   Spinner,
+  Alert,
+  AlertIcon,
+  AlertContent,
+  AlertTitle,
+  AlertDescription,
+  CopyableValue,
   type LucideIconName,
 } from "@checkstack/ui";
+import {
+  deriveTestErrorMessage,
+  deriveTestRejectionMessage,
+} from "./userChannelCard.logic";
 
 /**
  * User channel data from getUserDeliveryChannels endpoint
@@ -104,6 +115,10 @@ export function UserChannelCard({
   );
   const [localEnabled, setLocalEnabled] = useState(channel.enabled);
   const [configValid, setConfigValid] = useState(true); // Start true since existing config is valid
+  // Holds the full error message from the last failed test so it can be shown
+  // (and copied) inline. Toasts truncate to ~100 chars, which hid the actual
+  // transport error; the operator needs the whole thing to diagnose.
+  const [testError, setTestError] = useState<string | null>(null);
 
   const requiresOAuth = channel.contactResolution.type === "oauth-link";
   const requiresUserConfig = channel.contactResolution.type === "user-config";
@@ -140,6 +155,22 @@ export function UserChannelCard({
 
   const handleSaveConfig = async () => {
     await onSaveConfig(channel.strategyId, userConfig);
+  };
+
+  const handleTest = async () => {
+    // Clear any stale error so a retry starts from a clean slate. A passing
+    // test is toasted by the page's mutation; the card only owns the failure.
+    setTestError(null);
+    try {
+      const message = deriveTestErrorMessage(await onTest(channel.strategyId));
+      if (message !== null) {
+        setTestError(message);
+      }
+    } catch (error) {
+      // A rejected mutation (transport / auth failure) never reaches the
+      // success/error contract above - surface its message here too.
+      setTestError(deriveTestRejectionMessage(error));
+    }
   };
 
   // Get status badge. Connection state is a status signal, so it uses the
@@ -271,7 +302,7 @@ export function UserChannelCard({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => void onTest(channel.strategyId)}
+              onClick={() => void handleTest()}
               disabled={testing || saving}
               title="Send test notification"
             >
@@ -299,6 +330,41 @@ export function UserChannelCard({
           )}
         </div>
       </div>
+
+      {/* Test-notification failure: full, copyable error so operators can
+          diagnose a misconfigured channel without opening the network console. */}
+      {testError && (
+        <div className="border-t p-4 pl-5">
+          <Alert variant="error">
+            <AlertIcon>
+              <AlertCircle className="h-4 w-4" />
+            </AlertIcon>
+            <AlertContent>
+              <div className="flex items-start justify-between gap-2">
+                <AlertTitle>Test notification failed</AlertTitle>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setTestError(null)}
+                  aria-label="Dismiss error"
+                  className="-mr-1 -mt-1 h-6 w-6 shrink-0 p-0"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <AlertDescription>
+                The channel could not deliver the test notification. Copy the
+                error below when reporting the problem.
+              </AlertDescription>
+              <CopyableValue
+                value={testError}
+                label="Error message"
+                className="pt-1"
+              />
+            </AlertContent>
+          </Alert>
+        </div>
+      )}
 
       {/* User config form */}
       {expanded && hasUserConfigSchema && channel.userConfigSchema && (

--- a/core/notification-frontend/src/components/userChannelCard.logic.test.ts
+++ b/core/notification-frontend/src/components/userChannelCard.logic.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import {
+  deriveTestErrorMessage,
+  deriveTestRejectionMessage,
+} from "./userChannelCard.logic";
+
+describe("deriveTestErrorMessage", () => {
+  it("returns null for a successful test", () => {
+    expect(deriveTestErrorMessage({ success: true })).toBeNull();
+  });
+
+  it("ignores an error field on a successful result", () => {
+    expect(
+      deriveTestErrorMessage({ success: true, error: "stale" }),
+    ).toBeNull();
+  });
+
+  it("surfaces the backend error verbatim on failure", () => {
+    const error = "connect ECONNREFUSED 10.0.0.5:443 while calling webhook";
+    expect(deriveTestErrorMessage({ success: false, error })).toBe(error);
+  });
+
+  it("preserves a long multi-line error untruncated (the whole point)", () => {
+    const error = `HTTP 500 from provider\n${"x".repeat(500)}`;
+    expect(deriveTestErrorMessage({ success: false, error })).toBe(error);
+  });
+
+  it("falls back to a message when a failure omits error detail", () => {
+    const message = deriveTestErrorMessage({ success: false });
+    expect(message).not.toBeNull();
+    expect(message).toContain("no error detail");
+  });
+});
+
+describe("deriveTestRejectionMessage", () => {
+  it("uses the Error message when the mutation rejects with an Error", () => {
+    expect(deriveTestRejectionMessage(new Error("Unauthorized"))).toBe(
+      "Unauthorized",
+    );
+  });
+
+  it("surfaces a string rejection verbatim", () => {
+    expect(deriveTestRejectionMessage("boom")).toBe("boom");
+  });
+
+  it("falls back to a generic message for an opaque rejection", () => {
+    expect(deriveTestRejectionMessage({ weird: true })).toBe(
+      "Failed to send the test notification.",
+    );
+  });
+});

--- a/core/notification-frontend/src/components/userChannelCard.logic.ts
+++ b/core/notification-frontend/src/components/userChannelCard.logic.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure helpers for surfacing a channel test-notification outcome. Kept out of
+ * the component so the fallback logic (a failing test must always yield a
+ * copyable message, even when the backend omits `error`) is unit-testable.
+ */
+import { extractErrorMessage } from "@checkstack/common";
+
+/** Result contract returned by the `sendTestNotification` procedure. */
+export interface ChannelTestResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Derive the inline error message to show for a channel test outcome, or `null`
+ * when the test succeeded. A failed result with no `error` still yields a
+ * message so the operator never sees a silent failure.
+ */
+export function deriveTestErrorMessage(result: ChannelTestResult): string | null {
+  if (result.success) return null;
+  return (
+    result.error ??
+    "The test notification failed, but the channel returned no error detail."
+  );
+}
+
+/**
+ * Derive the inline error message for a rejected test mutation - a transport or
+ * auth failure that never produced the success/error contract above.
+ */
+export function deriveTestRejectionMessage(error: unknown): string {
+  return extractErrorMessage(error, "Failed to send the test notification.");
+}

--- a/core/notification-frontend/src/pages/NotificationSettingsPage.tsx
+++ b/core/notification-frontend/src/pages/NotificationSettingsPage.tsx
@@ -168,6 +168,14 @@ export const NotificationSettingsPage = () => {
     });
 
   const sendTestMutation = notificationClient.sendTestNotification.useMutation({
+    onSuccess: (data) => {
+      // The procedure resolves for both outcomes (a failed test returns
+      // `{ success: false, error }` rather than throwing), so only toast on a
+      // genuine pass - the card surfaces the copyable error for a failure.
+      if (data.success) {
+        toastSuccess(toast, "Test notification sent");
+      }
+    },
     onSettled: () => {
       setChannelTesting(undefined);
     },


### PR DESCRIPTION
## Problem

Testing a configured notification channel that fails gives the operator no feedback. The backend `sendTestNotification` procedure returns `{ success, error }` (it does not throw), but the frontend discarded the result via `void onTest(...)`. A failed test simply cleared the spinner, so the only way to see *why* it failed was to open the browser network console. Even the existing error toasts truncate to ~100 chars, hiding the real transport error.

## Change

- **`UserChannelCard`** now awaits the test result and, on failure (or a rejected mutation, e.g. transport/auth), renders the **full** error inline in a dismissible `error`-variant `Alert` containing a `CopyableValue` (existing UI primitive: monospace value + copy-to-clipboard + toast). The message is shown untruncated so it is readable and shareable. A stale error is cleared when a new test starts.
- **`NotificationSettingsPage`** reports a passing test via a success toast from `sendTestMutation.onSuccess`, gated on `data.success` (the procedure resolves for both outcomes, so an ungated toast would wrongly report success on a failed test).
- The result-to-message mapping is extracted into a pure **`userChannelCard.logic`** module (following the repo's `*.logic.ts` convention) and unit-tested.

## Tests

New `userChannelCard.logic.test.ts` (8 cases): success, failure with error, failure without error detail (fallback), a long multi-line error preserved verbatim, and Error/string/opaque rejections.

- `bun test core/notification-frontend` -> 27 pass
- `bun run typecheck` -> clean
- `bun run lint` -> clean

No backend/contract/API change, so no docs update needed. Changeset: `patch` for `@checkstack/notification-frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)