### PR TITLE
test(healthcheck): real-Redis coverage for BullMQ recurring jobs + reconciler

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1119,6 +1119,7 @@
         "@checkstack/tsconfig": "workspace:*",
         "@types/bun": "^1.0.0",
         "@types/tdigest": "^0.1.5",
+        "bullmq": "^5.66.4",
         "date-fns": "^4.4.0",
         "drizzle-kit": "^0.31.10",
         "typescript": "^5.0.0",

--- a/core/healthcheck-backend/package.json
+++ b/core/healthcheck-backend/package.json
@@ -57,6 +57,7 @@
     "@checkstack/tsconfig": "workspace:*",
     "@types/bun": "^1.0.0",
     "@types/tdigest": "^0.1.5",
+    "bullmq": "^5.66.4",
     "date-fns": "^4.4.0",
     "drizzle-kit": "^0.31.10",
     "typescript": "^5.0.0"

--- a/core/healthcheck-backend/src/schedule-reconciler.it.test.ts
+++ b/core/healthcheck-backend/src/schedule-reconciler.it.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Integration test (real Redis / BullMQ) for `reconcileHealthCheckJobs`.
+ *
+ * The reconciler's decisions are DATA-DRIVEN by what it reads back from the
+ * queue: `listRecurringJobs()` + `getRecurringJobDetails()` feed `planReconcile`,
+ * which then schedules / reschedules / cancels. The unit test
+ * (`schedule-reconciler.test.ts`) proves the plan against an in-memory fake, but
+ * only a real backend proves the read-back semantics the plan depends on:
+ * upsert-in-place (no duplicate scheduler), interval read-back driving a
+ * reschedule, and prefix-scoped orphan cancellation actually removing the right
+ * schedulers from Redis.
+ *
+ * To honour the dependency direction (healthcheck-backend must not depend on a
+ * queue *implementation* plugin), this drives raw `bullmq` primitives through a
+ * thin shim that mirrors the `BullMQQueue` adapter's recurring methods
+ * EXACTLY - `upsertJobScheduler` / `getJobSchedulers` / `removeJobScheduler`.
+ * The adapter's own conformance to that contract is pinned separately by
+ * `plugins/queue-bullmq-backend/src/bullmq-queue.it.test.ts`; here we exercise
+ * the RECONCILER against a backend with real persistence between calls.
+ *
+ * Gated behind `CHECKSTACK_IT`; the `integration` CI job sets it and provides a
+ * real Redis (`CHECKSTACK_IT_REDIS_URL`). Each test uses a unique queue name +
+ * key prefix and obliterates afterwards.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { Queue } from "bullmq";
+import type { RecurringJobDetails } from "@checkstack/queue-api";
+import { reconcileHealthCheckJobs } from "./schedule-reconciler";
+import {
+  HEALTH_CHECK_QUEUE,
+  type HealthCheckJobPayload,
+} from "./queue-executor";
+
+type ReconcileProps = Parameters<typeof reconcileHealthCheckJobs>[0];
+
+function redisParts(): { host: string; port: number; password?: string } {
+  const url = new URL(
+    process.env.CHECKSTACK_IT_REDIS_URL ?? "redis://localhost:6379",
+  );
+  return {
+    host: url.hostname,
+    port: Number(url.port || 6379),
+    password: url.password || undefined,
+  };
+}
+
+const PREFIX = `it:${crypto.randomUUID().replace(/-/g, "")}`;
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as ReconcileProps["logger"];
+
+/** Mock db: two selects - (1) enabled checks join, (2) last-run-per-slice. */
+function makeDb(props: {
+  checks: Array<{
+    systemId: string;
+    configId: string;
+    interval: number;
+    environmentIds: string[] | null;
+  }>;
+  lastRuns?: Array<{
+    systemId: string;
+    configurationId: string;
+    environmentId: string | null;
+    maxTimestamp: Date | null;
+  }>;
+}): ReconcileProps["db"] {
+  const from = () => ({
+    innerJoin: () => ({ where: () => Promise.resolve(props.checks) }),
+    groupBy: () => Promise.resolve(props.lastRuns ?? []),
+  });
+  return { select: () => ({ from }) } as unknown as ReconcileProps["db"];
+}
+
+function makeCatalogClient(
+  membershipBySystem: Record<string, Array<{ id: string; name: string }>>,
+): ReconcileProps["catalogClient"] {
+  return {
+    resolveSystemEnvironments: async ({ systemId }: { systemId: string }) =>
+      (membershipBySystem[systemId] ?? []).map((m) => ({
+        ...m,
+        description: null,
+        metadata: {},
+        systemIds: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })),
+  } as unknown as ReconcileProps["catalogClient"];
+}
+
+/**
+ * A queue-api shim over raw BullMQ, using the SAME scheduler primitives as the
+ * `BullMQQueue` adapter, plus per-method call counters so a test can assert the
+ * reconciler did (or did NOT) schedule/cancel.
+ */
+function makeQueueEnv(queueName: string) {
+  const raw = new Queue(queueName, { connection: redisParts(), prefix: PREFIX });
+  const calls = { scheduleRecurring: 0, cancelRecurring: 0 };
+
+  const shim = {
+    async scheduleRecurring(
+      data: HealthCheckJobPayload,
+      opts: {
+        jobId: string;
+        priority?: number;
+        startDelay?: number;
+        intervalSeconds?: number;
+        cronPattern?: string;
+      },
+    ): Promise<string> {
+      calls.scheduleRecurring += 1;
+      const isCron = Boolean(opts.cronPattern);
+      await raw.upsertJobScheduler(
+        opts.jobId,
+        isCron
+          ? { pattern: opts.cronPattern! }
+          : {
+              every: opts.intervalSeconds! * 1000,
+              ...(opts.startDelay && opts.startDelay > 0
+                ? { startDate: Date.now() + opts.startDelay * 1000 }
+                : {}),
+            },
+        { name: queueName, data, opts: { priority: opts.priority } },
+      );
+      return opts.jobId;
+    },
+    async cancelRecurring(jobId: string): Promise<void> {
+      calls.cancelRecurring += 1;
+      await raw.removeJobScheduler(jobId);
+    },
+    async listRecurringJobs(): Promise<string[]> {
+      const schedulers = await raw.getJobSchedulers();
+      return schedulers.map((s) => s.key);
+    },
+    async getRecurringJobDetails(
+      jobId: string,
+    ): Promise<RecurringJobDetails<HealthCheckJobPayload> | undefined> {
+      const schedulers = await raw.getJobSchedulers();
+      const s = schedulers.find((x) => x.key === jobId);
+      if (!s) return undefined;
+      const base = {
+        jobId,
+        // Cross the untyped bullmq template boundary exactly as the adapter does.
+        data: s.template?.data as HealthCheckJobPayload,
+        priority: s.template?.opts?.priority,
+        nextRunAt: s.next ? new Date(s.next) : undefined,
+      };
+      return s.pattern
+        ? { ...base, cronPattern: s.pattern }
+        : { ...base, intervalSeconds: s.every ? Number(s.every) / 1000 : 0 };
+    },
+  };
+
+  const queueManager = {
+    getQueue: () => shim,
+  } as unknown as ReconcileProps["queueManager"];
+
+  return { raw, calls, queueManager, shim };
+}
+
+describe.skipIf(!process.env.CHECKSTACK_IT)(
+  "reconcileHealthCheckJobs (real Redis)",
+  () => {
+    const raws: Queue[] = [];
+    function env() {
+      const e = makeQueueEnv(`it_reconcile_${crypto.randomUUID().replace(/-/g, "")}`);
+      raws.push(e.raw);
+      return e;
+    }
+
+    afterEach(async () => {
+      for (const raw of raws.splice(0)) {
+        await raw.obliterate({ force: true }).catch(() => {});
+        await raw.close();
+      }
+    });
+
+    it("schedules one recurring job per effective environment with the right payload", async () => {
+      const { queueManager, shim } = env();
+      await reconcileHealthCheckJobs({
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+          ],
+        }),
+        catalogClient: makeCatalogClient({
+          s1: [
+            { id: "prod", name: "Production" },
+            { id: "staging", name: "Staging" },
+          ],
+        }),
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+
+      expect((await shim.listRecurringJobs()).toSorted()).toEqual([
+        "healthcheck:c1:s1:prod",
+        "healthcheck:c1:s1:staging",
+      ]);
+      const prod = await shim.getRecurringJobDetails("healthcheck:c1:s1:prod");
+      expect(prod?.intervalSeconds).toBe(30);
+      expect(prod?.data).toEqual({
+        configId: "c1",
+        systemId: "s1",
+        environmentId: "prod",
+      });
+    });
+
+    it("schedules a single bare job for an env-less system (environmentId null)", async () => {
+      const { queueManager, shim } = env();
+      await reconcileHealthCheckJobs({
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+          ],
+        }),
+        catalogClient: makeCatalogClient({ s1: [] }),
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+
+      expect(await shim.listRecurringJobs()).toEqual(["healthcheck:c1:s1"]);
+      const details = await shim.getRecurringJobDetails("healthcheck:c1:s1");
+      expect(details?.data.environmentId).toBeNull();
+    });
+
+    it("is idempotent: a second identical full reconcile schedules and cancels nothing", async () => {
+      const { queueManager, shim, calls } = env();
+      const args = {
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+          ],
+        }),
+        catalogClient: makeCatalogClient({
+          s1: [{ id: "prod", name: "Production" }],
+        }),
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      };
+
+      await reconcileHealthCheckJobs(args);
+      const afterFirst = { ...calls };
+
+      // Fresh db/catalog (same desired), same real Redis state.
+      await reconcileHealthCheckJobs({
+        ...args,
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+          ],
+        }),
+      });
+
+      // Interval already matches, job already present -> no work the 2nd time.
+      expect(calls.scheduleRecurring).toBe(afterFirst.scheduleRecurring);
+      expect(calls.cancelRecurring).toBe(afterFirst.cancelRecurring);
+      expect(await shim.listRecurringJobs()).toEqual(["healthcheck:c1:s1:prod"]);
+    });
+
+    it("reschedules in place when the interval changes (no duplicate scheduler)", async () => {
+      const { queueManager, shim, calls } = env();
+      const catalogClient = makeCatalogClient({
+        s1: [{ id: "prod", name: "Production" }],
+      });
+
+      await reconcileHealthCheckJobs({
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+          ],
+        }),
+        catalogClient,
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+      const scheduledAfterFirst = calls.scheduleRecurring;
+
+      await reconcileHealthCheckJobs({
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 60, environmentIds: null },
+          ],
+        }),
+        catalogClient,
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+
+      // Exactly one slice, interval updated in place, no orphan cancels.
+      expect(await shim.listRecurringJobs()).toEqual(["healthcheck:c1:s1:prod"]);
+      const details = await shim.getRecurringJobDetails("healthcheck:c1:s1:prod");
+      expect(details?.intervalSeconds).toBe(60);
+      expect(calls.scheduleRecurring).toBe(scheduledAfterFirst + 1);
+      expect(calls.cancelRecurring).toBe(0);
+    });
+
+    it("cancels orphaned jobs when a check disappears from the desired set", async () => {
+      const { queueManager, shim } = env();
+      const catalogClient = makeCatalogClient({
+        s1: [{ id: "prod", name: "Production" }],
+      });
+
+      await reconcileHealthCheckJobs({
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+          ],
+        }),
+        catalogClient,
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+      expect(await shim.listRecurringJobs()).toEqual(["healthcheck:c1:s1:prod"]);
+
+      // Check removed (e.g. disabled/deleted) -> desired set empty -> orphan cancel.
+      await reconcileHealthCheckJobs({
+        db: makeDb({ checks: [] }),
+        catalogClient,
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+      expect(await shim.listRecurringJobs()).toEqual([]);
+    });
+
+    it("a system-scoped reconcile never cancels another system's jobs", async () => {
+      const { queueManager, shim, calls } = env();
+      const catalogClient = makeCatalogClient({
+        s1: [{ id: "prod", name: "Production" }],
+        s2: [{ id: "prod", name: "Production" }],
+      });
+
+      // Full reconcile schedules both systems.
+      await reconcileHealthCheckJobs({
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+            { systemId: "s2", configId: "c2", interval: 30, environmentIds: null },
+          ],
+        }),
+        catalogClient,
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+      const cancelsAfterFull = calls.cancelRecurring;
+
+      // Scoped reconcile for s1 only (buildDesiredJobs filters to s1); it must
+      // NOT sweep s2's job even though s2 is absent from this scoped desired set.
+      await reconcileHealthCheckJobs({
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+          ],
+        }),
+        catalogClient,
+        queueManager,
+        logger: silentLogger,
+        systemId: "s1",
+        now: 1_000_000,
+      });
+
+      expect((await shim.listRecurringJobs()).toSorted()).toEqual([
+        "healthcheck:c1:s1:prod",
+        "healthcheck:c2:s2:prod",
+      ]);
+      expect(calls.cancelRecurring).toBe(cancelsAfterFull);
+    });
+
+    it("leaves a foreign (non-healthcheck) recurring job untouched on a full reconcile", async () => {
+      const { queueManager, shim, raw } = env();
+      // A recurring job owned by some other plugin, not the healthcheck prefix.
+      await raw.upsertJobScheduler(
+        "otherplugin:job1",
+        { every: 60_000 },
+        { name: "other", data: {} },
+      );
+
+      await reconcileHealthCheckJobs({
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+          ],
+        }),
+        catalogClient: makeCatalogClient({
+          s1: [{ id: "prod", name: "Production" }],
+        }),
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+
+      // The orphan filter is prefix-scoped, so the foreign scheduler survives.
+      expect((await shim.listRecurringJobs()).toSorted()).toEqual([
+        "healthcheck:c1:s1:prod",
+        "otherplugin:job1",
+      ]);
+    });
+
+    it("cancels the bare env-less job and fans out when a system gains environments", async () => {
+      const { queueManager, shim } = env();
+      const db = makeDb({
+        checks: [
+          { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+        ],
+      });
+
+      // First: no environments -> a single bare job.
+      await reconcileHealthCheckJobs({
+        db,
+        catalogClient: makeCatalogClient({ s1: [] }),
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+      expect(await shim.listRecurringJobs()).toEqual(["healthcheck:c1:s1"]);
+
+      // Then: the system joins two environments -> the bare job is now an
+      // orphan and must be cancelled, replaced by one job per environment.
+      await reconcileHealthCheckJobs({
+        db: makeDb({
+          checks: [
+            { systemId: "s1", configId: "c1", interval: 30, environmentIds: null },
+          ],
+        }),
+        catalogClient: makeCatalogClient({
+          s1: [
+            { id: "prod", name: "Production" },
+            { id: "staging", name: "Staging" },
+          ],
+        }),
+        queueManager,
+        logger: silentLogger,
+        now: 1_000_000,
+      });
+
+      expect((await shim.listRecurringJobs()).toSorted()).toEqual([
+        "healthcheck:c1:s1:prod",
+        "healthcheck:c1:s1:staging",
+      ]);
+    });
+  },
+);

--- a/plugins/queue-bullmq-backend/src/bullmq-queue.it.test.ts
+++ b/plugins/queue-bullmq-backend/src/bullmq-queue.it.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration test (real Redis / BullMQ) for the recurring-job interface of the
+ * `BullMQQueue` adapter.
+ *
+ * The scheduling reconciler (and any other caller) drives recurring jobs purely
+ * through this contract: `scheduleRecurring` (create-or-UPDATE by jobId),
+ * `listRecurringJobs`, `getRecurringJobDetails`, `cancelRecurring`. The unit
+ * tests mock the `bullmq` module, so they can only assert we CALL
+ * `upsertJobScheduler`; they cannot prove BullMQ actually REPLACES a
+ * scheduler's template (data + interval) when the same jobId is re-scheduled.
+ * That upsert-data subtlety has bitten us before - a re-schedule that silently
+ * kept the stale payload - so this pins it against a real Redis:
+ *
+ *  - re-scheduling the SAME jobId updates data AND interval in place, with NO
+ *    duplicate scheduler, and
+ *  - a job the scheduler actually PRODUCES carries the updated data, not the
+ *    original.
+ *
+ * Gated behind `CHECKSTACK_IT`, so the default `bun test` never runs it. The
+ * `integration` CI job sets the flag and provides a real Redis service; the URL
+ * comes from `CHECKSTACK_IT_REDIS_URL` (defaulting to the `docker-compose-dev`
+ * Redis port). Each run uses a unique queue name + key prefix and obliterates
+ * the queue afterwards.
+ */
+import { afterAll, beforeEach, afterEach, describe, expect, it } from "bun:test";
+import { Queue, Worker } from "bullmq";
+import { BullMQQueue } from "./bullmq-queue";
+
+interface Payload {
+  configId: string;
+  systemId: string;
+  environmentId: string | null;
+  marker: string;
+}
+
+function redisParts(): { host: string; port: number; password?: string } {
+  const url = new URL(
+    process.env.CHECKSTACK_IT_REDIS_URL ?? "redis://localhost:6379",
+  );
+  return {
+    host: url.hostname,
+    port: Number(url.port || 6379),
+    password: url.password || undefined,
+  };
+}
+
+const PREFIX = `it:${crypto.randomUUID().replace(/-/g, "")}`;
+
+/** Poll `fn` until it returns a truthy value or `timeoutMs` elapses. */
+async function waitFor<T>(
+  fn: () => Promise<T | undefined> | T | undefined,
+  { timeoutMs = 5000, stepMs = 50 }: { timeoutMs?: number; stepMs?: number } = {},
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await fn();
+    if (value) return value;
+    if (Date.now() >= deadline) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, stepMs));
+  }
+}
+
+describe.skipIf(!process.env.CHECKSTACK_IT)(
+  "BullMQQueue recurring interface (real Redis)",
+  () => {
+    // A fresh queue name per test keeps schedulers isolated; the shared PREFIX
+    // is obliterated once at the end.
+    let queueName: string;
+    let queue: BullMQQueue<Payload>;
+    const workers: Worker[] = [];
+
+    beforeEach(() => {
+      queueName = `it_recurring_${crypto.randomUUID().replace(/-/g, "")}`;
+      queue = new BullMQQueue<Payload>(queueName, {
+        ...redisParts(),
+        db: 0,
+        keyPrefix: PREFIX,
+        concurrency: 5,
+      });
+    });
+
+    afterEach(async () => {
+      for (const w of workers.splice(0)) await w.close();
+      await queue.stop();
+    });
+
+    afterAll(async () => {
+      // One handle over the shared prefix to wipe every test's keyspace.
+      const sweeper = new Queue(`it_recurring_sweep`, {
+        connection: redisParts(),
+        prefix: PREFIX,
+      });
+      await sweeper.obliterate({ force: true }).catch(() => {});
+      await sweeper.close();
+    });
+
+    it("schedules, lists, reads back, and cancels a recurring job", async () => {
+      const jobId = "healthcheck:c1:s1:prod";
+      const payload: Payload = {
+        configId: "c1",
+        systemId: "s1",
+        environmentId: "prod",
+        marker: "v1",
+      };
+
+      await queue.scheduleRecurring(payload, { jobId, intervalSeconds: 30 });
+
+      expect(await queue.listRecurringJobs()).toEqual([jobId]);
+
+      const details = await queue.getRecurringJobDetails(jobId);
+      expect(details?.jobId).toBe(jobId);
+      expect(details?.intervalSeconds).toBe(30);
+      expect(details?.data).toEqual(payload);
+
+      await queue.cancelRecurring(jobId);
+
+      expect(await queue.listRecurringJobs()).toEqual([]);
+      expect(await queue.getRecurringJobDetails(jobId)).toBeUndefined();
+    });
+
+    it("re-scheduling the same jobId UPSERTS data + interval in place (no duplicate)", async () => {
+      const jobId = "healthcheck:c1:s1:prod";
+      const first: Payload = {
+        configId: "c1",
+        systemId: "s1",
+        environmentId: "prod",
+        marker: "before",
+      };
+      const second: Payload = { ...first, marker: "after" };
+
+      await queue.scheduleRecurring(first, { jobId, intervalSeconds: 30 });
+      // Same jobId, different data AND different interval.
+      await queue.scheduleRecurring(second, { jobId, intervalSeconds: 60 });
+
+      // Still exactly ONE scheduler - upsert, not append.
+      expect(await queue.listRecurringJobs()).toEqual([jobId]);
+
+      // The template reflects the SECOND schedule, not the stale first one.
+      const details = await queue.getRecurringJobDetails(jobId);
+      expect(details?.intervalSeconds).toBe(60);
+      expect(details?.data).toEqual(second);
+      expect(details?.data.marker).toBe("after");
+    });
+
+    it("a job the scheduler PRODUCES carries the upserted data, not the original", async () => {
+      const jobId = "healthcheck:c1:s1:prod";
+      const first: Payload = {
+        configId: "c1",
+        systemId: "s1",
+        environmentId: "prod",
+        marker: "original",
+      };
+      const updated: Payload = { ...first, marker: "upserted" };
+
+      // Record every payload the scheduler actually delivers.
+      const delivered: string[] = [];
+      const worker = new Worker<Payload>(
+        queueName,
+        async (job) => {
+          delivered.push(job.data.marker);
+        },
+        { connection: redisParts(), prefix: PREFIX },
+      );
+      workers.push(worker);
+      await worker.waitUntilReady();
+
+      // Short interval so jobs are produced within the test window.
+      await queue.scheduleRecurring(first, { jobId, intervalSeconds: 1 });
+      await waitFor(() => delivered.includes("original") || undefined);
+
+      // Upsert the data; subsequent produced jobs must carry the new payload.
+      await queue.scheduleRecurring(updated, { jobId, intervalSeconds: 1 });
+      await waitFor(() => delivered.includes("upserted") || undefined, {
+        timeoutMs: 8000,
+      });
+
+      // After the upsert we must NOT keep seeing the stale payload.
+      const upsertedAt = delivered.indexOf("upserted");
+      expect(upsertedAt).toBeGreaterThanOrEqual(0);
+      expect(delivered.slice(upsertedAt)).not.toContain("original");
+    });
+
+    it("lists and cancels the correct job among several schedulers", async () => {
+      const ids = [
+        "healthcheck:c1:s1:prod",
+        "healthcheck:c1:s1:staging",
+        "healthcheck:c2:s2:prod",
+      ];
+      for (const jobId of ids) {
+        await queue.scheduleRecurring(
+          {
+            configId: jobId.split(":")[1]!,
+            systemId: jobId.split(":")[2]!,
+            environmentId: jobId.split(":")[3]!,
+            marker: "v1",
+          },
+          { jobId, intervalSeconds: 30 },
+        );
+      }
+
+      const listedBefore = await queue.listRecurringJobs();
+      expect(listedBefore.toSorted()).toEqual(ids.toSorted());
+
+      await queue.cancelRecurring(ids[1]!);
+
+      const listedAfter = await queue.listRecurringJobs();
+      expect(listedAfter.toSorted()).toEqual([ids[0]!, ids[2]!].toSorted());
+      expect(await queue.getRecurringJobDetails(ids[1]!)).toBeUndefined();
+    });
+
+    // ─── Edge cases / subtle behaviours ──────────────────────────────────────
+
+    it("cancelRecurring on an unknown jobId is a no-op (idempotent orphan cancel)", async () => {
+      // Two pods can both decide a job is orphaned and both call cancel; the
+      // second cancel of an already-removed scheduler must NOT throw. The
+      // reconciler relies on this - orphan cleanup is not serialized per-job.
+      await queue.scheduleRecurring(
+        {
+          configId: "c1",
+          systemId: "s1",
+          environmentId: "prod",
+          marker: "v1",
+        },
+        { jobId: "healthcheck:c1:s1:prod", intervalSeconds: 30 },
+      );
+
+      // Never-existed jobId.
+      await queue.cancelRecurring("healthcheck:does:not:exist");
+      // Cancel twice - the second is a no-op.
+      await queue.cancelRecurring("healthcheck:c1:s1:prod");
+      await queue.cancelRecurring("healthcheck:c1:s1:prod");
+
+      expect(await queue.listRecurringJobs()).toEqual([]);
+    });
+
+    it("round-trips a null environmentId and priority through the scheduler template", async () => {
+      // Env-less slices schedule with `environmentId: null`; the payload is
+      // JSON-serialised into the scheduler template, and `null` must survive
+      // (not become undefined / dropped) or the executor loses env context.
+      const jobId = "healthcheck:c1:s1";
+      const payload: Payload = {
+        configId: "c1",
+        systemId: "s1",
+        environmentId: null,
+        marker: "envless",
+      };
+
+      await queue.scheduleRecurring(payload, {
+        jobId,
+        intervalSeconds: 30,
+        priority: 7,
+      });
+
+      const details = await queue.getRecurringJobDetails(jobId);
+      expect(details?.data).toEqual(payload);
+      expect(details?.data.environmentId).toBeNull();
+      expect(details?.priority).toBe(7);
+
+      // Upsert a new priority; it must be reflected, not stuck at the old value.
+      await queue.scheduleRecurring(payload, {
+        jobId,
+        intervalSeconds: 30,
+        priority: 3,
+      });
+      expect((await queue.getRecurringJobDetails(jobId))?.priority).toBe(3);
+    });
+
+    it("supports a cron schedule and reports cronPattern, not intervalSeconds", async () => {
+      const jobId = "healthcheck:c1:s1:prod";
+      await queue.scheduleRecurring(
+        {
+          configId: "c1",
+          systemId: "s1",
+          environmentId: "prod",
+          marker: "cron",
+        },
+        { jobId, cronPattern: "*/5 * * * *" },
+      );
+
+      const details = await queue.getRecurringJobDetails(jobId);
+      expect(details?.cronPattern).toBe("*/5 * * * *");
+      expect(details?.intervalSeconds).toBeUndefined();
+      expect(await queue.listRecurringJobs()).toEqual([jobId]);
+    });
+
+    it("switches a job from interval to cron on the same jobId (upsert replaces schedule type)", async () => {
+      const jobId = "healthcheck:c1:s1:prod";
+      const payload: Payload = {
+        configId: "c1",
+        systemId: "s1",
+        environmentId: "prod",
+        marker: "v1",
+      };
+
+      await queue.scheduleRecurring(payload, { jobId, intervalSeconds: 30 });
+      let details = await queue.getRecurringJobDetails(jobId);
+      expect(details?.intervalSeconds).toBe(30);
+      expect(details?.cronPattern).toBeUndefined();
+
+      // Same jobId, now a cron schedule - the interval schedule must be gone.
+      await queue.scheduleRecurring(payload, { jobId, cronPattern: "0 * * * *" });
+
+      expect(await queue.listRecurringJobs()).toEqual([jobId]);
+      details = await queue.getRecurringJobDetails(jobId);
+      expect(details?.cronPattern).toBe("0 * * * *");
+      expect(details?.intervalSeconds).toBeUndefined();
+    });
+
+    it("re-scheduling identical data + interval keeps a single scheduler", async () => {
+      const jobId = "healthcheck:c1:s1:prod";
+      const payload: Payload = {
+        configId: "c1",
+        systemId: "s1",
+        environmentId: "prod",
+        marker: "same",
+      };
+
+      await queue.scheduleRecurring(payload, { jobId, intervalSeconds: 30 });
+      await queue.scheduleRecurring(payload, { jobId, intervalSeconds: 30 });
+      await queue.scheduleRecurring(payload, { jobId, intervalSeconds: 30 });
+
+      expect(await queue.listRecurringJobs()).toEqual([jobId]);
+      const details = await queue.getRecurringJobDetails(jobId);
+      expect(details?.intervalSeconds).toBe(30);
+      expect(details?.data).toEqual(payload);
+    });
+  },
+);


