### PR TITLE
fix(security): auto-remediate fixable vulnerabilities

### DIFF
--- a/.changeset/auto-security-remediation.md
+++ b/.changeset/auto-security-remediation.md
@@ -1,0 +1,14 @@
+---
+"@checkstack/backend-api": patch
+"@checkstack/healthcheck-mysql-backend": patch
+---
+
+Security: auto-remediated fixable vulnerabilities flagged by the daily scan.
+
+- `mysql2` 3.23.0 → 3.23.1 (GHSA-rgwj-5xj2-c3m3)
+- `sanitize-html` 2.17.6 → 2.17.7 (CVE-2026-84371)
+- `@xmldom/xmldom` 0.8.13 → 0.8.15 (CVE-2026-83610)
+- `browserslist` 4.28.6 → 4.28.7 (CVE-2026-73088, CVE-2026-73089)
+- `fast-uri` 3.1.5 → 3.1.6 (CVE-2026-75899, CVE-2026-75931, CVE-2026-75975, CVE-2026-76172)
+- `libcrypto3` 3.5.7-r0 → 3.5.8-r0 (CVE-2026-14456, CVE-2026-18798, CVE-2026-63072, CVE-2026-63076)
+- `libssl3` 3.5.7-r0 → 3.5.8-r0 (CVE-2026-14456, CVE-2026-18798, CVE-2026-63072, CVE-2026-63076)

--- a/bun.lock
+++ b/bun.lock
@@ -534,7 +534,7 @@
         "drizzle-orm": "^0.45.0",
         "hono": "^4.12.34",
         "marked": "^17.0.1",
-        "sanitize-html": "^2.17.5",
+        "sanitize-html": "^2.17.7",
         "tdigest": "^0.1.2",
         "zod": "^4.2.1",
       },
@@ -3090,7 +3090,7 @@
         "@checkstack/backend-api": "workspace:*",
         "@checkstack/common": "workspace:*",
         "@checkstack/healthcheck-common": "workspace:*",
-        "mysql2": "^3.9.0",
+        "mysql2": "^3.23.1",
       },
       "devDependencies": {
         "@checkstack/scripts": "workspace:*",
@@ -3600,11 +3600,16 @@
   "overrides": {
     "@astrojs/markdown-remark": "^7.2.0",
     "@types/node": "^26.2.0",
+    "@xmldom/xmldom": "^0.8.15",
     "adm-zip": "^0.6.0",
+    "browserslist": "^4.28.7",
     "dompurify": "^3.4.13",
     "drizzle-kit": ">=0.31.0 <1.0.0",
     "drizzle-orm": "^0.45.0",
     "esbuild": "^0.28.1",
+    "fast-uri": "^3.1.6",
+    "libcrypto3": "^3.5.8-r0",
+    "libssl3": "^3.5.8-r0",
     "minimatch": "^10.2.5",
     "postcss-selector-parser": "^7.1.4",
     "react": "19.2.7",
@@ -4912,7 +4917,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -7033,6 +7038,8 @@
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "@types/bun/bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/core/backend-api/package.json
+++ b/core/backend-api/package.json
@@ -25,7 +25,7 @@
     "drizzle-orm": "^0.45.0",
     "hono": "^4.12.34",
     "marked": "^17.0.1",
-    "sanitize-html": "^2.17.5",
+    "sanitize-html": "^2.17.7",
     "tdigest": "^0.1.2",
     "zod": "^4.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,12 @@
     "postcss-selector-parser": "^7.1.4",
     "@astrojs/markdown-remark": "^7.2.0",
     "adm-zip": "^0.6.0",
-    "undici": "^7.29.0"
+    "undici": "^7.29.0",
+    "@xmldom/xmldom": "^0.8.15",
+    "browserslist": "^4.28.7",
+    "fast-uri": "^3.1.6",
+    "libcrypto3": "^3.5.8-r0",
+    "libssl3": "^3.5.8-r0"
   },
   "resolutions": {
     "drizzle-orm": "^0.45.0",
@@ -100,6 +105,11 @@
     "postcss-selector-parser": "^7.1.4",
     "@astrojs/markdown-remark": "^7.2.0",
     "adm-zip": "^0.6.0",
-    "undici": "^7.29.0"
+    "undici": "^7.29.0",
+    "@xmldom/xmldom": "^0.8.15",
+    "browserslist": "^4.28.7",
+    "fast-uri": "^3.1.6",
+    "libcrypto3": "^3.5.8-r0",
+    "libssl3": "^3.5.8-r0"
   }
 }

