### PR TITLE
fix(docs): restore light-mode theme on the docs site

### DIFF
--- a/docs/src/styles/checkstack.css
+++ b/docs/src/styles/checkstack.css
@@ -8,29 +8,15 @@
  * code blocks, subtle borders.
  */
 
+/* Base ramp = DARK theme, matching Starlight's own dark-first `:root`. This
+ * file is injected UNLAYERED via `customCss`, so every token here beats
+ * Starlight's `@layer starlight.base` rules regardless of specificity. That is
+ * why the gray ramp / white / black MUST be split per theme below: a single
+ * unqualified `:root` (as this file previously had) would clobber Starlight's
+ * `:root[data-theme='light']` in light mode and leave the page background
+ * (`--sl-color-bg: var(--sl-color-black)`) and every gray surface dark. */
 :root {
-  /* Checkstack purple ramp (light mode) */
-  --sl-color-accent-low: #ede9fe;
-  --sl-color-accent: #7c3aed;
-  --sl-color-accent-high: #4c1d95;
-
-  --sl-color-white: #ffffff;
-  --sl-color-gray-1: #f4f4f5;
-  --sl-color-gray-2: #e4e4e7;
-  --sl-color-gray-3: #a1a1aa;
-  --sl-color-gray-4: #71717a;
-  --sl-color-gray-5: #52525b;
-  --sl-color-gray-6: #27272a;
-  --sl-color-gray-7: #18181b;
-  --sl-color-black: #09090b;
-
-  --sl-font: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", Roboto, sans-serif;
-  --sl-font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo,
-    Consolas, monospace;
-}
-
-:root[data-theme="dark"] {
+  /* Checkstack purple accent (dark mode) */
   --sl-color-accent-low: #2e1065;
   --sl-color-accent: #a78bfa;
   --sl-color-accent-high: #ede9fe;
@@ -44,6 +30,31 @@
   --sl-color-gray-6: #18181b;
   --sl-color-gray-7: #0e0e10;
   --sl-color-black: #09090b;
+
+  --sl-font: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, sans-serif;
+  --sl-font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo,
+    Consolas, monospace;
+}
+
+/* Light theme: the inverted zinc ramp (dark text on light surfaces), mirroring
+ * how Starlight's own `[data-theme='light']` flips its ramp. Because this block
+ * is also unlayered, it wins over both the base `:root` above and Starlight's
+ * layered light rules, so the background and surfaces read light. */
+:root[data-theme="light"] {
+  --sl-color-accent-low: #ede9fe;
+  --sl-color-accent: #7c3aed;
+  --sl-color-accent-high: #4c1d95;
+
+  --sl-color-white: #18181b;
+  --sl-color-gray-1: #27272a;
+  --sl-color-gray-2: #3f3f46;
+  --sl-color-gray-3: #52525b;
+  --sl-color-gray-4: #71717a;
+  --sl-color-gray-5: #d4d4d8;
+  --sl-color-gray-6: #e4e4e7;
+  --sl-color-gray-7: #f4f4f5;
+  --sl-color-black: #ffffff;
 }
 
 /* Slightly tighter heading rhythm and a subtle accent bar on H1, matching


### PR DESCRIPTION
## Problem

Light mode on the documentation site rendered with a dark background, making code, links, and environment-variable text hard to read without switching to dark mode.

## Root cause

`docs/src/styles/checkstack.css` is injected **unlayered** via Starlight's `customCss`. Unlayered rules beat any `@layer` rule regardless of specificity, so this file's token overrides win over Starlight's own `@layer starlight.base` definitions.

The file defined the gray ramp plus `--sl-color-white` / `--sl-color-black` in a single **unqualified** `:root` block (dark values, no `data-theme`). Those dark values therefore applied in *every* theme and clobbered Starlight's `:root[data-theme='light']` palette. Since the page background resolves to `--sl-color-bg: var(--sl-color-black)`, light mode kept a dark background and dark surfaces. The stylesheet never defined a light palette at all.

## Fix

Split the ramp per theme, mirroring Starlight's own dark-first structure:

- Base `:root` now carries the **dark** palette (identical values to the previous `[data-theme="dark"]` block, so **dark mode is byte-for-byte unchanged**).
- A new `:root[data-theme="light"]` block supplies the **inverted light** palette (dark text on light surfaces). Being unlayered too, it wins in light mode, so the background and surfaces render light again.

## Verification

- Verified visually via `astro dev`: light mode now has a light background with readable code, links, and inline env-var text; dark mode is unchanged.

## Notes

Docs-styling-only change (no package versioned, no content under `docs/src/content/docs/` touched), so no changeset and no docs-index regeneration are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tB8vZmB9gDDpf285XoeLy