### PR TITLE
perf(frontend): kill the catalog-manager render/query storm

### DIFF
--- a/.changeset/frontend-api-share-plugin-client-wrapper.md
+++ b/.changeset/frontend-api-share-plugin-client-wrapper.md
@@ -1,0 +1,24 @@
+---
+"@checkstack/frontend-api": patch
+---
+
+perf(frontend-api): share the wrapped plugin client across component instances
+
+`usePluginClient` memoized `wrapPluginUtils` per component instance only.
+`wrapPluginUtils` walks a plugin's ENTIRE contract and allocates a hook-wrapper
+closure per procedure (the AuthApi contract alone is ~80), so a page that gates
+many rows on auth - the catalog manager, where every system row mounts several
+auth-gated badges/actions (each calling `usePluginClient(AuthApi)` via
+`useResourceAccess`/`useAccess`/`useProcedureAccess`) - rebuilt the whole wrapper
+once PER ROW on navigation: hundreds of throwaway closures and a main-thread GC
+storm (visible in a profile as `updateMemo` hot under every gating hook, ~half
+its time in GC/CC).
+
+The wrappers are render-agnostic - their methods call React hooks at CALL time
+and close over only stable values - so the wrapped object is a pure function of
+`(pluginUtils, contract)` and safe to build ONCE and share. It is now cached in
+a module-level WeakMap keyed on the stable `pluginUtils` (with the contract as a
+second key), so it is built once per plugin and reused by every caller, and the
+whole cache falls away automatically when the provider re-creates its rpc client.
+This collapses navigation cost from O(instances x procedures) to
+O(plugins x procedures).

--- a/.changeset/healthcheck-frontend-batch-system-access-gate.md
+++ b/.changeset/healthcheck-frontend-batch-system-access-gate.md
@@ -1,0 +1,16 @@
+---
+"@checkstack/healthcheck-frontend": patch
+---
+
+perf(healthcheck): batch the system-access gate in the catalog "Health Checks"
+action so it no longer N+1s per row
+
+`SystemHealthCheckAssignment` (contributed once per system row to the catalog
+`CatalogSystemActionsSlot`) gated its button with
+`useResourceAccess({ resourceIds: [systemId] })` - a single id per row. Each
+row's query key differed, so React Query could not dedupe them and N systems
+fired N separate `listMyAccessibleResources` requests on every catalog-manager
+render. It now passes the `visibleSystemIds` it already receives (the whole
+visible list), so every row's identical-input query dedupes to ONE request and
+the row still gates on `canAccess(systemId)` - the exact pattern the same file's
+`getBulkAssignedHealthCheckCounts` counts query already uses.

--- a/core/frontend-api/src/orpc-client-cache.test.ts
+++ b/core/frontend-api/src/orpc-client-cache.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "bun:test";
+import { getOrBuildWrappedClient } from "./orpc-query";
+
+/**
+ * The wrapped plugin client is expensive to build (it walks a plugin's entire
+ * contract, allocating a hook wrapper per procedure). It MUST be shared across
+ * component instances, keyed on the stable `pluginUtils` + contract, or a page
+ * that gates many rows on auth rebuilds the whole tree per row (a main-thread
+ * GC storm - the regression these tests guard). We assert the sharing directly
+ * on the pure cache helper, without a DOM/render harness.
+ */
+
+/** A minimal contract + matching utils: one query procedure named `getFoo`. */
+function makeFixture() {
+  const contract = {
+    getFoo: { "~orpc": { meta: { operationType: "query" } } },
+  } as Record<string, unknown>;
+  const pluginUtils = {
+    getFoo: { queryOptions: () => ({}) },
+  } as Record<string, unknown>;
+  return { contract, pluginUtils };
+}
+
+describe("getOrBuildWrappedClient", () => {
+  it("returns the SAME wrapped client for the same (pluginUtils, contract)", () => {
+    const { contract, pluginUtils } = makeFixture();
+
+    const a = getOrBuildWrappedClient(pluginUtils, contract, "test");
+    const b = getOrBuildWrappedClient(pluginUtils, contract, "test");
+
+    // Identical reference => built once and reused (a rebuild would be a new object).
+    expect(b).toBe(a);
+    // And it actually wrapped the procedure.
+    expect(typeof (a.getFoo as Record<string, unknown>).useQuery).toBe(
+      "function",
+    );
+  });
+
+  it("builds a SEPARATE wrapped client for a different pluginUtils", () => {
+    const first = makeFixture();
+    const second = makeFixture();
+
+    const a = getOrBuildWrappedClient(first.pluginUtils, first.contract, "test");
+    const b = getOrBuildWrappedClient(
+      second.pluginUtils,
+      second.contract,
+      "test",
+    );
+
+    // Different provider objects (e.g. after the rpc client is re-created) must
+    // not collide - each gets its own wrapper.
+    expect(b).not.toBe(a);
+  });
+
+  it("keys on the contract under a shared pluginUtils", () => {
+    const { pluginUtils } = makeFixture();
+    const contractA = {
+      getFoo: { "~orpc": { meta: { operationType: "query" } } },
+    } as Record<string, unknown>;
+    const contractB = {
+      getBar: { "~orpc": { meta: { operationType: "query" } } },
+    } as Record<string, unknown>;
+    // pluginUtils must expose the procedures both contracts reference.
+    pluginUtils.getBar = { queryOptions: () => ({}) };
+
+    const a1 = getOrBuildWrappedClient(pluginUtils, contractA, "test");
+    const a2 = getOrBuildWrappedClient(pluginUtils, contractA, "test");
+    const b = getOrBuildWrappedClient(pluginUtils, contractB, "test");
+
+    expect(a2).toBe(a1); // same contract => cached
+    expect(b).not.toBe(a1); // different contract => distinct wrapper
+    expect(typeof (b.getBar as Record<string, unknown>).useQuery).toBe(
+      "function",
+    );
+  });
+});

