### PR TITLE
chore(security): prune redundant managed overrides

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3572,7 +3572,6 @@
     "drizzle-kit": ">=0.31.0 <1.0.0",
     "drizzle-orm": "^0.45.0",
     "esbuild": "^0.28.1",
-    "fast-uri": "^3.1.4",
     "minimatch": "^10.2.5",
     "postcss-selector-parser": "^7.1.4",
     "react": "19.2.7",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "postcss-selector-parser": "^7.1.4",
     "@astrojs/markdown-remark": "^7.2.0",
     "adm-zip": "^0.6.0",
-    "fast-uri": "^3.1.4",
     "sharp": "^0.35.0"
   },
   "resolutions": {
@@ -96,7 +95,6 @@
     "postcss-selector-parser": "^7.1.4",
     "@astrojs/markdown-remark": "^7.2.0",
     "adm-zip": "^0.6.0",
-    "fast-uri": "^3.1.4",
     "sharp": "^0.35.0"
   }
 }

--- a/security/managed-overrides.json
+++ b/security/managed-overrides.json
@@ -57,14 +57,6 @@
       "addedAt": "2026-07-23",
       "removeWhen": "No dependency resolves below 0.6.0 without this override."
     },
-    "fast-uri": {
-      "safeFloor": "3.1.4",
-      "severity": "HIGH",
-      "advisory": "CVE-2026-16221",
-      "reason": "Auto-remediated by Security Maintenance: fast-uri 3.1.3 had fixable advisories; pinned to the fixed 3.x line.",
-      "addedAt": "2026-07-23",
-      "removeWhen": "No dependency resolves below 3.1.4 without this override."
-    },
     "sharp": {
       "safeFloor": "0.35.0",
       "severity": "HIGH",


### PR DESCRIPTION
Automated by the daily **Security Maintenance** workflow.

## Redundant overrides removed

These security overrides are no longer needed — the dependency graph
now resolves at/above their `safeFloor` without the pin:

- Pruned 1 redundant override(s): fast-uri

## Current CVE state

### Fixable vulnerabilities (a patched version exists): 6

- **MEDIUM** `astro` 6.4.8 → fixed in **7.1.0** (GHSA-4g3v-8h47-v7g6)
- **MEDIUM** `astro` 6.4.8 → fixed in **7.0.6** (CVE-2026-59729)
- **HIGH** `sharp` 0.34.5 → fixed in **0.35.0** (GHSA-f88m-g3jw-g9cj)
- **HIGH** `fast-xml-parser` 5.10.0 → fixed in **5.10.1** (GHSA-8r6m-32jq-jx6q)
- **HIGH** `adm-zip` 0.5.10 → fixed in **0.6.0** (CVE-2026-39244)
- **HIGH** `fast-uri` 3.1.3 → fixed in **2.4.3, 3.1.4, 4.1.1** (CVE-2026-16221)

<details><summary>Known unfixed (monitoring only)</summary>


</details>
