### PR TITLE
fix(ci): tolerate missing changeset file in renovate-changeset commit step

### DIFF
--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -93,7 +93,16 @@ jobs:
           set -euo pipefail
           git config user.name  "checkstack-security-bot"
           git config user.email "security-bot@users.noreply.github.com"
-          git add -A .changeset/renovate-lock-file-maintenance.md
+          # `git add -A <path>` exits 128 when the path is neither in the working
+          # tree nor in the index - the generator's legitimate no-op case (no
+          # resolution changes, no pending changeset, so no file was ever
+          # written). Only add when there is something to stage; a tracked file
+          # deleted by the generator still passes `git ls-files --error-unmatch`,
+          # so staging the deletion keeps working.
+          if [ -e .changeset/renovate-lock-file-maintenance.md ] || \
+             git ls-files --error-unmatch .changeset/renovate-lock-file-maintenance.md >/dev/null 2>&1; then
+            git add -A .changeset/renovate-lock-file-maintenance.md
+          fi
           if git diff --cached --quiet; then
             echo "Changeset already up to date - nothing to commit."
             exit 0


### PR DESCRIPTION
## Problem

The "Generate lock-file changeset" job crashed on the Renovate lock-file-maintenance PR #458:

```
git add -A .changeset/renovate-lock-file-maintenance.md
fatal: pathspec '.changeset/renovate-lock-file-maintenance.md' did not match any files
```

That refresh was a legitimate no-op for shipping: the only `bun.lock` change was the `core/sdk` workspace version stamp (`0.131.0 -> 0.132.0`), so `scripts/renovate-changeset.ts` correctly reported `0 resolution change(s)` and wrote no changeset. With no pending changeset on `main` either, the file existed neither in the working tree nor in the index — and `git add -A <path>` exits 128 when the pathspec matches nothing. Every earlier refresh either wrote the file or had it already tracked, so this path was never exercised before.

## Fix

Only run `git add` when the changeset file exists or is tracked:

- **Absent + untracked** (the failing no-op case): skip the add; the existing `git diff --cached --quiet` early-exit reports "nothing to commit".
- **Generator wrote/updated the file**: staged as before.
- **Tracked but deleted by the generator**: still passes `git ls-files --error-unmatch`, so the deletion is staged as before.

All three cases verified in a scratch repo.

No changeset: CI/workflow-only change (no package functionality affected). Once this merges, re-running the failed job on #458 (or letting Renovate rebase it) should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGdppnU5vbeT8XrJtAwsGB