### PR DESCRIPTION
## Why

Follow-up to #418. The per-environment scheduling reconciler drives BullMQ recurring
jobs purely through the queue-api contract (`scheduleRecurring` = create-or-UPDATE
by jobId, `listRecurringJobs`, `getRecurringJobDetails`, `cancelRecurring`). The
existing unit tests mock the `bullmq` module, so they can only assert we *call*
`upsertJobScheduler` - they cannot prove BullMQ actually **replaces** a scheduler's
template (data + interval) on re-schedule. That upsert-data subtlety has bitten us
before (a re-schedule silently keeping the stale payload), so this adds real-Redis
coverage for both the adapter contract and the reconciler that depends on it.

Runs in the existing **Integration** lane, which already provides a `redis:7-alpine`
service container and sets `CHECKSTACK_IT=1` / `CHECKSTACK_IT_REDIS_URL`. Both suites
are gated with `describe.skipIf(!process.env.CHECKSTACK_IT)`, so the default unit
lane never touches Redis.

## What

### `plugins/queue-bullmq-backend/src/bullmq-queue.it.test.ts` (9 tests)
Drives the **real `BullMQQueue`** recurring interface against Redis:
- **Upsert replaces the template** - same jobId, different data + interval -> one
  scheduler, new data/interval (not the stale first).
