### PR TITLE
fix(security): don't prune overrides that re-introduce a fixable CVE

### DIFF
--- a/.github/workflows/security-maintenance.yml
+++ b/.github/workflows/security-maintenance.yml
@@ -141,8 +141,44 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Compose PR body
+      # A prune is "redundant" only against each removed package's OWN safeFloor;
+      # it cannot see a DIFFERENT (unmanaged, transitive) package that the lockfile
+      # re-resolution drags down to a vulnerable version once the pins come out.
+      # Re-scan the pruned tree and refuse to surface a prune that re-introduces a
+      # FIXABLE CVE - revert it so no PR is opened.
+      - name: Trivy filesystem re-scan (after prune)
         if: steps.prune.outputs.changed == 'true'
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: json
+          exit-code: "0"
+          severity: CRITICAL,HIGH,MEDIUM
+          output: /tmp/fs-after.json
+
+      - name: Verify prune introduces no new fixable CVEs
+        id: verify
+        if: steps.prune.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          [ -s /tmp/fs-after.json ] || echo '{"Results":[]}' > /tmp/fs-after.json
+          jq -s '
+            [ .[].Results[]?.Vulnerabilities[]?
+              | { id:.VulnerabilityID, pkg:.PkgName, installed:.InstalledVersion,
+                  fixed:(.FixedVersion // ""), sev:.Severity } ]
+            | unique_by(.id + "|" + .pkg + "|" + .installed)
+          ' /tmp/fs-after.json > /tmp/vulns-after.json
+          if bun run scripts/audit-overrides.ts --verify-prune /tmp/vulns.json /tmp/vulns-after.json; then
+            echo "safe=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "safe=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Override prune blocked::Pruning redundant overrides re-introduced a fixable CVE; reverting and skipping the PR (see the log for the offending package)."
+            git checkout -- package.json bun.lock security/managed-overrides.json
+          fi
+
+      - name: Compose PR body
+        if: steps.prune.outputs.changed == 'true' && steps.verify.outputs.safe == 'true'
         run: |
           {
             echo "Automated by the daily **Security Maintenance** workflow."
@@ -160,7 +196,7 @@ jobs:
           } > /tmp/pr-body.md
 
       - name: Open / update override-removal PR
-        if: steps.prune.outputs.changed == 'true'
+        if: steps.prune.outputs.changed == 'true' && steps.verify.outputs.safe == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           # See the remediation PR step for why a non-GITHUB_TOKEN identity is

--- a/scripts/audit-overrides.test.ts
+++ b/scripts/audit-overrides.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   applyPrune,
+  diffNewFixable,
   extractInstalledVersions,
   findDrift,
   isRedundant,
@@ -9,6 +10,7 @@ import {
   type ManagedOverride,
   type ManagedOverrideMeta,
 } from "./audit-overrides";
+import type { Finding } from "./remediate-vulns";
 
 // Human-only metadata as it appears under a name key in the `security` bucket
 // (no version - that lives in package.json).
@@ -220,5 +222,46 @@ describe("isRedundant", () => {
 
   test("redundant when the package left the graph entirely", () => {
     expect(isRedundant({ resolvedVersions: [], safeFloor: "8.21.0" })).toBe(true);
+  });
+});
+
+describe("diffNewFixable", () => {
+  const f = (
+    pkg: string,
+    installed: string,
+    fixed: string,
+    id = `CVE-${pkg}`,
+    sev = "HIGH",
+  ): Finding => ({ id, pkg, installed, fixed, sev });
+
+  test("flags a fixable vuln that appears only AFTER the prune", () => {
+    // A resolution shift dragged brace-expansion down to a vulnerable version
+    // that no managed override (and thus no isRedundant floor) protects.
+    const baseline: Finding[] = [];
+    const after = [f("brace-expansion", "5.0.7", "5.0.8", "CVE-2026-14257")];
+    expect(diffNewFixable({ baseline, after })).toEqual(after);
+  });
+
+  test("ignores a fixable vuln that already existed before (not introduced)", () => {
+    const finding = f("left-pad", "1.0.0", "1.0.1");
+    expect(
+      diffNewFixable({ baseline: [finding], after: [finding] }),
+    ).toEqual([]);
+  });
+
+  test("ignores UNFIXABLE (fixed==='') findings - only gated vulns count", () => {
+    const after = [f("nofix", "1.0.0", "")];
+    expect(diffNewFixable({ baseline: [], after })).toEqual([]);
+  });
+
+  test("a version bump of the same package+id counts as new (different installed)", () => {
+    const baseline = [f("pkg", "2.0.0", "2.0.1", "CVE-1")];
+    const after = [f("pkg", "1.9.0", "1.9.1", "CVE-1")];
+    expect(diffNewFixable({ baseline, after })).toEqual(after);
+  });
+
+  test("clean prune (no new fixable) returns empty", () => {
+    const shared = [f("a", "1.0.0", "1.0.1")];
+    expect(diffNewFixable({ baseline: shared, after: shared })).toEqual([]);
   });
 });

--- a/scripts/audit-overrides.ts
+++ b/scripts/audit-overrides.ts
@@ -34,6 +34,7 @@ import { readFileSync, writeFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import semver from "semver";
 import { z } from "zod";
+import { VulnsSchema, type Finding } from "./remediate-vulns";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const MANIFEST_PATH = path.join(ROOT, "security", "managed-overrides.json");
@@ -247,6 +248,29 @@ export function isRedundant({
   return resolvedVersions.every((v) => semver.gte(v, safeFloor));
 }
 
+/**
+ * FIXABLE findings present AFTER a prune that were NOT present before (matched
+ * by id|pkg|installed). `isRedundant` only guards the REMOVED package's own
+ * floor; it cannot see a DIFFERENT package (e.g. a transitive with no managed
+ * override) that a resolution shift drags down to a vulnerable version when the
+ * overrides come out. A prune that yields any of these has RE-INTRODUCED a
+ * fixable vulnerability and must NOT be surfaced as a PR. Pure - unit-tested;
+ * the Trivy re-scan that produces the inputs runs in the daily workflow.
+ */
+export function diffNewFixable({
+  baseline,
+  after,
+}: {
+  baseline: Finding[];
+  after: Finding[];
+}): Finding[] {
+  const key = (f: Finding) => `${f.id}|${f.pkg}|${f.installed}`;
+  const wasFixableBefore = new Set(
+    baseline.filter((f) => f.fixed !== "").map((f) => key(f)),
+  );
+  return after.filter((f) => f.fixed !== "" && !wasFixableBefore.has(key(f)));
+}
+
 interface RedundancyResult {
   name: string;
   redundant: boolean;
@@ -425,27 +449,69 @@ async function runPrune(): Promise<void> {
   console.log("Run `bun install` to update the lockfile.");
 }
 
+/**
+ * Post-prune safety gate. Given the BASELINE Trivy findings (overrides present)
+ * and the AFTER findings (overrides pruned + lockfile re-resolved), exit non-zero
+ * if the prune re-introduced any FIXABLE vulnerability. The daily workflow runs
+ * this before opening the prune PR and reverts the prune when it fails, so a
+ * prune that trades a redundant pin for a fresh CVE never surfaces.
+ */
+async function runVerifyPrune(): Promise<void> {
+  const [baselinePath, afterPath] = [process.argv[3], process.argv[4]];
+  if (!baselinePath || !afterPath) {
+    console.error(
+      "Usage: bun run scripts/audit-overrides.ts --verify-prune <baseline-vulns.json> <after-vulns.json>",
+    );
+    process.exit(2);
+  }
+  const baseline = VulnsSchema.parse(
+    JSON.parse(readFileSync(baselinePath, "utf8")),
+  );
+  const after = VulnsSchema.parse(JSON.parse(readFileSync(afterPath, "utf8")));
+
+  const introduced = diffNewFixable({ baseline, after });
+  if (introduced.length === 0) {
+    console.log("✓ Prune introduces no new fixable vulnerabilities.");
+    return;
+  }
+
+  console.error(
+    `❌ Prune re-introduces ${introduced.length} fixable vulnerabilit${introduced.length === 1 ? "y" : "ies"} — refusing to surface it:`,
+  );
+  for (const f of introduced) {
+    console.error(
+      `   - [${f.sev}] ${f.pkg} ${f.installed} -> fixed in ${f.fixed} (${f.id})`,
+    );
+  }
+  process.exit(1);
+}
+
 if (import.meta.main) {
   const mode = process.argv[2];
   switch (mode) {
   case "--check": {
     await runCheck();
-  
+
   break;
   }
   case "--redundant": {
     await runRedundant();
-  
+
   break;
   }
   case "--prune": {
     await runPrune();
-  
+
+  break;
+  }
+  case "--verify-prune": {
+    await runVerifyPrune();
+
   break;
   }
   default: {
     console.error(
-      "Usage: bun run scripts/audit-overrides.ts <--check | --redundant [--json] | --prune>",
+      "Usage: bun run scripts/audit-overrides.ts <--check | --redundant [--json] | --prune | --verify-prune <baseline> <after>>",
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Problem

The daily Security Maintenance prune (#489) removed `fast-uri`, `sharp`, `adm-zip` — each individually "redundant" against its **own** `safeFloor` — but the combined lockfile re-resolution dragged **`brace-expansion`** down to a vulnerable `5.0.7`, failing the Trivy gate (`❌ Fixable vulnerabilities (3)`).

Root cause: `audit-overrides.ts` `isRedundant` only checks the *removed* package's own floor. It cannot see a *different*, unmanaged, transitive package that a resolution shift makes vulnerable — so a prune could trade a redundant pin for a fresh fixable CVE and still be surfaced as a PR.

## Fix

- **`diffNewFixable`** (pure, unit-tested): given the baseline Trivy findings (overrides present) and the after findings (pruned), returns any **fixable** vuln introduced by the prune.
- **`--verify-prune <baseline> <after>`** CLI: exits non-zero, listing the offending packages, when the prune re-introduces a fixable CVE.
- **Workflow**: after the prune + `bun install`, re-scan the tree with Trivy and run `--verify-prune`. If it fails, the prune is **reverted** (`git checkout`) and **no PR is opened** — the override just stays until the dependency graph genuinely no longer needs it.

## Note on #489

This prevents the *recurrence*. #489 itself (the already-open bad prune) should be **closed** — its next daily run will either produce nothing or only genuinely-safe prunes. The `fast-uri`/`sharp`/etc. overrides are **not** redundant yet.

## Verification

- `diffNewFixable` unit tests (new-only, ignore-existing, ignore-unfixable, version-bump-counts). Full script test file green.
- CLI smoke-tested: correctly blocks a synthetic `brace-expansion@5.0.7` re-introduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiVAPXAuVtVemtYvvyPXzp