### PR TITLE
feat(dev): predev bootstrap so the cockpit TUI can launch on a fresh clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "docs"
   ],
   "scripts": {
+    "predev": "bun run scripts/ensure-deps.ts",
     "dev": "bun run core/scripts/src/cockpit/cli.tsx",
     "preview": "bun run core/scripts/src/cockpit/cli.tsx preview",
     "preview:prs": "bun run core/scripts/src/cockpit/cli.tsx",

--- a/scripts/ensure-deps.test.ts
+++ b/scripts/ensure-deps.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { needsBootstrap } from "./ensure-deps.ts";
+
+describe("needsBootstrap", () => {
+  it("installs when node_modules is absent (fresh clone)", () => {
+    expect(needsBootstrap({ exists: () => false })).toBe(true);
+  });
+
+  it("is a no-op when node_modules is present", () => {
+    expect(needsBootstrap({ exists: (p) => p === "node_modules" })).toBe(false);
+  });
+});

--- a/scripts/ensure-deps.ts
+++ b/scripts/ensure-deps.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+/**
+ * `predev` bootstrap: make sure `node_modules` exists so the developer cockpit
+ * (an @opentui/react TUI) can even launch - a fresh clone has none, and a TUI
+ * cannot render a "please install" prompt if its own renderer isn't installed.
+ *
+ * It ONLY installs when `node_modules` is absent. The normal case - syncing to a
+ * just-pulled Renovate lock-file change - is handled with streamed progress
+ * INSIDE the cockpit (see core/scripts/src/cockpit/install-deps.ts), so this
+ * stays a no-op on every launch after the first.
+ *
+ * Written as a bun script rather than a shell `test -d ... || ...` so it behaves
+ * identically on Windows, Linux, and macOS. `process.execPath` is the very bun
+ * binary running this script, so the install spawn needs no PATH/`.exe`/`.cmd`
+ * resolution.
+ */
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+/** Pure decision, so it is trivially testable without touching the filesystem. */
+export function needsBootstrap({ exists }: { exists: (path: string) => boolean }): boolean {
+  return !exists("node_modules");
+}
+
+if (import.meta.main && needsBootstrap({ exists: existsSync })) {
+  console.log("node_modules missing - bootstrapping (bun install --frozen-lockfile)...");
+  const { status } = spawnSync(process.execPath, ["install", "--frozen-lockfile"], {
+    stdio: "inherit",
+  });
+  if (status !== 0) process.exit(status ?? 1);
+}


### PR DESCRIPTION
The developer cockpit is an `@opentui/react` TUI, so it can't render a "please install" prompt if its own renderer isn't installed - a fresh clone (no `node_modules`) would just fail to start. This adds a `predev` script that ensures `node_modules` exists before `bun dev` launches the cockpit.

## Behaviour
- **Only installs when `node_modules` is absent.** Syncing to a just-pulled Renovate lock-file change is handled with streamed progress *inside* the cockpit (#438), so this is a no-op on every launch after the first.
- **Cross-platform by construction.** Implemented as a bun script (`scripts/ensure-deps.ts`), not a shell `test -d ... || ...`. bun runs it identically on Windows/Linux/macOS, and `process.execPath` spawns the same bun binary with no PATH/`.exe`/`.cmd` resolution. (For the record: Bun Shell *does* implement `test`, but a script removes the dependency on that entirely.) The install decision is a pure, unit-tested function.

## Relationship to #438
Independent and composable: this covers the fresh-clone / cold-start case; #438 gives the running dev instance its nice in-TUI install-with-progress. Either can merge alone.

No changeset: dev-tooling change to the private root `package.json` + a repo-root script, not part of any published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)