### PR TITLE
feat(healthcheck-frontend): group old checks, resolve env names, stack run timestamps

### DIFF
--- a/.changeset/healthcheck-overview-old-checks-and-timestamps.md
+++ b/.changeset/healthcheck-overview-old-checks-and-timestamps.md
@@ -1,0 +1,24 @@
+---
+"@checkstack/healthcheck-frontend": minor
+---
+
+Health-check overview and run history: group stale checks, resolve environment
+names for old runs, and show absolute run timestamps.
+
+- The system overview now detects health-check slices that no longer receive
+  runs after an environment change - the env-less leftover of a check that has
+  since fanned out to environments, a slice for an environment that was removed,
+  and the case where all environments are removed - and tucks them into a
+  collapsed "Old checks" group. Their history is preserved; they just stop
+  cluttering the live list.
+- Environment pills across the overview and the run-history surfaces now resolve
+  names from all environments (not only those still assigned to the system), so
+  a run for an environment that was later UNASSIGNED shows the environment's
+  name instead of its raw id. An environment that was actually DELETED reads as
+  "Removed environment" rather than a UUID.
+- The overview environment pill is now a single shared primitive with
+  context-independent sizing, so pills render at the same size inside the "Old
+  checks" group as in the live list.
+- The "Recent Runs" table now stacks the absolute datetime over the relative
+  "x ago" string instead of hiding the datetime behind a hover tooltip, so the
+  exact time is readable at a glance.

--- a/core/healthcheck-frontend/src/components/EnvironmentPill.tsx
+++ b/core/healthcheck-frontend/src/components/EnvironmentPill.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Layers } from "lucide-react";
+
+/**
+ * The small environment chip shown next to a check name in the system overview.
+ * Sizing is fully self-contained (explicit font-size AND `leading-none`) so it
+ * renders identically regardless of the parent's text size — e.g. inside the
+ * `text-sm` "Old checks" accordion vs the base-size live list, which otherwise
+ * inherit different line-heights and make the pill taller in one context.
+ */
+export const EnvironmentPill: React.FC<{ label: string }> = ({ label }) => (
+  <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border/60 bg-surface-inset px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">
+    <Layers className="h-2.5 w-2.5" />
+    {label}
+  </span>
+);

--- a/core/healthcheck-frontend/src/components/HealthCheckDrawer.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckDrawer.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback } from "react";
 import { ExternalLink, Server } from "lucide-react";
 import { Satellite as SatelliteIcon } from "lucide-react";
 import {
-  CatalogApi,
   catalogAccess,
   catalogResourceTypes,
 } from "@checkstack/catalog-common";
@@ -61,6 +60,7 @@ import {
 } from "../auto-charts/baseline.logic";
 import { BaselineChipStack } from "../auto-charts/BaselineChips";
 import { useHealthCheckData } from "../hooks/useHealthCheckData";
+import { useEnvironmentLabels } from "../hooks/useEnvironmentLabels";
 import { AggregatedDataBanner } from "./AggregatedDataBanner";
 import { HealthCheckDiagramSlot } from "../slots";
 import {
@@ -137,15 +137,14 @@ export const HealthCheckDrawer: React.FC<HealthCheckDrawerProps> = ({
 }) => {
   const healthCheckClient = usePluginClient(HealthCheckApi);
   const satelliteClient = usePluginClient(SatelliteApi);
-  const catalogClient = usePluginClient(CatalogApi);
 
-  // Environments the system belongs to - resolves run.environmentId to a
-  // human-readable name in the run-history table (per-environment fan-out).
-  const { data: systemEnvironments = [] } =
-    catalogClient.getSystemEnvironments.useQuery(
-      { systemId },
-      { enabled: !!systemId },
-    );
+  // Resolve run.environmentId to a human-readable name in the run-history
+  // table. Uses ALL environments (not just those still assigned to the system)
+  // so runs for an unassigned environment show its name, not its raw id.
+  const {
+    environmentLabels,
+    isLoading: environmentLabelsLoading,
+  } = useEnvironmentLabels();
   const accessApi = useApi(accessApiRef);
   // Detailed run history is a MANAGER surface: global manage, a team grant on
   // THIS configuration, or manage access to THIS system (a system's owning
@@ -519,9 +518,9 @@ export const HealthCheckDrawer: React.FC<HealthCheckDrawerProps> = ({
 
               <HealthCheckRunsTable
                 runs={runs}
-                loading={historyLoading}
+                loading={historyLoading || environmentLabelsLoading}
                 emptyMessage={`No runs match the ${runsStatusFilter} filter.`}
-                environmentLabels={systemEnvironments}
+                environmentLabels={environmentLabels}
                 pagination={pagination}
                 selectedRunId={detailRunId}
                 onRowSelect={

--- a/core/healthcheck-frontend/src/components/HealthCheckOverviewRow.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckOverviewRow.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { cn } from "@checkstack/ui";
+import { EnvironmentPill } from "./EnvironmentPill";
+import { HealthCheckSparkline } from "./HealthCheckSparkline";
+import { HealthStatusPill } from "./HealthStatusPill";
+import {
+  countHealthy,
+  pausedToTone,
+  statusToLabel,
+  statusToTone,
+  toneStyles,
+  type StatusTone,
+} from "./healthcheckDisplay.logic";
+import type {
+  StateThresholds,
+  HealthCheckStatus,
+} from "@checkstack/healthcheck-common";
+
+export interface HealthCheckOverviewItem {
+  configurationId: string;
+  strategyId: string;
+  name: string;
+  state: HealthCheckStatus;
+  paused: boolean;
+  intervalSeconds: number;
+  lastRunAt?: Date;
+  stateThresholds?: StateThresholds;
+  recentStatusHistory: HealthCheckStatus[];
+  /**
+   * The environment this row is scoped to. `null` for an env-less run; a
+   * concrete string for a per-env row. `undefined` (absent) for the
+   * rollup-only shape the overview used prior to per-env flattening —
+   * signals the row is not env-scoped and should render without an env
+   * pill.
+   */
+  environmentId?: string | null;
+  /**
+   * Human-readable env name for an env-scoped row. The overview fetches the
+   * system's `getSystemEnvironments` and resolves the env id → name here so
+   * each row carries a stable operator-facing label.
+   */
+  environmentName?: string;
+  /**
+   * Stable per-row key: the check id for env-less / single-env rows, or
+   * `${configurationId}::${environmentId}` for a per-(check, env) row.
+   */
+  rowKey: string;
+  /**
+   * True when this row is a leftover env slice that no longer receives runs:
+   * either the env-less slice of a check that now fans out to environments, or
+   * a slice for an environment that has been removed from the system. Its
+   * history is preserved but the overview groups it under "Old checks" so it
+   * doesn't masquerade as a live check.
+   */
+  isOrphaned: boolean;
+}
+
+/**
+ * Compact relative time formatter that prevents layout shift.
+ * Returns fixed-width strings like "< 1m", "5m", "2h", "3d".
+ */
+export function formatCompactTime(date: Date | undefined): string {
+  if (!date) return "—";
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return "< 1m";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+/**
+ * A single health-check row in the system overview: status pill, name (with an
+ * env pill when the row is env-scoped), the recent-history hero figure,
+ * sparkline, and a compact last-run stamp. Shared between the live list and the
+ * collapsed "Old checks" group so both render identically.
+ */
+export const HealthCheckOverviewRow: React.FC<{
+  item: HealthCheckOverviewItem;
+  onSelect: (item: HealthCheckOverviewItem) => void;
+}> = ({ item, onSelect }) => {
+  const tone = statusToTone({ status: item.state });
+  const historyLength = item.recentStatusHistory.length;
+  const healthyCount = countHealthy({ history: item.recentStatusHistory });
+  // A paused check is dormant — render a "Paused" pill (unknown tone) instead
+  // of the run-evaluated status, since its stale runs are not a meaningful
+  // current verdict. The accent stripe and the healthy/total figure +
+  // sparkline still reflect the pre-pause history for context.
+  const displayTone = item.paused
+    ? (pausedToTone({ paused: true }) as StatusTone)
+    : tone;
+  const displayLabel = item.paused
+    ? "Paused"
+    : statusToLabel({ status: item.state });
+  // An env-scoped row carries the env name as a pill next to the check name.
+  // `null` is the env-less slice; `undefined` is the single-row rollup (no
+  // pill). A non-null env with no resolved name has been deleted from the
+  // catalog, so it reads as "Removed environment" rather than a raw id.
+  const envScoped =
+    item.environmentId !== undefined && item.environmentId !== null;
+  const envLabel =
+    item.environmentId === null
+      ? "No environment"
+      : (item.environmentName ?? "Removed environment");
+  return (
+    <button
+      className="group relative flex w-full items-center gap-3 py-3 pl-5 pr-4 text-left transition-colors hover:bg-surface-inset"
+      onClick={() => onSelect(item)}
+    >
+      {/* Status accent stripe: status by position + hue. */}
+      <span
+        className={cn(
+          "absolute inset-y-0 left-0 w-1",
+          toneStyles[displayTone].accent,
+        )}
+        aria-hidden
+      />
+
+      {/* Status pill + check name (with env pill when scoped) */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="truncate text-sm font-medium text-foreground">
+            {item.name}
+          </span>
+          {envScoped && <EnvironmentPill label={envLabel} />}
+        </div>
+        <HealthStatusPill
+          tone={displayTone}
+          label={displayLabel}
+          className="self-start"
+        />
+      </div>
+
+      {/* Recent-history hero figure */}
+      {historyLength > 0 && (
+        <div className="hidden shrink-0 text-right sm:block">
+          <span className="text-lg font-semibold leading-none tabular-nums text-foreground">
+            {healthyCount}/{historyLength}
+          </span>
+          <span className="mt-0.5 block text-[10px] uppercase tracking-wide text-muted-foreground">
+            healthy
+          </span>
+        </div>
+      )}
+
+      {/* Sparkline */}
+      {historyLength > 0 && (
+        <div className="hidden shrink-0 md:block">
+          <HealthCheckSparkline
+            runs={item.recentStatusHistory.map((status) => ({
+              status,
+            }))}
+          />
+        </div>
+      )}
+
+      {/* Last run — compact fixed-width to prevent shift */}
+      <span className="hidden w-10 shrink-0 text-right text-xs tabular-nums text-muted-foreground md:block">
+        {formatCompactTime(item.lastRunAt)}
+      </span>
+    </button>
+  );
+};

--- a/core/healthcheck-frontend/src/components/HealthCheckRunsTable.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckRunsTable.tsx
@@ -24,11 +24,32 @@ import {
   toneStyles,
 } from "./healthcheckDisplay.logic";
 
-export const RunTimestamp: React.FC<{ timestamp: Date }> = ({ timestamp }) => (
-  <span title={format(new Date(timestamp), "PPpp")}>
-    {formatDistanceToNow(new Date(timestamp), { addSuffix: true })}
-  </span>
-);
+/**
+ * Stacks the absolute datetime (primary line) over the relative "x ago" string
+ * (muted, secondary) so the exact time is visible at a glance instead of hidden
+ * behind a hover tooltip. The full-precision timestamp stays on `title` for the
+ * seconds/timezone detail.
+ */
+export const RunTimestamp: React.FC<{
+  timestamp: Date;
+  align?: "start" | "end";
+}> = ({ timestamp, align = "start" }) => {
+  const date = new Date(timestamp);
+  return (
+    <span
+      className={cn(
+        "flex flex-col leading-tight",
+        align === "end" ? "items-end" : "items-start",
+      )}
+      title={format(date, "PPpp")}
+    >
+      <span className="tabular-nums text-foreground">{format(date, "PPp")}</span>
+      <span className="text-xs text-muted-foreground">
+        {formatDistanceToNow(date, { addSuffix: true })}
+      </span>
+    </span>
+  );
+};
 
 /** Neutral metadata chip on surface tokens; the table's signal hue is reserved
  * for the remote/satellite source so the data reads consistently. */
@@ -44,7 +65,11 @@ export const RunEnvironmentChip: React.FC<{
   environmentId ? (
     <span className={NEUTRAL_CHIP}>
       <Layers className="h-3 w-3" />
-      {label ?? environmentId}
+      {/* A run's environment id with no resolved name is an environment that no
+          longer exists (deleted from the catalog). Callers resolve names from
+          ALL environments, so an unresolved id here means "deleted", not merely
+          "unassigned" — read it as such rather than dumping the raw id. */}
+      {label ?? "Removed environment"}
     </span>
   ) : (
     <span className="text-xs text-muted-foreground">None</span>
@@ -315,8 +340,8 @@ export const HealthCheckRunsTable: React.FC<HealthCheckRunsTableProps> = ({
                 tone={tone}
                 label={statusToLabel({ status: run.status })}
               />
-              <span className="text-right text-xs text-muted-foreground">
-                <RunTimestamp timestamp={run.timestamp} />
+              <span className="text-xs text-muted-foreground">
+                <RunTimestamp timestamp={run.timestamp} align="end" />
               </span>
             </div>
             {showFilterColumns && (

--- a/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
+++ b/core/healthcheck-frontend/src/components/HealthCheckSystemOverview.tsx
@@ -12,19 +12,17 @@ import {
   CardHeader,
   CardTitle,
   Button,
-  cn,
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
 } from "@checkstack/ui";
-import { Heart, Layers } from "lucide-react";
-import { HealthCheckSparkline } from "./HealthCheckSparkline";
-import { HealthStatusPill } from "./HealthStatusPill";
+import { Heart, Archive } from "lucide-react";
 import {
-  countHealthy,
-  pausedToTone,
-  statusToLabel,
-  statusToTone,
-  toneStyles,
-  type StatusTone,
-} from "./healthcheckDisplay.logic";
+  HealthCheckOverviewRow,
+  type HealthCheckOverviewItem,
+} from "./HealthCheckOverviewRow";
+import { buildOverviewRows } from "./overviewRows.logic";
 // Lazy-loaded: the drawer pulls in the full chart stack (timeline, latency,
 // auto-chart tiles). This component is an eagerly-registered slot extension,
 // so a static import would ship all of that in the initial bundle. The drawer
@@ -34,10 +32,7 @@ const HealthCheckDrawer = lazy(() =>
   import("./HealthCheckDrawer").then((m) => ({ default: m.HealthCheckDrawer })),
 );
 
-import type {
-  StateThresholds,
-  HealthCheckStatus,
-} from "@checkstack/healthcheck-common";
+import type { HealthCheckStatus } from "@checkstack/healthcheck-common";
 
 type HealthFilter = "all" | "failing" | "healthy";
 
@@ -68,53 +63,6 @@ function matchesFilter(
 
 type SlotProps = SlotContext<typeof SystemDetailsSlot>;
 
-/**
- * Compact relative time formatter that prevents layout shift.
- * Returns fixed-width strings like "< 1m", "5m", "2h", "3d".
- */
-function formatCompactTime(date: Date | undefined): string {
-  if (!date) return "—";
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 60) return "< 1m";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `${days}d`;
-}
-
-interface HealthCheckOverviewItem {
-  configurationId: string;
-  strategyId: string;
-  name: string;
-  state: HealthCheckStatus;
-  paused: boolean;
-  intervalSeconds: number;
-  lastRunAt?: Date;
-  stateThresholds?: StateThresholds;
-  recentStatusHistory: HealthCheckStatus[];
-  /**
-   * The environment this row is scoped to. `null` for an env-less run; a
-   * concrete string for a per-env row. `undefined` (absent) for the
-   * rollup-only shape the overview used prior to per-env flattening —
-   * signals the row is not env-scoped and should render without an env
-   * pill.
-   */
-  environmentId?: string | null;
-  /**
-   * Human-readable env name for an env-scoped row. The overview fetches the
-   * system's `getSystemEnvironments` and resolves the env id → name here so
-   * each row carries a stable operator-facing label.
-   */
-  environmentName?: string;
-  /**
-   * Stable per-row key: the check id for env-less / single-env rows, or
-   * `${configurationId}::${environmentId}` for a per-(check, env) row.
-   */
-  rowKey: string;
-}
-
 export function HealthCheckSystemOverview(props: SlotProps) {
   const systemId = props.system.id;
   const healthCheckClient = usePluginClient(HealthCheckApi);
@@ -132,90 +80,41 @@ export function HealthCheckSystemOverview(props: SlotProps) {
       systemId,
     });
 
-  // Resolve env names for env-qualified rows. Same query the drawer already
-  // issues, so the resulting cache entry is shared when both surfaces mount.
-  // Disabled when there is no systemId (can't happen here, but defensively
-  // typed so React Query doesn't fetch in a unit test).
-  const { data: systemEnvironments = [] } =
+  // Environments CURRENTLY ASSIGNED to this system — the source of truth for
+  // which env slices are still live (orphan detection). Same query the drawer
+  // issues, so the cache entry is shared when both surfaces mount. Disabled
+  // when there is no systemId (can't happen here, but defensively typed so
+  // React Query doesn't fetch in a unit test).
+  const { data: assignedEnvironments = [], isLoading: assignedEnvsLoading } =
     catalogClient.getSystemEnvironments.useQuery(
       { systemId },
       { enabled: !!systemId },
     );
+  // ALL environments in the instance — used only to resolve display names, so a
+  // check for an environment that was UNASSIGNED (but still exists) shows the
+  // environment's name instead of its raw id. A truly DELETED environment isn't
+  // here and falls back to a "Removed environment" label in the row.
+  const { data: allEnvironments = [], isLoading: allEnvsLoading } =
+    catalogClient.listEnvironments.useQuery();
   const envNameById = React.useMemo(
-    () => new Map(systemEnvironments.map((e) => [e.id, e.name])),
-    [systemEnvironments],
+    () => new Map(allEnvironments.map((e) => [e.id, e.name])),
+    [allEnvironments],
   );
 
   // Transform API response to component format. Flatten into one row per
-  // (check, environment) when an assignment fans out to multiple envs —
-  // surfacing per-env outages the rollup intentionally hides in the aggregate
-  // view. Single-env / env-less assignments stay one row (the pre-flattening
-  // shape). Each row opens the same check-level drawer; the env context is
-  // just a label so the operator sees which environment this row's status
-  // is scoped to.
-  const overview: HealthCheckOverviewItem[] = React.useMemo(() => {
-    if (!overviewData) return [];
-    const rows: HealthCheckOverviewItem[] = [];
-    for (const check of overviewData.checks) {
-      const stateThresholds = check.stateThresholds;
-      const checkLastRunAt = check.recentRuns.at(-1)?.timestamp
-        ? new Date(check.recentRuns.at(-1)!.timestamp)
-        : undefined;
-      const checkRecentStatusHistory = check.recentRuns.map((r) => r.status);
-
-      const perEnv = check.perEnvironment;
-      if (!perEnv || perEnv.length <= 1) {
-        // Single-env / env-less: keep the historical single-row shape. The
-        // row is the rollup for this check (worst-wins across envs, which
-        // equals the per-env status when there's only one env).
-        rows.push({
-          rowKey: check.configurationId,
-          configurationId: check.configurationId,
-          strategyId: check.strategyId,
-          name: check.configurationName,
-          state: check.status,
-          paused: check.paused,
-          intervalSeconds: check.intervalSeconds,
-          lastRunAt: checkLastRunAt,
-          stateThresholds,
-          recentStatusHistory: checkRecentStatusHistory,
-        });
-        continue;
-      }
-      // Multi-env: one row per environment. Each row carries the env id +
-      // the resolved env name (rendered as a pill next to the check name),
-      // the per-env status, the per-env sparkline, and the per-env last
-      // run. `state` here is the per-env rollup, so the failing/healthy
-      // filter applies per env — one failing env shows up under "failing"
-      // while its healthy sibling doesn't. Clicking any env row opens the
-      // drawer for the whole check (the drawer still aggregates envs in
-      // its history table; this UI is the disambiguation surface).
-      for (const pe of perEnv) {
-        const environmentId = pe.environmentId;
-        const envName =
-          environmentId === null
-            ? undefined
-            : (envNameById.get(environmentId) ?? environmentId);
-        rows.push({
-          rowKey: `${check.configurationId}::${environmentId ?? "<none>"}`,
-          configurationId: check.configurationId,
-          strategyId: check.strategyId,
-          name: check.configurationName,
-          state: pe.status,
-          paused: check.paused,
-          intervalSeconds: check.intervalSeconds,
-          lastRunAt: pe.recentRuns.at(-1)?.timestamp
-            ? new Date(pe.recentRuns.at(-1)!.timestamp)
-            : undefined,
-          stateThresholds,
-          recentStatusHistory: pe.recentRuns.map((r) => r.status),
-          environmentId,
-          environmentName: envName,
-        });
-      }
-    }
-    return rows;
-  }, [overviewData, envNameById]);
+  // (check, environment), tagging leftover env slices as orphaned so they can
+  // be grouped under "Old checks". See buildOverviewRows for the rules.
+  const overview = React.useMemo(
+    () =>
+      overviewData
+        ? buildOverviewRows({
+            checks: overviewData.checks,
+            environmentIds: assignedEnvironments.map((e) => e.id),
+            envNameById,
+          })
+        : [],
+    [overviewData, envNameById, assignedEnvironments],
+  );
 
   const visible = React.useMemo(
     () =>
@@ -223,6 +122,17 @@ export function HealthCheckSystemOverview(props: SlotProps) {
         matchesFilter(item.state, filter, item.paused),
       ),
     [overview, filter],
+  );
+
+  // Partition into live checks and the "Old checks" group. Both respect the
+  // active health filter so a stale slice can't slip past it.
+  const currentRows = React.useMemo(
+    () => visible.filter((r) => !r.isOrphaned),
+    [visible],
+  );
+  const oldRows = React.useMemo(
+    () => visible.filter((r) => r.isOrphaned),
+    [visible],
   );
 
   const setFilter = (next: HealthFilter) => {
@@ -235,7 +145,10 @@ export function HealthCheckSystemOverview(props: SlotProps) {
     setSearchParams(params, { replace: true });
   };
 
-  if (initialLoading) {
+  // Wait for the environment data too: assigned envs decide orphan grouping and
+  // the full list decides display names, so rendering before they resolve would
+  // flash live checks into "Old checks" or mislabel envs as "Removed".
+  if (initialLoading || assignedEnvsLoading || allEnvsLoading) {
     return <LoadingSpinner />;
   }
 
@@ -279,105 +192,68 @@ export function HealthCheckSystemOverview(props: SlotProps) {
           </div>
         </CardHeader>
         <CardContent className="p-0">
-          {visible.length === 0 ? (
+          {currentRows.length === 0 && oldRows.length === 0 ? (
             <div className="px-4 py-6 text-center text-xs text-muted-foreground">
               No health checks match the{" "}
               <span className="font-medium">{filter}</span> filter.
             </div>
           ) : (
-            <div className="divide-y divide-border/60">
-              {visible.map((item) => {
-                const tone = statusToTone({ status: item.state });
-                const historyLength = item.recentStatusHistory.length;
-                const healthyCount = countHealthy({
-                  history: item.recentStatusHistory,
-                });
-                // A paused check is dormant — render a "Paused" pill (unknown
-                // tone) instead of the run-evaluated status, since its stale
-                // runs are not a meaningful current verdict. The accent stripe
-                // and the healthy/total figure + sparkline still reflect the
-                // pre-pause history for context.
-                const displayTone = item.paused
-                  ? (pausedToTone({ paused: true }) as StatusTone)
-                  : tone;
-                const displayLabel = item.paused
-                  ? "Paused"
-                  : statusToLabel({ status: item.state });
-                // An env-scoped row carries the env name as a pill next to
-                // the check name. `null` is the env-less slice; `undefined`
-                // is the single-row rollup (no pill).
-                const envScoped =
-                  item.environmentId !== undefined && item.environmentId !== null;
-                const envLabel =
-                  item.environmentId === null
-                    ? "No environment"
-                    : (item.environmentName ?? item.environmentId ?? "");
-                return (
-                  <button
-                    key={item.rowKey}
-                    className="group relative flex w-full items-center gap-3 py-3 pl-5 pr-4 text-left transition-colors hover:bg-surface-inset"
-                    onClick={() => setSelectedCheck(item)}
-                  >
-                    {/* Status accent stripe: status by position + hue. */}
-                    <span
-                      className={cn(
-                        "absolute inset-y-0 left-0 w-1",
-                        toneStyles[displayTone].accent,
-                      )}
-                      aria-hidden
+            <>
+              {currentRows.length > 0 ? (
+                <div className="divide-y divide-border/60">
+                  {currentRows.map((item) => (
+                    <HealthCheckOverviewRow
+                      key={item.rowKey}
+                      item={item}
+                      onSelect={setSelectedCheck}
                     />
+                  ))}
+                </div>
+              ) : (
+                <div className="px-4 py-6 text-center text-xs text-muted-foreground">
+                  No current health checks match the{" "}
+                  <span className="font-medium">{filter}</span> filter.
+                </div>
+              )}
 
-                    {/* Status pill + check name (with env pill when scoped) */}
-                    <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <span className="truncate text-sm font-medium text-foreground">
-                          {item.name}
+              {/* Orphaned slices (removed environments, or env-less leftovers of
+                  a now-fanned-out check) are tucked into a collapsed group so
+                  they keep their history without cluttering the live list. */}
+              {oldRows.length > 0 && (
+                <Accordion type="single" collapsible>
+                  <AccordionItem
+                    value="old-checks"
+                    className="border-b-0 border-t border-border/60"
+                  >
+                    <AccordionTrigger className="px-5 py-3 text-xs font-medium text-muted-foreground hover:no-underline">
+                      <span className="flex items-center gap-2">
+                        <Archive className="h-3.5 w-3.5" />
+                        Old checks
+                        <span className="rounded-full bg-surface-inset px-1.5 py-0.5 text-[10px] tabular-nums text-muted-foreground">
+                          {oldRows.length}
                         </span>
-                        {envScoped && (
-                          <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border/60 bg-surface-inset px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                            <Layers className="h-2.5 w-2.5" />
-                            {envLabel}
-                          </span>
-                        )}
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="p-0">
+                      <p className="px-5 pb-3 text-xs text-muted-foreground">
+                        These checks ran for environments that were removed, or
+                        before this system used environments. Their history is
+                        kept, but they no longer receive updates.
+                      </p>
+                      <div className="divide-y divide-border/60 border-t border-border/60">
+                        {oldRows.map((item) => (
+                          <HealthCheckOverviewRow
+                            key={item.rowKey}
+                            item={item}
+                            onSelect={setSelectedCheck}
+                          />
+                        ))}
                       </div>
-                      <HealthStatusPill
-                        tone={displayTone}
-                        label={displayLabel}
-                        className="self-start"
-                      />
-                    </div>
-
-                    {/* Recent-history hero figure */}
-                    {historyLength > 0 && (
-                      <div className="hidden shrink-0 text-right sm:block">
-                        <span className="text-lg font-semibold leading-none tabular-nums text-foreground">
-                          {healthyCount}/{historyLength}
-                        </span>
-                        <span className="mt-0.5 block text-[10px] uppercase tracking-wide text-muted-foreground">
-                          healthy
-                        </span>
-                      </div>
-                    )}
-
-                    {/* Sparkline */}
-                    {historyLength > 0 && (
-                      <div className="hidden shrink-0 md:block">
-                        <HealthCheckSparkline
-                          runs={item.recentStatusHistory.map((status) => ({
-                            status,
-                          }))}
-                        />
-                      </div>
-                    )}
-
-                    {/* Last run — compact fixed-width to prevent shift */}
-                    <span className="hidden w-10 shrink-0 text-right text-xs tabular-nums text-muted-foreground md:block">
-                      {formatCompactTime(item.lastRunAt)}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+              )}
+            </>
           )}
         </CardContent>
       </div>

--- a/core/healthcheck-frontend/src/components/overviewRows.logic.test.ts
+++ b/core/healthcheck-frontend/src/components/overviewRows.logic.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "bun:test";
+import {
+  buildOverviewRows,
+  type OverviewCheckLike,
+} from "./overviewRows.logic";
+
+const ts = "2026-07-03T12:00:00.000Z";
+
+function run(status: "healthy" | "unhealthy" | "degraded" = "healthy") {
+  return { status, timestamp: ts };
+}
+
+/** A check with a fixed identity; per-env slices are supplied per test. */
+function check(
+  overrides: Partial<OverviewCheckLike> = {},
+): OverviewCheckLike {
+  return {
+    configurationId: "cfg-1",
+    strategyId: "http",
+    configurationName: "API check",
+    status: "healthy",
+    paused: false,
+    intervalSeconds: 60,
+    recentRuns: [run()],
+    ...overrides,
+  };
+}
+
+const noEnvNames = new Map<string, string>();
+
+describe("buildOverviewRows – orphan detection", () => {
+  it("keeps a plain env-less check (no environments) live", () => {
+    const rows = buildOverviewRows({
+      checks: [check({ perEnvironment: [{ environmentId: null, status: "healthy", recentRuns: [run()] }] })],
+      environmentIds: [],
+      envNameById: noEnvNames,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].isOrphaned).toBe(false);
+    // No pill for a live single-row rollup.
+    expect(rows[0].environmentId).toBeUndefined();
+  });
+
+  it("keeps an opt-out env-less check live even when the system has environments", () => {
+    // Only a null slice (opt-out) => the check does not fan out => env-less is live.
+    const rows = buildOverviewRows({
+      checks: [check({ perEnvironment: [{ environmentId: null, status: "healthy", recentRuns: [run()] }] })],
+      environmentIds: ["env-prod", "env-staging"],
+      envNameById: new Map([["env-prod", "Production"]]),
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].isOrphaned).toBe(false);
+  });
+
+  it("case 1: env-less leftover of a now-fanned-out check is orphaned", () => {
+    const rows = buildOverviewRows({
+      checks: [
+        check({
+          perEnvironment: [
+            { environmentId: null, status: "healthy", recentRuns: [run()] },
+            { environmentId: "env-prod", status: "healthy", recentRuns: [run()] },
+          ],
+        }),
+      ],
+      environmentIds: ["env-prod"],
+      envNameById: new Map([["env-prod", "Production"]]),
+    });
+    const nullRow = rows.find((r) => r.environmentId === null);
+    const prodRow = rows.find((r) => r.environmentId === "env-prod");
+    expect(nullRow?.isOrphaned).toBe(true);
+    expect(prodRow?.isOrphaned).toBe(false);
+    expect(prodRow?.environmentName).toBe("Production");
+  });
+
+  it("case 2: all environments removed – env-less slice is live, old env slices are orphaned", () => {
+    const rows = buildOverviewRows({
+      checks: [
+        check({
+          perEnvironment: [
+            { environmentId: null, status: "healthy", recentRuns: [run()] },
+            { environmentId: "env-prod", status: "unhealthy", recentRuns: [run("unhealthy")] },
+            { environmentId: "env-staging", status: "healthy", recentRuns: [run()] },
+          ],
+        }),
+      ],
+      environmentIds: [], // every environment removed from the system
+      envNameById: noEnvNames,
+    });
+    const nullRow = rows.find((r) => r.environmentId === null);
+    const prodRow = rows.find((r) => r.environmentId === "env-prod");
+    const stagingRow = rows.find((r) => r.environmentId === "env-staging");
+    expect(nullRow?.isOrphaned).toBe(false); // live env-less shape again
+    expect(prodRow?.isOrphaned).toBe(true);
+    expect(stagingRow?.isOrphaned).toBe(true);
+  });
+
+  it("case 3: a single removed environment is orphaned while the surviving one stays live", () => {
+    const rows = buildOverviewRows({
+      checks: [
+        check({
+          perEnvironment: [
+            { environmentId: "env-prod", status: "healthy", recentRuns: [run()] },
+            { environmentId: "env-legacy", status: "healthy", recentRuns: [run()] },
+          ],
+        }),
+      ],
+      environmentIds: ["env-prod"], // env-legacy was removed
+      envNameById: new Map([["env-prod", "Production"]]),
+    });
+    const prodRow = rows.find((r) => r.environmentId === "env-prod");
+    const legacyRow = rows.find((r) => r.environmentId === "env-legacy");
+    expect(prodRow?.isOrphaned).toBe(false);
+    expect(legacyRow?.isOrphaned).toBe(true);
+  });
+
+  it("resolves the name of an unassigned-but-still-existing environment", () => {
+    // The env is no longer assigned to the system (so it's orphaned), but still
+    // exists in the catalog, so its NAME must resolve from the all-envs map.
+    const rows = buildOverviewRows({
+      checks: [
+        check({
+          perEnvironment: [
+            { environmentId: "env-prod", status: "healthy", recentRuns: [run()] },
+            { environmentId: "env-staging", status: "healthy", recentRuns: [run()] },
+          ],
+        }),
+      ],
+      environmentIds: ["env-prod"], // staging unassigned but not deleted
+      envNameById: new Map([
+        ["env-prod", "Production"],
+        ["env-staging", "Staging"],
+      ]),
+    });
+    const staging = rows.find((r) => r.environmentId === "env-staging");
+    expect(staging?.isOrphaned).toBe(true);
+    expect(staging?.environmentName).toBe("Staging");
+  });
+
+  it("leaves a deleted environment's name unresolved (row renders 'Removed environment')", () => {
+    // Only one slice, for an environment that no longer exists in the catalog
+    // (deleted, not merely unassigned). It should be orphaned and carry the id,
+    // but with no resolved name so the row can label it "Removed environment".
+    const rows = buildOverviewRows({
+      checks: [
+        check({
+          perEnvironment: [{ environmentId: "env-deleted", status: "healthy", recentRuns: [run()] }],
+        }),
+      ],
+      environmentIds: ["env-prod"],
+      envNameById: noEnvNames, // deleted env absent from the all-envs map
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].isOrphaned).toBe(true);
+    expect(rows[0].environmentId).toBe("env-deleted");
+    expect(rows[0].environmentName).toBeUndefined();
+  });
+
+  it("keeps a lone current-environment slice live without a pill", () => {
+    const rows = buildOverviewRows({
+      checks: [
+        check({
+          perEnvironment: [{ environmentId: "env-prod", status: "healthy", recentRuns: [run()] }],
+        }),
+      ],
+      environmentIds: ["env-prod"],
+      envNameById: new Map([["env-prod", "Production"]]),
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].isOrphaned).toBe(false);
+    expect(rows[0].environmentId).toBeUndefined();
+  });
+
+  it("treats a check with no perEnvironment data as a live rollup row", () => {
+    const rows = buildOverviewRows({
+      checks: [check({ perEnvironment: undefined })],
+      environmentIds: ["env-prod"],
+      envNameById: noEnvNames,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].isOrphaned).toBe(false);
+  });
+});

--- a/core/healthcheck-frontend/src/components/overviewRows.logic.ts
+++ b/core/healthcheck-frontend/src/components/overviewRows.logic.ts
@@ -1,0 +1,160 @@
+import type {
+  StateThresholds,
+  HealthCheckStatus,
+} from "@checkstack/healthcheck-common";
+import type { HealthCheckOverviewItem } from "./HealthCheckOverviewRow";
+
+/**
+ * Minimal structural shapes of the `getSystemHealthOverview` response consumed
+ * by the row builder. Declared locally (rather than importing the full RPC
+ * output type) so the pure logic is trivially unit-testable — the real client
+ * data is structurally assignable to these.
+ */
+export interface OverviewRunLike {
+  status: HealthCheckStatus;
+  timestamp: Date | string;
+}
+
+export interface OverviewPerEnvLike {
+  environmentId: string | null;
+  status: HealthCheckStatus;
+  recentRuns: OverviewRunLike[];
+}
+
+export interface OverviewCheckLike {
+  configurationId: string;
+  strategyId: string;
+  configurationName: string;
+  status: HealthCheckStatus;
+  paused: boolean;
+  intervalSeconds: number;
+  stateThresholds?: StateThresholds;
+  recentRuns: OverviewRunLike[];
+  perEnvironment?: OverviewPerEnvLike[];
+}
+
+function lastRunAt(runs: OverviewRunLike[]): Date | undefined {
+  const last = runs.at(-1)?.timestamp;
+  return last ? new Date(last) : undefined;
+}
+
+/**
+ * A slice is orphaned (old) when it no longer receives runs: a concrete
+ * environment that is no longer part of the system, or the env-less (`null`)
+ * slice of a check that currently fans out to a live environment.
+ */
+function isSliceOrphaned({
+  environmentId,
+  currentEnvIds,
+  hasLiveEnvSlice,
+}: {
+  environmentId: string | null;
+  currentEnvIds: Set<string>;
+  hasLiveEnvSlice: boolean;
+}): boolean {
+  return environmentId === null
+    ? hasLiveEnvSlice
+    : !currentEnvIds.has(environmentId);
+}
+
+/**
+ * Flattens the system-health overview into one row per (check, environment),
+ * tagging each row's `isOrphaned` state.
+ *
+ * A slice is "orphaned" (old) when it no longer receives runs:
+ * - a concrete environment that is no longer part of the system (removed, or
+ *   all environments removed), or
+ * - the env-less (`null`) slice of a check that currently fans out to real
+ *   environments (was env-less before environments were added).
+ *
+ * The env-less slice is the ambiguous one: it is live when the check does NOT
+ * currently fan out (opt-out, or the system has no environments so runs are
+ * env-less again), and stale only when the check DOES fan out to an environment
+ * the system still has. `hasLiveEnvSlice` is exactly that disambiguator.
+ */
+export function buildOverviewRows({
+  checks,
+  environmentIds,
+  envNameById,
+}: {
+  checks: OverviewCheckLike[];
+  environmentIds: string[];
+  envNameById: Map<string, string>;
+}): HealthCheckOverviewItem[] {
+  const currentEnvIds = new Set(environmentIds);
+  const rows: HealthCheckOverviewItem[] = [];
+
+  for (const check of checks) {
+    const stateThresholds = check.stateThresholds;
+    const perEnv = check.perEnvironment;
+
+    const hasLiveEnvSlice = (perEnv ?? []).some(
+      (pe) => pe.environmentId !== null && currentEnvIds.has(pe.environmentId),
+    );
+
+    if (!perEnv || perEnv.length <= 1) {
+      // Single-env / env-less: keep the historical single-row shape (the
+      // check-level rollup). Surface the env pill only when this lone slice
+      // is an orphaned, now-removed environment so the operator sees which
+      // env it was.
+      const only = perEnv?.[0];
+      const environmentId = only ? only.environmentId : undefined;
+      const orphaned =
+        environmentId !== undefined &&
+        isSliceOrphaned({ environmentId, currentEnvIds, hasLiveEnvSlice });
+      rows.push({
+        rowKey: check.configurationId,
+        configurationId: check.configurationId,
+        strategyId: check.strategyId,
+        name: check.configurationName,
+        state: check.status,
+        paused: check.paused,
+        intervalSeconds: check.intervalSeconds,
+        lastRunAt: lastRunAt(check.recentRuns),
+        stateThresholds,
+        recentStatusHistory: check.recentRuns.map((r) => r.status),
+        environmentId: orphaned ? environmentId : undefined,
+        // Left undefined when the env can't be resolved (deleted) so the row
+        // renders a "Removed environment" label rather than a raw id.
+        environmentName:
+          orphaned && environmentId
+            ? envNameById.get(environmentId)
+            : undefined,
+        isOrphaned: orphaned,
+      });
+      continue;
+    }
+
+    // Multi-env: one row per environment. `state` is the per-env rollup, so
+    // the failing/healthy filter applies per env. Clicking any row opens the
+    // drawer for the whole check.
+    for (const pe of perEnv) {
+      const environmentId = pe.environmentId;
+      // Undefined for the env-less slice or an unresolvable (deleted) env; the
+      // row turns the latter into a "Removed environment" label.
+      const envName =
+        environmentId === null ? undefined : envNameById.get(environmentId);
+      rows.push({
+        rowKey: `${check.configurationId}::${environmentId ?? "<none>"}`,
+        configurationId: check.configurationId,
+        strategyId: check.strategyId,
+        name: check.configurationName,
+        state: pe.status,
+        paused: check.paused,
+        intervalSeconds: check.intervalSeconds,
+        lastRunAt: lastRunAt(pe.recentRuns),
+        stateThresholds,
+        recentStatusHistory: pe.recentRuns.map((r) => r.status),
+        environmentId,
+        environmentName: envName,
+        isOrphaned: isSliceOrphaned({
+          environmentId,
+          currentEnvIds,
+          hasLiveEnvSlice,
+        }),
+      });
+    }
+  }
+
+  return rows;
+}

--- a/core/healthcheck-frontend/src/hooks/useEnvironmentLabels.ts
+++ b/core/healthcheck-frontend/src/hooks/useEnvironmentLabels.ts
@@ -1,0 +1,23 @@
+import { usePluginClient } from "@checkstack/frontend-api";
+import { CatalogApi } from "@checkstack/catalog-common";
+import type { EnvironmentLabel } from "../components/HealthCheckRunsTable";
+
+/**
+ * Resolves display names for run-row environment pills from ALL environments in
+ * the instance, not just those currently assigned to a system. A run recorded
+ * for an environment that was later UNASSIGNED still shows the environment's
+ * name instead of its raw id; a truly DELETED environment isn't returned here,
+ * so the run chip falls back to a "Removed environment" label.
+ *
+ * `isLoading` lets callers hold the run list until names are ready, so a
+ * still-loading environment can't briefly render as "Removed environment".
+ */
+export function useEnvironmentLabels(): {
+  environmentLabels: EnvironmentLabel[];
+  isLoading: boolean;
+} {
+  const catalogClient = usePluginClient(CatalogApi);
+  const { data: environments = [], isLoading } =
+    catalogClient.listEnvironments.useQuery();
+  return { environmentLabels: environments, isLoading };
+}

--- a/core/healthcheck-frontend/src/pages/HealthCheckHistoryDetailPage.tsx
+++ b/core/healthcheck-frontend/src/pages/HealthCheckHistoryDetailPage.tsx
@@ -14,7 +14,7 @@ import {
   HealthCheckConfigDetailsSlot,
   DEFAULT_RETENTION_CONFIG,
 } from "@checkstack/healthcheck-common";
-import { catalogResourceTypes, CatalogApi } from "@checkstack/catalog-common";
+import { catalogResourceTypes } from "@checkstack/catalog-common";
 import { SatelliteApi } from "@checkstack/satellite-common";
 import { resolveRoute } from "@checkstack/common";
 import {
@@ -45,6 +45,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { History, MousePointerClick } from "lucide-react";
 import { type HealthCheckRunDetailed } from "../components/HealthCheckRunsTable";
 import { RunHistoryList } from "../components/RunHistoryList";
+import { useEnvironmentLabels } from "../hooks/useEnvironmentLabels";
 import { RunDetailPanel } from "../components/RunDetailPanel";
 import {
   StatusFilterPills,
@@ -70,7 +71,6 @@ const HealthCheckHistoryDetailPageContent = () => {
   const navigate = useNavigate();
   const healthCheckClient = usePluginClient(HealthCheckApi);
   const satelliteClient = usePluginClient(SatelliteApi);
-  const catalogClient = usePluginClient(CatalogApi);
   const accessApi = useApi(accessApiRef);
   const isMobile = useIsMobile();
   const { isLowPower } = usePerformance();
@@ -96,12 +96,13 @@ const HealthCheckHistoryDetailPageContent = () => {
   const { data: satellitesData } = satelliteClient.listSatellites.useQuery({});
   const satellites = satellitesData?.satellites ?? [];
 
-  // Environment names for the run rows (per-environment fan-out).
-  const { data: systemEnvironments = [] } =
-    catalogClient.getSystemEnvironments.useQuery(
-      { systemId: systemId! },
-      { enabled: !!systemId },
-    );
+  // Environment names for the run rows (per-environment fan-out). Uses ALL
+  // environments (not just those still assigned to the system) so a run for an
+  // unassigned environment shows its name instead of its raw id.
+  const {
+    environmentLabels,
+    isLoading: environmentLabelsLoading,
+  } = useEnvironmentLabels();
 
   // Fetch configurations to get strategyId
   const { data: configurations } = healthCheckClient.getConfigurations.useQuery(
@@ -345,9 +346,9 @@ const HealthCheckHistoryDetailPageContent = () => {
               selectedRunId={runId}
               onSelectRun={({ runId: nextRunId }) => selectRun(nextRunId)}
               onKeyNavigate={({ direction }) => handleAdjacent(direction)}
-              loading={isLoading}
+              loading={isLoading || environmentLabelsLoading}
               isStale={isStale}
-              environmentLabels={systemEnvironments}
+              environmentLabels={environmentLabels}
               emptyMessage={emptyMessage}
               className="min-h-0 flex-1 max-md:h-[60vh]"
             />


### PR DESCRIPTION
## Summary

Polish for the health-check system overview and run-history surfaces, from three rounds of user feedback.

### 1. "Old checks" grouping (orphaned env slices)
When a system's environments change, a check can be left with slices that no longer receive runs. These now render in a **collapsed "Old checks"** disclosure instead of masquerading as live checks. Their history is preserved. Detected cases:
- the env-less leftover of a check that has since fanned out to environments,
- a slice for an environment that was **removed** from the system,
- the case where **all** environments are removed (the env-less slice becomes live again; the old per-env slices become old).

Opt-out ("none") env-less checks and plain no-environment checks correctly stay live. Detection uses the system's current catalog environments as the source of truth and is extracted into a pure, unit-tested module (`overviewRows.logic.ts`, 9 tests).

### 2. Environment name resolution for old runs
Environment pills resolved names only from environments **currently assigned** to a system, so a run for a later-**unassigned** environment showed its raw id. Names are now resolved from **all** environments (`listEnvironments`) across the overview, the drawer's Recent Runs, and the Run History page (new shared `useEnvironmentLabels` hook). An environment that was actually **deleted** reads as **"Removed environment"** rather than a UUID. Run lists gate their loading on the labels so a still-loading env can't briefly flash as "Removed".

### 3. Stacked run timestamps
The "Recent Runs" table now stacks the absolute datetime over the relative "x ago" string, instead of hiding the datetime behind a hover tooltip.

### 4. Unified environment pill
Extracted a single `EnvironmentPill` primitive with context-independent sizing, so pills render at the same size inside the "Old checks" group as in the live list.

## Note on run-detail permissions (no code change)
A related report - a system "manager" unable to see run details / charts - was investigated and is **not** a code bug: detailed charts and run details are deliberately gated on `catalog.system` **manage** (editor/owner), while the overview and Recent Runs table are gated on **read** (viewer). The affected user holds a read-only (viewer) grant. Fix is to grant that team **Manage** on the system (or set it as the owning team). Left as-is per decision.

## Testing
- `bun run lint` - clean
- `bun run typecheck` - clean
- `bun test overviewRows.logic.test.ts` - 9 pass

## Docs
No public API / schema / contract change; frontend-only UI. No docs update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaGbNufbgngS1uhFT5oKjd