--- a/plugins/healthcheck-mysql-backend/package.json
+++ b/plugins/healthcheck-mysql-backend/package.json
@@ -17,7 +17,7 @@
     "@checkstack/backend-api": "workspace:*",
     "@checkstack/common": "workspace:*",
     "@checkstack/healthcheck-common": "workspace:*",
-    "mysql2": "^3.9.0"
+    "mysql2": "^3.23.1"
   },
   "devDependencies": {
     "@types/bun": "^1.0.0",

--- a/security/managed-overrides.json
+++ b/security/managed-overrides.json
@@ -64,6 +64,46 @@
       "reason": "Auto-remediated by Security Maintenance: undici 7.28.0 had fixable advisories; pinned to the fixed 7.x line.",
       "addedAt": "2026-08-23",
       "removeWhen": "No dependency resolves below 7.29.0 without this override."
+    },
+    "@xmldom/xmldom": {
+      "safeFloor": "0.8.15",
+      "severity": "MEDIUM",
+      "advisory": "CVE-2026-83610",
+      "reason": "Auto-remediated by Security Maintenance: @xmldom/xmldom 0.8.13 had fixable advisories; pinned to the fixed 0.x line.",
+      "addedAt": "2026-09-05",
+      "removeWhen": "No dependency resolves below 0.8.15 without this override."
+    },
+    "browserslist": {
+      "safeFloor": "4.28.7",
+      "severity": "HIGH",
+      "advisory": "CVE-2026-73088, CVE-2026-73089",
+      "reason": "Auto-remediated by Security Maintenance: browserslist 4.28.6 had fixable advisories; pinned to the fixed 4.x line.",
+      "addedAt": "2026-09-05",
+      "removeWhen": "No dependency resolves below 4.28.7 without this override."
+    },
+    "fast-uri": {
+      "safeFloor": "3.1.6",
+      "severity": "HIGH",
+      "advisory": "CVE-2026-75899, CVE-2026-75931, CVE-2026-75975, CVE-2026-76172",
+      "reason": "Auto-remediated by Security Maintenance: fast-uri 3.1.5 had fixable advisories; pinned to the fixed 3.x line.",
+      "addedAt": "2026-09-05",
+      "removeWhen": "No dependency resolves below 3.1.6 without this override."
+    },
+    "libcrypto3": {
+      "safeFloor": "3.5.8-r0",
+      "severity": "HIGH",
+      "advisory": "CVE-2026-14456, CVE-2026-18798, CVE-2026-63072, CVE-2026-63076",
+      "reason": "Auto-remediated by Security Maintenance: libcrypto3 3.5.7-r0 had fixable advisories; pinned to the fixed 3.x line.",
+      "addedAt": "2026-09-05",
+      "removeWhen": "No dependency resolves below 3.5.8-r0 without this override."
+    },
+    "libssl3": {
+      "safeFloor": "3.5.8-r0",
+      "severity": "HIGH",
+      "advisory": "CVE-2026-14456, CVE-2026-18798, CVE-2026-63072, CVE-2026-63076",
+      "reason": "Auto-remediated by Security Maintenance: libssl3 3.5.7-r0 had fixable advisories; pinned to the fixed 3.x line.",
+      "addedAt": "2026-09-05",
+      "removeWhen": "No dependency resolves below 3.5.8-r0 without this override."
     }
   },
   "intentional": {


### PR DESCRIPTION
Automated by the daily **Security Maintenance** workflow.

## Direct dependency range bumps

- **MEDIUM** `mysql2` 3.23.0 → ^3.23.1 (GHSA-rgwj-5xj2-c3m3)
- **MEDIUM** `sanitize-html` 2.17.6 → ^2.17.7 (CVE-2026-84371)

## Managed security overrides

- **MEDIUM** `@xmldom/xmldom` 0.8.13 → pinned to ^0.8.15 (CVE-2026-83610)
- **HIGH** `browserslist` 4.28.6 → pinned to ^4.28.7 (CVE-2026-73088, CVE-2026-73089)
- **HIGH** `fast-uri` 3.1.5 → pinned to ^3.1.6 (CVE-2026-75899, CVE-2026-75931, CVE-2026-75975, CVE-2026-76172)
- **HIGH** `libcrypto3` 3.5.7-r0 → pinned to ^3.5.8-r0 (CVE-2026-14456, CVE-2026-18798, CVE-2026-63072, CVE-2026-63076)
- **HIGH** `libssl3` 3.5.7-r0 → pinned to ^3.5.8-r0 (CVE-2026-14456, CVE-2026-18798, CVE-2026-63072, CVE-2026-63076)


Closes #513
