### PR TITLE
fix(announcement): accessible names for row actions + robust E2E selectors

### DIFF
--- a/.changeset/announcement-row-action-a11y-labels.md
+++ b/.changeset/announcement-row-action-a11y-labels.md
@@ -1,0 +1,10 @@
+---
+"@checkstack/announcement-frontend": patch
+---
+
+Give the Edit and Delete row actions on the announcement management page
+accessible names (`aria-label`). The icon-only buttons previously exposed no
+accessible name, so assistive technology announced them only as "button" and
+tests had to target them positionally - which broke once the reorder Move
+up/down controls were added to the same action group. The buttons now read as
+"Edit announcement" / "Delete announcement".

--- a/core/announcement-frontend/src/pages/AnnouncementManagePage.tsx
+++ b/core/announcement-frontend/src/pages/AnnouncementManagePage.tsx
@@ -694,6 +694,7 @@ const AnnouncementManageContent: React.FC = () => {
                             <Button
                               variant="ghost"
                               size="icon"
+                              aria-label="Edit announcement"
                               onClick={() => handleEdit(a)}
                             >
                               <Edit2 className="h-4 w-4" />
@@ -701,6 +702,7 @@ const AnnouncementManageContent: React.FC = () => {
                             <Button
                               variant="ghost"
                               size="icon"
+                              aria-label="Delete announcement"
                               onClick={() => setDeleteId(a.id)}
                             >
                               <Trash2 className="h-4 w-4 text-destructive" />
@@ -754,6 +756,7 @@ const AnnouncementManageContent: React.FC = () => {
                       <Button
                         variant="ghost"
                         size="icon"
+                        aria-label="Edit announcement"
                         onClick={() => handleEdit(a)}
                       >
                         <Edit2 className="h-4 w-4" />
@@ -761,6 +764,7 @@ const AnnouncementManageContent: React.FC = () => {
                       <Button
                         variant="ghost"
                         size="icon"
+                        aria-label="Delete announcement"
                         onClick={() => setDeleteId(a.id)}
                       >
                         <Trash2 className="h-4 w-4 text-destructive" />

--- a/core/e2e/tests/announcement.spec.ts
+++ b/core/e2e/tests/announcement.spec.ts
@@ -117,8 +117,9 @@ test.describe("announcements (boot-once)", () => {
     const row = page.getByRole("row", { name: new RegExp(NS) });
     await expect(row).toBeVisible({ timeout: 30_000 });
 
-    // The first action button in the row is Edit (pencil), the second is Delete.
-    await row.getByRole("button").first().click();
+    // Select the Edit action by its accessible name so the assertion is robust
+    // to other row buttons (e.g. the reorder Move up/down controls).
+    await row.getByRole("button", { name: "Edit announcement" }).click();
 
     const dialog = page.getByRole("dialog");
     await expect(
@@ -146,8 +147,9 @@ test.describe("announcements (boot-once)", () => {
     const row = page.getByRole("row", { name: new RegExp(NS) });
     await expect(row).toBeVisible({ timeout: 30_000 });
 
-    // Open the delete confirmation (second action button = trash).
-    await row.getByRole("button").nth(1).click();
+    // Open the delete confirmation via the trash action, selected by its
+    // accessible name (robust to the reorder Move up/down controls).
+    await row.getByRole("button", { name: "Delete announcement" }).click();
 
     const confirm = page.getByRole("dialog");
     await expect(
@@ -165,7 +167,7 @@ test.describe("announcements (boot-once)", () => {
     await expect(page.getByRole("cell", { name: EDITED_TITLE })).toBeVisible();
 
     // Now actually delete it.
-    await row.getByRole("button").nth(1).click();
+    await row.getByRole("button", { name: "Delete announcement" }).click();
     await expect(
       page.getByRole("dialog").getByRole("heading", {
         name: "Delete Announcement",


### PR DESCRIPTION
## Problem

`core/e2e/tests/announcement.spec.ts` is failing on `main` (E2E shard 1),
which blocks the E2E job on **every** open PR.

Root cause: the sortable-announcements feature (#379) added **Move up / Move
down** reorder controls to each announcement row's action group. The Edit and
Delete buttons are icon-only with **no accessible name**, so the spec selected
them positionally (`row.getByRole("button").first()` / `.nth(1)`). With the new
reorder buttons in front, `.first()` now resolves to a *disabled* "Move up"
button and the test times out.

## Fix

- Add `aria-label="Edit announcement"` / `aria-label="Delete announcement"` to
  the icon-only row action buttons (both the table and the mobile card list).
  This is an accessibility fix in its own right - the buttons previously
  announced only as "button".
- Update `announcement.spec.ts` to select those actions by accessible name,
  making the tests robust to sibling row controls.

## Verification

- `bun run typecheck`, `eslint` on the changed files, and
  `bun test core/announcement-frontend` all pass locally.
- The E2E itself runs in CI.

> [!NOTE]
> This is a pre-existing breakage on `main`, independent of the current feature
> PRs. Merging this first unblocks their E2E jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqy1sbnxFTRLhTBjg6psJ