### PR TITLE
feat(announcement): operator-sortable, stably-ordered announcements

### DIFF
--- a/.changeset/announcement-sortable-stable-order.md
+++ b/.changeset/announcement-sortable-stable-order.md
@@ -1,0 +1,35 @@
+---
+"@checkstack/announcement-backend": minor
+"@checkstack/announcement-common": minor
+"@checkstack/announcement-frontend": minor
+---
+
+Announcements now have a stable, operator-controlled display order.
+
+## What changed
+
+- **Stable ordering (bugfix).** `getActiveAnnouncements` had no `ORDER BY`, so
+  Postgres returned rows in heap order, which shifts after any `UPDATE` - that
+  is why announcements jumped position whenever one was edited. Both
+  `getActiveAnnouncements` and `listAllAnnouncements` now order by
+  `sort_order`, with `created_at` and `id` as stable tiebreakers, so the
+  sequence never changes on its own.
+- **Manual sorting.** `announcements` gained a `sort_order` integer column
+  (migration `0001`, back-filled from existing creation order). A new
+  `reorderAnnouncements` admin procedure takes the full ordered id list and
+  writes each announcement's position in one atomic `UPDATE ... CASE`. Operators
+  reorder from the management page with per-row up/down arrows (desktop table
+  and mobile cards). New announcements append at the end; editing an
+  announcement never moves it.
+- **Pure manual order everywhere.** The public banner no longer force-sorts by
+  severity - banner, dashboard, and admin list all render the operator's order.
+- The `announcement.updated` signal payload's `action` gained a `"reordered"`
+  value so listeners refetch after a reorder.
+
+## Notes
+
+- `sort_order` is backend-internal; it is not exposed on the public
+  `Announcement` schema (the frontend derives order from query order).
+- Migration `0001_typical_omega_red.sql` adds the column (default `0`) and
+  back-fills distinct values via `row_number()` over `created_at, id`. It
+  applies cleanly to both fresh and already-populated databases.

--- a/core/announcement-backend/drizzle/0001_typical_omega_red.sql
+++ b/core/announcement-backend/drizzle/0001_typical_omega_red.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "announcements" ADD COLUMN "sort_order" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+-- Backfill distinct order values from existing creation order so the manual
+-- ordering is meaningful before an operator ever reorders anything.
+UPDATE "announcements" AS a SET "sort_order" = s.rn
+FROM (
+  SELECT "id", row_number() OVER (ORDER BY "created_at", "id") - 1 AS rn
+  FROM "announcements"
+) AS s
+WHERE a."id" = s."id";