--- a/core/frontend-api/src/orpc-query.tsx
+++ b/core/frontend-api/src/orpc-query.tsx
@@ -288,6 +288,51 @@ type WrappedClient<TContract extends AnyContractRouter, TClient> = {
  * };
  * ```
  */
+/**
+ * Cross-instance cache of wrapped plugin clients, keyed on the STABLE
+ * `pluginUtils` object (one per provider+plugin) and then the contract.
+ *
+ * `wrapPluginUtils` walks a plugin's ENTIRE contract and allocates a
+ * hook-wrapper closure per procedure (the AuthApi contract alone is ~80
+ * procedures). Memoizing that inside {@link usePluginClient} makes it cheap on
+ * re-render, but NOT across component instances: a page that gates many rows on
+ * auth (e.g. the catalog manager, where every system row mounts several
+ * auth-gated badges/actions) would otherwise rebuild the whole wrapper once per
+ * instance - hundreds of throwaway closures per navigation, a real main-thread
+ * GC storm. The wrappers are render-agnostic (their methods call React hooks at
+ * CALL time and close over only stable values), so the wrapped object is a pure
+ * function of `(pluginUtils, contract)` and safe to build ONCE and share. A
+ * WeakMap keyed on `pluginUtils` lets the whole cache fall away automatically
+ * when the provider re-creates its utils (new rpc client).
+ */
+const wrappedClientCache = new WeakMap<
+  object,
+  WeakMap<object, Record<string, unknown>>
+>();
+
+/**
+ * Return the shared wrapped client for `(pluginUtils, contract)`, building it
+ * once and reusing it for every subsequent caller. Exported for unit testing;
+ * production code reaches it through {@link usePluginClient}.
+ */
+export function getOrBuildWrappedClient(
+  pluginUtils: Record<string, unknown>,
+  contract: Record<string, unknown>,
+  pluginId: string,
+): Record<string, unknown> {
+  let byContract = wrappedClientCache.get(pluginUtils);
+  if (!byContract) {
+    byContract = new WeakMap();
+    wrappedClientCache.set(pluginUtils, byContract);
+  }
+  let wrapped = byContract.get(contract);
+  if (!wrapped) {
+    wrapped = wrapPluginUtils(pluginUtils, contract, pluginId);
+    byContract.set(contract, wrapped);
+  }
+  return wrapped;
+}
+
 export function usePluginClient<T extends ClientDefinition>(
   definition: T,
 ): WrappedClient<NonNullable<T["__contractType"]>, InferClient<T>> {
@@ -307,8 +352,11 @@ export function usePluginClient<T extends ClientDefinition>(
   // Get contract for operationType checking
   const contract = definition.contract as Record<string, unknown>;
 
+  // Shared across every instance (see wrappedClientCache): the useMemo keeps the
+  // reference stable per render; the cache keeps it stable ACROSS instances so a
+  // gate-heavy page doesn't rebuild the whole wrapper per row.
   return useMemo(() => {
-    return wrapPluginUtils(pluginUtils, contract, definition.pluginId);
+    return getOrBuildWrappedClient(pluginUtils, contract, definition.pluginId);
   }, [pluginUtils, contract, definition.pluginId]) as WrappedClient<
     NonNullable<T["__contractType"]>,
     InferClient<T>

--- a/core/healthcheck-frontend/src/components/SystemHealthCheckAssignment.tsx
+++ b/core/healthcheck-frontend/src/components/SystemHealthCheckAssignment.tsx
@@ -36,11 +36,16 @@ export const SystemHealthCheckAssignment: React.FC<Props> = ({
     healthCheckAccess.configuration.manage,
   );
   // Assigning health checks to a system requires MANAGE on the target system
-  // (enforced backend-side by `associateSystem` / `createAndAssign`).
+  // (enforced backend-side by `associateSystem` / `createAndAssign`). Resolve the
+  // manageable subset for the WHOLE visible list in ONE request: every row passes
+  // the same `visibleSystemIds`, so these identical-input queries dedupe to a
+  // single `listMyAccessibleResources` call (same pattern as the counts query
+  // below), instead of one per-row single-id query. `canManageSystem(systemId)`
+  // then checks THIS row against that batched set.
   const { canAccess: canManageSystem } = accessApi.useResourceAccess({
     accessRule: catalogAccess.system.manage,
     objectType: catalogResourceTypes.system,
-    resourceIds: [systemId],
+    resourceIds: visibleSystemIds,
   });
   const navigate = useNavigate();
 


### PR DESCRIPTION
## Summary

Navigating to/from the catalog manager blocked the main thread (profiled: `updateMemo` hot under every auth-gating hook, ~half its time in GC/CC). Two causes, both **multiplied by the team-scoped RLAC gating** that PR #422 added to every per-system surface. This fixes both.

### 1. Share the wrapped plugin client across instances (`@checkstack/frontend-api`)

`usePluginClient` memoized `wrapPluginUtils` **per component instance**. `wrapPluginUtils` walks a plugin's entire contract and allocates a hook-wrapper closure per procedure (~80 for AuthApi). Every auth-gated badge/action on a system row calls `usePluginClient(AuthApi)` (via `useResourceAccess`/`useAccess`/`useProcedureAccess`), so a row rebuilt the whole wrapper ~8× — hundreds of throwaway closures per row on navigation.

The wrappers are render-agnostic (their methods call React hooks at call time, closing over only stable values), so the wrapped client is a pure function of `(pluginUtils, contract)`. It's now cached in a module-level `WeakMap` keyed on the stable `pluginUtils` (+ contract) and built **once per plugin**, reused by every caller. Navigation cost drops from **O(instances × procedures) → O(plugins × procedures)**. The WeakMap key means the cache falls away automatically when the provider re-creates its rpc client.

Covered by `orpc-client-cache.test.ts` (sharing + isolation + contract-keying).

### 2. Batch the per-row system-access gate (`@checkstack/healthcheck-frontend`)

`SystemHealthCheckAssignment` (contributed once per system row to `CatalogSystemActionsSlot`) gated on `useResourceAccess({ resourceIds: [systemId] })` — a single id per row, so N systems fired N distinct `listMyAccessibleResources` queries (keys differ → no dedupe). It now passes the `visibleSystemIds` it already receives, so every row's identical-input query dedupes to **one** request, and the row still gates on `canAccess(systemId)`. This is the exact pattern the same file's `getBulkAssignedHealthCheckCounts` counts query already uses.

## Audit

A frontend-wide audit confirmed these were the **only** two instances of these classes. Every other per-row surface already batches correctly: the state badges disable their single-id query when a bulk data-provider slot is mounted; every list-page gate batches via `.map()` (`SystemsTab`, `GroupsTab`, `SloConfigPage`, `HealthCheckList`, `StatusPagesListPage`, `AutomationListPage`, `DependencyMapPage`). Remaining single-id `resourceIds:[id]` sites are all single-instance detail/drawer/editor pages, where one id is correct.

## Verification
- `bun run typecheck` clean
- `bun run lint` clean
- 202 frontend tests pass (healthcheck-frontend + frontend-api), incl. the 3 new cache tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8p5PjRH1VS7iLXECyHos5
