### PR TITLE
fix(ci): run lockFileMaintenance at any time, not a 4h window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,8 +26,9 @@
   ],
 
   "lockFileMaintenance": {
+    "description": "Runs 'at any time'. A narrow window couples PR creation to Mend running inside it, and Mend's hosted cadence is unpredictable - an idle repo can miss a 4h band for a day. lockFileMaintenance only creates/refreshes the single PR when the regenerated lockfile actually changes, and the bunfig.toml minimumReleaseAge cooldown gates eligibility, so 'any time' is not noisy. NOTE: omitting the schedule key reverts to lockFileMaintenance's built-in weekly default ('before 4am on monday'), so it is set explicitly.",
     "enabled": true,
-    "schedule": ["before 4am"],
+    "schedule": ["at any time"],
     "commitMessageAction": "Refresh",
     "commitMessageTopic": "bun.lock (lock-file maintenance)",
     "labels": ["dependencies", "security-maintenance"],


### PR DESCRIPTION
The `before 4am` schedule coupled lock-file-maintenance PR creation to Mend actually running Renovate inside that 4-hour band. Mend's hosted cadence is unpredictable - an idle repo saw a ~9h gap overnight (dashboard last updated 22:57 UTC, no run through the 00:00-04:00 window), so no lock-file PR was ever created.

**Change:** `schedule` → `["at any time"]`, so the PR appears on the next Mend run regardless of hour.

**Not noisy:** `lockFileMaintenance` only creates/refreshes the single PR when the regenerated `bun.lock` actually changes, and the `bunfig.toml` `minimumReleaseAge` cooldown gates which versions are eligible - so refreshes track "a fix cleared the 3-day cooldown", not "a run happened".

**Why set explicitly, not removed:** omitting the key reverts to `lockFileMaintenance`'s built-in weekly default (`before 4am on monday`), which is *more* restrictive. Validated with `renovate-config-validator` → `Config validated successfully`.

No changeset: CI/config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)