### PR TITLE
chore(renovate): run lock-file maintenance once a day

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,9 +29,9 @@
   ],
 
   "lockFileMaintenance": {
-    "description": "Runs 'at any time'. A narrow window couples PR creation to Mend running inside it, and Mend's hosted cadence is unpredictable - an idle repo can miss a 4h band for a day. lockFileMaintenance only creates/refreshes the single PR when the regenerated lockfile actually changes, and the bunfig.toml minimumReleaseAge cooldown gates eligibility, so 'any time' is not noisy. NOTE: omitting the schedule key reverts to lockFileMaintenance's built-in weekly default ('before 4am on monday'), so it is set explicitly.",
+    "description": "Runs once a day inside a nightly UTC window ('after 2am and before 3am'). The previous 'at any time' let every hosted Mend run act on the PR, so on an active main the single lock-file PR was rebased (behind-base-branch) and re-CI'd 5-6 times a day - pure notification/CI spam. Constraining to a one-hour daily band caps that to (at most) one refresh/rebase per day. Trade-off: if Mend's unpredictable cadence skips the band on some day, lock-file maintenance simply runs the next day - it is not time-critical, and the bunfig.toml minimumReleaseAge cooldown still gates eligibility. NOTE: omitting the schedule key reverts to lockFileMaintenance's built-in weekly default ('before 4am on monday'), so it is set explicitly.",
     "enabled": true,
-    "schedule": ["at any time"],
+    "schedule": ["after 2am and before 3am"],
     "commitMessageAction": "Refresh",
     "commitMessageTopic": "bun.lock (lock-file maintenance)",
     "labels": ["dependencies", "security-maintenance"],


### PR DESCRIPTION
## Problem

The single lock-file-maintenance PR was regenerating CI runs and notifications
5-6 times a day.

`lockFileMaintenance.schedule` was `["at any time"]`, so every hosted Mend run
could act on the PR. With `rebaseWhen: "behind-base-branch"` and an active
`main`, the PR got rebased (force-pushed) and re-CI'd on essentially every Mend
run.

## Change

Constrain `lockFileMaintenance.schedule` to a nightly one-hour UTC window
(`["after 2am and before 3am"]`, timezone already `UTC`), so it refreshes/rebases
at most once a day.

**Trade-off** (documented in the config `description`): if Mend's unpredictable
cadence skips the window on a given day, lock-file maintenance simply runs the
next day. It is not time-critical, and the `bunfig.toml` `minimumReleaseAge`
cooldown still gates eligibility.

Nothing else about Renovate changes: ordinary version-bump PRs stay disabled;
only lock-file maintenance is affected.

## Testing

- `renovate.json` is valid JSON; `"after 2am and before 3am"` is the canonical
  Renovate schedule string format.
- Config-only (CI tooling) change - no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNFMjcLpE8iXUZHffW8voE