### PR TITLE
chore(security): prune redundant managed overrides

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3185,8 +3185,6 @@
     "postcss-selector-parser": "^7.1.4",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "undici": "^7.28.0",
-    "uuid": "^14.0.0",
     "ws": "^8.21.0",
     "yaml": "^2.9.0",
   },
@@ -6289,7 +6287,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@8.7.0", "", {}, "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -6518,6 +6516,8 @@
     "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "@mdx-js/mdx/remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "@module-federation/dts-plugin/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "@module-federation/managers/empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 

--- a/package.json
+++ b/package.json
@@ -71,14 +71,12 @@
     "drizzle-kit": ">=0.31.0 <1.0.0",
     "esbuild": "^0.28.1",
     "dompurify": "^3.4.11",
-    "uuid": "^14.0.0",
     "yaml": "^2.9.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "ws": "^8.21.0",
     "minimatch": "^10.2.5",
     "postcss-selector-parser": "^7.1.4",
-    "undici": "^7.28.0",
     "@astrojs/markdown-remark": "^7.2.0"
   },
   "resolutions": {
@@ -86,14 +84,12 @@
     "drizzle-kit": ">=0.31.0 <1.0.0",
     "esbuild": "^0.28.1",
     "dompurify": "^3.4.11",
-    "uuid": "^14.0.0",
     "yaml": "^2.9.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "ws": "^8.21.0",
     "minimatch": "^10.2.5",
     "postcss-selector-parser": "^7.1.4",
-    "undici": "^7.28.0",
     "@astrojs/markdown-remark": "^7.2.0"
   }
 }

--- a/security/managed-overrides.json
+++ b/security/managed-overrides.json
@@ -41,14 +41,6 @@
       "addedAt": "2026-06-14",
       "removeWhen": "No dependency resolves esbuild below 0.28.1 without this override."
     },
-    "uuid": {
-      "safeFloor": "14.0.0",
-      "severity": "MEDIUM",
-      "advisory": "Added in #210 (extend Trivy scope to MEDIUM and bump vulnerable deps).",
-      "reason": "Pins uuid to the 14.x fixed line. Confirm the exact advisory ID from #210 if refining.",
-      "addedAt": "2026-05-13",
-      "removeWhen": "No dependency resolves uuid below 14.0.0 without this override."
-    },
     "yaml": {
       "safeFloor": "2.9.0",
       "severity": "MEDIUM",
@@ -56,14 +48,6 @@
       "reason": "Forces every consumer onto a fixed yaml release. Confirm the exact advisory ID if refining.",
       "addedAt": "2026-06-06",
       "removeWhen": "No dependency resolves yaml below 2.9.0 without this override."
-    },
-    "undici": {
-      "safeFloor": "7.28.0",
-      "severity": "HIGH",
-      "advisory": "CVE-2026-9678, CVE-2026-9697",
-      "reason": "Auto-remediated by Security Maintenance: undici 7.24.7 had fixable advisories; pinned to the fixed 7.x line.",
-      "addedAt": "2026-06-19",
-      "removeWhen": "No dependency resolves below 7.28.0 without this override."
     }
   },
   "intentional": {


### PR DESCRIPTION
Automated by the daily **Security Maintenance** workflow.

## Redundant overrides removed

These security overrides are no longer needed — the dependency graph
now resolves at/above their `safeFloor` without the pin:

- Pruned 2 redundant override(s): uuid, undici

## Current CVE state

### Fixable vulnerabilities (a patched version exists): 0

_None._

<details><summary>Known unfixed (monitoring only)</summary>


</details>
