### PR TITLE
fix(ci): exclude stamped @checkstack/sdk from generated changeset

### DIFF
--- a/scripts/renovate-changeset.test.ts
+++ b/scripts/renovate-changeset.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  CHANGESET_STAMPED_PACKAGES,
   diffPackages,
   owningWorkspaces,
   parseLock,
@@ -133,6 +134,24 @@ describe("owningWorkspaces", () => {
     const lock = parseLock({ raw: HEAD_LOCK });
     // @x/e2e reaches ajv only through devDependencies.
     expect(owningWorkspaces({ lock, target: "fast-uri", isPublic })).not.toContain("@x/e2e");
+  });
+
+  it("excludes version-stamped packages (@checkstack/sdk) - forbidden in changesets (§7.3)", () => {
+    // @checkstack/sdk is PUBLIC but its version is stamped from @checkstack/release,
+    // so a changeset must never name it even though it declares a changed prod dep.
+    const raw = `{
+      "lockfileVersion": 1,
+      "workspaces": {
+        "core/sdk": { "name": "@checkstack/sdk", "dependencies": { "tar": "^7.0.0" } },
+        "core/backend": { "name": "@checkstack/backend", "dependencies": { "tar": "^7.0.0" } }
+      },
+      "packages": { "tar": ["tar@7.5.19", "", {}, "sha"] }
+    }`;
+    const lock = parseLock({ raw });
+    const owners = owningWorkspaces({ lock, target: "tar", isPublic: () => true });
+    expect(owners).toContain("@checkstack/backend");
+    expect(owners).not.toContain("@checkstack/sdk");
+    expect(CHANGESET_STAMPED_PACKAGES.has("@checkstack/sdk")).toBe(true);
   });
 });
 

--- a/scripts/renovate-changeset.ts
+++ b/scripts/renovate-changeset.ts
@@ -42,6 +42,18 @@ import { readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 
+/**
+ * Published packages whose version is STAMPED from `@checkstack/release`, not
+ * driven by changesets - a changeset must NEVER reference them (plan §7.3, and
+ * enforced by `generate:sdk:check`). They are public, so the `isPublic` filter
+ * does not catch them; they must be excluded explicitly. `@checkstack/release`
+ * is itself private (already excluded) but is listed for clarity.
+ */
+export const CHANGESET_STAMPED_PACKAGES = new Set<string>([
+  "@checkstack/sdk",
+  "@checkstack/release",
+]);
+
 const DepMapSchema = z.record(z.string(), z.string());
 
 const WorkspaceEntrySchema = z.object({
@@ -202,6 +214,7 @@ export function owningWorkspaces({
   const owners = new Set<string>();
   for (const ws of lock.workspaces) {
     if (!isPublic(ws.name)) continue;
+    if (CHANGESET_STAMPED_PACKAGES.has(ws.name)) continue;
     if (ws.prodDeps.some((dep) => ancestors.has(dep))) owners.add(ws.name);
   }
   return [...owners].toSorted();


### PR DESCRIPTION
The first real Renovate lock-file-maintenance PR (#434) failed `generate:sdk:check`:

> ❌ A pending changeset references @checkstack/sdk, but its version is stamped from @checkstack/release and MUST NOT appear in a changeset (plan §7.3)

**Cause:** `scripts/renovate-changeset.ts` attributes each changed transitive dep to every *public* workspace package that declares it. `@checkstack/sdk` is published (not `private`), so the `isPublic` filter let it through - but its version is stamped from `@checkstack/release`, so a changeset must never name it.

**Fix:** an explicit `CHANGESET_STAMPED_PACKAGES` exclusion (`@checkstack/sdk`, `@checkstack/release`) applied in `owningWorkspaces`, plus a regression test. Verified against #434's actual lockfile diff: `@checkstack/sdk` is now excluded (97 owners, was 98). Tests 17/17.

Once merged, Renovate rebases #434 onto main (`rebaseWhen: behind-base-branch`) and regenerates the changeset with the fixed script, clearing this failure.

No changeset: CI/tooling-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)