- **Produced jobs carry the upserted data** - a real `Worker` proves the already-queued
  job is replaced, not left carrying the original payload.
- **interval -> cron switch** on the same jobId (schedule type replaced).
- **cancel on unknown / already-cancelled jobId is a no-op** (orphan cleanup is not
  serialized per-job across pods).
- **null environmentId + priority round-trip** through the JSON template.
- idempotent identical re-schedule; multi-scheduler list/cancel.

### `core/healthcheck-backend/src/schedule-reconciler.it.test.ts` (8 tests)
Runs the **real `reconcileHealthCheckJobs`** against Redis (db/catalog mocked), so
`planReconcile` is driven by genuine `list`/`getDetails` read-back:
- one job per effective environment (correct payload); single bare job for env-less
  systems;
- **idempotent** - a second identical reconcile schedules/cancels nothing (asserted via
  call counters -> no fire-phase reset / thundering-herd regression);
- **interval change reschedules in place** (no duplicate);
- **orphan cancellation** when a check disappears;
- **system-scoped reconcile never sweeps another system's jobs**;
- **foreign (non-`healthcheck:`) recurring job survives** a full reconcile;
- **env-less -> per-env transition** cancels the bare job and fans out.

## Dependency direction

healthcheck-backend must not depend on a queue *implementation* plugin, so the
reconciler test drives raw `bullmq` primitives through a thin queue-api shim that
mirrors the adapter's exact scheduler calls (`upsertJobScheduler` /
`getJobSchedulers` / `removeJobScheduler`). The adapter's own conformance is pinned
separately by the queue-interface suite. Adds `bullmq` as a **devDependency** (same
version and pattern automation-backend already uses for its `.it.test.ts`).

## Verification

- `CHECKSTACK_IT=1 bun test it.test` (real Redis): **17 pass** across both files.
- Default `bun test`: new suites **skip**; healthcheck unit suite still **581 pass**.
- `bun run typecheck` + `bun run lint` clean; reference graph unchanged (bullmq is external).

Test-only + a devDependency, so no changeset (no package functionality change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8p5PjRH1VS7iLXECyHos5
