### PR TITLE
feat(cockpit): install deps from the lockfile before starting the dev instance

### DIFF
--- a/.changeset/cockpit-install-on-start.md
+++ b/.changeset/cockpit-install-on-start.md
@@ -1,0 +1,10 @@
+---
+"@checkstack/scripts": patch
+---
+
+Install dependencies from the lockfile before starting the dev instance in the
+developer cockpit. Selecting "1 Dev" now runs `bun install --frozen-lockfile`
+with streamed progress before booting deps + backend + frontend, so pulling a
+Renovate lock-file refresh no longer leaves you running against a stale
+`node_modules`. The PR-preview flow (option 2) already installs its own merged
+worktree, so it is unchanged.

--- a/core/scripts/src/cockpit/app.tsx
+++ b/core/scripts/src/cockpit/app.tsx
@@ -5,11 +5,10 @@ import {
   useSelectionHandler,
   useTerminalDimensions,
 } from "@opentui/react";
-import { createSupervisor } from "../dev-tui/supervisor.ts";
-import { getProcessDefs, type ProcessDef } from "../dev-tui/process-config.ts";
-import { createProcessStore, type ProcessStore } from "./process-store.ts";
+import type { ProcessDef } from "../dev-tui/process-config.ts";
+import { type ProcessStore } from "./process-store.ts";
 import { CockpitSessionProvider, type CockpitSession } from "./session.ts";
