### PR TITLE
fix(ci): let Renovate keep managing lock-file PRs after our changeset commit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
     "bun": "1.3.14"
   },
 
+  "description": "gitIgnoredAuthors lists the security-bot identity that renovate-changeset.yml uses to push the generated changeset onto the lock-file-maintenance branch. Without it, Renovate sees a commit it did not author, assumes a human edited the PR, and STOPS auto-rebasing (every lock-file PR goes stale the moment main moves ahead). Listing the bot makes Renovate ignore that commit for edit-detection and keep managing the PR; it recreates the branch on rebase and the workflow re-adds the changeset, so it is never lost.",
+  "gitIgnoredAuthors": ["security-bot@users.noreply.github.com"],
+
   "packageRules": [
     {
       "description": "Lock-file maintenance is the ONLY update this repo wants from Renovate. Ordinary version-bump PRs are disabled: package.json ranges are curated by hand, and transitive pins live in security/managed-overrides.json.",


### PR DESCRIPTION
On the first real lock-file PR (#434), Renovate posted:

> Renovate will not automatically rebase this PR, because it does not recognize the last commit author and assumes somebody else may have edited the PR.

**Cause:** `renovate-changeset.yml` pushes the generated changeset onto the branch as `checkstack-security-bot`. Renovate sees a last commit it didn't author, assumes a human edited the PR, and **stops auto-rebasing it**. This isn't a one-off - it would strand *every* lock-file-maintenance PR the moment `main` moves ahead, breaking the automation's core loop (stale lockfile, eventual conflicts).

**Fix:** add the bot's email to [`gitIgnoredAuthors`](https://docs.renovatebot.com/configuration-options/#gitignoredauthors), the option built for exactly this. Renovate then ignores that commit for edit-detection and keeps managing the PR. It recreates the branch on rebase and the workflow re-adds the changeset, so the changeset is never lost.

Validated with `renovate-config-validator` → `Config validated successfully`.

Once merged, Renovate resumes auto-rebasing #434 (and all future lock-file PRs) despite our changeset commit.

No changeset: CI/config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)