### PR TITLE
chore(security): prune redundant managed overrides

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2093,7 +2093,7 @@
     },
     "core/sdk": {
       "name": "@checkstack/sdk",
-      "version": "0.135.1",
+      "version": "0.136.0",
       "dependencies": {
         "@checkstack/announcement-common": "workspace:*",
         "@checkstack/anomaly-common": "workspace:*",
@@ -3595,12 +3595,10 @@
     "drizzle-kit": ">=0.31.0 <1.0.0",
     "drizzle-orm": "^0.45.0",
     "esbuild": "^0.28.1",
-    "fast-uri": "^3.1.4",
     "minimatch": "^10.2.5",
     "postcss-selector-parser": "^7.1.4",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "sharp": "^0.35.0",
     "ws": "^8.21.0",
     "yaml": "^2.9.0",
   },

--- a/package.json
+++ b/package.json
@@ -80,9 +80,7 @@
     "minimatch": "^10.2.5",
     "postcss-selector-parser": "^7.1.4",
     "@astrojs/markdown-remark": "^7.2.0",
-    "adm-zip": "^0.6.0",
-    "fast-uri": "^3.1.4",
-    "sharp": "^0.35.0"
+    "adm-zip": "^0.6.0"
   },
   "resolutions": {
     "drizzle-orm": "^0.45.0",
@@ -96,8 +94,6 @@
     "minimatch": "^10.2.5",
     "postcss-selector-parser": "^7.1.4",
     "@astrojs/markdown-remark": "^7.2.0",
-    "adm-zip": "^0.6.0",
-    "fast-uri": "^3.1.4",
-    "sharp": "^0.35.0"
+    "adm-zip": "^0.6.0"
   }
 }

--- a/security/managed-overrides.json
+++ b/security/managed-overrides.json
@@ -56,22 +56,6 @@
       "reason": "Auto-remediated by Security Maintenance: adm-zip 0.5.10 had fixable advisories; pinned to the fixed 0.x line.",
       "addedAt": "2026-07-23",
       "removeWhen": "No dependency resolves below 0.6.0 without this override."
-    },
-    "fast-uri": {
-      "safeFloor": "3.1.4",
-      "severity": "HIGH",
-      "advisory": "CVE-2026-16221",
-      "reason": "Auto-remediated by Security Maintenance: fast-uri 3.1.3 had fixable advisories; pinned to the fixed 3.x line.",
-      "addedAt": "2026-07-23",
-      "removeWhen": "No dependency resolves below 3.1.4 without this override."
-    },
-    "sharp": {
-      "safeFloor": "0.35.0",
-      "severity": "HIGH",
-      "advisory": "GHSA-f88m-g3jw-g9cj",
-      "reason": "Auto-remediated by Security Maintenance: sharp 0.34.5 had fixable advisories; pinned to the fixed 0.x line.",
-      "addedAt": "2026-07-23",
-      "removeWhen": "No dependency resolves below 0.35.0 without this override."
     }
   },
   "intentional": {


### PR DESCRIPTION
Automated by the daily **Security Maintenance** workflow.

## Redundant overrides removed

These security overrides are no longer needed — the dependency graph
now resolves at/above their `safeFloor` without the pin:

- Pruned 2 redundant override(s): fast-uri, sharp

## Current CVE state

### Fixable vulnerabilities (a patched version exists): 3

- **MEDIUM** `tar` 7.5.20 → fixed in **7.5.21** (GHSA-r292-9mhp-454m)
- **HIGH** `react-router` 7.18.1 → fixed in **8.3.0** (GHSA-qwww-vcr4-c8h2)
- **HIGH** `brace-expansion` 5.0.7 → fixed in **5.0.8** (CVE-2026-14257)

<details><summary>Known unfixed (monitoring only)</summary>


</details>