-import { DevRunView } from "./views/DevRunView.tsx";
+import { DevRunView, type DevInstance } from "./views/DevRunView.tsx";
 import { PrPreviewView, type PreviewInfo } from "./views/PrPreviewView.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
 import {
@@ -17,16 +16,9 @@ import {
   type TeardownInstance,
 } from "./components/ShutdownScreen.tsx";
 import { copyToClipboard } from "./clipboard.ts";
-import { attachBrowserAutoOpen } from "./open-browser.ts";
 import { ACCENT } from "./theme.ts";
 
 type View = "home" | "dev" | "pr-preview";
-
-interface DevInstance {
-  store: ProcessStore;
-  defs: readonly ProcessDef[];
-  unregister: () => void;
-}
 
 interface PreviewInstance {
   store: ProcessStore;
@@ -82,19 +74,10 @@ export function App({
     setPreviewState(v);
   };
 
+  // Just reveal the dev view; DevRunView installs dependencies (with progress),
+  // then creates + starts the instance and lifts it back via `setDev`. Guarded
+  // so a running instance is never re-prepared.
   const startDev = () => {
-    if (!devRef.current) {
-      const defs = getProcessDefs(session.args.devMode);
-      const supervisor = createSupervisor({
-        cwd: session.repoRoot,
-        mode: session.args.devMode,
-      });
-      const store = createProcessStore(supervisor);
-      const unregister = session.registerShutdown(() => supervisor.shutdown());
-      attachBrowserAutoOpen({ supervisor });
-      store.start();
-      setDev({ store, defs, unregister });
-    }
     setView("dev");
   };
 
@@ -197,8 +180,13 @@ export function App({
         <box flexGrow={1}>
           {view === "home" ? (
             <HomeView dev={dev !== null} preview={preview !== null} />
-          ) : view === "dev" && dev ? (
-            <DevRunView store={dev.store} defs={dev.defs} active />
+          ) : view === "dev" ? (
+            <DevRunView
+              store={dev?.store ?? null}
+              defs={dev?.defs ?? null}
+              active
+              onReady={setDev}
+            />
           ) : view === "pr-preview" ? (
             <PrPreviewView
               store={preview?.store ?? null}

--- a/core/scripts/src/cockpit/install-deps.test.ts
+++ b/core/scripts/src/cockpit/install-deps.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import type { ExecCommand, ExecResult, ExecRunner } from "./pr-preview/exec.ts";
+import { installDependencies } from "./install-deps.ts";
+
+const cmdOf = (c: ExecCommand) => `${c.command} ${c.args.join(" ")}`;
+
+function fakeExec(responder: (c: ExecCommand) => Partial<ExecResult>): {
+  exec: ExecRunner;
+  calls: ExecCommand[];
+} {
+  const calls: ExecCommand[] = [];
+  return {
+    calls,
+    exec: {
+      run(command) {
+        calls.push(command);
+        const r = responder(command);
+        return Promise.resolve({
+          code: r.code ?? 0,
+          stdout: r.stdout ?? "",
+          stderr: r.stderr ?? "",
+        });
+      },
+    },
+  };
+}
+
+describe("installDependencies", () => {
+  it("runs a frozen-lockfile install in the repo root and reports steps", async () => {
+    const { exec, calls } = fakeExec(() => ({ code: 0 }));
+    const steps: string[] = [];
+    const result = await installDependencies({
+      exec,
+      repoRoot: "/repo",
+      onStep: (m) => steps.push(m),
+    });
+    expect(result).toEqual({ ok: true });
+    expect(calls).toHaveLength(1);
+    expect(cmdOf(calls[0])).toBe("bun install --frozen-lockfile");
+    expect(calls[0].cwd).toBe("/repo");
+    expect(steps[0]).toContain("Installing dependencies");
+    expect(steps.at(-1)).toContain("up to date");
+  });
+
+  it("never uses a plain install (which would rewrite the lockfile)", async () => {
+    const { exec, calls } = fakeExec(() => ({ code: 0 }));
+    await installDependencies({ exec, repoRoot: "/repo", onStep: () => {} });
+    expect(calls[0].args).toContain("--frozen-lockfile");
+  });
+
+  it("fails with a lockfile-drift hint when the install exits non-zero", async () => {
+    const { exec } = fakeExec(() => ({ code: 1, stderr: "lockfile had changes" }));
+    const result = await installDependencies({ exec, repoRoot: "/repo", onStep: () => {} });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("out of sync");
+    expect(result.reason).toContain("lockfile had changes");
+  });
+});

--- a/core/scripts/src/cockpit/install-deps.ts
+++ b/core/scripts/src/cockpit/install-deps.ts
@@ -1,0 +1,49 @@
+import type { ExecRunner } from "./pr-preview/exec.ts";
+
+/** Outcome of a dependency install. `ok: false` carries a user-facing reason. */
+export interface InstallResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+}
+
+/**
+ * Reconcile the repo's `node_modules` with the committed lockfile before a dev
+ * instance starts, so a developer who just pulled a Renovate lock-file refresh
+ * boots against the current dependency set instead of a stale tree.
+ *
+ * Uses `--frozen-lockfile` deliberately: it installs EXACTLY what `bun.lock`
+ * pins and never rewrites the lockfile (a plain `bun install` re-serializes it
+ * even on a no-op, dirtying the working tree on every launch). The trade-off is
+ * that it fails when `package.json` has drifted from `bun.lock` - that is a real
+ * signal surfaced to the user, not silently started against a mismatched tree.
+ * (The PR-preview flow installs its own merged worktree separately, without
+ * `--frozen-lockfile`, because a merge can legitimately change the manifest.)
+ */
+export async function installDependencies({
+  exec,
+  repoRoot,
+  onStep,
+}: {
+  exec: ExecRunner;
+  repoRoot: string;
+  onStep: (message: string) => void;
+}): Promise<InstallResult> {
+  onStep("Installing dependencies (bun install --frozen-lockfile)...");
+  const result = await exec.run({
+    command: "bun",
+    args: ["install", "--frozen-lockfile"],
+    cwd: repoRoot,
+  });
+  if (result.code !== 0) {
+    const detail = (result.stderr || result.stdout).trim();
+    return {
+      ok: false,
+      reason:
+        `bun install --frozen-lockfile failed (exit ${result.code}).\n` +
+        `The lockfile is likely out of sync with package.json - run \`bun install\` to update it.\n\n` +
+        detail,
+    };
+  }
+  onStep("Dependencies are up to date.");
+  return { ok: true };
+}

--- a/core/scripts/src/cockpit/views/DevRunView.tsx
+++ b/core/scripts/src/cockpit/views/DevRunView.tsx
@@ -1,27 +1,124 @@
 /** @jsxImportSource @opentui/react */
-import { useEffect } from "react";
-import type { ProcessDef } from "../../dev-tui/process-config.ts";
-import type { ProcessStore } from "../process-store.ts";
+import { useEffect, useRef, useState } from "react";
+import { extractErrorMessage } from "@checkstack/common";
+import { createSupervisor } from "../../dev-tui/supervisor.ts";
+import { getProcessDefs, type ProcessDef } from "../../dev-tui/process-config.ts";
+import { createProcessStore, type ProcessStore } from "../process-store.ts";
+import { useCockpitSession } from "../session.ts";
+import { installDependencies } from "../install-deps.ts";
 import { InstancePanel } from "../components/InstancePanel.tsx";
+import { attachBrowserAutoOpen } from "../open-browser.ts";
+import { ACCENT } from "../theme.ts";
+
+/** What the App lifts up once the dev instance is running. */
+export interface DevInstance {
+  store: ProcessStore;
+  defs: readonly ProcessDef[];
+  unregister: () => void;
+}
+
+type Phase =
+  | { kind: "preparing"; steps: string[] }
+  | { kind: "error"; message: string };
 
 /**
- * The dev-run view: the primary local instance (deps + backend + frontend),
- * driven by a persistent {@link ProcessStore} so its output survives tab
- * switches. Starts the supervisor on first mount and renders the full instance
- * panel (sidebar, scrollable focused log, alerts).
+ * The dev-run view: the primary local instance (deps + backend + frontend).
+ *
+ * Before the processes start it reconciles `node_modules` with the committed
+ * lockfile (see {@link installDependencies}) so a developer who just pulled a
+ * Renovate lock-file refresh boots against the current dependency set. The
+ * install streams progress the same way the PR-preview flow does; once it
+ * succeeds the supervisor is created, started, and lifted to the App via
+ * `onReady` so its output survives tab switches.
  */
 export function DevRunView({
   store,
   defs,
   active,
+  onReady,
 }: {
-  store: ProcessStore;
-  defs: readonly ProcessDef[];
+  store: ProcessStore | null;
+  defs: readonly ProcessDef[] | null;
   active: boolean;
+  onReady: (next: DevInstance) => void;
 }) {
+  const session = useCockpitSession();
+  const [phase, setPhase] = useState<Phase>({ kind: "preparing", steps: [] });
+  // Guard against duplicate preparation (async effect + re-renders).
+  const preparingRef = useRef(false);
+
   useEffect(() => {
-    store.start();
+    if (store) return; // already running
+    if (preparingRef.current) return;
+    preparingRef.current = true;
+
+    const steps: string[] = [];
+    const pushStep = (message: string) => {
+      steps.push(message);
+      setPhase({ kind: "preparing", steps: [...steps] });
+    };
+    setPhase({ kind: "preparing", steps: [] });
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const install = await installDependencies({
+          exec: session.exec,
+          repoRoot: session.repoRoot,
+          onStep: pushStep,
+        });
+        if (cancelled) return;
+        if (!install.ok) {
+          setPhase({ kind: "error", message: install.reason ?? "install failed" });
+          preparingRef.current = false;
+          return;
+        }
+
+        pushStep("Starting deps + backend + frontend...");
+        const nextDefs = getProcessDefs(session.args.devMode);
+        const supervisor = createSupervisor({
+          cwd: session.repoRoot,
+          mode: session.args.devMode,
+        });
+        const nextStore = createProcessStore(supervisor);
+        const unregister = session.registerShutdown(() => supervisor.shutdown());
+        attachBrowserAutoOpen({ supervisor });
+        nextStore.start();
+        onReady({ store: nextStore, defs: nextDefs, unregister });
+      } catch (error) {
+        if (cancelled) return;
+        setPhase({ kind: "error", message: extractErrorMessage(error) });
+        preparingRef.current = false;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once until running
   }, [store]);
 
-  return <InstancePanel store={store} defs={defs} active={active} />;
+  if (store && defs) {
+    return <InstancePanel store={store} defs={defs} active={active} />;
+  }
+
+  if (phase.kind === "error") {
+    return (
+      <box flexDirection="column" paddingLeft={1}>
+        <text fg="red">Could not start the dev instance</text>
+        <text>{phase.message}</text>
+      </box>
+    );
+  }
+
+  return (
+    <box flexDirection="column" paddingLeft={1}>
+      <text fg={ACCENT}>Starting dev instance</text>
+      {phase.steps.map((step, index) => (
+        <text key={index} fg="gray">
+          {step}
+        </text>
+      ))}
+    </box>
+  );
 }


### PR DESCRIPTION
Starting the dev instance from the cockpit (option **1**) now reconciles `node_modules` with the committed lockfile *before* booting, so a developer who just pulled a Renovate lock-file refresh runs against the current dependency set instead of a stale tree. It's done in the TUI (not the `dev` npm script) so the install shows as a proper progress step, matching the PR-preview flow.

## Changes
- **`install-deps.ts`** — `installDependencies()` runs `bun install --frozen-lockfile`: installs exactly what `bun.lock` pins and never rewrites it (a plain install re-serializes the lockfile on a no-op, dirtying the tree). Fails loudly with a drift hint if `package.json` is out of sync. + unit tests.
- **`DevRunView`** — refactored to mirror `PrPreviewView`'s prepare pattern: a phase machine that streams install progress, then creates + starts the supervisor and lifts it to the App via `onReady`.
- **`App`** — `startDev()` just reveals the view; the view owns prepare + start.

## Scope
- **Option 2 (PR preview)** already installs its own merged worktree (`prepare.ts`), so it's unchanged.
- **Known edge:** the cockpit's own deps must already be installed for the TUI to launch, so a fresh clone still needs one initial `bun install`. This covers the far more common "pulled a lockfile change" case. Happy to add a minimal `predev` bootstrap if you'd rather it self-heal fresh clones too.

Typecheck + lint clean, 53 cockpit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)