### PR TITLE
feat(ci): bulletproof automerge for lock-file-maintenance PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -162,15 +162,24 @@ jobs:
       # into one lockfile). syncpack enforces a single shared range for the
       # unified set declared in `.syncpackrc.json`. Run `bun run deps:fix`
       # locally to auto-align, then `bun install`.
-      # Two gates share this job:
+      # Three gates share this job:
       #  1. syncpack alignment (issue #245) — one shared range per external dep.
       #  2. managed-override drift — every SECURITY override in package.json
       #     `overrides`/`resolutions` is documented in
       #     security/managed-overrides.json and still sits at/above its
       #     safeFloor. Stops undocumented security pins (which rot silently)
       #     from sneaking in. See scripts/audit-overrides.ts.
+      #  3. lock-file changeset drift (Renovate lock-file-maintenance PRs only) —
+      #     the committed changeset MUST match a fresh generation. This feeds the
+      #     required `Report` check, so AUTOMERGE can never ship a lockfile
+      #     refresh whose changeset is missing/stale/drifted (which would merge a
+      #     patched lockfile that never triggers a release). HEAD_REF/BASE_REF are
+      #     passed via env, never interpolated into the shell (injection safety).
       - name: Check Dependency Alignment
         id: deps
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           set +e
           : > /tmp/deps-output.txt
@@ -182,6 +191,15 @@ jobs:
           echo "── managed-override drift ──" | tee -a /tmp/deps-output.txt
           bun run audit:overrides:check 2>&1 | tee -a /tmp/deps-output.txt
           [ "${PIPESTATUS[0]}" != "0" ] && rc=1
+          if [ "$HEAD_REF" = "renovate/lock-file-maintenance" ]; then
+            echo "" | tee -a /tmp/deps-output.txt
+            echo "── lock-file changeset drift ──" | tee -a /tmp/deps-output.txt
+            git fetch origin "$BASE_REF" --depth=1 -q
+            git show "origin/${BASE_REF}:bun.lock" > /tmp/base-bun.lock
+            bun run scripts/renovate-changeset.ts \
+              --base /tmp/base-bun.lock --head bun.lock --check 2>&1 | tee -a /tmp/deps-output.txt
+            [ "${PIPESTATUS[0]}" != "0" ] && rc=1
+          fi
           echo "exit_code=$rc" >> $GITHUB_OUTPUT
 
       - name: Upload Output

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,9 @@
     "commitMessageAction": "Refresh",
     "commitMessageTopic": "bun.lock (lock-file maintenance)",
     "labels": ["dependencies", "security-maintenance"],
-    "rebaseWhen": "behind-base-branch"
+    "rebaseWhen": "behind-base-branch",
+    "automerge": true,
+    "platformAutomerge": true,
+    "automergeStrategy": "squash"
   }
 }

--- a/scripts/renovate-changeset.test.ts
+++ b/scripts/renovate-changeset.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
   CHANGESET_STAMPED_PACKAGES,
+  checkChangeset,
   diffPackages,
+  expectedChangeset,
   owningWorkspaces,
   parseLock,
   renderChangeset,
@@ -181,5 +183,60 @@ describe("renderChangeset", () => {
     });
     expect(md).toStartWith('---\n"@x/backend": patch\n"@x/ui": patch\n---');
     expect(md).toContain("- `tar` 7.5.16 -> 7.5.19");
+  });
+});
+
+describe("expectedChangeset", () => {
+  it("produces content when a public prod owner is affected", () => {
+    const base = parseLock({ raw: BASE_LOCK });
+    const head = parseLock({ raw: HEAD_LOCK });
+    const { owners, content } = expectedChangeset({ base, head, isPublic });
+    expect(owners).toEqual(["@x/backend", "@x/ui"]);
+    expect(content).toContain('"@x/backend": patch');
+  });
+
+  it("returns null content when nothing resolvable changed", () => {
+    const lock = parseLock({ raw: BASE_LOCK });
+    expect(expectedChangeset({ base: lock, head: lock, isPublic }).content).toBeNull();
+  });
+
+  it("returns null content when only a dev-only dependency moved", () => {
+    const base = parseLock({ raw: BASE_LOCK });
+    const head = parseLock({ raw: BASE_LOCK.replace("typescript@5.7.2", "typescript@5.7.3") });
+    expect(expectedChangeset({ base, head, isPublic }).content).toBeNull();
+  });
+});
+
+describe("checkChangeset (the automerge drift guard)", () => {
+  const content = "---\n\"@x/backend\": patch\n---\n\nbody\n";
+
+  it("passes when committed matches a fresh generation", () => {
+    expect(checkChangeset({ expected: content, actual: content })).toEqual({ ok: true });
+  });
+
+  it("passes when none is expected and none is committed", () => {
+    expect(checkChangeset({ expected: null, actual: null })).toEqual({ ok: true });
+  });
+
+  it("FAILS when a changeset is expected but missing (the silent no-release hole)", () => {
+    const v = checkChangeset({ expected: content, actual: null });
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain("no changeset is committed");
+  });
+
+  it("FAILS when the committed changeset drifted from a fresh run", () => {
+    const v = checkChangeset({ expected: content, actual: content.replace("@x/backend", "@x/wrong") });
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain("drift");
+  });
+
+  it("FAILS when a stale changeset exists but none is warranted", () => {
+    const v = checkChangeset({ expected: null, actual: content });
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain("should be removed");
+  });
+
+  it("ignores trailing-whitespace differences", () => {
+    expect(checkChangeset({ expected: content, actual: content + "\n\n" })).toEqual({ ok: true });
   });
 });

