### PR TITLE
fix(ci): stop lock-file changeset from clobbering a pending refresh

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -196,8 +196,14 @@ jobs:
             echo "── lock-file changeset drift ──" | tee -a /tmp/deps-output.txt
             git fetch origin "$BASE_REF" --depth=1 -q
             git show "origin/${BASE_REF}:bun.lock" > /tmp/base-bun.lock
+            # Union base for the drift guard: same pending changeset the generator
+            # reads, so a still-unreleased refresh's entries are expected, not
+            # flagged as drift. Absent on the first refresh after a release.
+            git show "origin/${BASE_REF}:.changeset/renovate-lock-file-maintenance.md" \
+              > /tmp/pending-changeset.md 2>/dev/null || : > /tmp/pending-changeset.md
             bun run scripts/renovate-changeset.ts \
-              --base /tmp/base-bun.lock --head bun.lock --check 2>&1 | tee -a /tmp/deps-output.txt
+              --base /tmp/base-bun.lock --head bun.lock \
+              --pending /tmp/pending-changeset.md --check 2>&1 | tee -a /tmp/deps-output.txt
             [ "${PIPESTATUS[0]}" != "0" ] && rc=1
           fi
           echo "exit_code=$rc" >> $GITHUB_OUTPUT

--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -64,10 +64,18 @@ jobs:
             exit 1
           fi
 
-      - name: Extract the base lockfile
+      - name: Extract the base lockfile and pending changeset
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: git show "origin/${BASE_REF}:bun.lock" > /tmp/base-bun.lock
+        run: |
+          git show "origin/${BASE_REF}:bun.lock" > /tmp/base-bun.lock
+          # The changeset as it exists on the base branch. When a previous refresh
+          # is merged to main but not yet released (its Version Packages PR is
+          # still open), this file still lists those pending owners/bumps; the
+          # generator UNIONs them in so the overwrite cannot drop them. Absent on
+          # the first refresh after a release - then the file simply does not exist.
+          git show "origin/${BASE_REF}:.changeset/renovate-lock-file-maintenance.md" \
+            > /tmp/pending-changeset.md 2>/dev/null || : > /tmp/pending-changeset.md
 
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/bun-install
@@ -77,6 +85,7 @@ jobs:
           bun run scripts/renovate-changeset.ts \
             --base /tmp/base-bun.lock \
             --head bun.lock \
+            --pending /tmp/pending-changeset.md \
             --out .changeset/renovate-lock-file-maintenance.md
 
       - name: Commit changeset if it changed