--- a/core/announcement-backend/drizzle/meta/0001_snapshot.json
+++ b/core/announcement-backend/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,171 @@
+{
+  "id": "28ba7786-ee5c-4f20-935f-1fae9fa85917",
+  "prevId": "fb3688d6-20bb-4c60-8f3b-c0cd4674e705",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcement_dismissals": {
+      "name": "announcement_dismissals",
+      "schema": "",
+      "columns": {
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_dismissals_announcement_id_announcements_id_fk": {
+          "name": "announcement_dismissals_announcement_id_announcements_id_fk",
+          "tableFrom": "announcement_dismissals",
+          "tableTo": "announcements",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "announcement_dismissals_announcement_id_user_id_pk": {
+          "name": "announcement_dismissals_announcement_id_user_id_pk",
+          "columns": [
+            "announcement_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "display_mode": {
+          "name": "display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'both'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/core/announcement-backend/drizzle/meta/_journal.json
+++ b/core/announcement-backend/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776417116365,
       "tag": "0000_cooing_onslaught",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1782913349500,
+      "tag": "0001_typical_omega_red",
+      "breakpoints": true
     }
   ]
 }

--- a/core/announcement-backend/src/router.test.ts
+++ b/core/announcement-backend/src/router.test.ts
@@ -72,8 +72,11 @@ describe("Announcement Router", () => {
     it("returns active announcements for anonymous users", async () => {
       const context = createMockRpcContext({ user: undefined });
 
-      // Mock select chain for announcements query
-      const mockWhereChain = Promise.resolve([sampleAnnouncement]);
+      // Mock select chain for announcements query (ends in orderBy)
+      const mockWhereChain = Object.assign(
+        Promise.resolve([sampleAnnouncement]),
+        { orderBy: mock(() => Promise.resolve([sampleAnnouncement])) },
+      );
       const mockFromChain = Object.assign(
         Promise.resolve([sampleAnnouncement]),
         { where: mock(() => mockWhereChain) },
@@ -99,10 +102,14 @@ describe("Announcement Router", () => {
         visibility: "authenticated",
       };
 
-      const mockWhereChain = Promise.resolve([
-        sampleAnnouncement,
-        authenticatedOnly,
-      ]);
+      const mockWhereChain = Object.assign(
+        Promise.resolve([sampleAnnouncement, authenticatedOnly]),
+        {
+          orderBy: mock(() =>
+            Promise.resolve([sampleAnnouncement, authenticatedOnly]),
+          ),
+        },
+      );
       const mockFromChain = Object.assign(
         Promise.resolve([sampleAnnouncement, authenticatedOnly]),
         { where: mock(() => mockWhereChain) },
@@ -123,8 +130,11 @@ describe("Announcement Router", () => {
     it("excludes dismissed announcements for authenticated users", async () => {
       const context = createMockRpcContext({ user: adminUser });
 
-      // First query: active announcements
-      const mockWhereChain = Promise.resolve([sampleAnnouncement]);
+      // First query: active announcements (ends in orderBy)
+      const mockWhereChain = Object.assign(
+        Promise.resolve([sampleAnnouncement]),
+        { orderBy: mock(() => Promise.resolve([sampleAnnouncement])) },
+      );
       const mockFromChain = Object.assign(
         Promise.resolve([sampleAnnouncement]),
         { where: mock(() => mockWhereChain) },
@@ -155,8 +165,11 @@ describe("Announcement Router", () => {
     it("includes dismissed announcements when includeDismissed is true", async () => {
       const context = createMockRpcContext({ user: adminUser });
 
-      // Query returns one active announcement
-      const mockWhereChain = Promise.resolve([sampleAnnouncement]);
+      // Query returns one active announcement (ends in orderBy)
+      const mockWhereChain = Object.assign(
+        Promise.resolve([sampleAnnouncement]),
+        { orderBy: mock(() => Promise.resolve([sampleAnnouncement])) },
+      );
       const mockFromChain = Object.assign(
         Promise.resolve([sampleAnnouncement]),
         { where: mock(() => mockWhereChain) },
@@ -298,6 +311,41 @@ describe("Announcement Router", () => {
       );
     });
 
+    it("appends new announcements at the end of the sort order", async () => {
+      const context = createMockRpcContext({ user: adminUser });
+
+      // max(sort_order) currently 7 → the new row must be 8.
+      mockDb.select.mockReturnValueOnce({
+        from: mock(() => Promise.resolve([{ maxOrder: 7 }])),
+      } as never);
+
+      let capturedValues: Record<string, unknown> | undefined;
+      mockDb.insert.mockReturnValueOnce({
+        values: mock((v: Record<string, unknown>) => {
+          capturedValues = v;
+          return {
+            returning: mock(() =>
+              Promise.resolve([{ ...sampleAnnouncement, id: "new-id" }]),
+            ),
+          };
+        }),
+      } as never);
+
+      await call(
+        router.createAnnouncement,
+        {
+          title: "New",
+          message: "Body",
+          severity: "info",
+          visibility: "all",
+          displayMode: "both",
+        },
+        { context },
+      );
+
+      expect(capturedValues?.sortOrder).toBe(8);
+    });
+
     it("rejects unauthenticated users", async () => {
       const context = createMockRpcContext({ user: undefined });
 
@@ -343,6 +391,35 @@ describe("Announcement Router", () => {
         ANNOUNCEMENT_UPDATED,
         { announcementId: "ann-1", action: "updated" },
       );
+    });
+
+    it("never changes sort order on update (position stays stable)", async () => {
+      const context = createMockRpcContext({ user: adminUser });
+
+      // Regression guard for the reported bug: editing an announcement must not
+      // move it. The handler must never write sort_order.
+      let capturedSet: Record<string, unknown> | undefined;
+      mockDb.update.mockReturnValueOnce({
+        set: mock((v: Record<string, unknown>) => {
+          capturedSet = v;
+          return {
+            where: mock(() => ({
+              returning: mock(() =>
+                Promise.resolve([{ ...sampleAnnouncement, title: "Updated" }]),
+              ),
+            })),
+          };
+        }),
+      } as never);
+
+      await call(
+        router.updateAnnouncement,
+        { id: "ann-1", title: "Updated" },
+        { context },
+      );
+
+      expect(capturedSet).toBeDefined();
+      expect(capturedSet && "sortOrder" in capturedSet).toBe(false);
     });
 
     it("invalidates both active and list-all caches after a successful update", async () => {
@@ -428,6 +505,50 @@ describe("Announcement Router", () => {
         ANNOUNCEMENT_UPDATED,
         { announcementId: "ann-1", action: "deleted" },
       );
+    });
+  });
+
+  describe("reorderAnnouncements", () => {
+    it("persists the new order in one update and broadcasts a reordered signal", async () => {
+      const context = createMockRpcContext({ user: adminUser });
+
+      let capturedSet: Record<string, unknown> | undefined;
+      const whereSpy = mock(() => Promise.resolve());
+      mockDb.update.mockReturnValueOnce({
+        set: mock((v: Record<string, unknown>) => {
+          capturedSet = v;
+          return { where: whereSpy };
+        }),
+      } as never);
+
+      const result = await call(
+        router.reorderAnnouncements,
+        { orderedIds: ["a", "b", "c"] },
+        { context },
+      );
+
+      expect(result.success).toBe(true);
+      // A single atomic UPDATE with a CASE expression on sort_order.
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+      expect(whereSpy).toHaveBeenCalledTimes(1);
+      expect(capturedSet?.sortOrder).toBeDefined();
+
+      expect(mockSignalService.broadcast).toHaveBeenCalledWith(
+        ANNOUNCEMENT_UPDATED,
+        { announcementId: "a", action: "reordered" },
+      );
+    });
+
+    it("rejects unauthenticated users", async () => {
+      const context = createMockRpcContext({ user: undefined });
+
+      await expect(
+        call(
+          router.reorderAnnouncements,
+          { orderedIds: ["a"] },
+          { context },
+        ),
+      ).rejects.toThrow("Authentication required");
     });
   });
 

--- a/core/announcement-backend/src/router.ts
+++ b/core/announcement-backend/src/router.ts
@@ -13,7 +13,7 @@ import {
 } from "@checkstack/backend-api";
 import type { SafeDatabase } from "@checkstack/backend-api";
 import * as schema from "./schema";
-import { eq, and, or, lte, gte, isNull } from "drizzle-orm";
+import { eq, and, or, lte, gte, isNull, asc, inArray, sql } from "drizzle-orm";
 import type { AnnouncementCache } from "./cache";
 
 type AnnouncementDb = SafeDatabase<typeof schema>;
@@ -83,6 +83,13 @@ export function createAnnouncementRouter(
                   gte(schema.announcements.expiresAt, now),
                 ),
               ),
+            )
+            // Stable, operator-controlled order. createdAt + id break ties so
+            // the sequence never shifts when an announcement is merely updated.
+            .orderBy(
+              asc(schema.announcements.sortOrder),
+              asc(schema.announcements.createdAt),
+              asc(schema.announcements.id),
             );
 
           let announcements = rows.map((row) => toAnnouncement(row));
@@ -158,7 +165,11 @@ export function createAnnouncementRouter(
         const rows = await db
           .select()
           .from(schema.announcements)
-          .orderBy(schema.announcements.createdAt);
+          .orderBy(
+            asc(schema.announcements.sortOrder),
+            asc(schema.announcements.createdAt),
+            asc(schema.announcements.id),
+          );
 
         return { announcements: rows.map((row) => toAnnouncement(row)) };
       }),
@@ -174,6 +185,16 @@ export function createAnnouncementRouter(
         const id = crypto.randomUUID();
         const now = new Date();
 
+        // Append new announcements at the end of the operator's ordering.
+        const [maxRow] = await db
+          .select({
+            maxOrder: sql<
+              number | null
+            >`max(${schema.announcements.sortOrder})`,
+          })
+          .from(schema.announcements);
+        const nextSortOrder = (maxRow?.maxOrder ?? -1) + 1;
+
         const [row] = await db
           .insert(schema.announcements)
           .values({
@@ -184,6 +205,7 @@ export function createAnnouncementRouter(
             visibility: input.visibility,
             displayMode: input.displayMode,
             active: input.active ?? true,
+            sortOrder: nextSortOrder,
             startsAt: input.startsAt ?? undefined,
             expiresAt: input.expiresAt ?? undefined,
             createdBy: userId,
@@ -280,6 +302,39 @@ export function createAnnouncementRouter(
       }
 
       return { success: result.length > 0 };
+    }),
+
+    // -------------------------------------------------------------------------
+    // Admin: Reorder announcements
+    // -------------------------------------------------------------------------
+    reorderAnnouncements: os.reorderAnnouncements.handler(async ({ input }) => {
+      const { orderedIds } = input;
+
+      // Write the new position for every listed id in a single atomic UPDATE:
+      // sort_order = index of the id in `orderedIds`. A CASE keeps it to one
+      // statement (no partial reorder on failure); ids not listed are untouched.
+      const whenClauses = orderedIds.map(
+        (id, index) =>
+          sql`when ${schema.announcements.id} = ${id} then ${index}`,
+      );
+      const sortOrderCase = sql`case ${sql.join(whenClauses, sql` `)} else ${schema.announcements.sortOrder} end`;
+
+      await db
+        .update(schema.announcements)
+        .set({ sortOrder: sortOrderCase })
+        .where(inArray(schema.announcements.id, orderedIds));
+
+      await Promise.all([
+        cache.invalidateAllActive(),
+        cache.invalidateListAll(),
+      ]);
+
+      await signalService.broadcast(ANNOUNCEMENT_UPDATED, {
+        announcementId: orderedIds[0],
+        action: "reordered",
+      });
+
+      return { success: true };
     }),
   });
 }

--- a/core/announcement-backend/src/schema.ts
+++ b/core/announcement-backend/src/schema.ts
@@ -3,6 +3,7 @@ import {
   text,
   timestamp,
   boolean,
+  integer,
   primaryKey,
 } from "drizzle-orm/pg-core";
 
@@ -18,6 +19,13 @@ export const announcements = pgTable("announcements", {
   visibility: text("visibility").notNull().default("all"),
   displayMode: text("display_mode").notNull().default("both"),
   active: boolean("active").notNull().default(true),
+  /**
+   * Operator-controlled display order (ascending). Lower values appear first
+   * across the admin list, dashboard cards, and public banner. New rows append
+   * at the end; it is only ever changed via the explicit reorder procedure, so
+   * a plain edit never moves an announcement.
+   */
+  sortOrder: integer("sort_order").notNull().default(0),
   startsAt: timestamp("starts_at"),
   expiresAt: timestamp("expires_at"),
   createdBy: text("created_by").notNull(),

--- a/core/announcement-common/src/rpc-contract.ts
+++ b/core/announcement-common/src/rpc-contract.ts
@@ -88,6 +88,19 @@ export const announcementContract = {
     .route({ method: "DELETE" })
     .input(z.object({ id: z.string() }))
     .output(z.object({ success: z.boolean() })),
+
+  /**
+   * Persist a new operator-defined display order.
+   * `orderedIds` is the complete list of announcement ids in the desired order;
+   * each announcement's position becomes its index in the array.
+   */
+  reorderAnnouncements: proc({
+    operationType: "mutation",
+    userType: "authenticated",
+    access: [announcementAccess.manage],
+  })
+    .input(z.object({ orderedIds: z.array(z.string()).min(1) }))
+    .output(z.object({ success: z.boolean() })),
 };
 
 // Export contract type

--- a/core/announcement-common/src/signals.ts
+++ b/core/announcement-common/src/signals.ts
@@ -11,6 +11,6 @@ export const ANNOUNCEMENT_UPDATED = createSignal({
   event: "updated",
   payloadSchema: z.object({
     announcementId: z.string(),
-    action: z.enum(["created", "updated", "deleted"]),
+    action: z.enum(["created", "updated", "deleted", "reordered"]),
   }),
 });

--- a/core/announcement-frontend/src/components/AnnouncementBanner.tsx
+++ b/core/announcement-frontend/src/components/AnnouncementBanner.tsx
@@ -175,15 +175,6 @@ function BannerItem({
 }
 
 /**
- * Severity sort priority for sorting banners (critical first).
- */
-const SEVERITY_ORDER: Record<string, number> = {
-  critical: 0,
-  warning: 1,
-  info: 2,
-};
-
-/**
  * Global announcement banner component.
  * Renders active banner announcements as slim strips above the navbar.
  *
@@ -206,13 +197,10 @@ export const AnnouncementBanner: React.FC = () => {
   const bannerAnnouncements = React.useMemo(() => {
     if (!data?.announcements) return [];
 
+    // Preserve the operator-defined order the backend returns; only filter.
     return data.announcements
       .filter((a) => a.displayMode === "banner" || a.displayMode === "both")
-      .filter((a) => !localDismissedIds.has(a.id))
-      .toSorted(
-        (a, b) =>
-          (SEVERITY_ORDER[a.severity] ?? 2) - (SEVERITY_ORDER[b.severity] ?? 2),
-      );
+      .filter((a) => !localDismissedIds.has(a.id));
   }, [data?.announcements, localDismissedIds]);
 
   const handleDismiss = useCallback(

--- a/core/announcement-frontend/src/pages/AnnouncementManagePage.tsx
+++ b/core/announcement-frontend/src/pages/AnnouncementManagePage.tsx
@@ -70,6 +70,8 @@ import {
   Monitor,
   LayoutDashboard,
   Columns,
+  ArrowUp,
+  ArrowDown,
 } from "lucide-react";
 import { formatDistanceToNow, format } from "date-fns";
 
@@ -430,6 +432,45 @@ function VisibilityIcon({
   }
 }
 
+/**
+ * Up/down controls for manually reordering an announcement. Ends of the list
+ * and an in-flight reorder disable the relevant buttons.
+ */
+function ReorderControls({
+  index,
+  count,
+  disabled,
+  onMove,
+}: {
+  index: number;
+  count: number;
+  disabled: boolean;
+  onMove: (direction: -1 | 1) => void;
+}) {
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Move up"
+        disabled={disabled || index === 0}
+        onClick={() => onMove(-1)}
+      >
+        <ArrowUp className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Move down"
+        disabled={disabled || index === count - 1}
+        onClick={() => onMove(1)}
+      >
+        <ArrowDown className="h-4 w-4" />
+      </Button>
+    </>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main Page
 // ---------------------------------------------------------------------------
@@ -463,7 +504,40 @@ const AnnouncementManageContent: React.FC = () => {
     },
   });
 
+  const reorderMutation = announcementClient.reorderAnnouncements.useMutation({
+    onError: (error) => {
+      toastError(toast, "Failed to reorder announcements", error);
+      // Revert the optimistic order back to the server's source of truth.
+      void refetch();
+    },
+  });
+
   const announcements = announcementsData?.announcements ?? [];
+
+  // Local, optimistically-ordered copy so the up/down arrows feel instant. It
+  // re-syncs whenever the server data changes (create/delete/edit or another
+  // operator reordering), so the server stays the source of truth.
+  const [orderedAnnouncements, setOrderedAnnouncements] = useState<
+    Announcement[]
+  >([]);
+  React.useEffect(() => {
+    setOrderedAnnouncements(announcementsData?.announcements ?? []);
+  }, [announcementsData]);
+
+  const handleMove = (index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    if (target < 0 || target >= orderedAnnouncements.length) return;
+    const next = [...orderedAnnouncements];
+    [next[index], next[target]] = [next[target], next[index]];
+    setOrderedAnnouncements(next);
+    reorderMutation.mutate({ orderedIds: next.map((a) => a.id) });
+  };
+
+  // Fall back to the server list for the first paint before the sync effect
+  // runs, so the table never flashes empty.
+  const listedAnnouncements =
+    orderedAnnouncements.length > 0 ? orderedAnnouncements : announcements;
+  const reorderDisabled = reorderMutation.isPending;
 
   const handleCreate = () => {
     setEditingAnnouncement(undefined);
@@ -562,11 +636,11 @@ const AnnouncementManageContent: React.FC = () => {
                       <TableHead>Display</TableHead>
                       <TableHead>Visibility</TableHead>
                       <TableHead>Created</TableHead>
-                      <TableHead className="w-24">Actions</TableHead>
+                      <TableHead className="w-40">Actions</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {announcements.map((a) => (
+                    {listedAnnouncements.map((a, index) => (
                       <TableRow
                         key={a.id}
                         className="transition-colors hover:bg-surface-inset"
@@ -611,6 +685,12 @@ const AnnouncementManageContent: React.FC = () => {
                         </TableCell>
                         <TableCell>
                           <div className="flex gap-1">
+                            <ReorderControls
+                              index={index}
+                              count={listedAnnouncements.length}
+                              disabled={reorderDisabled}
+                              onMove={(direction) => handleMove(index, direction)}
+                            />
                             <Button
                               variant="ghost"
                               size="icon"
@@ -634,7 +714,7 @@ const AnnouncementManageContent: React.FC = () => {
               </ResponsiveTable>
 
               <MobileCardList className="p-4">
-                {announcements.map((a) => (
+                {listedAnnouncements.map((a, index) => (
                   <div
                     key={a.id}
                     className="relative overflow-hidden rounded-[var(--d-card-r)] border border-border/70 bg-gradient-to-b from-surface-2 to-surface p-[var(--d-pad)] shadow-[0_1px_2px_hsl(var(--foreground)/0.04),0_10px_30px_-14px_hsl(var(--foreground)/0.12)]"
@@ -665,6 +745,12 @@ const AnnouncementManageContent: React.FC = () => {
                       </span>
                     </div>
                     <div className="mt-3 flex justify-end gap-1 pl-2">
+                      <ReorderControls
+                        index={index}
+                        count={listedAnnouncements.length}
+                        disabled={reorderDisabled}
+                        onMove={(direction) => handleMove(index, direction)}
+                      />
                       <Button
                         variant="ghost"
                         size="icon"


### PR DESCRIPTION
## Problem

Announcements changed position whenever one was edited, and operators had no way to sort them.

The root cause of the movement: `getActiveAnnouncements` had **no `ORDER BY`**, so Postgres returned rows in heap order, which shifts after any `UPDATE`. The dashboard rendered that raw order; the banner re-sorted by severity but ties stayed unstable.

## Solution

Give every announcement a persistent, operator-controlled order and fix the stability bug.

### Stability (bugfix)
- `getActiveAnnouncements` and `listAllAnnouncements` now order by `sort_order`, then `created_at`, then `id` (stable tiebreakers).
- `updateAnnouncement` never writes `sort_order`, so editing an announcement no longer moves it.

### Manual sorting (feature)
- **Schema**: new `sort_order` integer column. Migration `0001` adds it (default `0`) and back-fills distinct values from existing creation order via `row_number()`. Applies cleanly to fresh and already-populated DBs.
- **Backend**: new `reorderAnnouncements` admin procedure writes the full ordered id list in one atomic `UPDATE ... CASE`. `createAnnouncement` appends new items at the end (`max(sort_order)+1`).
- **Common**: `reorderAnnouncements` contract (`manage` access); the `announcement.updated` signal `action` gained `"reordered"`. `sort_order` stays backend-internal (not on the public `Announcement` schema).
- **Frontend**: per-row up/down arrows on the management page (desktop table + mobile cards) via a shared `ReorderControls`, with optimistic local ordering that re-syncs to the server. The public banner no longer force-sorts by severity - banner, dashboard, and admin list all render the operator's order.

## Tests
- Added: create-append, an **update-stability regression guard** (asserts `sort_order` is never written on update), and reorder coverage.
- `bun test` on announcement packages: 27 pass, 0 fail.
- `bun run typecheck` and `bun run lint`: clean.

## Notes
- Announcements have no docs page anywhere under `docs/src/content/docs/` (the feature shipped undocumented), so there is no page to update/drift. Happy to add a concept page in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)