--- a/scripts/renovate-changeset.ts
+++ b/scripts/renovate-changeset.ts
@@ -264,11 +264,59 @@ export function resolveOwners({
   return [...owners].toSorted();
 }
 
+/**
+ * The changeset content the current lockfiles SHOULD produce - or `null` when no
+ * changeset is warranted (no resolution changes, or only private / dev-only
+ * owners). Pure over its inputs so both write and `--check` share one source of
+ * truth.
+ */
+export function expectedChangeset({
+  base,
+  head,
+  isPublic,
+}: {
+  base: ParsedLock;
+  head: ParsedLock;
+  isPublic: (workspaceName: string) => boolean;
+}): { changes: DepChange[]; owners: string[]; content: string | null } {
+  const changes = diffPackages({ base, head });
+  if (changes.length === 0) return { changes, owners: [], content: null };
+  const owners = resolveOwners({ head, changes, isPublic });
+  const content = owners.length === 0 ? null : renderChangeset({ owners, changes });
+  return { changes, owners, content };
+}
+
+/**
+ * Verdict of comparing the committed changeset against a fresh generation.
+ * `ok: false` is a hard CI failure - the guard that keeps automerge from
+ * shipping a lockfile refresh whose changeset is missing, stale, or drifted.
+ */
+export function checkChangeset({
+  expected,
+  actual,
+}: {
+  expected: string | null;
+  actual: string | null;
+}): { ok: boolean; reason?: string } {
+  if (expected === null) {
+    return actual === null
+      ? { ok: true }
+      : { ok: false, reason: "a changeset is committed but none is warranted (no public prod owner changed); it should be removed" };
+  }
+  if (actual === null) {
+    return { ok: false, reason: "no changeset is committed, but this refresh affects public prod packages; the generator must run" };
+  }
+  return actual.trim() === expected.trim()
+    ? { ok: true }
+    : { ok: false, reason: "the committed changeset does not match a fresh generation (drift); re-run the generator" };
+}
+
 interface Args {
   base: string;
   head: string;
   out: string;
   dryRun: boolean;
+  check: boolean;
 }
 
 function parseArgs({ argv }: { argv: string[] }): Args {
@@ -279,30 +327,19 @@ function parseArgs({ argv }: { argv: string[] }): Args {
   const base = read("--base");
   const head = read("--head");
   if (!base || !head) {
-    throw new Error("usage: renovate-changeset.ts --base <lock> --head <lock> [--out <md>] [--dry-run]");
+    throw new Error("usage: renovate-changeset.ts --base <lock> --head <lock> [--out <md>] [--dry-run|--check]");
   }
   return {
     base,
     head,
     out: read("--out") ?? ".changeset/renovate-lock-file-maintenance.md",
     dryRun: argv.includes("--dry-run"),
+    check: argv.includes("--check"),
   };
 }
 
-async function main(): Promise<void> {
-  const args = parseArgs({ argv: Bun.argv.slice(2) });
-
-  const base = parseLock({ raw: await readFile(args.base, "utf8") });
-  const head = parseLock({ raw: await readFile(args.head, "utf8") });
-  const changes = diffPackages({ base, head });
-
-  if (changes.length === 0) {
-    console.log("No resolution changes in bun.lock - nothing to do.");
-    if (!args.dryRun && existsSync(args.out)) await rm(args.out);
-    return;
-  }
-
-  // Privacy is read from disk: bun.lock does not record it.
+/** Read each workspace's `private` flag from disk (bun.lock does not record it). */
+async function readIsPublic({ head }: { head: ParsedLock }): Promise<(name: string) => boolean> {
   const privateByName = new Map<string, boolean>();
   for (const ws of head.workspaces) {
     const manifest = path.join(ws.dir, "package.json");
@@ -312,31 +349,47 @@ async function main(): Promise<void> {
       .parse(JSON.parse(await readFile(manifest, "utf8")));
     privateByName.set(ws.name, parsed.private);
   }
-  const isPublic = (name: string): boolean => privateByName.get(name) === false;
+  return (name: string): boolean => privateByName.get(name) === false;
+}
 
-  const owners = resolveOwners({ head, changes, isPublic });
+async function main(): Promise<void> {
+  const args = parseArgs({ argv: Bun.argv.slice(2) });
 
-  console.log(`${changes.length} resolution change(s):`);
-  for (const c of changes) console.log(`  ${c.name} ${c.from} -> ${c.to}`);
+  const base = parseLock({ raw: await readFile(args.base, "utf8") });
+  const head = parseLock({ raw: await readFile(args.head, "utf8") });
+  const isPublic = await readIsPublic({ head });
+  const { changes, owners, content } = expectedChangeset({ base, head, isPublic });
 
-  if (owners.length === 0) {
-    console.log(
-      "\nNo public workspace package reaches any changed dependency through a\n" +
-        "prod edge. Nothing shippable changed; writing no changeset.",
-    );
+  console.log(`${changes.length} resolution change(s), ${owners.length} public prod owner(s).`);
+
+  // --check: the CI drift guard. The committed changeset MUST match a fresh
+  // generation, or automerge could ship a lockfile refresh that never releases.
+  if (args.check) {
+    const actual = existsSync(args.out) ? await readFile(args.out, "utf8") : null;
+    const verdict = checkChangeset({ expected: content, actual });
+    if (!verdict.ok) {
+      console.error(`\n❌ changeset check failed: ${verdict.reason}`);
+      console.error(`   run: bun run scripts/renovate-changeset.ts --base <base bun.lock> --head bun.lock`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log("✓ committed changeset matches a fresh generation.");
+    return;
+  }
+
+  if (content === null) {
+    console.log("Nothing shippable changed (no resolution changes, or only private / dev-only owners); no changeset.");
     if (!args.dryRun && existsSync(args.out)) await rm(args.out);
     return;
   }
 
-  console.log(`\nowners (${owners.length}): ${owners.join(", ")}`);
-  const content = renderChangeset({ owners, changes });
-
   if (args.dryRun) {
+    console.log(`\nowners (${owners.length}): ${owners.join(", ")}`);
     console.log(`\n--- ${args.out} ---\n${content}`);
     return;
   }
   await writeFile(args.out, content, "utf8");
-  console.log(`\nwrote ${args.out}`);
+  console.log(`wrote ${args.out} (${owners.length} owners)`);
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
Enables Renovate automerge for lock-file-maintenance PRs, gated so it can **only** merge when CI is green **and** the release-triggering changeset is provably correct. Pairs with a branch-protection ruleset split (below) applied separately.

## Changes
- **`renovate.json`** — `automerge` + `platformAutomerge` (GitHub-native; merges the instant checks pass, not on Mend's cadence) + `automergeStrategy: squash` on `lockFileMaintenance`.
- **`renovate-changeset.ts`** — new `--check` mode + pure `expectedChangeset` / `checkChangeset` helpers. Regenerates from the lockfiles and fails if the committed changeset is missing, stale, or drifted.
- **`pr-checks.yml`** — runs `--check` inside the `deps` job for the Renovate branch, so it feeds the **required `Report`** check.

## The three guarantees
1. **Never merges red CI** — Renovate doesn't bypass the checks ruleset; `Report` is required.
2. **Never merges anyone else's PR unreviewed** — the bypass (applied separately) is scoped to the Renovate app; Renovate only ever opens lock-file PRs.
3. **Never merges a lockfile change that wouldn't release** — the `--check` guard is now part of required `Report`.

Verified on #434's real lockfile diff: `--check` **fails** on a missing changeset and on a tampered one, **passes** on a correct one. 26 unit tests, config validated with `renovate-config-validator`.

## Required companion (not in this PR)
The branch-protection ruleset split that lets the Renovate app bypass review-only. Applied via API after review.

No changeset: CI/tooling-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)