--- a/scripts/renovate-changeset.test.ts
+++ b/scripts/renovate-changeset.test.ts
@@ -4,8 +4,10 @@ import {
   checkChangeset,
   diffPackages,
   expectedChangeset,
+  mergeChangeset,
   owningWorkspaces,
   parseLock,
+  parsePendingChangeset,
   renderChangeset,
   resolveOwners,
   reachableAncestors,
@@ -187,23 +189,134 @@ describe("renderChangeset", () => {
 });
 
 describe("expectedChangeset", () => {
-  it("produces content when a public prod owner is affected", () => {
+  const anchors = ["@x/app"] as const;
+
+  it("emits the fixed anchors (NOT the reachable owners) when the image is affected", () => {
     const base = parseLock({ raw: BASE_LOCK });
     const head = parseLock({ raw: HEAD_LOCK });
-    const { owners, content } = expectedChangeset({ base, head, isPublic });
-    expect(owners).toEqual(["@x/backend", "@x/ui"]);
-    expect(content).toContain('"@x/backend": patch');
+    const { owners, content } = expectedChangeset({ base, head, isPublic, anchors });
+    // @x/backend and @x/ui reach the changed deps, but the frontmatter is the anchor.
+    expect(owners).toEqual(["@x/app"]);
+    expect(content).toContain('"@x/app": patch');
+    expect(content).not.toContain('"@x/backend": patch');
+    // ...while the changed deps stay itemised in the body as the audit trail.
+    expect(content).toContain("- `tar` 7.5.16 -> 7.5.19");
+    expect(content).toContain("- `fast-uri` 3.1.2 -> 3.1.3");
   });
 
   it("returns null content when nothing resolvable changed", () => {
     const lock = parseLock({ raw: BASE_LOCK });
-    expect(expectedChangeset({ base: lock, head: lock, isPublic }).content).toBeNull();
+    expect(expectedChangeset({ base: lock, head: lock, isPublic, anchors }).content).toBeNull();
   });
 
-  it("returns null content when only a dev-only dependency moved", () => {
+  it("returns null content when only a dev-only dependency moved (image built --production)", () => {
     const base = parseLock({ raw: BASE_LOCK });
     const head = parseLock({ raw: BASE_LOCK.replace("typescript@5.7.2", "typescript@5.7.3") });
-    expect(expectedChangeset({ base, head, isPublic }).content).toBeNull();
+    expect(expectedChangeset({ base, head, isPublic, anchors }).content).toBeNull();
+  });
+});
+
+describe("parsePendingChangeset", () => {
+  it("is the inverse of renderChangeset over owners and dep bumps", () => {
+    const md = renderChangeset({
+      owners: ["@x/backend", "@x/ui"],
+      changes: [
+        { name: "fast-uri", from: "3.1.2", to: "3.1.3" },
+        { name: "tar", from: "7.5.16", to: "7.5.19" },
+      ],
+    });
+    expect(parsePendingChangeset({ raw: md })).toEqual({
+      owners: ["@x/backend", "@x/ui"],
+      changes: [
+        { name: "fast-uri", from: "3.1.2", to: "3.1.3" },
+        { name: "tar", from: "7.5.16", to: "7.5.19" },
+      ],
+    });
+  });
+
+  it("returns an empty set for an absent/empty base-branch file", () => {
+    expect(parsePendingChangeset({ raw: "" })).toEqual({ owners: [], changes: [] });
+  });
+
+  it("does not mistake body prose for a frontmatter owner", () => {
+    const md = renderChangeset({ owners: ["@x/backend"], changes: [{ name: "tar", from: "1", to: "2" }] });
+    // The body sentence mentions `package.json`; only the fenced frontmatter counts.
+    expect(parsePendingChangeset({ raw: md }).owners).toEqual(["@x/backend"]);
+  });
+});
+
+describe("mergeChangeset", () => {
+  it("chains a dep changed in BOTH windows from pending.from to incremental.to", () => {
+    const merged = mergeChangeset({
+      pending: { owners: ["@x/ui"], changes: [{ name: "tar", from: "7.5.16", to: "7.5.19" }] },
+      incremental: { owners: ["@x/backend"], changes: [{ name: "tar", from: "7.5.19", to: "7.5.22" }] },
+    });
+    expect(merged.owners).toEqual(["@x/backend", "@x/ui"]);
+    expect(merged.changes).toEqual([{ name: "tar", from: "7.5.16", to: "7.5.22" }]);
+  });
+
+  it("carries deps that appear in only one window", () => {
+    const merged = mergeChangeset({
+      pending: { owners: ["@x/ui"], changes: [{ name: "ajv", from: "8.0.0", to: "8.1.0" }] },
+      incremental: { owners: ["@x/backend"], changes: [{ name: "tar", from: "7.5.16", to: "7.5.19" }] },
+    });
+    expect(merged.changes).toEqual([
+      { name: "ajv", from: "8.0.0", to: "8.1.0" },
+      { name: "tar", from: "7.5.16", to: "7.5.19" },
+    ]);
+  });
+
+  it("drops a bump the incremental refresh rolled back to a no-op", () => {
+    const merged = mergeChangeset({
+      pending: { owners: ["@x/ui"], changes: [{ name: "tar", from: "7.5.16", to: "7.5.19" }] },
+      incremental: { owners: [], changes: [{ name: "tar", from: "7.5.19", to: "7.5.16" }] },
+    });
+    // Net change is zero across the window -> no misleading `x -> x` line.
+    expect(merged.changes).toEqual([]);
+    expect(merged.owners).toEqual(["@x/ui"]);
+  });
+});
+
+describe("expectedChangeset with a pending (unreleased) changeset", () => {
+  const anchors = ["@x/app"] as const;
+  // The base lock already carries a previous refresh's resolutions (as main does
+  // when a Version Packages PR is still open), so the incremental diff is tiny.
+  const MAIN_LOCK = HEAD_LOCK; // main = base already refreshed tar + fast-uri
+  const NEXT_HEAD = MAIN_LOCK.replace("tar@7.5.19", "tar@7.5.22");
+  // A previous refresh's committed changeset - its BODY is the audit trail we
+  // must not lose; its (older, fanned-out) owners are irrelevant now.
+  const pending = parsePendingChangeset({
+    raw: renderChangeset({
+      owners: ["@x/backend", "@x/ui"],
+      changes: [
+        { name: "fast-uri", from: "3.1.2", to: "3.1.3" },
+        { name: "tar", from: "7.5.16", to: "7.5.19" },
+      ],
+    }),
+  });
+
+  it("preserves the pending dep list, chains the new refresh, and re-anchors the owners", () => {
+    const base = parseLock({ raw: MAIN_LOCK });
+    const head = parseLock({ raw: NEXT_HEAD });
+    const { owners, content } = expectedChangeset({ base, head, isPublic, pending, anchors });
+    expect(owners).toEqual(["@x/app"]); // fixed anchors, not the pending fan-out
+    // fast-uri survives (pending only), tar chains 7.5.16 -> 7.5.22 across the window.
+    expect(content).toContain("- `fast-uri` 3.1.2 -> 3.1.3");
+    expect(content).toContain("- `tar` 7.5.16 -> 7.5.22");
+  });
+
+  it("does NOT delete a pending changeset when the new refresh is a no-op (the release-cancelling hole)", () => {
+    const base = parseLock({ raw: MAIN_LOCK });
+    const { owners, content } = expectedChangeset({ base, head: base, isPublic, pending, anchors });
+    // Incremental diff is empty, but the pending refresh is still unreleased.
+    expect(content).not.toBeNull();
+    expect(owners).toEqual(["@x/app"]);
+    expect(content).toContain("- `tar` 7.5.16 -> 7.5.19");
+  });
+
+  it("still yields null when there is no pending changeset and nothing changed", () => {
+    const base = parseLock({ raw: MAIN_LOCK });
+    expect(expectedChangeset({ base, head: base, isPublic, pending: null }).content).toBeNull();
   });
 });
 

--- a/scripts/renovate-changeset.ts
+++ b/scripts/renovate-changeset.ts
@@ -23,6 +23,28 @@
  * the nearest-ancestor set is small and semantically right (`fast-uri` arrives
  * via `ajv`, so it lands on the frontend packages that declare `ajv`).
  *
+ * Accumulation across an unreleased window: the changeset uses a single fixed
+ * filename that this script OVERWRITES on every refresh. If the diff base were
+ * the current base branch, a still-PENDING refresh (one merged to main whose
+ * `changeset-release/main` "Version Packages" PR has not merged yet) would be
+ * silently clobbered: main already carries the previous refresh's resolutions,
+ * so a fresh diff sees only the small incremental delta and the overwrite drops
+ * the ~100 pending entries - in the worst case (empty/dev-only delta) deleting
+ * the pending changeset and CANCELLING a needed release. So the caller passes
+ * the changeset as it currently exists ON THE BASE BRANCH via `--pending`, and
+ * the incremental diff is UNIONED into its dep list (`mergeChangeset`): every
+ * still-unreleased bump is preserved and this refresh's changes are chained on
+ * top, so the audit body is complete across the whole window. The presence of a
+ * pending changeset also keeps the file alive when THIS refresh is a no-op /
+ * dev-only, which is what actually closes the release-cancelling hole. The
+ * result stays a pure function of (base lock, head lock, pending changeset) so
+ * the `--check` drift guard is unaffected; and because the pending file is read
+ * from the base branch and NOT from the branch's own prior output, re-running on
+ * a Renovate force-push does not double-accumulate. (The frontmatter owners are
+ * always the fixed image anchors - see `CHANGESET_IMAGE_ANCHORS` - not the
+ * unioned pending owners, so re-anchoring shrinks an over-fanned pending release
+ * down to the anchors on the next regeneration.)
+ *
  * Two filters keep the result honest:
  *   - PRIVATE workspace packages are excluded. They never publish, so they
  *     cannot flip `changesets/action`'s `published` output, and naming them
@@ -53,6 +75,24 @@ export const CHANGESET_STAMPED_PACKAGES = new Set<string>([
   "@checkstack/sdk",
   "@checkstack/release",
 ]);
+
+/**
+ * The public package(s) the changeset bumps purely to TRIGGER the Docker image
+ * rebuild. `release.yml` builds the image only when `changesets/action` actually
+ * PUBLISHED a public package, so the changeset needs at least one public bump to
+ * fire. It does NOT need one per affected package: every workspace publishes RAW
+ * SOURCE and resolves its transitive deps from `package.json` ranges at the
+ * consumer's install time, so a lock-file refresh changes NO published artifact
+ * - only the image, which is built `--frozen-lockfile`. Charging every reachable
+ * owner would republish ~100 packages with identical code per refresh for zero
+ * consumer benefit; a fixed anchor set representing the deployable (server + web)
+ * is the minimal honest trigger. The changed dependencies are still itemised in
+ * the changeset BODY as the audit trail - they just land in these anchors'
+ * changelogs instead of a hundred. The owner-attribution graph below is retained
+ * ONLY as the shippability gate: "does any changed dep reach a PUBLIC PROD
+ * package?" (i.e. is the production image affected at all).
+ */
+export const CHANGESET_IMAGE_ANCHORS = ["@checkstack/backend", "@checkstack/frontend"] as const;
 
 const DepMapSchema = z.record(z.string(), z.string());
 
@@ -97,6 +137,12 @@ export interface DepChange {
   name: string;
   from: string;
   to: string;
+}
+
+/** The load-bearing content of a rendered changeset: its owners and dep bumps. */
+export interface PendingChangeset {
+  owners: string[];
+  changes: DepChange[];
 }
 
 const isWorkspaceLink = (range: string): boolean => range.startsWith("workspace:");
@@ -245,6 +291,66 @@ export function renderChangeset({
   ].join("\n");
 }
 
+/**
+ * Recover the `{ owners, changes }` from a previously-rendered changeset. This
+ * is the inverse of `renderChangeset` over the load-bearing fields: frontmatter
+ * `"name": patch` lines become owners and `- \`name\` from -> to` body lines
+ * become dep changes. Robust to an empty/absent file (`git show` of a path that
+ * does not exist on the base branch) - returns an empty pending set.
+ */
+export function parsePendingChangeset({ raw }: { raw: string }): PendingChangeset {
+  const owners: string[] = [];
+  const changes: DepChange[] = [];
+
+  const frontmatter = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (frontmatter) {
+    for (const line of frontmatter[1].split("\n")) {
+      const owner = line.match(/^"(.+)":\s*patch\s*$/);
+      if (owner) owners.push(owner[1]);
+    }
+  }
+  for (const line of raw.split("\n")) {
+    const change = line.match(/^- `([^`]+)` (\S+) -> (\S+)\s*$/);
+    if (change) changes.push({ name: change[1], from: change[2], to: change[3] });
+  }
+
+  return {
+    owners: [...new Set(owners)].toSorted(),
+    changes: changes.toSorted((a, b) => a.name.localeCompare(b.name)),
+  };
+}
+
+/**
+ * Union a still-pending changeset with this refresh's incremental diff. Owners
+ * are the sorted union of both lists. Dep bumps are keyed by name: a dep in BOTH
+ * chains the pending `from` to the incremental `to` (the true span across the
+ * unreleased window); a dep in only one side is carried as-is. A bump that nets
+ * to `from === to` (an incremental rollback of a pending bump) is dropped so the
+ * list never shows a no-op `x -> x` line.
+ */
+export function mergeChangeset({
+  pending,
+  incremental,
+}: {
+  pending: PendingChangeset;
+  incremental: PendingChangeset;
+}): PendingChangeset {
+  const owners = [...new Set([...pending.owners, ...incremental.owners])].toSorted();
+
+  const byName = new Map<string, DepChange>();
+  for (const change of pending.changes) byName.set(change.name, change);
+  for (const change of incremental.changes) {
+    const prev = byName.get(change.name);
+    byName.set(change.name, { name: change.name, from: prev?.from ?? change.from, to: change.to });
+  }
+
+  const changes = [...byName.values()]
+    .filter((change) => change.from !== change.to)
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  return { owners, changes };
+}
+
 /** Owners for the whole change set, unioned across every changed package. */
 export function resolveOwners({
   head,
@@ -274,14 +380,42 @@ export function expectedChangeset({
   base,
   head,
   isPublic,
+  pending = null,
+  anchors = CHANGESET_IMAGE_ANCHORS,
 }: {
   base: ParsedLock;
   head: ParsedLock;
   isPublic: (workspaceName: string) => boolean;
+  /** The changeset as it exists on the BASE branch, so a pending (unreleased)
+   *  refresh is unioned in rather than clobbered. Omit / null when none exists. */
+  pending?: PendingChangeset | null;
+  /** Public packages bumped to trigger the image rebuild (see
+   *  `CHANGESET_IMAGE_ANCHORS`). Injectable for tests. */
+  anchors?: readonly string[];
 }): { changes: DepChange[]; owners: string[]; content: string | null } {
-  const changes = diffPackages({ base, head });
-  if (changes.length === 0) return { changes, owners: [], content: null };
-  const owners = resolveOwners({ head, changes, isPublic });
+  const incrementalChanges = diffPackages({ base, head });
+  // Gate only: does this refresh move a dep that reaches a PUBLIC PROD package,
+  // i.e. is the production image affected? The owners themselves are discarded -
+  // the emitted owner set is the fixed anchor(s), not the reachable closure.
+  const incrementalAffectsImage =
+    resolveOwners({ head, changes: incrementalChanges, isPublic }).length > 0;
+
+  const pendingSet = pending ?? { owners: [], changes: [] };
+  // BODY: union the full lockfile diff across the unreleased window as the audit
+  // trail (prod + dev lines, chained, net-zero rollbacks dropped). Owners are
+  // ignored here; they are the fixed anchors below.
+  const { changes } = mergeChangeset({
+    pending: { owners: [], changes: pendingSet.changes },
+    incremental: { owners: [], changes: incrementalChanges },
+  });
+
+  // A pending changeset is an in-flight, still-unreleased refresh we must never
+  // silently cancel, so its mere presence keeps the changeset alive even when
+  // THIS refresh is a no-op / dev-only. Combined with the image gate above, this
+  // is what closes the release-cancelling hole.
+  const pendingIsShippable = pendingSet.owners.length > 0 || pendingSet.changes.length > 0;
+  const owners = incrementalAffectsImage || pendingIsShippable ? [...anchors] : [];
+
   const content = owners.length === 0 ? null : renderChangeset({ owners, changes });
   return { changes, owners, content };
 }
@@ -315,6 +449,7 @@ interface Args {
   base: string;
   head: string;
   out: string;
+  pending?: string;
   dryRun: boolean;
   check: boolean;
 }
@@ -327,12 +462,13 @@ function parseArgs({ argv }: { argv: string[] }): Args {
   const base = read("--base");
   const head = read("--head");
   if (!base || !head) {
-    throw new Error("usage: renovate-changeset.ts --base <lock> --head <lock> [--out <md>] [--dry-run|--check]");
+    throw new Error("usage: renovate-changeset.ts --base <lock> --head <lock> [--out <md>] [--pending <md>] [--dry-run|--check]");
   }
   return {
     base,
     head,
     out: read("--out") ?? ".changeset/renovate-lock-file-maintenance.md",
+    pending: read("--pending"),
     dryRun: argv.includes("--dry-run"),
     check: argv.includes("--check"),
   };
@@ -358,9 +494,17 @@ async function main(): Promise<void> {
   const base = parseLock({ raw: await readFile(args.base, "utf8") });
   const head = parseLock({ raw: await readFile(args.head, "utf8") });
   const isPublic = await readIsPublic({ head });
-  const { changes, owners, content } = expectedChangeset({ base, head, isPublic });
 
-  console.log(`${changes.length} resolution change(s), ${owners.length} public prod owner(s).`);
+  // The changeset as it currently exists on the base branch. A pending
+  // (unreleased) refresh MUST be unioned in, not clobbered - see file header.
+  const pending =
+    args.pending && existsSync(args.pending)
+      ? parsePendingChangeset({ raw: await readFile(args.pending, "utf8") })
+      : null;
+
+  const { changes, owners, content } = expectedChangeset({ base, head, isPublic, pending });
+
+  console.log(`${changes.length} resolution change(s), ${owners.length} image anchor(s).`);
 
   // --check: the CI drift guard. The committed changeset MUST match a fresh
   // generation, or automerge could ship a lockfile refresh that never releases.


### PR DESCRIPTION
## Problem

The lock-file-maintenance changeset generator (`scripts/renovate-changeset.ts`) diffs the refreshed `bun.lock` against `origin/main`. But main already carries a *previous* refresh whose `Version Packages` PR has not merged yet (e.g. #429 open, #434's changeset still pending). So the fresh diff sees only the small incremental delta, and the single fixed-filename overwrite **clobbers the pending entries** - reducing a ~100-package changeset down to a handful. In the worst case (empty / dev-only delta) it **deletes** the changeset entirely, which cancels a needed release and the refreshed (potentially security-patched) resolutions never ship in the image.

Observed on #441: the committed changeset dropped from 97 owners / 363 dep bumps down to a single owner.

## Fix 1 - never clobber a pending refresh

Both workflows now pass the base-branch changeset via a new `--pending` flag. The generator unions its dep list into the regeneration:

- every still-unreleased bump is preserved, and this refresh's changes are chained on top (`pending.from -> incremental.to`), with net-zero rollbacks dropped;
- the mere presence of a pending changeset keeps the file alive when the current refresh is a no-op, closing the release-cancelling hole;
- output stays a pure function of `(base lock, head lock, pending changeset)`, so the `--check` drift guard is unaffected;
- the pending file is read from the **base branch**, not the branch's own prior output, so a Renovate force-push does not double-accumulate.

## Fix 2 - stop fanning owners across ~100 packages

Workspaces publish **raw source** and resolve transitive deps from ranges at the consumer's install time, so a lock-file refresh changes **no published artifact** - only the Docker image, built `--frozen-lockfile`. The image rebuild only needs `changesets/action` to publish **one** public package.

So the owner-attribution graph is now only the *shippability gate* ("does a changed dep reach a public prod package → is the production image affected?"). When it fires, the changeset bumps the fixed image anchors `@checkstack/backend` + `@checkstack/frontend` as the rebuild trigger; the full dependency diff stays in the **body** as the audit trail. Re-anchoring also shrinks an over-fanned *pending* release down to the anchors on the next regeneration.

## Verified against real #441 data

| | owners | dep body |
|---|---|---|
| before (broken) | `@checkstack/frontend` only | drops 363 pending bumps |
| after | `@checkstack/backend` + `@checkstack/frontend` | full 363-line audit body |

The actual #441 delta is just `empathic 2.0.1 -> 2.0.0` - a rollback of a bump the pending changeset introduced - which the union correctly net-zeroes out.

`bun test scripts/renovate-changeset.test.ts` 35 pass · typecheck clean · lint clean.

## Files
- `scripts/renovate-changeset.ts` - `CHANGESET_IMAGE_ANCHORS`, `parsePendingChangeset`, `mergeChangeset`, anchor-based `expectedChangeset`, `--pending` flag.
- `.github/workflows/renovate-changeset.yml` + `pr-checks.yml` - read the base-branch changeset and pass `--pending`.
- `scripts/renovate-changeset.test.ts` - +8 regression tests (union chaining, net-zero drop, pending preservation, the release-cancelling-hole guard, anchor re-write).

No changeset: CI/tooling only, no published-package behavior change.

## Follow-up
Once merged, main moves ahead → Renovate rebases #441 → the workflow regenerates its changeset with the fixed logic (and the `--check` guard agrees). No manual edit of #441 required; the over-fanned pending release (#429) also shrinks to the two anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)