### PR TITLE
fix(ci): drop invalid lockFileMaintenance options from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,10 +28,8 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 4am"],
-    "commitMessageAction": "refresh",
-    "commitMessageTopic": "bun.lock",
-    "prTitle": "chore(deps): refresh bun.lock (lock-file maintenance)",
-    "prBodyDefinition": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
+    "commitMessageAction": "Refresh",
+    "commitMessageTopic": "bun.lock (lock-file maintenance)",
     "labels": ["dependencies", "security-maintenance"],
     "rebaseWhen": "behind-base-branch"
   }


### PR DESCRIPTION
Renovate rejected the config merged in #428 with:

> Invalid configuration option: `lockFileMaintenance.prBodyDefinition`

so it aborted before doing anything - no Dependency Dashboard, no lock-file PR.

**Fix:** removed two options that can't be nested inside `lockFileMaintenance`:
- `prBodyDefinition` - a repository-level option (and the value was just the default).
- `prTitle` - not nestable there either; would have been the next error.

The PR title now derives from `commitMessageAction` + `commitMessageTopic`, which are valid inside `lockFileMaintenance`. The maintenance branch is still `renovate/lock-file-maintenance` (from the default `branchTopic`), so the `renovate-changeset.yml` guard still matches.

Validated locally with `renovate-config-validator` → `Config validated successfully`.

No changeset: CI/config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)