### PR TITLE
fix(catalog): manage multiple team grants for groups and environments

### DIFF
--- a/.changeset/group-environment-multi-team-access.md
+++ b/.changeset/group-environment-multi-team-access.md
@@ -1,0 +1,14 @@
+---
+"@checkstack/catalog-frontend": patch
+---
+
+Let groups and environments be scoped to multiple teams and un-scoped again. The
+Group and Environment edit dialogs now embed the full `TeamAccessEditor` (the
+same control systems use on their detail page) when editing an existing
+group/environment, so you can add any number of teams, remove a team, toggle a
+team between Manage and Read-only, and flip privacy. Previously the only
+team-scoping surfaces for groups/environments were the create-time single owner
+picker and the additive per-row "Scope to team" action, so a group/environment
+could effectively only be handed to one team and never un-scoped. No backend
+change: the generic relation endpoints already supported this; the editors just
+never exposed it.

--- a/core/catalog-frontend/src/components/CatalogConfigPage.tsx
+++ b/core/catalog-frontend/src/components/CatalogConfigPage.tsx
@@ -697,7 +697,9 @@ export const CatalogConfigPage = () => {
         }}
         onSave={handleSaveGroup}
         initialData={
-          editingGroup ? { name: editingGroup.name } : undefined
+          editingGroup
+            ? { id: editingGroup.id, name: editingGroup.name }
+            : undefined
         }
       />
 
@@ -711,6 +713,7 @@ export const CatalogConfigPage = () => {
         initialData={
           editingEnvironment
             ? {
+                id: editingEnvironment.id,
                 name: editingEnvironment.name,
                 description: editingEnvironment.description ?? undefined,
                 metadata: editingEnvironment.metadata,

--- a/core/catalog-frontend/src/components/EnvironmentEditor.tsx
+++ b/core/catalog-frontend/src/components/EnvironmentEditor.tsx
@@ -15,10 +15,11 @@ import {
 } from "@checkstack/ui";
 import {
   TeamOwnershipPicker,
+  TeamAccessEditor,
   teamCreateErrorMessage,
 } from "@checkstack/auth-frontend";
 import { useApi, accessApiRef } from "@checkstack/frontend-api";
-import { catalogAccess } from "@checkstack/catalog-common";
+import { catalogAccess, catalogResourceTypes } from "@checkstack/catalog-common";
 import {
   metadataToRows,
   rowsToMetadata,
@@ -28,6 +29,7 @@ import {
 import { CustomFieldsEditor } from "./CustomFieldsEditor";
 
 export interface EnvironmentEditorInitialData {
+  id: string;
   name: string;
   description?: string;
   metadata?: Record<string, unknown> | null;
@@ -176,6 +178,20 @@ export const EnvironmentEditor: React.FC<EnvironmentEditorProps> = ({
                   error={ownerTeamError}
                 />
               </div>
+            )}
+
+            {/* Full team-access management - only when editing an existing
+                environment (needs its id). Environments have no detail page, so
+                this is the home for adding/removing multiple teams and toggling
+                privacy, mirroring how systems manage it on their detail page. It
+                writes immediately, independent of this form's deferred Save. */}
+            {initialData?.id && (
+              <TeamAccessEditor
+                resourceType={catalogResourceTypes.environment}
+                resourceId={initialData.id}
+                compact
+                expanded
+              />
             )}
           </div>
 

--- a/core/catalog-frontend/src/components/GroupEditor.tsx
+++ b/core/catalog-frontend/src/components/GroupEditor.tsx
@@ -15,16 +15,17 @@ import {
 } from "@checkstack/ui";
 import {
   TeamOwnershipPicker,
+  TeamAccessEditor,
   teamCreateErrorMessage,
 } from "@checkstack/auth-frontend";
 import { useApi, accessApiRef } from "@checkstack/frontend-api";
-import { catalogAccess } from "@checkstack/catalog-common";
+import { catalogAccess, catalogResourceTypes } from "@checkstack/catalog-common";
 
 interface GroupEditorProps {
   open: boolean;
   onClose: () => void;
   onSave: (data: { name: string; teamId?: string }) => Promise<void>;
-  initialData?: { name: string };
+  initialData?: { id: string; name: string };
 }
 
 export const GroupEditor: React.FC<GroupEditorProps> = ({
@@ -119,6 +120,20 @@ export const GroupEditor: React.FC<GroupEditorProps> = ({
                   error={ownerTeamError}
                 />
               </div>
+            )}
+
+            {/* Full team-access management - only when editing an existing
+                group (needs its id). Groups have no detail page, so this is the
+                home for adding/removing multiple teams and toggling privacy,
+                mirroring how systems manage it on their detail page. It writes
+                immediately, independent of this form's deferred Save. */}
+            {initialData?.id && (
+              <TeamAccessEditor
+                resourceType={catalogResourceTypes.group}
+                resourceId={initialData.id}
+                compact
+                expanded
+              />
             )}
           </div>
 


### PR DESCRIPTION
## Problem

Two gaps in team-scoping for catalog **groups** and **environments**:

1. They could only be scoped to **one** team.
2. A team could **not be removed** once scoped.

The only team-scoping surfaces were the create-time single **owner** picker
(`TeamOwnershipPicker`) and the additive per-row **"Scope to team"** action
(`ScopeToTeamDialog`, single team, add-only). Neither shows existing grants or
allows removal, so a group/environment could effectively be handed to one team
and never un-scoped.

Systems (and incidents/maintenance/health checks) already solve this with the
full `TeamAccessEditor` - but on a **detail page**. Groups/environments have no
detail page, so that editor was never wired in.

## Fix

Embed `TeamAccessEditor` in the Group and Environment **edit** dialogs when
editing an existing resource, mirroring the healthcheck editor pattern
(create -> `TeamOwnershipPicker`, edit -> `TeamAccessEditor`). This gives:

- **Multiple teams** - add as many as you want.
- **Un-scoping** - each team row has a remove button.
- Per-team **Manage vs Read-only** toggle and the **Private** (team-only) switch,
  same as systems.

Files (all frontend):
- `GroupEditor.tsx` / `EnvironmentEditor.tsx` - render `TeamAccessEditor` for
  `catalog.group` / `catalog.environment` in edit mode; `initialData` gains `id`.
- `CatalogConfigPage.tsx` - thread the resource `id` into both editors.

**No backend change**: `writeRelation` / `removeRelation` / `listObjectRelations`
/ `setObjectPublic` are already `objectType: z.string()` and gated on
`authAccess.teams.manage`, so they handle these types exactly as `catalog.system`
(the scope dialog already proves `writeRelation` works for them).

Note: `TeamAccessEditor` writes **immediately** (independent of the dialog's
deferred Save), the same way systems manage team access separately from the
identity form.

## Testing

- `bun run typecheck`, `bun run lint` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNFMjcLpE8iXUZHffW8voE